### PR TITLE
fix(phase-a/followup): schema_version rename reconciliation + drop api/repository compose mounts

### DIFF
--- a/api/functions/migration-runner.R
+++ b/api/functions/migration-runner.R
@@ -153,6 +153,146 @@ get_applied_migrations <- function(conn = NULL) {
   })
 }
 
+#' Historical migration renames tracked by the runner
+#'
+#' Map of `old_filename = new_filename` for files that were renamed in master
+#' after they had already been applied in long-lived deployments. The
+#' reconciliation step below rewrites `schema_version.filename` before the
+#' pending-migration diff so a rename does not re-execute the migration.
+#'
+#' Add a new entry whenever a historical migration is renamed. Keep the map
+#' small; prefer not renaming migrations once deployed.
+#'
+#' @keywords internal
+MIGRATION_RENAMES <- list(
+  # Phase A.A4 (v11.0): duplicate 008_ prefix resolved by renaming to 018_
+  # See docs/reviews/2026-04-11-codebase-review.md §2 and .plans/v11.0/phase-a.md §3 A4.
+  "008_hgnc_symbol_lookup.sql" = "018_hgnc_symbol_lookup.sql"
+)
+
+#' Reconcile schema_version for historical migration renames
+#'
+#' Before computing the pending-migration diff, rewrite any rows in
+#' `schema_version` whose filename is listed in [MIGRATION_RENAMES] as an
+#' old name and whose new name (a) exists on disk and (b) is not already
+#' recorded. This prevents a renamed migration from being re-executed on
+#' long-lived deployments after the rename PR merges.
+#'
+#' The operation is idempotent: re-running it on an already-reconciled
+#' database is a no-op.
+#'
+#' @param conn Optional database connection or pool object. If NULL, uses global pool.
+#' @param migrations_dir Directory containing migration `.sql` files.
+#'
+#' @return Character vector of (old → new) pairs that were rewritten.
+#' @keywords internal
+reconcile_schema_version_renames <- function(conn = NULL, migrations_dir = "db/migrations") {
+  if (length(MIGRATION_RENAMES) == 0) {
+    return(character(0))
+  }
+
+  use_pool <- if (is.null(conn)) pool else conn
+  is_pool_obj <- inherits(use_pool, "Pool")
+
+  if (is_pool_obj) {
+    use_conn <- pool::poolCheckout(use_pool)
+    on.exit(pool::poolReturn(use_conn), add = TRUE)
+  } else {
+    use_conn <- use_pool
+  }
+
+  # Read the on-disk file set once.
+  on_disk <- tryCatch(
+    list_migration_files(migrations_dir),
+    error = function(e) {
+      log_debug("reconcile_schema_version_renames: list_migration_files failed: {e$message}")
+      character(0)
+    }
+  )
+
+  rewritten <- character(0)
+
+  for (old_name in names(MIGRATION_RENAMES)) {
+    new_name <- MIGRATION_RENAMES[[old_name]]
+
+    # Only rewrite if the new file exists on disk (otherwise the rename PR has
+    # not landed yet in this tree and the reconciliation is premature).
+    if (!(new_name %in% on_disk)) {
+      next
+    }
+
+    # Check current schema_version state for both rows.
+    old_row <- tryCatch(
+      DBI::dbGetQuery(
+        use_conn,
+        "SELECT filename FROM schema_version WHERE filename = ? LIMIT 1",
+        params = list(old_name)
+      ),
+      error = function(e) NULL
+    )
+    new_row <- tryCatch(
+      DBI::dbGetQuery(
+        use_conn,
+        "SELECT filename FROM schema_version WHERE filename = ? LIMIT 1",
+        params = list(new_name)
+      ),
+      error = function(e) NULL
+    )
+
+    old_present <- !is.null(old_row) && nrow(old_row) > 0
+    new_present <- !is.null(new_row) && nrow(new_row) > 0
+
+    if (old_present && !new_present) {
+      # Rewrite the row.
+      log_info(paste0(
+        "reconcile_schema_version_renames: rewriting schema_version.filename ",
+        "'", old_name, "' -> '", new_name, "'"
+      ))
+      tryCatch({
+        DBI::dbExecute(
+          use_conn,
+          "UPDATE schema_version SET filename = ? WHERE filename = ?",
+          params = list(new_name, old_name)
+        )
+        rewritten <- c(rewritten, paste0(old_name, " -> ", new_name))
+      }, error = function(e) {
+        log_error(paste0(
+          "reconcile_schema_version_renames: failed to rewrite '", old_name,
+          "' -> '", new_name, "': ", conditionMessage(e)
+        ))
+      })
+    } else if (old_present && new_present) {
+      # Both present — this is a soft anomaly (A4's 018 re-ran before this
+      # reconciliation was deployed, OR the rename ran twice). Keep the new
+      # row and drop the old row so future checks are clean. Do not touch
+      # any other table; the duplicate-row cleanup (if any) is a manual
+      # follow-up.
+      log_info(paste0(
+        "reconcile_schema_version_renames: both '", old_name, "' and '", new_name,
+        "' present in schema_version; dropping stale old row"
+      ))
+      tryCatch({
+        DBI::dbExecute(
+          use_conn,
+          "DELETE FROM schema_version WHERE filename = ?",
+          params = list(old_name)
+        )
+        rewritten <- c(rewritten, paste0(old_name, " -> ", new_name, " (dedup)"))
+      }, error = function(e) {
+        log_error(paste0(
+          "reconcile_schema_version_renames: failed to drop stale '", old_name,
+          "': ", conditionMessage(e)
+        ))
+      })
+    }
+    # Else: nothing to do (old_name not recorded; new_name already recorded, or
+    # neither present — the rename PR has not been applied to this deployment
+    # yet).
+  }
+
+  return(rewritten)
+}
+
 #' Record a successful migration
 #'
 #' Inserts a record into schema_version to track that a migration
