### PR TITLE
phase-b/B3: wire skip_if_not_slow_tests + add slow-tests-nightly CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ on:
       - '*.md'
       - '.planning/**'
       - '.plan/**'
+  # Phase B B3: nightly slow-tests schedule trigger
+  # Runs the slow-tests suite (Mailpit + live external APIs) every night at 03:00 UTC
+  # and on manual dispatch. See `slow-tests-nightly` job below.
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
 
 # Cancel in-progress runs for the same branch
 concurrency:
@@ -178,6 +184,110 @@ jobs:
           MYSQL_USER: test
           MYSQL_PASSWORD: test
         run: Rscript -e "testthat::test_dir('tests/testthat')"
+
+  # =========================================================================
+  # Phase B B3: slow-tests-nightly
+  # =========================================================================
+  # Runs the full R testthat suite with RUN_SLOW_TESTS=true so that tests
+  # wired with `skip_if_not_slow_tests()` actually execute. This exercises
+  # Mailpit-dependent integration tests (test-integration-email.R,
+  # test-e2e-user-lifecycle.R) and live external API tests
+  # (test-external-pubmed.R, test-external-pubtator.R).
+  #
+  # Triggers:
+  #   - nightly at 03:00 UTC via `schedule:` (top of file)
+  #   - manual via `workflow_dispatch:` (top of file)
+  #
+  # Skipped on normal push/PR runs so that the regular `test-api` job never
+  # depends on Mailpit or external APIs. Per Phase B.B3 the regular CI run
+  # must complete without Mailpit — that contract is preserved because this
+  # job is gated on `github.event_name` below.
+  #
+  # Owned by B3 (v11.0/phase-b/skip-slow-wiring). B4 will add a disjoint
+  # `smoke-test` job elsewhere in this file; on merge-conflict with B4 the
+  # resolution rule is keep both job blocks.
+  # =========================================================================
+  slow-tests-nightly:
+    name: Slow Tests (nightly)
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    defaults:
+      run:
+        working-directory: ./api
+    services:
+      mysql:
+        image: mysql:8.4.8
+        env:
+          MYSQL_DATABASE: sysndd_test
+          MYSQL_USER: test
+          MYSQL_PASSWORD: test
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+      mailpit:
+        image: axllent/mailpit:latest
+        ports:
+          - 1025:1025
+          - 8025:8025
+        options: >-
+          --health-cmd="wget -qO- http://localhost:8025/api/v1/messages || exit 1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: '4.5.3'
+          use-public-rspm: true
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libglpk-dev \
+            libxml2-dev \
+            libcurl4-openssl-dev \
+            libssl-dev \
+            libmariadb-dev \
+            libsodium-dev \
+            libpng-dev \
+            libsecret-1-dev \
+            libgit2-dev \
+            libpoppler-cpp-dev \
+            libfontconfig1-dev \
+            libfreetype6-dev \
+            libjpeg-dev \
+            cmake \
+            pandoc
+
+      - uses: r-lib/actions/setup-renv@v2
+        with:
+          working-directory: ./api
+          cache-version: 3
+
+      - name: Run slow testthat tests (RUN_SLOW_TESTS=true)
+        env:
+          RUN_SLOW_TESTS: 'true'
+          MYSQL_HOST: 127.0.0.1
+          MYSQL_PORT: 3306
+          MYSQL_DATABASE: sysndd_test
+          MYSQL_USER: test
+          MYSQL_PASSWORD: test
+          MAILPIT_URL: http://127.0.0.1:8025
+          SMTP_HOST: 127.0.0.1
+          SMTP_PORT: '1025'
+          SMTP_PASSWORD: 'test'
+        run: Rscript -e "testthat::test_dir('tests/testthat')"
+  # =========================================================================
+  # End Phase B B3: slow-tests-nightly
+  # =========================================================================
 
   # ============================================================================
   # Frontend Jobs - Combined for efficiency

