### PR TITLE
phase-b/B4: add CI smoke-test job + real verify-test-gate.sh logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,13 +309,44 @@ jobs:
       - name: make doctor
         run: make doctor
 
+  # =================== Phase B B4: smoke-test ===================
+  # End-to-end production smoke test (Phase B4, v11.0). Builds the prod API
+  # image, brings the full docker-compose stack up, and hits /api/health/ready
+  # via scripts/ci-smoke.sh. This is the primary acceptance signal that the
+  # production boot path still works.
+  #
+  # Disjoint from B3's `slow-tests-nightly` job (which uses `schedule:`). Merge
+  # rule (.plans/v11.0/phase-b.md §2.4): if B3 and B4 land close in time and
+  # conflict inside `jobs:`, keep both job blocks — never drop a job.
+  smoke-test:
+    name: Smoke Test (prod stack)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify docker is available
+        run: |
+          docker --version
+          docker compose version
+
+      - name: Run ci-smoke.sh
+        run: ./scripts/ci-smoke.sh
+
+      - name: Dump compose logs on failure
+        if: failure()
+        run: |
+          docker compose -f docker-compose.yml logs --tail=200 || true
+          docker ps -a || true
+  # =================== end Phase B B4: smoke-test ===============
+
   # ============================================================================
   # Summary Job (ensures required checks pass)
   # ============================================================================
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [changes, lint-api, test-api, check-app, build-app, make-doctor]
+    needs: [changes, lint-api, test-api, check-app, build-app, make-doctor, smoke-test]
     if: always()
     steps:
       - name: Check all jobs passed
@@ -328,16 +359,19 @@ jobs:
           build_ok="${{ needs.build-app.result == 'success' || needs.build-app.result == 'skipped' }}"
           # Doctor matrix (Phase A7): must succeed on both ubuntu-latest and macos-latest.
           doctor_ok="${{ needs.make-doctor.result == 'success' }}"
+          # Smoke test (Phase B B4): must succeed on every PR that boots the stack.
+          smoke_ok="${{ needs.smoke-test.result == 'success' }}"
 
           if [[ "$api_ok" != "true" ]] || [[ "$test_ok" != "true" ]] || \
              [[ "$app_ok" != "true" ]] || [[ "$build_ok" != "true" ]] || \
-             [[ "$doctor_ok" != "true" ]]; then
+             [[ "$doctor_ok" != "true" ]] || [[ "$smoke_ok" != "true" ]]; then
             echo "One or more jobs failed"
             echo "lint-api: ${{ needs.lint-api.result }}"
             echo "test-api: ${{ needs.test-api.result }}"
             echo "check-app: ${{ needs.check-app.result }}"
             echo "build-app: ${{ needs.build-app.result }}"
             echo "make-doctor: ${{ needs.make-doctor.result }}"
+            echo "smoke-test: ${{ needs.smoke-test.result }}"
             exit 1
           fi
           echo "All CI checks passed!"

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,16 @@ _ci-cleanup:
 	@printf "\n$(CYAN)Cleaning up test database...$(RESET)\n"
 	@cd $(ROOT_DIR) && docker compose -f docker-compose.dev.yml stop mysql-test 2>/dev/null || true
 
+verify-gate: ## [quality] Run verify-test-gate.sh + its bash harness (Phase B B4)
+	@printf "$(CYAN)==> Running verify-test-gate.sh harness...$(RESET)\n"
+	@bash $(ROOT_DIR)/scripts/tests/test-verify-test-gate.sh && \
+		printf "$(GREEN)✓ verify-test-gate harness green$(RESET)\n" || \
+		(printf "$(RED)✗ verify-test-gate harness failed$(RESET)\n" && exit 1)
+	@printf "$(CYAN)==> Running verify-test-gate.sh on current branch...$(RESET)\n"
+	@bash $(ROOT_DIR)/scripts/verify-test-gate.sh && \
+		printf "$(GREEN)✓ verify-test-gate clean on current branch$(RESET)\n" || \
+		(printf "$(RED)✗ verify-test-gate rejected current branch$(RESET)\n" && exit 1)
+
 # Configuration for preflight validation
 PREFLIGHT_TIMEOUT := 120
 PREFLIGHT_HEALTH_ENDPOINT := http://localhost/api/health/ready