@@ -524,6 +664,20 @@ run_migrations <- function(migrations_dir = "db/migrations", conn = NULL, verbos
 
   # Ensure tracking table exists
   ensure_schema_version_table(conn)
+
+  # Reconcile schema_version for any historical migration renames BEFORE the
+  # pending-migration diff. Without this, A4's rename of 008_ -> 018_ would
+  # cause the renamed migration to re-run on long-lived deployments (and
+  # duplicate hgnc_symbol_lookup rows, since its INSERT statements are not
+  # idempotent). The reconciliation is a no-op on fresh DBs or on already-
+  # reconciled DBs. See MIGRATION_RENAMES for the mapping.
+  rewritten <- reconcile_schema_version_renames(conn, migrations_dir)
+  if (length(rewritten) > 0) {
+    log_info(paste0(
+      "Reconciled ", length(rewritten),
+      " schema_version rename(s): ", paste(rewritten, collapse = ", ")
+    ))
+  }
 
   # Get list of all migration files
   migration_files <- list_migration_files(migrations_dir)

--- a/api/tests/testthat/test-unit-migration-runner.R
+++ b/api/tests/testthat/test-unit-migration-runner.R
@@ -298,3 +298,172 @@ describe("edge cases", {
     expect_true(length(non_empty) >= 1)
   })
 })