--- a/api/tests/testthat/test-e2e-user-lifecycle.R
+++ b/api/tests/testthat/test-e2e-user-lifecycle.R
@@ -110,6 +110,7 @@ get_admin_token <- function() {
 # =============================================================================
 
 test_that("user registration sends confirmation email", {
+  skip_if_not_slow_tests()
   skip_if_no_mailpit()
   skip_if_no_api()
   skip_if_no_test_db()
@@ -148,6 +149,7 @@ test_that("user registration sends confirmation email", {
 
 
 test_that("duplicate registration is rejected", {
+  skip_if_not_slow_tests()
   skip_if_no_mailpit()
   skip_if_no_api()
   skip_if_no_test_db()
@@ -185,6 +187,7 @@ test_that("duplicate registration is rejected", {
 
 
 test_that("invalid registration data is rejected", {
+  skip_if_not_slow_tests()
   skip_if_no_mailpit()
   skip_if_no_api()
 
@@ -223,6 +226,7 @@ test_that("invalid registration data is rejected", {
 # =============================================================================
 
 test_that("curator approval sends password email", {
+  skip_if_not_slow_tests()
   skip_if_no_mailpit()
   skip_if_no_api()
   skip_if_no_test_db()
@@ -278,6 +282,7 @@ test_that("curator approval sends password email", {
 
 
 test_that("curator rejection deletes user without email", {
+  skip_if_not_slow_tests()
   skip_if_no_mailpit()
   skip_if_no_api()
   skip_if_no_test_db()
@@ -331,6 +336,7 @@ test_that("curator rejection deletes user without email", {
 # =============================================================================
 
 test_that("password reset request sends email with reset link", {
+  skip_if_not_slow_tests()
   skip_if_no_mailpit()
   skip_if_no_api()
   skip_if_no_test_db()
@@ -385,6 +391,7 @@ test_that("password reset request sends email with reset link", {
 
 
 test_that("password reset with valid token changes password", {
+  skip_if_not_slow_tests()
   skip_if_no_mailpit()
   skip_if_no_api()
   skip_if_no_test_db()
@@ -450,6 +457,7 @@ test_that("password reset with valid token changes password", {
 
 
 test_that("password reset with invalid token is rejected", {
+  skip_if_not_slow_tests()
   skip_if_no_api()
 
   # Use a made-up invalid JWT
@@ -468,6 +476,7 @@ test_that("password reset with invalid token is rejected", {
 
 
 test_that("password reset with weak password is rejected", {
+  skip_if_not_slow_tests()
   skip_if_no_mailpit()
   skip_if_no_api()
   skip_if_no_test_db()
@@ -520,6 +529,7 @@ test_that("password reset with weak password is rejected", {
 
 
 test_that("password reset for non-existent email silently succeeds", {
+  skip_if_not_slow_tests()
   skip_if_no_mailpit()
   skip_if_no_api()
 
@@ -543,6 +553,7 @@ test_that("password reset for non-existent email silently succeeds", {
 
 
 test_that("password reset token cannot be reused", {
+  skip_if_not_slow_tests()
   skip_if_no_mailpit()
   skip_if_no_api()
   skip_if_no_test_db()

--- a/api/tests/testthat/test-external-pubmed.R
+++ b/api/tests/testthat/test-external-pubmed.R
@@ -178,6 +178,7 @@ test_that("check_pmid handles PMID: prefix correctly", {
 
   # Test that the function processes input correctly
   # (actual API test skipped if no network)
+  skip_if_not_slow_tests()
   skip_if_no_fixtures_or_network(test_path("fixtures", "pubmed"))
 
   with_pubmed_mock({
@@ -193,6 +194,7 @@ test_that("check_pmid handles PMID: prefix correctly", {
 })
 
 test_that("check_pmid validates single PMID", {
+  skip_if_not_slow_tests()
   skip_if_no_fixtures_or_network(test_path("fixtures", "pubmed"))
 
   with_pubmed_mock({
@@ -207,6 +209,7 @@ test_that("check_pmid validates single PMID", {
 })
 
 test_that("check_pmid handles list of PMIDs", {
+  skip_if_not_slow_tests()
   skip_if_no_fixtures_or_network(test_path("fixtures", "pubmed"))
 
   with_pubmed_mock({

--- a/api/tests/testthat/test-external-pubtator.R
+++ b/api/tests/testthat/test-external-pubtator.R
@@ -116,6 +116,7 @@ test_that("build_pmid_annotations_table handles missing required fields", {
 # ============================================================================
 
 test_that("pubtator_v3_total_pages_from_query returns page count", {
+  skip_if_not_slow_tests()
   skip_if_no_fixtures_or_network(test_path("fixtures", "pubtator"))
 
   with_pubtator_mock({
@@ -135,6 +136,7 @@ test_that("pubtator_v3_total_pages_from_query returns page count", {
 })
 
 test_that("pubtator_v3_total_pages_from_query handles empty results", {
+  skip_if_not_slow_tests()
   skip_if_no_fixtures_or_network(test_path("fixtures", "pubtator"))
 
   with_pubtator_mock({
@@ -151,6 +153,7 @@ test_that("pubtator_v3_total_pages_from_query handles empty results", {
 })
 
 test_that("pubtator_v3_pmids_from_request returns tibble", {
+  skip_if_not_slow_tests()
   skip_if_no_fixtures_or_network(test_path("fixtures", "pubtator"))
 
   with_pubtator_mock({

--- a/api/tests/testthat/test-integration-email.R
+++ b/api/tests/testthat/test-integration-email.R
@@ -12,6 +12,7 @@ library(testthat)
 # =============================================================================
 
 test_that("Mailpit is accessible", {
+  skip_if_not_slow_tests()
   skip_if_no_mailpit()
 
   # Should be able to get messages (even if empty)
@@ -23,6 +24,7 @@ test_that("Mailpit is accessible", {
 
 
 test_that("Mailpit can delete all messages", {
+  skip_if_not_slow_tests()
   skip_if_no_mailpit()
 
   # Delete should not error
@@ -41,6 +43,7 @@ test_that("Mailpit can delete all messages", {
 # =============================================================================
 
 test_that("send_noreply_email delivers to Mailpit", {
+  skip_if_not_slow_tests()
   skip_if_no_mailpit()
 
   # Clean inbox first
@@ -95,6 +98,7 @@ test_that("send_noreply_email delivers to Mailpit", {
 # =============================================================================
 
 test_that("SMTP test endpoint function exists", {
+  skip_if_not_slow_tests()
   skip_if_no_mailpit()
 
   # The endpoint is in admin_endpoints.R
@@ -150,6 +154,7 @@ test_that("SMTP connection fails gracefully for invalid host", {
 # =============================================================================
 
 test_that("Mailpit search finds messages by recipient", {
+  skip_if_not_slow_tests()
   skip_if_no_mailpit()
 
   # This test verifies search works


### PR DESCRIPTION
## Summary

Phase B unit **B3 (skip-slow-wiring)**. Wires `skip_if_not_slow_tests()` (already defined in `api/tests/testthat/helper-skip.R` but never called) into Mailpit-dependent and live-external-API tests, and adds a nightly-scheduled `slow-tests-nightly` CI job that runs the full testthat suite with `RUN_SLOW_TESTS=true`.

Normal CI (`push`/`pull_request`) continues to run only the existing `test-api` job and never depends on Mailpit or external APIs.

## Audit table

Grep used: `grep -rln "mailpit\|pubmed\|pubtator" api/tests/testthat/ | grep -v helper-`

| File | Classification | Action |
|---|---|---|
| `test-integration-email.R` | **HIT** (Mailpit) | 5 skip wrappers added (not the `invalid host` graceful-failure test — it tests socket to `invalid.host.example`, does not reach Mailpit) |
| `test-external-pubtator.R` | **HIT** (live PubTator API fallback from fixtures) | 3 skip wrappers added, only on the integration test_that blocks. The 10 pure-function tests (hash, parse) are untouched. |
| `test-e2e-user-lifecycle.R` | **HIT** (Mailpit + live API server) | 11 skip wrappers added, one per test_that block. All hit the local API via httr2 and most also hit Mailpit. |
| `test-external-pubmed.R` | **HIT** (live PubMed API fallback from fixtures) | 3 skip wrappers added on the integration tests. The 3 pure XML-parse tests and the already-hard-skipped `info_from_pmid` test are untouched. |
| `test-unit-publication-functions.R` | **MOCK** (grep false positive) | No change. File is pure XML parsing. Grep matches "pubmed" in comments and the `check_pmid` reference in the "NOT tested" block header. |
| `test-unit-pubtator-parse.R` | **MOCK** (grep false positive) | No change. Uses `file://` URLs, `local_mocked_bindings` on `Sys.sleep`, and `tempfile` only. |
| `test-unit-genereviews-functions.R` | **MOCK** (grep false positive) | No change. Pure string manipulation tests. The `https://` matches are inside `expect_equal` string assertions, not HTTP calls. |
| `test-unit-pubtator-functions.R` | **MOCK** (grep false positive) | No change. Uses `readLines` over the source file + rate-limit constant checks. |

**Total skip wrappers added: 22** across 4 HIT files.

Verification of non-zero count:

```
$ grep -rn "skip_if_not_slow_tests" api/tests/testthat/ | grep -v helper-skip.R | wc -l
22
```

## slow-tests-nightly job definition summary

Added to `.github/workflows/ci.yml`:

- **Triggers (added to top-level `on:` block):**
  - `schedule: cron '0 3 * * *'` (nightly 03:00 UTC)
  - `workflow_dispatch` (manual run)
- **Job `slow-tests-nightly`** (inserted between `test-api` and `check-app`, fenced with banner comments so it is easy to spot in a merge):
  - Gated with `if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'` so **normal push/PR runs never touch it**. This preserves the Phase B contract that regular CI completes without Mailpit.
  - Spins up MySQL 8.4.8 and `axllent/mailpit:latest` as GitHub Actions service containers with healthchecks.
  - Installs the same R + system deps as `test-api`.
  - Runs `Rscript -e "testthat::test_dir('tests/testthat')"` with `RUN_SLOW_TESTS=true`, `MYSQL_*`, `MAILPIT_URL`, `SMTP_*` env vars.
- **`ci-success` summary job intentionally NOT updated** to include `slow-tests-nightly` in `needs:`. Normal PR runs skip the nightly job, and adding it to `needs:` would make it a required check on every PR which defeats the purpose.

## Clean-skip evidence

**Docker-based verification deferred to CI.** Per the host-env workaround documented in `CLAUDE.md` (Ubuntu 25.10 "questing" + Conda R), `make install-dev` and `make test-api` cannot run on the host without several hours of manual toolchain work. The sysndd-api container is not currently running in this worktree, so `docker exec sysndd-api-1 ...` is also unavailable at report time.

The equivalent assertion — "tests skip cleanly when `RUN_SLOW_TESTS=true` is not set" — is structurally guaranteed by the `skip_if_not_slow_tests()` helper, which calls `testthat::skip_if_not(Sys.getenv("RUN_SLOW_TESTS") == "true", ...)` (see `api/tests/testthat/helper-skip.R:7-12`). The helper was already in the codebase but un-called; this PR only adds call sites. Authoritative verification is the ubuntu-latest CI run attached to this PR.

YAML parse check on the updated workflow:

```
$ python3 -c "import yaml; d = yaml.safe_load(open('.github/workflows/ci.yml')); print('jobs:', list(d['jobs'].keys())); print('triggers:', list(d[True].keys()))"
jobs: ['changes', 'lint-api', 'test-api', 'slow-tests-nightly', 'check-app', 'build-app', 'make-doctor', 'ci-success']
triggers: ['push', 'pull_request', 'schedule', 'workflow_dispatch']
```

## Shared-file caveats for combined-PR integration

- **`ci.yml` is also edited by B4 (`ci-smoke-test`)** which will add a disjoint `smoke-test` job. This PR fences `slow-tests-nightly` in a clearly banner-commented block (`# ====== Phase B B3: slow-tests-nightly ======` ... `# End Phase B B3: slow-tests-nightly`) so any merge conflict is trivially resolvable by keeping both blocks. B4 must not touch this block.
- **`test-e2e-user-lifecycle.R` is also edited by B5 (`sys-sleep-eviction`)** which will replace `Sys.sleep` calls. Per the plan's merge rule, B5 merges first and B5's replacements will end up inside the test_that bodies that this PR guards. This PR only adds top-of-block `skip_if_not_slow_tests()` lines and does not touch any `Sys.sleep` call, so the edits are disjoint.
- **No modifications to `CLAUDE.md` or `api/config.yml`** (both are gitignored and left in place for the worktree).

## slow-tests-nightly dispatch result

`workflow_dispatch` on `schedule:` triggers is only callable from the default branch. This PR is on `v11.0/phase-b/skip-slow-wiring`, so a manual dispatch cannot be fired against this branch pre-merge. Per the B3 spec ("If the nightly run hasn't fired yet by the gate check, a manual workflow dispatch to `slow-tests-nightly` is acceptable evidence"), a manual dispatch will be triggered after merge to master during the Phase B gate check.

## Test plan

- [ ] CI green on ubuntu-latest (`lint-api`, `test-api`, `check-app`, `build-app`, `make-doctor`).
- [ ] Normal `test-api` job does NOT enable Mailpit/external APIs and still passes.
- [ ] Post-merge: manual `workflow_dispatch` run of `slow-tests-nightly` succeeds (or first scheduled run at 03:00 UTC).
- [ ] Combined-PR merge with B4 preserves both the `slow-tests-nightly` and `smoke-test` job blocks.
- [ ] Combined-PR merge with B5 does not drop any `skip_if_not_slow_tests()` call when reapplying `Sys.sleep` replacements.