--- a/scripts/ci-smoke.sh
+++ b/scripts/ci-smoke.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# ci-smoke.sh
+#
+# CI smoke test: build the production image, bring the stack up, and curl
+# /api/health/ready until it returns 200. Used by the `smoke-test` job in
+# .github/workflows/ci.yml (Phase B B4) and also runnable locally:
+#
+#   ./scripts/ci-smoke.sh
+#
+# The heavy lifting (build + compose up + health poll + teardown) is already
+# implemented as `make preflight`. This wrapper adds an extra belt-and-braces
+# retry loop against the same endpoint once preflight finishes, which catches
+# the pathological case where preflight passes its own health loop but the
+# container dies between the probe and the teardown. It also fails loudly with
+# context (docker ps / docker logs) so CI logs are immediately actionable.
+#
+# Exit codes:
+#   0 — health endpoint responded 200
+#   1 — preflight failed
+#   2 — health endpoint never returned 200 after retries
+
+set -eu
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+HEALTH_URL="${SMOKE_HEALTH_URL:-http://localhost/api/health/ready}"
+# Total retries = RETRIES, sleep = RETRY_SLEEP_SECONDS.
+RETRIES="${SMOKE_RETRIES:-30}"
+RETRY_SLEEP_SECONDS="${SMOKE_RETRY_SLEEP_SECONDS:-2}"
+
+log() { printf '[ci-smoke] %s\n' "$*"; }
+fail() { printf '[ci-smoke] FAIL: %s\n' "$*" >&2; }
+
+dump_context() {
+  fail "dumping diagnostic context"
+  (cd "$REPO_ROOT" && docker ps -a || true) >&2
+  (cd "$REPO_ROOT" && docker compose -f docker-compose.yml logs --tail=80 api || true) >&2
+}
+
+log "step 1/3: make preflight (builds prod image + compose up + internal health poll)"
+if ! (cd "$REPO_ROOT" && make preflight); then
+  dump_context
+  exit 1
+fi
+
+# preflight tears the stack down on success. To exercise the actual smoke loop
+# we bring the stack back up briefly and re-probe. This catches race conditions
+# where the container died between preflight's probe and teardown.
+log "step 2/3: re-up prod stack for independent curl probe"
+if ! (cd "$REPO_ROOT" && docker compose -f docker-compose.yml up -d); then
+  dump_context
+  exit 1
+fi
+trap '(cd "$REPO_ROOT" && docker compose -f docker-compose.yml down) || true' EXIT
+
+log "step 3/3: curl -f $HEALTH_URL (retries=$RETRIES, sleep=${RETRY_SLEEP_SECONDS}s)"
+i=0
+while [ "$i" -lt "$RETRIES" ]; do
+  if curl -fsS "$HEALTH_URL" >/dev/null 2>&1; then
+    log "health endpoint OK on attempt $((i + 1))"
+    exit 0
+  fi
+  i=$((i + 1))
+  sleep "$RETRY_SLEEP_SECONDS"
+done
+
+fail "health endpoint did not return 200 after $RETRIES attempts"
+dump_context
+exit 2

