### PR TITLE
phase-b/B5: evict Sys.sleep from R test suite via event-based wait_for helper

### DIFF
--- a/api/tests/testthat/helper-mailpit.R
+++ b/api/tests/testthat/helper-mailpit.R
@@ -99,23 +99,32 @@ mailpit_message_count <- function(mailpit_url = "http://localhost:8025") {
 #' Polls Mailpit until a message matching the query appears or timeout.
 #' Useful when email sending is asynchronous.
 #'
+#' Delegates to `wait_for()` from `helper-wait.R` so that the poll cadence
+#' is uniform across the test suite and timeouts produce diagnostic errors
+#' (attempt count, last observed value) rather than a bare "Timeout" string.
+#'
 #' @param query Search query (typically recipient email)
 #' @param timeout_seconds Maximum time to wait (default: 10)
 #' @param mailpit_url Base URL for Mailpit
+#' @param interval Poll interval in seconds (default: 0.1)
 #' @return First matching message, or error on timeout
 mailpit_wait_for_message <- function(
     query,
     timeout_seconds = 10,
-    mailpit_url = "http://localhost:8025") {
-  start_time <- Sys.time()
-  while (difftime(Sys.time(), start_time, units = "secs") < timeout_seconds) {
-    result <- mailpit_search(query, mailpit_url)
-    if (!is.null(result$total) && result$total > 0) {
-      return(result$messages[[1]])
-    }
-    Sys.sleep(0.5)
-  }
-  stop(paste("Timeout waiting for email matching:", query))
+    mailpit_url = "http://localhost:8025",
+    interval = 0.1) {
+  wait_for(
+    condition = function() {
+      result <- mailpit_search(query, mailpit_url)
+      if (!is.null(result$total) && result$total > 0) {
+        return(result$messages[[1]])
+      }
+      NULL
+    },
+    timeout = timeout_seconds,
+    label = paste0("mailpit message matching '", query, "' at ", mailpit_url),
+    interval = interval
+  )
 }
 
 

--- a/api/tests/testthat/helper-wait.R
+++ b/api/tests/testthat/helper-wait.R
@@ -1,0 +1,344 @@
+# tests/testthat/helper-wait.R
+# Event-based wait helpers for flake-free async assertions
+#
+# Replaces ad-hoc `Sys.sleep(N)` patterns in integration/E2E tests with
+# helpers that poll a probe function and fail loudly on timeout (or on
+# unexpected state change, for the "nothing should happen" case).
+#
+# Two public helpers:
+#
+#   wait_for(condition, timeout, ..., label, interval)
+#     Poll `condition()` until it returns a truthy value. Return that value
+#     on success. On timeout, stop() with a clear message naming the label,
+#     the timeout, and the last observed probe value.
+#
+#   wait_stable(probe, duration, ..., label, interval, tolerate = NULL)
+#     Poll `probe()` and assert it stays equal to the FIRST observed value
+#     for `duration` seconds. Returns the stable value. On change, stop()
+#     immediately with a clear message naming the label, the observed
+#     transition, and the elapsed time.
+#
+# Design notes:
+#   - Both helpers stop() on failure rather than testthat::fail() so they
+#     work from inside helpers (helper-mailpit.R) that do not have a test
+#     context, and so they surface as real errors in E2E tests instead of
+#     silent failures.
+#   - Default interval is 50ms — small enough to make "what the sleep was
+#     masking" observable, large enough not to hammer the API/Mailpit.
+#   - `label` is REQUIRED in practice (defaulted to a generic string only
+#     so tests of the helper itself work): always pass a meaningful label
+#     so timeout diagnostics are actionable.
+
+#' Poll a condition until it is truthy or timeout elapses
+#'
+#' Event-based replacement for `Sys.sleep(N); stopifnot(condition())`.
+#' Evaluates `condition()` on a tight interval and returns the condition's
+#' value the moment it becomes truthy. On timeout, raises an error whose
+#' message identifies the label, elapsed time, and last observed value.
+#'
+#' A value is considered "truthy" if it is non-NULL, has length > 0, and
+#' `isTRUE(as.logical(value))` OR is any non-empty list / non-empty data
+#' frame / non-NA single atomic TRUE. The common happy path — the caller
+#' returns TRUE or a non-NULL object — is handled directly; the extended
+#' list/data.frame handling supports "wait until the DB query returns a
+#' non-empty row set" usage.
+#'
+#' @param condition Zero-arg function returning the value to test.
+#' @param timeout Maximum seconds to wait (default 10).
+#' @param label Human-readable description of what is being waited on;
+#'   surfaces in the timeout error message.
+#' @param interval Poll interval in seconds (default 0.05).
+#' @return The value returned by `condition()` on the first truthy poll.
+#' @examples
+#' \dontrun{
+#'   msg <- wait_for(
+#'     function() {
+#'       hits <- mailpit_search("user@example.com")
+#'       if (!is.null(hits$total) && hits$total > 0) hits$messages[[1]] else NULL
+#'     },
+#'     timeout = 10,
+#'     label = "mailpit message for user@example.com"
+#'   )
+#' }
+wait_for <- function(
+    condition,
+    timeout = 10,
+    label = "wait_for condition",
+    interval = 0.05) {
+  if (!is.function(condition)) {
+    stop("wait_for: 'condition' must be a zero-arg function")
+  }
+  if (!is.numeric(timeout) || length(timeout) != 1 || timeout < 0) {
+    stop("wait_for: 'timeout' must be a single non-negative number")
+  }
+  if (!is.numeric(interval) || length(interval) != 1 || interval <= 0) {
+    stop("wait_for: 'interval' must be a single positive number")
+  }
+
+  start_time <- Sys.time()
+  last_value <- NULL
+  last_error <- NULL
+  attempts <- 0L
+
+  is_truthy <- function(v) {
+    if (is.null(v)) return(FALSE)
+    if (length(v) == 0) return(FALSE)
+    if (is.data.frame(v)) return(nrow(v) > 0)
+    if (is.list(v)) return(TRUE)
+    if (is.logical(v) && length(v) == 1 && !is.na(v)) return(isTRUE(v))
+    if (is.atomic(v)) return(TRUE)
+    TRUE
+  }
+
+  repeat {
+    attempts <- attempts + 1L
+    value <- tryCatch(
+      condition(),
+      error = function(e) {
+        last_error <<- e
+        NULL
+      }
+    )
+    last_value <- value
+    if (is_truthy(value)) {
+      return(value)
+    }
+
+    elapsed <- as.numeric(difftime(Sys.time(), start_time, units = "secs"))
+    if (elapsed >= timeout) {
+      diag <- paste0(
+        "wait_for timeout after ", format(round(elapsed, 3), nsmall = 3),
+        "s (limit ", timeout, "s, ", attempts, " polls) ",
+        "while waiting for: ", label, ". ",
+        "Last observed value: ", .wait_repr(last_value)
+      )
+      if (!is.null(last_error)) {
+        diag <- paste0(
+          diag, " Last error while polling: ",
+          conditionMessage(last_error)
+        )
+      }
+      stop(diag, call. = FALSE)
+    }
+    Sys.sleep(interval)
+  }
+}
+
+
+#' Assert that a probe value remains stable for a duration
+#'
+#' Event-based replacement for `Sys.sleep(N); expect_equal(count, 0)`. Polls
+#' `probe()` at the given interval; the first observation is treated as the
+#' baseline. If any subsequent poll returns a value that is not `identical()`
+#' to the baseline, this function fails immediately with a diagnostic naming
+#' the observed transition. If the baseline holds for the full `duration`,
+#' the baseline value is returned.
+#'
+#' Use this to replace sleeps that were masking "nothing should happen"
+#' assertions — e.g. "no email should be sent", "count should still be zero".
+#' The old pattern slept for N seconds and then checked once; this helper
+#' catches the violation at the moment it occurs, which is both faster on
+#' failure and more informative.
+#'
+#' @param probe Zero-arg function returning the value to monitor.
+#' @param duration Seconds to require the value to remain stable (default 2).
+#' @param label Human-readable description of what is being monitored.
+#' @param interval Poll interval in seconds (default 0.1).
+#' @param tolerate Optional function(old, new) returning TRUE if a transition
+#'   should be tolerated (rarely needed). NULL means "any change fails".
+#' @return The stable baseline value.
+#' @examples
+#' \dontrun{
+#'   wait_stable(
+#'     function() mailpit_message_count(),
+#'     duration = 1,
+#'     label = "mailpit inbox after invalid signup"
+#'   )
+#' }
+wait_stable <- function(
+    probe,
+    duration = 2,
+    label = "wait_stable probe",
+    interval = 0.1,
+    tolerate = NULL) {
+  if (!is.function(probe)) {
+    stop("wait_stable: 'probe' must be a zero-arg function")
+  }
+  if (!is.numeric(duration) || length(duration) != 1 || duration < 0) {
+    stop("wait_stable: 'duration' must be a single non-negative number")
+  }
+  if (!is.numeric(interval) || length(interval) != 1 || interval <= 0) {
+    stop("wait_stable: 'interval' must be a single positive number")
+  }
+  if (!is.null(tolerate) && !is.function(tolerate)) {
+    stop("wait_stable: 'tolerate' must be NULL or a function(old, new)")
+  }
+
+  start_time <- Sys.time()
+  baseline <- probe()
+
+  repeat {
+    Sys.sleep(interval)
+    current <- probe()
+    if (!identical(current, baseline)) {
+      if (!is.null(tolerate) && isTRUE(tolerate(baseline, current))) {
+        # Tolerated: update baseline and continue.
+        baseline <- current
+      } else {
+        elapsed <- as.numeric(difftime(Sys.time(), start_time, units = "secs"))
+        stop(
+          "wait_stable violation after ",
+          format(round(elapsed, 3), nsmall = 3), "s ",
+          "(required stability window ", duration, "s) ",
+          "while monitoring: ", label, ". ",
+          "Baseline: ", .wait_repr(baseline),
+          " -> observed: ", .wait_repr(current),
+          call. = FALSE
+        )
+      }
+    }
+    elapsed <- as.numeric(difftime(Sys.time(), start_time, units = "secs"))
+    if (elapsed >= duration) {
+      return(baseline)
+    }
+  }
+}
+
+
+# Internal: produce a short printable representation for diagnostics.
+.wait_repr <- function(value) {
+  if (is.null(value)) return("NULL")
+  if (is.data.frame(value)) {
+    return(paste0("<data.frame ", nrow(value), "x", ncol(value), ">"))
+  }
+  if (is.list(value)) {
+    return(paste0("<list length ", length(value), ">"))
+  }
+  if (is.atomic(value) && length(value) == 1) {
+    return(format(value))
+  }
+  if (is.atomic(value)) {
+    head_vals <- utils::head(value, 3)
+    tail_marker <- if (length(value) > 3) ", ..." else ""
+    return(paste0(
+      "<", class(value)[1], " length ", length(value), ": ",
+      paste(format(head_vals), collapse = ", "), tail_marker, ">"
+    ))
+  }
+  paste0("<", class(value)[1], ">")
+}
+
+
+# ---------------------------------------------------------------------------
+# Self-tests for the helpers above. Guarded so they only run inside a
+# testthat session (TESTTHAT=true is set by testthat::test_file()). Other
+# test files can rely on wait_for / wait_stable being defined without
+# re-running these smoke assertions.
+# ---------------------------------------------------------------------------
+
+if (identical(Sys.getenv("TESTTHAT"), "true")) {
+  local({
+    testthat::test_that("wait_for returns immediately on a truthy probe", {
+      start <- Sys.time()
+      result <- wait_for(function() TRUE, timeout = 5, label = "instant truthy")
+      elapsed <- as.numeric(difftime(Sys.time(), start, units = "secs"))
+      testthat::expect_true(isTRUE(result))
+      testthat::expect_lt(elapsed, 0.5)
+    })
+
+    testthat::test_that("wait_for returns the condition value (not just TRUE)", {
+      result <- wait_for(
+        function() list(id = 42, name = "grin2b"),
+        timeout = 1,
+        label = "list return value"
+      )
+      testthat::expect_equal(result$id, 42)
+      testthat::expect_equal(result$name, "grin2b")
+    })
+
+    testthat::test_that("wait_for polls until the condition becomes truthy", {
+      counter <- 0L
+      result <- wait_for(
+        function() {
+          counter <<- counter + 1L
+          if (counter >= 3L) TRUE else NULL
+        },
+        timeout = 2,
+        label = "counter probe",
+        interval = 0.01
+      )
+      testthat::expect_true(isTRUE(result))
+      testthat::expect_gte(counter, 3L)
+    })
+
+    testthat::test_that("wait_for fails loudly on timeout with a clear message", {
+      start <- Sys.time()
+      err <- tryCatch(
+        wait_for(
+          function() FALSE,
+          timeout = 0.1,
+          label = "always-false",
+          interval = 0.02
+        ),
+        error = function(e) e
+      )
+      elapsed <- as.numeric(difftime(Sys.time(), start, units = "secs"))
+      testthat::expect_s3_class(err, "error")
+      testthat::expect_match(conditionMessage(err), "wait_for timeout")
+      testthat::expect_match(conditionMessage(err), "always-false")
+      testthat::expect_match(conditionMessage(err), "0.1")
+      # Should give up soon after the timeout (allow generous slack).
+      testthat::expect_lt(elapsed, 0.5)
+    })
+
+    testthat::test_that("wait_for surfaces probe errors in the timeout message", {
+      err <- tryCatch(
+        wait_for(
+          function() stop("probe exploded"),
+          timeout = 0.1,
+          label = "error probe",
+          interval = 0.02
+        ),
+        error = function(e) e
+      )
+      testthat::expect_s3_class(err, "error")
+      testthat::expect_match(conditionMessage(err), "probe exploded")
+    })
+
+    testthat::test_that("wait_stable returns baseline when probe stays constant", {
+      start <- Sys.time()
+      result <- wait_stable(
+        function() 0L,
+        duration = 0.2,
+        label = "zero probe",
+        interval = 0.05
+      )
+      elapsed <- as.numeric(difftime(Sys.time(), start, units = "secs"))
+      testthat::expect_equal(result, 0L)
+      testthat::expect_gte(elapsed, 0.2)
+    })
+
+    testthat::test_that("wait_stable fails immediately when probe value changes", {
+      counter <- 0L
+      start <- Sys.time()
+      err <- tryCatch(
+        wait_stable(
+          function() {
+            counter <<- counter + 1L
+            if (counter == 1L) 0L else 1L
+          },
+          duration = 5,
+          label = "changing probe",
+          interval = 0.01
+        ),
+        error = function(e) e
+      )
+      elapsed <- as.numeric(difftime(Sys.time(), start, units = "secs"))
+      testthat::expect_s3_class(err, "error")
+      testthat::expect_match(conditionMessage(err), "wait_stable violation")
+      testthat::expect_match(conditionMessage(err), "changing probe")
+      # Should fail long before the 5s duration.
+      testthat::expect_lt(elapsed, 1)
+    })
+  })
+}

--- a/api/tests/testthat/test-e2e-user-lifecycle.R
+++ b/api/tests/testthat/test-e2e-user-lifecycle.R
@@ -177,9 +177,15 @@ test_that("duplicate registration is rejected", {
     httr2::req_error(is_error = function(resp) FALSE) |>
     httr2::req_perform()
 
-  # Should not send additional email on duplicate attempt
-  Sys.sleep(1)
-  final_count <- mailpit_message_count()
+  # Should not send additional email on duplicate attempt.
+  # Event-based assertion: poll the Mailpit count for 1s and fail as soon
+  # as it diverges from the initial count, instead of blindly burning a
+  # second before a single count check.
+  final_count <- wait_stable(
+    probe = function() mailpit_message_count(),
+    duration = 1,
+    label = "mailpit count after duplicate signup (expected: unchanged)"
+  )
   expect_equal(final_count, initial_count)
 })
 
@@ -211,9 +217,14 @@ test_that("invalid registration data is rejected", {
   # Should return error status (404 per endpoint code)
   expect_equal(httr2::resp_status(resp), 404)
 
-  # No email should be sent
-  Sys.sleep(1)
-  count <- mailpit_message_count()
+  # No email should be sent. Poll the count for 1s; wait_stable fails
+  # immediately (with a diagnostic) if a rogue email arrives during the
+  # window, instead of burning a full second before checking once.
+  count <- wait_stable(
+    probe = function() mailpit_message_count(),
+    duration = 1,
+    label = "mailpit count after invalid signup (expected: 0)"
+  )
   expect_equal(count, 0)
 })
 
@@ -319,9 +330,14 @@ test_that("curator rejection deletes user without email", {
   user_after <- get_user_by_email(test_user$email)
   expect_null(user_after)
 
-  # No rejection email should be sent
-  Sys.sleep(1)
-  count <- mailpit_message_count()
+  # No rejection email should be sent. wait_stable polls for 1s and
+  # fails the moment a rogue rejection email arrives, rather than
+  # uniformly sleeping before a single count assertion.
+  count <- wait_stable(
+    probe = function() mailpit_message_count(),
+    duration = 1,
+    label = "mailpit count after curator rejection (expected: 0)"
+  )
   expect_equal(count, 0)
 })
 
@@ -535,9 +551,15 @@ test_that("password reset for non-existent email silently succeeds", {
   # Should return 200 (security: don't reveal if email exists)
   expect_equal(httr2::resp_status(resp), 200)
 
-  # No email should be sent
-  Sys.sleep(2)
-  count <- mailpit_message_count()
+  # No email should be sent. Poll for 2s (longer than other cases because
+  # password-reset enumeration protection is silent — the API intentionally
+  # does the same work as a real reset to equalize timing, so we need to
+  # tolerate a slightly longer "quiet window" before asserting zero).
+  count <- wait_stable(
+    probe = function() mailpit_message_count(),
+    duration = 2,
+    label = "mailpit count after reset for nonexistent email (expected: 0)"
+  )
   expect_equal(count, 0)
 })
 


### PR DESCRIPTION
## Summary

Replace every real `Sys.sleep(N)` in the R test suite with event-based polling via two new helpers in `api/tests/testthat/helper-wait.R`:

- **`wait_for(condition, timeout, label, interval = 0.05)`** — polls a condition function until it returns a truthy value, or fails loudly with a diagnostic (elapsed time, attempt count, label, last observed value). Used for positive waits (e.g. email arriving in Mailpit).
- **`wait_stable(probe, duration, label, interval = 0.1)`** — polls a probe function and asserts its value stays `identical()` to the first observation for the full `duration`. Fails the instant a transition occurs. Used for negative assertions (e.g. "no email should be sent").

Both helpers `stop()` on failure so they surface as real errors from inside `helper-mailpit.R` (which has no test context) and never silently pass.

## Per-site audit

| File | Line | Old | Condition being masked | Replacement |
|---|---|---|---|---|
| `test-e2e-user-lifecycle.R` | 181 | `Sys.sleep(1)` | Duplicate-signup email should NOT arrive | `wait_stable(mailpit_message_count, 1)` (baseline = `initial_count`) |
| `test-e2e-user-lifecycle.R` | 215 | `Sys.sleep(1)` | Invalid-signup email should NOT arrive | `wait_stable(mailpit_message_count, 1)` (baseline = 0) |
| `test-e2e-user-lifecycle.R` | 323 | `Sys.sleep(1)` | Curator-rejection email should NOT arrive | `wait_stable(mailpit_message_count, 1)` (baseline = 0) |
| `test-e2e-user-lifecycle.R` | 539 | `Sys.sleep(2)` | Reset-for-nonexistent-email should NOT arrive (enumeration protection keeps duration longer) | `wait_stable(mailpit_message_count, 2)` (baseline = 0) |
| `helper-mailpit.R` | 116 | `Sys.sleep(0.5)` | Poll interval inside `mailpit_wait_for_message`'s own wait loop | Entire function refactored to delegate to `wait_for()` |

**Not touched** (per spec §B5 constraints):
- `test-unit-pubtator-functions.R`, `test-unit-pubtator-parse.R` — `Sys.sleep` is inside `local_mock()` / `mockery::stub()` contexts, not real sleeps.
- `test-unit-logging-functions.R` — legitimate micro-sleeps for timestamp differentiation; `wait_for` doesn't fit.
- `test-unit-endpoint-functions.R:297` — legitimate timing measurement inside a test of execution-time formatting.
- `test-publication-refresh.R` — comment/mock references, not real sleeps.

## Verification

Acceptance grep:
```
$ grep -rn "Sys\.sleep" api/tests/testthat/test-e2e-user-lifecycle.R api/tests/testthat/helper-mailpit.R
$ echo $?
1
```
Zero hits.

### helper-wait.R self-tests (10-iteration flake check, prod container)

`helper-wait.R` ships with a testthat block (guarded by `TESTTHAT=true`) that runs 7 test groups with 19 assertions covering:
1. Immediate truthy return + elapsed time < 0.5s
2. Value pass-through (list return)
3. Polled-until-truthy (counter probe)
4. Timeout diagnostics (label, duration, elapsed < timeout + slack)
5. Probe-error surfacing in timeout message
6. wait_stable baseline return + duration respected
7. wait_stable fail-on-change (elapsed << full duration)

Ran 10 consecutive iterations in the prod `sys-sleep-eviction-api` docker container:
```
iter 1:  [ FAIL 0 | WARN 0 | SKIP 0 | PASS 19 ]
iter 2:  [ FAIL 0 | WARN 0 | SKIP 0 | PASS 19 ]
iter 3:  [ FAIL 0 | WARN 0 | SKIP 0 | PASS 19 ]
iter 4:  [ FAIL 0 | WARN 0 | SKIP 0 | PASS 19 ]
iter 5:  [ FAIL 0 | WARN 0 | SKIP 0 | PASS 19 ]
iter 6:  [ FAIL 0 | WARN 0 | SKIP 0 | PASS 19 ]
iter 7:  [ FAIL 0 | WARN 0 | SKIP 0 | PASS 19 ]
iter 8:  [ FAIL 0 | WARN 0 | SKIP 0 | PASS 19 ]
iter 9:  [ FAIL 0 | WARN 0 | SKIP 0 | PASS 19 ]
iter 10: [ FAIL 0 | WARN 0 | SKIP 0 | PASS 19 ]
ALL 10 ITERATIONS GREEN
```
**190/190 assertions green, 0 flakes** — including every timing-sensitive test (immediate return, polled counter, timeout, stable duration, change detection).

### test-e2e-user-lifecycle.R load + dispatch (10-iteration flake check, prod container)

Full-stack run (Mailpit + API + DB schema) is **not achievable on the host** that produced this PR: Ubuntu 25.10 + Conda R has no working `renv` library (per `CLAUDE.md` "Host-Env Workaround"), the local `mysql-test` container only has 7 analytics tables (no `user` table), and the `sysndd-api` production image's compose targets a `mysql` service that isn't running. The full-stack verification is **deferred to CI**, where `slow-tests-nightly` (B3's new nightly job) will exercise these tests with `RUN_SLOW_TESTS=true` against a real Mailpit + seeded DB.

As a structural flake check on this host, the test file was loaded + dispatched inside the prod container 10 consecutive times in skip mode:
```
iter 1:  [ FAIL 0 | WARN 0 | SKIP 11 | PASS 0 ]
iter 2:  [ FAIL 0 | WARN 0 | SKIP 11 | PASS 0 ]
iter 3:  [ FAIL 0 | WARN 0 | SKIP 11 | PASS 0 ]
iter 4:  [ FAIL 0 | WARN 0 | SKIP 11 | PASS 0 ]
iter 5:  [ FAIL 0 | WARN 0 | SKIP 11 | PASS 0 ]
iter 6:  [ FAIL 0 | WARN 0 | SKIP 11 | PASS 0 ]
iter 7:  [ FAIL 0 | WARN 0 | SKIP 11 | PASS 0 ]
iter 8:  [ FAIL 0 | WARN 0 | SKIP 11 | PASS 0 ]
iter 9:  [ FAIL 0 | WARN 0 | SKIP 11 | PASS 0 ]
iter 10: [ FAIL 0 | WARN 0 | SKIP 11 | PASS 0 ]
ALL 10 ITERATIONS GREEN
```
All 11 `test_that` blocks reach `skip_if_no_mailpit()` / `skip_if_no_api()` cleanly — no parse errors, no helper-source errors, no masking issues from the new `wait_stable` calls.

**Reviewers: please verify the real full-stack flake check runs green in CI on the `slow-tests-nightly` job once B3 lands it.**

### Host sanity checks

- `Rscript --no-init-file api/scripts/lint-check.R` — 82 files, 0 issues.
- `cd app && npm run lint` — clean.
- `cd app && npm run type-check` — clean.
- `cd app && npm run test:unit` — 244/244 green.

## Coordination with B3 (skip-slow-wiring)

B3 adds `skip_if_not_slow_tests()` wrappers to the same two files. Per the `phase-b.md` §2 resolution rule, **B5 merges first**; B3 rebases and places its skip wrapper at the top of each `test_that` block on top of the new `wait_for` / `wait_stable` calls.

Hints for B3's rebase:
- `test-e2e-user-lifecycle.R:181` is now inside the "duplicate registration is rejected" test at ~line 181-189 (was a single-line sleep, now a ~5-line `wait_stable` block with a comment).
- `test-e2e-user-lifecycle.R:215` is now inside "invalid registration data is rejected" at ~line 221-227.
- `test-e2e-user-lifecycle.R:323` is now inside "curator rejection deletes user without email" at ~line 335-341.
- `test-e2e-user-lifecycle.R:539` is now inside "password reset for non-existent email silently succeeds" at ~line 556-563.
- `helper-mailpit.R::mailpit_wait_for_message` is now a thin `wait_for` delegation; B3 will not touch this file.

No structural conflict — `skip_if_not_slow_tests()` sits at the top of each `test_that`, while `wait_stable` lines sit mid-body. Rebase is trivial.

## Test plan

- [x] `grep -rn "Sys\.sleep" api/tests/testthat/test-e2e-user-lifecycle.R api/tests/testthat/helper-mailpit.R` returns zero hits
- [x] `helper-wait.R` self-tests pass 10/10 in prod container
- [x] `test-e2e-user-lifecycle.R` loads + dispatches cleanly 10/10 in prod container (skip mode)
- [x] Frontend sanity green (lint, type-check, vitest)
- [x] Lint-api green (82 files, 0 issues)
- [ ] CI runs the new file against a real Mailpit + seeded DB via B3's `slow-tests-nightly` job once B3 merges