+
+# ============================================================================
+# reconcile_schema_version_renames() Tests
+# ============================================================================
+# Phase A.A4 rename of 008_hgnc_symbol_lookup.sql -> 018_hgnc_symbol_lookup.sql
+# introduced a hazard: on long-lived deployments, schema_version still records
+# the file under its old name, so the runner would re-execute the renamed file
+# and duplicate rows. `reconcile_schema_version_renames` handles that before
+# the pending-migration diff runs. These tests mock DBI to verify behavior in
+# each of the four possible states without needing a live database.
+
+describe("MIGRATION_RENAMES", {
+  it("is a named list mapping old -> new filenames", {
+    expect_true(is.list(MIGRATION_RENAMES))
+    expect_true(!is.null(names(MIGRATION_RENAMES)))
+    expect_true(all(nzchar(names(MIGRATION_RENAMES))))
+    for (nm in names(MIGRATION_RENAMES)) {
+      expect_true(is.character(MIGRATION_RENAMES[[nm]]))
+      expect_true(nzchar(MIGRATION_RENAMES[[nm]]))
+      expect_match(nm, "\\.sql$")
+      expect_match(MIGRATION_RENAMES[[nm]], "\\.sql$")
+    }
+  })
+
+  it("records the A4 rename: 008_hgnc_symbol_lookup -> 018_hgnc_symbol_lookup", {
+    expect_equal(
+      MIGRATION_RENAMES[["008_hgnc_symbol_lookup.sql"]],
+      "018_hgnc_symbol_lookup.sql"
+    )
+  })
+})
+
+describe("reconcile_schema_version_renames", {
+  # Helper: build a fake connection that records SELECTs and UPDATEs against
+  # a stub schema_version "table" represented as a character vector.
+  make_fake_conn <- function(initial_rows) {
+    rows_env <- new.env(parent = emptyenv())
+    rows_env$rows <- initial_rows
+    rows_env$executes <- list()
+    structure(
+      list(rows_env = rows_env),
+      class = c("FakeConn", "DBIConnection")
+    )
+  }
+
+  fake_dbGetQuery <- function(conn, sql, params = list()) {
+    filename <- params[[1]]
+    if (filename %in% conn$rows_env$rows) {
+      data.frame(filename = filename, stringsAsFactors = FALSE)
+    } else {
+      data.frame(filename = character(0), stringsAsFactors = FALSE)
+    }
+  }
+
+  fake_dbExecute <- function(conn, sql, params = list()) {
+    conn$rows_env$executes <- c(
+      conn$rows_env$executes,
+      list(list(sql = sql, params = params))
+    )
+    if (grepl("UPDATE schema_version SET filename", sql)) {
+      new_name <- params[[1]]
+      old_name <- params[[2]]
+      conn$rows_env$rows <- c(
+        setdiff(conn$rows_env$rows, old_name),
+        new_name
+      )
+    } else if (grepl("DELETE FROM schema_version", sql)) {
+      old_name <- params[[1]]
+      conn$rows_env$rows <- setdiff(conn$rows_env$rows, old_name)
+    }
+    1L
+  }
+
+  fake_list_migration_files <- function(migrations_dir) {
+    c(
+      "001_initial.sql",
+      "002_seed.sql",
+      "018_hgnc_symbol_lookup.sql"
+    )
+  }
+
+  it("rewrites schema_version when old name is present and new name is not", {
+    skip_if_not_installed("mockery")
+    conn <- make_fake_conn(c("001_initial.sql", "002_seed.sql", "008_hgnc_symbol_lookup.sql"))
+
+    mockery::stub(reconcile_schema_version_renames, "list_migration_files", fake_list_migration_files)
+    mockery::stub(reconcile_schema_version_renames, "DBI::dbGetQuery", fake_dbGetQuery)
+    mockery::stub(reconcile_schema_version_renames, "DBI::dbExecute", fake_dbExecute)
+
+    result <- reconcile_schema_version_renames(conn = conn, migrations_dir = "db/migrations")
+
+    expect_length(result, 1)
+    expect_match(result[1], "008_hgnc_symbol_lookup.sql -> 018_hgnc_symbol_lookup.sql")
+    expect_true("018_hgnc_symbol_lookup.sql" %in% conn$rows_env$rows)
+    expect_false("008_hgnc_symbol_lookup.sql" %in% conn$rows_env$rows)
+    expect_length(conn$rows_env$executes, 1)
+    expect_match(conn$rows_env$executes[[1]]$sql, "UPDATE schema_version")
+  })
+
+  it("is a no-op when the new name is already recorded (idempotent)", {
+    skip_if_not_installed("mockery")
+    conn <- make_fake_conn(c("001_initial.sql", "018_hgnc_symbol_lookup.sql"))
+
+    mockery::stub(reconcile_schema_version_renames, "list_migration_files", fake_list_migration_files)
+    mockery::stub(reconcile_schema_version_renames, "DBI::dbGetQuery", fake_dbGetQuery)
+    mockery::stub(reconcile_schema_version_renames, "DBI::dbExecute", fake_dbExecute)
+
+    result <- reconcile_schema_version_renames(conn = conn, migrations_dir = "db/migrations")
+
+    expect_length(result, 0)
+    expect_length(conn$rows_env$executes, 0)
+    expect_true("018_hgnc_symbol_lookup.sql" %in% conn$rows_env$rows)
+  })
+
+  it("drops stale old row when both old and new are recorded (dedup)", {
+    skip_if_not_installed("mockery")
+    conn <- make_fake_conn(c(
+      "001_initial.sql",
+      "008_hgnc_symbol_lookup.sql",
+      "018_hgnc_symbol_lookup.sql"
+    ))
+
+    mockery::stub(reconcile_schema_version_renames, "list_migration_files", fake_list_migration_files)
+    mockery::stub(reconcile_schema_version_renames, "DBI::dbGetQuery", fake_dbGetQuery)
+    mockery::stub(reconcile_schema_version_renames, "DBI::dbExecute", fake_dbExecute)
+
+    result <- reconcile_schema_version_renames(conn = conn, migrations_dir = "db/migrations")
+
+    expect_length(result, 1)
+    expect_match(result[1], "dedup")
+    expect_false("008_hgnc_symbol_lookup.sql" %in% conn$rows_env$rows)
+    expect_true("018_hgnc_symbol_lookup.sql" %in% conn$rows_env$rows)
+    expect_length(conn$rows_env$executes, 1)
+    expect_match(conn$rows_env$executes[[1]]$sql, "DELETE FROM schema_version")
+  })
+
+  it("is a no-op when neither name is recorded (fresh DB)", {
+    skip_if_not_installed("mockery")
+    conn <- make_fake_conn(c("001_initial.sql"))
+
+    mockery::stub(reconcile_schema_version_renames, "list_migration_files", fake_list_migration_files)
+    mockery::stub(reconcile_schema_version_renames, "DBI::dbGetQuery", fake_dbGetQuery)
+    mockery::stub(reconcile_schema_version_renames, "DBI::dbExecute", fake_dbExecute)
+
+    result <- reconcile_schema_version_renames(conn = conn, migrations_dir = "db/migrations")
+
+    expect_length(result, 0)
+    expect_length(conn$rows_env$executes, 0)
+  })
+
+  it("skips the rename when the new file is not yet on disk", {
+    skip_if_not_installed("mockery")
+    conn <- make_fake_conn(c("008_hgnc_symbol_lookup.sql"))
+
+    fake_files_without_new <- function(migrations_dir) {
+      c("001_initial.sql", "008_hgnc_symbol_lookup.sql")
+    }
+
+    mockery::stub(reconcile_schema_version_renames, "list_migration_files", fake_files_without_new)
+    mockery::stub(reconcile_schema_version_renames, "DBI::dbGetQuery", fake_dbGetQuery)
+    mockery::stub(reconcile_schema_version_renames, "DBI::dbExecute", fake_dbExecute)
+
+    result <- reconcile_schema_version_renames(conn = conn, migrations_dir = "db/migrations")
+
+    expect_length(result, 0)
+    expect_length(conn$rows_env$executes, 0)
+    expect_true("008_hgnc_symbol_lookup.sql" %in% conn$rows_env$rows)
+  })
+})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,7 +141,6 @@ services:
       - ./api/functions:/app/functions
       - ./api/core:/app/core
       - ./api/services:/app/services