--- a/scripts/tests/test-verify-test-gate.sh
+++ b/scripts/tests/test-verify-test-gate.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# test-verify-test-gate.sh
+#
+# Bash unit tests for scripts/verify-test-gate.sh.
+#
+# The gate script is driven by git state (merge-base, diff, branch name) so each
+# test case spins up a throwaway git repo under a temp directory, stages a base
+# commit, checks out a branch with whatever diff the case wants to verify, and
+# then invokes scripts/verify-test-gate.sh with VERIFY_GATE_REPO_ROOT pointing
+# at the fixture repo and VERIFY_GATE_BRANCH set to the simulated PR branch.
+#
+# No R, no docker, no network. Runs on host + CI equally.
+#
+# Usage: ./scripts/tests/test-verify-test-gate.sh
+#
+# Exit codes:
+#   0  all cases passed
+#   1  at least one case failed
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+GATE_SCRIPT="$REPO_ROOT/scripts/verify-test-gate.sh"
+
+PASS=0
+FAIL=0
+FAILED_CASES=""
+
+# -----------------------------------------------------------------------------
+# Test helpers
+# -----------------------------------------------------------------------------
+
+assert_equal() {
+  # assert_equal <expected> <actual> <message>
+  local expected="$1"
+  local actual="$2"
+  local message="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+    printf '  \033[32mPASS\033[0m  %s\n' "$message"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_CASES="$FAILED_CASES\n    - $message (expected=$expected actual=$actual)"
+    printf '  \033[31mFAIL\033[0m  %s (expected=%s actual=%s)\n' "$message" "$expected" "$actual"
+  fi
+}
+
+make_fixture_repo() {
+  # make_fixture_repo <dir>
+  # Initializes a git repo with a base commit containing a pre-existing spec
+  # file and a pre-existing R test file, so each case can create a PR branch
+  # on top and modify (or not) those files.
+  local dir="$1"
+  mkdir -p "$dir"
+  (
+    cd "$dir"
+    git init -q -b master
+    git config user.email "harness@test.local"
+    git config user.name "harness"
+    git config commit.gpgsign false
+
+    mkdir -p app/src/components api/tests/testthat
+    cat > app/src/components/Existing.spec.ts <<'EOF'
+// Pre-existing spec file checked into master.
+import { describe, it, expect } from 'vitest'
+describe('Existing', () => {
+  it('works', () => {
+    expect(true).toBe(true)
+  })
+})
+EOF
+    cat > api/tests/testthat/test-existing.R <<'EOF'
+# Pre-existing R test file checked into master.
+test_that("does the thing", {
+  expect_equal(1 + 1, 2)
+})
+EOF
+    cat > api/tests/testthat/test-integration-good.R <<'EOF'
+# Integration test that already opens with with_test_db_transaction.
+with_test_db_transaction({
+  test_that("reads from db", {
+    expect_true(TRUE)
+  })
+})
+EOF
+    cat > api/tests/testthat/test-integration-skip-exempt.R <<'EOF'
+# skip_if_no_test_db() exemption: this endpoint writes to a non-transactional
+# catalog table, so rollback would corrupt other tests.
+test_that("exempt case", {
+  skip_if_no_test_db()
+  expect_true(TRUE)
+})
+EOF
+    git add .
+    git commit -q -m "base commit"
+  )
+}
+
+run_gate() {
+  # run_gate <repo_dir> <branch_name> [--extended]
+  # Invokes verify-test-gate.sh against the fixture repo and prints stdout+stderr,
+  # returning its exit code via $?.
+  local repo_dir="$1"
+  local branch_name="$2"
+  shift 2
+  VERIFY_GATE_REPO_ROOT="$repo_dir" \
+    VERIFY_GATE_BRANCH="$branch_name" \
+    VERIFY_GATE_BASE_REF="master" \
+    bash "$GATE_SCRIPT" "$@"
+}
+
+# -----------------------------------------------------------------------------
+# Test cases
+# -----------------------------------------------------------------------------
+
+case_new_spec_allowed() {
+  # A Phase C branch that adds a BRAND NEW spec file should pass (exit 0).
+  local dir
+  dir=$(mktemp -d)
+  make_fixture_repo "$dir"
+  (
+    cd "$dir"
+    git checkout -q -b v11.0/phase-c/new-spec
+    cat > app/src/components/Brand.spec.ts <<'EOF'
+import { describe, it, expect } from 'vitest'
+describe('Brand', () => { it('is new', () => { expect(1).toBe(1) }) })
+EOF
+    git add app/src/components/Brand.spec.ts
+    git commit -q -m "add new spec"
+  )
+  run_gate "$dir" "v11.0/phase-c/new-spec" >/dev/null 2>&1
+  assert_equal 0 "$?" "new spec file on phase-c branch is allowed"
+  rm -rf "$dir"
+}
+
+case_preexisting_spec_rejected() {
+  # A Phase D branch that edits a pre-existing spec file (non-.todo) must fail.
+  local dir
+  dir=$(mktemp -d)
+  make_fixture_repo "$dir"
+  (
+    cd "$dir"
+    git checkout -q -b v11.0/phase-d/test-synthetic
+    cat > app/src/components/Existing.spec.ts <<'EOF'
+// Pre-existing spec file checked into master.
+import { describe, it, expect } from 'vitest'
+describe('Existing', () => {
+  it('works', () => {
+    expect(true).toBe(false) // MUTATION
+  })
+})
+EOF
+    git add app/src/components/Existing.spec.ts
+    git commit -q -m "mutate existing spec"
+  )
+  run_gate "$dir" "v11.0/phase-d/test-synthetic" >/dev/null 2>&1
+  assert_equal 1 "$?" "pre-existing spec edit on phase-d branch is rejected"
+  rm -rf "$dir"
+}
+
+case_skip_slow_exemption_phase_b() {
+  # On a phase-b branch, adding skip_if_not_slow_tests() to a pre-existing
+  # test-*.R file is allowed.
+  local dir
+  dir=$(mktemp -d)
+  make_fixture_repo "$dir"
+  (
+    cd "$dir"
+    git checkout -q -b v11.0/phase-b/skip-slow-wiring
+    cat > api/tests/testthat/test-existing.R <<'EOF'
+# Pre-existing R test file checked into master.
+test_that("does the thing", {
+  skip_if_not_slow_tests()
+  expect_equal(1 + 1, 2)
+})
+EOF
+    git add api/tests/testthat/test-existing.R
+    git commit -q -m "add skip wrapper"
+  )
+  run_gate "$dir" "v11.0/phase-b/skip-slow-wiring" >/dev/null 2>&1
+  assert_equal 0 "$?" "skip_if_not_slow_tests exemption on phase-b branch is allowed"
+  rm -rf "$dir"
+}
+
+case_sys_sleep_exemption_phase_b() {
+  # On a phase-b branch, replacing Sys.sleep(N) with wait_for(..., timeout = N)
+  # in a pre-existing test file is allowed.
+  local dir
+  dir=$(mktemp -d)
+  make_fixture_repo "$dir"
+  (
+    cd "$dir"
+    # first, stage a base version that CONTAINS Sys.sleep so the exemption diff
+    # is a real sleep->wait_for replacement rather than a bare addition.
+    cat > api/tests/testthat/test-existing.R <<'EOF'
+# Pre-existing R test file checked into master.
+test_that("does the thing", {
+  Sys.sleep(5)
+  expect_equal(1 + 1, 2)
+})
+EOF
+    git add api/tests/testthat/test-existing.R
+    git commit -q -m "reset base to sleepy version"
+    git checkout -q -b v11.0/phase-b/sys-sleep-eviction
+    cat > api/tests/testthat/test-existing.R <<'EOF'
+# Pre-existing R test file checked into master.
+test_that("does the thing", {
+  wait_for(Sys.time() > 0, timeout = 5)
+  expect_equal(1 + 1, 2)
+})
+EOF
+    git add api/tests/testthat/test-existing.R
+    git commit -q -m "replace Sys.sleep with wait_for"
+  )
+  run_gate "$dir" "v11.0/phase-b/sys-sleep-eviction" >/dev/null 2>&1
+  assert_equal 0 "$?" "Sys.sleep->wait_for exemption on phase-b branch is allowed"
+  rm -rf "$dir"
+}
+
+case_skip_slow_rejected_on_phase_d() {
+  # Sanity: the skip exemption must NOT leak into phase-d.
+  local dir
+  dir=$(mktemp -d)
+  make_fixture_repo "$dir"
+  (
+    cd "$dir"
+    git checkout -q -b v11.0/phase-d/rogue-skip
+    cat > api/tests/testthat/test-existing.R <<'EOF'
+test_that("does the thing", {
+  skip_if_not_slow_tests()
+  expect_equal(1 + 1, 2)
+})
+EOF
+    git add api/tests/testthat/test-existing.R
+    git commit -q -m "rogue skip wrapper on phase-d"
+  )
+  run_gate "$dir" "v11.0/phase-d/rogue-skip" >/dev/null 2>&1
+  assert_equal 1 "$?" "skip_if_not_slow_tests exemption does NOT leak into phase-d"
+  rm -rf "$dir"
+}
+
+case_extended_mode_catches_missing_rollback() {
+  # Extended mode greps test-integration-*.R files and asserts each opens with
+  # with_test_db_transaction or a documented skip_if_no_test_db exemption.
+  local dir
+  dir=$(mktemp -d)
+  make_fixture_repo "$dir"
+  (
+    cd "$dir"
+    # Add a new integration test that has NEITHER.
+    cat > api/tests/testthat/test-integration-bad.R <<'EOF'
+# No rollback wrapper and no documented exemption.
+test_that("writes to db", {
+  expect_true(TRUE)
+})
+EOF
+    git add api/tests/testthat/test-integration-bad.R
+    git commit -q -m "bad integration test"
+  )
+  # Extended mode runs on the master branch since it's a repo-wide invariant.
+  run_gate "$dir" "master" --extended >/dev/null 2>&1
+  assert_equal 1 "$?" "extended mode rejects integration test without with_test_db_transaction"
+  rm -rf "$dir"
+}
+
+case_extended_mode_accepts_good_repo() {
+  # The base fixture contains one good integration test and one exemption test,
+  # both should pass extended mode.
+  local dir
+  dir=$(mktemp -d)
+  make_fixture_repo "$dir"
+  run_gate "$dir" "master" --extended >/dev/null 2>&1
+  assert_equal 0 "$?" "extended mode accepts well-formed integration tests"
+  rm -rf "$dir"
+}
+
+# -----------------------------------------------------------------------------
+# Driver
+# -----------------------------------------------------------------------------
+
+printf '==> Running verify-test-gate.sh harness\n\n'
+case_new_spec_allowed
+case_preexisting_spec_rejected
+case_skip_slow_exemption_phase_b
+case_sys_sleep_exemption_phase_b
+case_skip_slow_rejected_on_phase_d
+case_extended_mode_catches_missing_rollback
+case_extended_mode_accepts_good_repo
+
+printf '\n==> Summary: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  printf 'Failed cases:%b\n' "$FAILED_CASES"
+  exit 1
+fi
+exit 0

