### PR TITLE
chore(phase-a/a6): fast wins — worktree-prune target + verify-test-gate stub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ RESET := \033[0m
 # =============================================================================
 # PHONY Declarations
 # =============================================================================
-.PHONY: help check-r check-npm check-docker install-api install-app dev serve-app build-app watch-app test-api test-api-full coverage lint-api lint-app format-api format-app pre-commit ci-local _ci-cleanup preflight docker-build docker-up docker-down docker-dev docker-dev-db docker-logs docker-status install-dev doctor worktree-setup
+.PHONY: help check-r check-npm check-docker install-api install-app dev serve-app build-app watch-app test-api test-api-full coverage lint-api lint-app format-api format-app pre-commit ci-local _ci-cleanup preflight docker-build docker-up docker-down docker-dev docker-dev-db docker-logs docker-status install-dev doctor worktree-setup worktree-prune
 
 # =============================================================================
 # Help Target (Self-documenting)
@@ -452,3 +452,19 @@ worktree-setup: ## [env] Create a parallel worktree. Usage: make worktree-setup 
 	printf "  cd %s\n" "$$WORKTREE_PATH"; \
 	printf "  make install-dev\n"; \
 	printf "  make doctor\n"
+
+# =============================================================================
+# Worktree Cleanup (Phase A6)
+# =============================================================================
+# Canonical git cleanup for parallel worktrees. Idempotent — safe to run on a
+# clean tree. Removes references to worktrees whose directories have been
+# deleted (e.g. after `rm -rf worktrees/phase-a/foo` without `git worktree
+# remove`), then prints the remaining list so you can see what's left.
+
+worktree-prune: ## [env] Prune stale worktree references and list remaining worktrees
+	@printf "$(CYAN)==> Pruning stale worktree references...$(RESET)\n"
+	@git -C $(ROOT_DIR) worktree prune -v && \
+		printf "$(GREEN)✓ worktree prune complete$(RESET)\n" || \
+		(printf "$(RED)✗ worktree prune failed$(RESET)\n" && exit 1)
+	@printf "\n$(CYAN)Remaining worktrees:$(RESET)\n"
+	@git -C $(ROOT_DIR) worktree list

--- a/scripts/verify-test-gate.sh
+++ b/scripts/verify-test-gate.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "stub — B4 will fill"
+exit 0


### PR DESCRIPTION
## Summary

Phase A6 (`fast-wins`) — three small, disjoint structural edits per `.plans/v11.0/phase-a.md` §3 A6:

- **`scripts/verify-test-gate.sh`** — new stub file with the exact body specified in the plan (`#!/bin/bash; echo "stub — B4 will fill"; exit 0`). Executable bit set. B4 (Phase B) will replace the stub with real test-gate verification logic.
- **`Makefile`** — new top-level target `worktree-prune` in its own `# === Worktree Cleanup (Phase A6) ===` section, visually disjoint from A7's "Developer Environment" section and A4's `lint-api` edit. Runs `git worktree prune -v`, then lists remaining worktrees. Idempotent and safe as a no-op on clean trees. Uses the Davis-Hansson style (`@printf` with color codes, `## [env]` help comment) to match A7.
- **`.gitignore`** — **verified, NOT modified.** `/worktrees/` was already added on master in commit `6b3c0441` ("chore(gitignore): ignore /worktrees/ for v11.0 parallel worktree workflow") as a pre-Phase-A setup commit so that A7's worktree could be created safely. Per the dispatch instructions, A6's ownership item for `.gitignore` became "verify" instead of "add". No `.gitignore` commit in this PR.

## Plan references

- `.plans/v11.0/phase-a.md` §3 A6 (lines 173–189)
- `docs/superpowers/specs/2026-04-11-v11.0-test-foundation-design.md` §3 Phase A.A6
- Merge rule §2.4: "keep both blocks, alphabetize top-level targets" if any conflict arises at merge time.

## Acceptance criteria (from plan §3 A6)

- [x] `make worktree-prune` runs as a no-op on clean `master` (verified: exit 0, prints remaining worktrees)
- [x] `scripts/verify-test-gate.sh` exists with the exact stub body
- [x] `scripts/verify-test-gate.sh` is executable (`-rwxrwxr-x`)
- [x] `.gitignore` contains `/worktrees/` (verified — pre-existing on master)

## Test plan

- [x] `grep "/worktrees/" .gitignore` → matches
- [x] `cat scripts/verify-test-gate.sh` → matches stub body exactly
- [x] `./scripts/verify-test-gate.sh` → prints "stub — B4 will fill" and exits 0
- [x] `make worktree-prune` → exits 0, runs `git worktree prune -v`, prints worktree list
- [x] `make help` → shows `worktree-prune` under the Environment category
- [x] `Rscript --no-init-file api/scripts/lint-check.R` → 82 files, 0 issues
- [ ] `cd app && npm run lint` — NOT verified locally: worktree has no `node_modules` yet and a stray global `eslint v6.4.0` on the host shadows it. Not a blocker — no frontend files changed in this PR, and CI runs `npm ci --legacy-peer-deps` first so the real project-local eslint will run.
- [x] `git status` → clean after commits, only the two intended files touched

## Deviations from plan

**`.gitignore` verify-only.** The plan originally instructed A6 to ADD `/worktrees/` to `.gitignore`, but it was already added in pre-Phase-A setup commit `6b3c0441` so that A7's worktree could be created safely before A6 ran. Per the dispatch instructions, this became a verify-only item. No commit for `.gitignore` in this PR.

## Commits

- `feat(scripts): add verify-test-gate.sh stub (B4 fills in)`
- `chore(makefile): add worktree-prune target`

Conventional commits, no amend / squash / force-push / --no-verify.