-      - ./api/repository:/app/repository
       - ./api/config:/app/config
       - ./api/data:/app/data
       - ./api/results:/app/results
@@ -192,9 +191,6 @@ services:
         - action: sync
           path: ./api/services
           target: /app/services
-        - action: sync
-          path: ./api/repository
-          target: /app/repository
         - action: rebuild
           path: ./api/renv.lock
     labels:


### PR DESCRIPTION
## Summary

Follow-up PR for two reviewer caveats raised on the Phase A.A4 (#225) and A.A5 (#223) PRs. Addresses both in a single branch: `v11.0/phase-a/a4-a5-followup`.

### 1. A4 follow-up — schema_version rename reconciliation

**The hazard.** A4 renames `db/migrations/008_hgnc_symbol_lookup.sql` → `018_hgnc_symbol_lookup.sql` to resolve a duplicate-prefix finding from the consolidated review. On long-lived deployments, `schema_version` still has a row recording the file under `008_…`. After A4 merges and the API reboots, `migration-runner.R` at line 544 computes `setdiff(migration_files, applied)` and sees `018_…` as pending — so it re-executes the migration. The `CREATE TABLE IF NOT EXISTS` is safe, but the three `INSERT INTO hgnc_symbol_lookup` statements are not idempotent and would duplicate rows.

**The fix.** `api/functions/migration-runner.R`:

- New `MIGRATION_RENAMES` map (internal): `list(old_filename = new_filename)` for historical renames. Currently one entry: `008_hgnc_symbol_lookup.sql → 018_hgnc_symbol_lookup.sql`.
- New `reconcile_schema_version_renames(conn, migrations_dir)` — runs BEFORE the pending diff in `run_migrations()`. For each mapping:
  - If old is recorded and new exists on disk but is not recorded → UPDATE schema_version SET filename = new WHERE filename = old.
  - If both are recorded (re-run already happened somewhere) → DELETE the stale old row so the next run is clean.
  - If new is recorded and old is not → no-op (already reconciled).
  - If new file is not yet on disk → no-op (rename PR has not been applied to this deployment).
- Five unit tests with `mockery::stub` covering each branch of the state space. No live DB required.

**Branch-order independence.** Works whether this PR merges before or after A4 (#225):
- A4 first → this PR's first boot rewrites the row and 018_ is not pending.
- This PR first → map references 018_ but file does not yet exist; reconciliation is a no-op until A4 lands. Next boot after A4 merges reconciles correctly.

### 2. A5 follow-up — remove `api/repository` bind-mounts

**The hazard.** A5 (#223) deletes the empty `api/repository/` directory on the host as archaeological debris. But `docker-compose.yml` has two active references that would recreate it:

- Line 144 (volume bind-mount): `./api/repository:/app/repository`
- Line ~196 (`develop.watch` sync rule): `path: ./api/repository` → `target: /app/repository`

Every `docker compose up` or `docker compose watch` would recreate the empty host-side directory, reintroducing the exact state A5 was meant to eliminate.

**The fix.** `docker-compose.yml`: remove both references. No runtime reference to `api/repository` or `/app/repository` exists in the live codebase (endpoints, functions, core, services, start script); `legacy-wrappers.R` already covers the repository-layer semantics.

**Note on CLAUDE.md.** CLAUDE.md's "Container vs host mounts" inventory still lists `api/repository`. CLAUDE.md is gitignored (host-local agent memory) so it's not in this PR; it is updated per-host as a local sweep.

## Refs

- Review: `docs/reviews/2026-04-11-codebase-review.md` §2 (duplicate prefix) and §3 (empty repository)
- Plan: `.plans/v11.0/phase-a.md` §3 A4 and §3 A5
- Upstream PRs: #225 (A4, dup-008 rename), #223 (A5, delete empty repository)

## Test plan

- [x] Host-side lint: `Rscript --no-init-file api/scripts/lint-check.R` → 82 files, 0 issues
- [ ] CI: `Lint R API` green (new function is lintr-clean)
- [ ] CI: `Test R API` green (new unit tests pass with mockery stubs)
- [ ] CI: `make doctor (ubuntu-latest)` green (no change in scope)
- [ ] Reviewer verifies:
  - New function signature makes sense and reconciliation is DB-transaction-safe within the advisory lock
  - docker-compose.yml volume list is still complete after the two removals
  - No `grep -r "api/repository" api/` hits in live R code (confirmed empty in A5)

## Commit history (2 atomic commits)

1. `fix(migration-runner): reconcile schema_version for historical renames` — `29808918`
2. `chore(compose): remove api/repository bind-mounts` — `7c2e9a7d`