--- a/scripts/verify-test-gate.sh
+++ b/scripts/verify-test-gate.sh
@@ -1,3 +1,121 @@
-#!/bin/bash
-echo "stub — B4 will fill"
+#!/usr/bin/env bash
+# verify-test-gate.sh
+#
+# Protects Phase D / Phase E PRs from silently mutating pre-existing test files
+# to "pin" behavior to whatever the refactor produced. Rule summary:
+#
+#   For every *.spec.ts or test-*.R file modified in this PR (vs merge-base with
+#   master):
+#     1. If the file was CREATED in this PR: ALLOWED (new unit/composable specs
+#        are how Phase C etc. legitimately add coverage).
+#     2. If the file is PRE-EXISTING and the diff touches anything, it is
+#        REJECTED — unless an exemption applies.
+#
+# Exemptions (gated on branch prefix so they cannot leak into other phases):
+#   - On v11.0/phase-b/* branches only: adding skip_if_not_slow_tests() calls
+#     to pre-existing test-*.R files is allowed. This exemption exists for B3.
+#   - On v11.0/phase-b/* branches only: replacing Sys.sleep(N) with
+#     wait_for(..., timeout = N) in pre-existing test-*.R or helper-*.R files
+#     is allowed. This exemption exists for B5.
+#
+# Extended mode (--extended): grep every api/tests/testthat/test-integration-*.R
+# file and assert each opens with EITHER `with_test_db_transaction` OR a
+# documented `skip_if_no_test_db()` exemption explaining why rollback isn't
+# usable.
+#
+# Test overrides (used by scripts/tests/test-verify-test-gate.sh):
+#   VERIFY_GATE_REPO_ROOT  override the repo root (default: auto-detect)
+#   VERIFY_GATE_BRANCH     override the current branch name
+#   VERIFY_GATE_BASE_REF   override the base ref (default: origin/master, then master)
+#
+# Exit codes: 0 = clean, 1 = violation.
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+DEFAULT_REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+REPO_ROOT="${VERIFY_GATE_REPO_ROOT:-$DEFAULT_REPO_ROOT}"
+cd "$REPO_ROOT" || { echo "gate: cannot cd $REPO_ROOT" >&2; exit 1; }
+
+EXTENDED=0
+for arg in "$@"; do
+  [ "$arg" = "--extended" ] && EXTENDED=1
+done
+
+# Resolve current branch (env override for harness).
+BRANCH="${VERIFY_GATE_BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)}"
+
+# Resolve base ref: prefer env, then origin/master, then master.
+if [ -n "${VERIFY_GATE_BASE_REF:-}" ]; then
+  BASE_REF="$VERIFY_GATE_BASE_REF"
+elif git rev-parse --verify -q origin/master >/dev/null; then
+  BASE_REF="origin/master"
+else
+  BASE_REF="master"
+fi
+
+VIOLATIONS=0
+
+# ---- Layer A: modified-spec-file gate (skipped if branch == base) -----------
+if [ "$BRANCH" != "$BASE_REF" ] && [ "$BRANCH" != "master" ]; then
+  MERGE_BASE=$(git merge-base "$BASE_REF" HEAD 2>/dev/null || git rev-parse HEAD)
+
+  # All *.spec.ts and test-*.R files touched since merge-base (any status).
+  CHANGED=$(git diff --name-only "$MERGE_BASE"..HEAD -- \
+    '*.spec.ts' 'app/**/*.spec.ts' \
+    'api/tests/testthat/test-*.R' 'api/tests/testthat/helper-*.R' 2>/dev/null || true)
+
+  for f in $CHANGED; do
+    # Status A=added, M=modified, D=deleted, R=renamed. Added files are allowed.
+    STATUS=$(git diff --name-status "$MERGE_BASE"..HEAD -- "$f" | awk '{print $1}' | head -n1)
+    [ "$STATUS" = "A" ] && continue
+    [ "$STATUS" = "D" ] && continue
+
+    # Exemptions: only on v11.0/phase-b/* branches.
+    if [[ "$BRANCH" == v11.0/phase-b/* ]]; then
+      # Consider the per-file diff — if every ADDED line matches a permitted
+      # pattern and every REMOVED line matches its paired pattern, exempt.
+      ADDED=$(git diff "$MERGE_BASE"..HEAD -- "$f" | grep -E '^\+[^+]' || true)
+      REMOVED=$(git diff "$MERGE_BASE"..HEAD -- "$f" | grep -E '^-[^-]' || true)
+
+      # Exemption 1: skip_if_not_slow_tests() additions, no corresponding deletions.
+      if [ -z "$REMOVED" ] && echo "$ADDED" | grep -qE 'skip_if_not_slow_tests\(' && \
+         ! echo "$ADDED" | grep -vE '^\+\s*$|skip_if_not_slow_tests\(' | grep -q .; then
+        continue
+      fi
+
+      # Exemption 2: Sys.sleep(N) -> wait_for(..., timeout = N) replacement.
+      # The regex matches any wait_for(...) call with a timeout= kwarg; we
+      # deliberately don't constrain the args, since the condition expression
+      # may itself contain parentheses.
+      if echo "$REMOVED" | grep -qE 'Sys\.sleep\(' && \
+         echo "$ADDED"   | grep -qE 'wait_for\(.*timeout[[:space:]]*='; then
+        continue
+      fi
+    fi
+
+    printf 'gate: REJECT pre-existing spec/test file modified: %s (status=%s, branch=%s)\n' \
+      "$f" "$STATUS" "$BRANCH" >&2
+    VIOLATIONS=$((VIOLATIONS + 1))
+  done
+fi
+
+# ---- Layer B (extended): integration-test rollback invariant ----------------
+if [ "$EXTENDED" = "1" ]; then
+  for f in api/tests/testthat/test-integration-*.R; do
+    [ -f "$f" ] || continue
+    # Accept if with_test_db_transaction appears anywhere, OR if there is a
+    # skip_if_no_test_db() call AND a comment explaining why rollback isn't used.
+    if grep -q 'with_test_db_transaction' "$f"; then continue; fi
+    if grep -q 'skip_if_no_test_db()' "$f" && \
+       grep -qE '^#.*(exempt|rollback|non-transactional|catalog)' "$f"; then continue; fi
+    printf 'gate: REJECT integration test missing rollback wrapper: %s\n' "$f" >&2
+    VIOLATIONS=$((VIOLATIONS + 1))
+  done
+fi
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+  printf 'gate: %d violation(s) — see above\n' "$VIOLATIONS" >&2
+  exit 1
+fi
 exit 0


### PR DESCRIPTION
## Summary

Phase B unit **B4 — ci-smoke-test** (v11.0 roadmap, `.plans/v11.0/phase-b.md` §3 B4). Lands:

- A new `smoke-test` CI job that builds the prod image, brings the compose stack up, and hits `/api/health/ready`.
- `scripts/ci-smoke.sh` — wraps `make preflight` + a curl retry loop.
- `scripts/verify-test-gate.sh` — **replaces A6's 2-line stub in place** with the real logic that protects Phase D/E from silently mutating pre-existing test files.
- `scripts/tests/test-verify-test-gate.sh` — 7-case bash harness (no R, no docker) that exercises every branch of the gate.
- `Makefile` — new `verify-gate` target runs the harness + the gate on the current branch.

**Disjoint from B3:** B3 (`v11.0/phase-b/skip-slow-wiring`) will add a `slow-tests-nightly` job in the same workflow file in a disjoint block. Per `.plans/v11.0/phase-b.md` §2.4, if the two land close in time and conflict inside `jobs:`, the resolution is "keep both job blocks — never drop a job." This PR adds a clear `# =================== Phase B B4: smoke-test ===================` banner to make a 3-way merge trivial.

## `verify-test-gate.sh` logic spec

```
For every *.spec.ts or test-*.R / helper-*.R file modified in this PR (vs merge-base with master):
  - if the file was CREATED in this PR  => ALLOWED (new unit/composable specs)
  - if the file was DELETED               => ALLOWED (legitimate removal)
  - if the file is PRE-EXISTING and touched in any way => REJECT, unless:
      * on v11.0/phase-b/* only: pure skip_if_not_slow_tests() addition
      * on v11.0/phase-b/* only: Sys.sleep(N) -> wait_for(..., timeout = N) replacement

Extended mode (--extended):
  - grep every api/tests/testthat/test-integration-*.R file
  - assert it opens with `with_test_db_transaction` OR has `skip_if_no_test_db()`
    PLUS a comment explaining why rollback isn't usable (`exempt|rollback|non-transactional|catalog`)
```

Final size: **121 lines total** (~40 lines header docs, 59 non-comment lines of logic, rest blanks).

## Harness cases (`scripts/tests/test-verify-test-gate.sh`)

Each case spins up a throwaway git repo with a base commit, checks out a branch with the exact diff shape being tested, and invokes the gate via `VERIFY_GATE_REPO_ROOT` / `VERIFY_GATE_BRANCH` / `VERIFY_GATE_BASE_REF` env overrides. No R, no docker — works on host + CI equally.

| # | Case | Expected |
|---|------|----------|
| 1 | New `*.spec.ts` file on `v11.0/phase-c/*` branch | exit 0 |
| 2 | Modify pre-existing `*.spec.ts` on `v11.0/phase-d/*` branch | exit 1 |
| 3 | Add `skip_if_not_slow_tests()` to pre-existing `test-*.R` on `v11.0/phase-b/*` | exit 0 |
| 4 | Replace `Sys.sleep(N)` with `wait_for(..., timeout = N)` in pre-existing file on `v11.0/phase-b/*` | exit 0 |
| 5 | (leak-check) Same skip-wrapper addition on `v11.0/phase-d/*` | exit 1 |
| 6 | Extended-mode grep catches integration test without `with_test_db_transaction` | exit 1 |
| 7 | Extended-mode grep accepts repo with proper rollback wrapper + documented exemption | exit 0 |

Harness output (`make verify-gate`):

```
==> Running verify-test-gate.sh harness

  PASS  new spec file on phase-c branch is allowed
  PASS  pre-existing spec edit on phase-d branch is rejected
  PASS  skip_if_not_slow_tests exemption on phase-b branch is allowed
  PASS  Sys.sleep->wait_for exemption on phase-b branch is allowed
  PASS  skip_if_not_slow_tests exemption does NOT leak into phase-d
  PASS  extended mode rejects integration test without with_test_db_transaction
  PASS  extended mode accepts well-formed integration tests

==> Summary: 7 passed, 0 failed
```

## Four synthetic validations

### 1. `ci-smoke.sh` fails when `make preflight` fails

Verified locally by stubbing `make` with a fake script that exits 1 with a message simulating `stop("simulated boot failure")` from `api/start_sysndd_api.R`:

```
[ci-smoke] step 1/3: make preflight (builds prod image + compose up + internal health poll)
[fake-make] preflight invoked; simulating stop("simulated boot failure") in api/start_sysndd_api.R
[ci-smoke] FAIL: dumping diagnostic context
... (docker ps output) ...
  => exit code: 1
```

This proves `ci-smoke.sh` propagates `make preflight`'s exit code. The **full** pipeline (real `stop("simulated boot failure")` in `api/start_sysndd_api.R` producing a CI-side smoke-test job failure) is naturally exercised by the CI pipeline itself on this PR's own run — the smoke-test job going green on this PR (with an unmodified `start_sysndd_api.R`) is the companion positive signal. A local full-image rebuild was not attempted because this host hits Conda R / Posit PPM issues orthogonal to B4's scope (see CLAUDE.md "Host-Env Workaround").

### 2. Gate rejects pre-existing spec edit on `v11.0/phase-d/*`

```
Branch: v11.0/phase-d/test-synthetic  (modifies pre-existing app/src/components/Existing.spec.ts)
gate: REJECT pre-existing spec/test file modified: app/src/components/Existing.spec.ts (status=M, branch=v11.0/phase-d/test-synthetic)
gate: 1 violation(s) — see above
  => exit code: 1 (expected 1)
```

### 3. Gate accepts new spec file on `v11.0/phase-c/*`

```
Branch: v11.0/phase-c/add-handler-specs  (creates new app/src/components/NewHandler.spec.ts)
  => exit code: 0 (expected 0)
```

### 4. Extended mode catches integration test without `with_test_db_transaction`

```
Repo contains: api/tests/testthat/test-integration-bad.R (no with_test_db_transaction, no exemption)
gate: REJECT integration test missing rollback wrapper: api/tests/testthat/test-integration-bad.R
gate: 1 violation(s) — see above
  => exit code: 1 (expected 1)
```

## Test plan

- [x] `make verify-gate` passes locally (harness + gate on current branch, 7/7)
- [x] `Rscript --no-init-file api/scripts/lint-check.R` clean (82 files, 0 issues) — conda bypass per CLAUDE.md
- [x] `cd app && npm run lint && npm run type-check && npm run test:unit` all exit 0
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` validates workflow YAML
- [x] Four synthetic validations above all return expected exit codes
- [ ] CI `smoke-test` job goes green on this PR — primary acceptance signal
- [ ] Merge-anxiety re B3: the `smoke-test` block is bracketed by a banner comment so a 3-way merge with B3's `slow-tests-nightly` block is trivial. If B3 lands first, this PR will rebase-then-merge cleanly because the two jobs sit in disjoint line ranges.

## Notes for reviewers

- `scripts/verify-test-gate.sh` uses `VERIFY_GATE_REPO_ROOT` / `VERIFY_GATE_BRANCH` / `VERIFY_GATE_BASE_REF` env overrides so the bash harness can drive it against fixture repos without modifying the production invocation surface. Default behavior (no env vars) reads from the actual repo + branch.
- Non-extended mode runs by default on every PR; extended mode (`--extended`) is an advisory target that currently reports 10 pre-existing integration tests lacking rollback wrappers. These are tracked as Phase B/C follow-up — the extended mode is **not** wired into the default PR gate, only available on demand.
- `make verify-gate` is a standalone target, not yet wired into `ci-local`. Wiring it into `ci-local` (or into a CI job directly) can happen in a follow-up once B3/B5 land and we've confirmed the exemptions hold in real commits.