### PR TITLE
phase-b/B1: expand MSW handlers, flip onUnhandledRequest to error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,11 +141,15 @@ lint-api: check-r ## [lint] Check R code with lintr + migration prefix check
 		printf "$(GREEN)✓ lint-api complete$(RESET)\n" || \
 		(printf "$(RED)✗ lint-api failed$(RESET)\n" && exit 1)
 
-lint-app: check-npm ## [lint] Check frontend code with ESLint
+lint-app: check-npm ## [lint] Check frontend code with ESLint and MSW↔OpenAPI drift
 	@printf "$(CYAN)==> Checking frontend code with ESLint...$(RESET)\n"
 	@cd $(ROOT_DIR)/app && npm run lint && \
+		printf "$(GREEN)✓ eslint complete$(RESET)\n" || \
+		(printf "$(RED)✗ eslint failed$(RESET)\n" && exit 1)
+	@printf "$(CYAN)==> Verifying MSW handlers against OpenAPI annotations...$(RESET)\n"
+	@$(ROOT_DIR)/scripts/verify-msw-against-openapi.sh && \
 		printf "$(GREEN)✓ lint-app complete$(RESET)\n" || \
-		(printf "$(RED)✗ lint-app failed$(RESET)\n" && exit 1)
+		(printf "$(RED)✗ verify-msw-against-openapi failed$(RESET)\n" && exit 1)
 
 format-api: check-r ## [lint] Format R code with styler
 	@printf "$(CYAN)==> Formatting R code with styler...$(RESET)\n"

--- a/app/src/test-utils/mocks/data/auth.ts
+++ b/app/src/test-utils/mocks/data/auth.ts
@@ -1,0 +1,55 @@
+// test-utils/mocks/data/auth.ts
+/**
+ * Static fixtures mirroring the OpenAPI response shapes for authentication
+ * endpoints defined in api/endpoints/authentication_endpoints.R (post Phase A1).
+ *
+ * Shapes follow R/Plumber's convention of wrapping JSON scalars in arrays — see
+ * api/config/openapi/schemas/inferred/api_auth_signin_GET.json for the canonical
+ * reference.
+ */
+
+export interface AuthSigninResponse {
+  user_id: number[];
+  user_name: string[];
+  email: string[];
+  user_role: string[];
+  user_created: string[];
+  abbreviation: string[];
+  orcid: Record<string, unknown>;
+  exp: number[];
+}
+
+export const signinOk: AuthSigninResponse = {
+  user_id: [42],
+  user_name: ['test_user'],
+  email: ['test_user@example.org'],
+  user_role: ['Viewer'],
+  user_created: ['2025-01-01 00:00:00'],
+  abbreviation: ['TU'],
+  orcid: {},
+  exp: [Math.floor(Date.now() / 1000) + 3600],
+};
+
+export const signinUnauthorized = {
+  error: 'Authentication not successful.',
+};
+
+/**
+ * POST /api/auth/authenticate returns the raw JWT token string (post A1).
+ * Plumber serialises it as a one-element JSON array, so the mock mirrors
+ * that shape.
+ */
+export const authenticateTokenOk: [string] = [
+  'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.mock.signature',
+];
+
+export const authenticateBadRequest = 'Please provide valid username and password.';
+export const authenticateUnauthorized = 'User or password wrong.';
+
+export const refreshTokenOk: [string] = [
+  'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.refreshed.signature',
+];
+
+export const refreshTokenUnauthorized = {
+  error: 'Authentication not successful.',
+};

--- a/app/src/test-utils/mocks/data/entities.ts
+++ b/app/src/test-utils/mocks/data/entities.ts
@@ -1,0 +1,112 @@
+// test-utils/mocks/data/entities.ts
+/**
+ * Static fixtures mirroring the OpenAPI response shapes for entity endpoints
+ * defined in api/endpoints/entity_endpoints.R.
+ *
+ * Reference: api/config/openapi/schemas/inferred/api_entity_GET.json.
+ *
+ * NOTE: `GET /api/entity/<sysndd_id>` is listed in the Phase B.B1 locked
+ * handler table but no bare `@get /<sysndd_id>` annotation exists in
+ * entity_endpoints.R on master (only `/`, `/<sysndd_id>/phenotypes`, etc.).
+ * The mock is kept to honour "do not widen, narrow, or rewrite the locked
+ * table"; the drift is flagged in scripts/msw-openapi-exceptions.txt.
+ */
+
+export interface EntityDetail {
+  entity_id: number;
+  sysndd_id: string;
+  symbol: string;
+  hgnc_id: string;
+  disease_ontology_id_version: string;
+  disease_ontology_name: string;
+  hpo_mode_of_inheritance_term: string;
+  hpo_mode_of_inheritance_term_name: string;
+  category_id: number;
+  category_value: string;
+}
+
+export const entityByIdOk: EntityDetail = {
+  entity_id: 501,
+  sysndd_id: 'sysndd:000501',
+  symbol: 'TEST1',
+  hgnc_id: 'HGNC:12345',
+  disease_ontology_id_version: 'MONDO:0000123_2025-01-01',
+  disease_ontology_name: 'Test Disease',
+  hpo_mode_of_inheritance_term: 'HP:0000006',
+  hpo_mode_of_inheritance_term_name: 'Autosomal dominant',
+  category_id: 1,
+  category_value: 'Definitive',
+};
+
+export const entityByIdNotFound = {
+  error: 'Entity not found.',
+};
+
+export const entityCreateOk = {
+  message: 'Entity successfully created.',
+  entity_id: [502],
+};
+
+export const entityCreateBadRequest = {
+  error: 'Missing or invalid entity fields.',
+};
+
+export const entityCreateConflict = {
+  error: 'Duplicate entity (gene + disease + inheritance) already exists.',
+};
+
+export const entityRenameOk = {
+  message: 'Entity successfully renamed.',
+  entity_id: 501,
+};
+
+export const entityRenameBadRequest = {
+  error: 'New symbol is required.',
+};
+
+export const entityDeactivateOk = {
+  message: 'Entity deactivated.',
+  entity_id: 501,
+};
+
+export const entityDeactivateBadRequest = {
+  error: 'Entity id missing.',
+};
+
+export const entityReviewListOk = [
+  {
+    review_id: 101,
+    entity_id: 501,
+    review_date: '2025-06-01 12:00:00',
+    review_user_name: 'alice_admin',
+    review_approved: 1,
+    is_primary: 1,
+  },
+  {
+    review_id: 102,
+    entity_id: 501,
+    review_date: '2025-07-01 12:00:00',
+    review_user_name: 'bob_viewer',
+    review_approved: 0,
+    is_primary: 0,
+  },
+];
+
+export const entityReviewListNotFound = {
+  error: 'Entity not found.',
+};
+
+export const entityStatusListOk = [
+  {
+    status_id: 201,
+    entity_id: 501,
+    category_id: 1,
+    status_date: '2025-06-01 12:00:00',
+    status_user_name: 'alice_admin',
+    status_approved: 1,
+  },
+];
+
+export const entityStatusListNotFound = {
+  error: 'Entity not found.',
+};

--- a/app/src/test-utils/mocks/data/jobs.ts
+++ b/app/src/test-utils/mocks/data/jobs.ts
@@ -1,0 +1,109 @@
+// test-utils/mocks/data/jobs.ts
+/**
+ * Static fixtures mirroring the OpenAPI response shapes for job endpoints
+ * defined in api/endpoints/jobs_endpoints.R.
+ *
+ * Reference: api/config/openapi/schemas/inferred/api_jobs_history_GET.json.
+ *
+ * R/Plumber serialises scalars as one-element arrays — job_id returned from
+ * submit endpoints must be `[string]`, not `string`.  See CLAUDE.md
+ * "R/Plumber returns JSON scalars as arrays" for details.
+ */
+
+export interface JobHistoryRow {
+  job_id: string;
+  job_type: string;
+  status: string;
+  submitted_at: string;
+  finished_at: string | null;
+  submitted_by: string;
+}
+
+export const jobsHistoryOk: {
+  data: JobHistoryRow[];
+  meta: { count: number[]; limit: number[] };
+} = {
+  data: [
+    {
+      job_id: 'hgnc-update-2025-06-01',
+      job_type: 'hgnc_update',
+      status: 'success',
+      submitted_at: '2025-06-01 00:00:00',
+      finished_at: '2025-06-01 00:05:12',
+      submitted_by: 'alice_admin',
+    },
+    {
+      job_id: 'ontology-update-2025-06-05',
+      job_type: 'ontology_update',
+      status: 'blocked',
+      submitted_at: '2025-06-05 00:00:00',
+      finished_at: '2025-06-05 00:01:42',
+      submitted_by: 'alice_admin',
+    },
+  ],
+  meta: {
+    count: [2],
+    limit: [50],
+  },
+};
+
+export const jobsHistoryForbidden = {
+  error: 'Not authorised to view job history.',
+};
+
+export const jobStatusOk = {
+  job_id: ['hgnc-update-2025-06-01'],
+  status: ['success'],
+  submitted_at: ['2025-06-01 00:00:00'],
+  finished_at: ['2025-06-01 00:05:12'],
+  result: [{ rows_updated: 42 }],
+};
+
+export const jobStatusNotFound = {
+  error: 'Job not found.',
+};
+
+export const hgncUpdateSubmitOk = {
+  message: 'HGNC update job submitted.',
+  job_id: ['hgnc-update-2025-07-01'],
+};
+
+export const hgncUpdateSubmitForbidden = {
+  error: 'HGNC update forbidden for non-admin.',
+};
+
+export const ontologyUpdateSubmitOk = {
+  message: 'Ontology update job submitted.',
+  job_id: ['ontology-update-2025-07-01'],
+};
+
+export const ontologyUpdateSubmitForbidden = {
+  error: 'Ontology update forbidden for non-admin.',
+};
+
+export const comparisonsUpdateSubmitOk = {
+  message: 'Comparisons update job submitted.',
+  job_id: ['comparisons-update-2025-07-01'],
+};
+
+export const comparisonsUpdateSubmitForbidden = {
+  error: 'Comparisons update forbidden for non-admin.',
+};
+
+export const clusteringSubmitOk = {
+  message: 'Clustering job submitted.',
+  job_id: ['clustering-2025-07-01'],
+};
+
+export const clusteringSubmitBadRequest = {
+  error: 'Invalid clustering parameters.',
+};
+
+export const phenotypeClusteringSubmitOk = {
+  message: 'Phenotype clustering job submitted.',
+  job_id: ['phenotype-clustering-2025-07-01'],
+};
+
+export const phenotypeClusteringSubmitBadRequest = {
+  error: 'Invalid phenotype clustering parameters.',
+};

--- a/app/src/test-utils/mocks/data/reviews.ts
+++ b/app/src/test-utils/mocks/data/reviews.ts
@@ -1,0 +1,152 @@
+// test-utils/mocks/data/reviews.ts
+/**
+ * Static fixtures mirroring the OpenAPI response shapes for review endpoints
+ * defined in api/endpoints/review_endpoints.R.
+ *
+ * Reference: api/config/openapi/schemas/inferred/api_review_GET.json.
+ */
+
+export interface ReviewRow {
+  review_id: number;
+  entity_id: number;
+  hgnc_id: string;
+  symbol: string;
+  disease_ontology_id_version: string;
+  disease_ontology_name: string;
+  hpo_mode_of_inheritance_term: string;
+  hpo_mode_of_inheritance_term_name: string;
+  synopsis: string;
+  is_primary: number;
+  review_date: string;
+  review_user_name: string;
+  review_user_role: string;
+  review_approved: number;
+  approving_user_name: string | null;
+  approving_user_role: string | null;
+  approving_user_id: number | null;
+  comment: string | null;
+  duplicate: string;
+  active_status: number;
+  active_category: number;
+  newest_status: number;
+  newest_category: number;
+  status_change: number;
+}
+
+export const reviewByIdOk: ReviewRow = {
+  review_id: 101,
+  entity_id: 501,
+  hgnc_id: 'HGNC:12345',
+  symbol: 'TEST1',
+  disease_ontology_id_version: 'MONDO:0000123_2025-01-01',
+  disease_ontology_name: 'Test Disease',
+  hpo_mode_of_inheritance_term: 'HP:0000006',
+  hpo_mode_of_inheritance_term_name: 'Autosomal dominant',
+  synopsis: 'A test synopsis.',
+  is_primary: 1,
+  review_date: '2025-06-01 12:00:00',
+  review_user_name: 'alice_admin',
+  review_user_role: 'Administrator',
+  review_approved: 0,
+  approving_user_name: null,
+  approving_user_role: null,
+  approving_user_id: null,
+  comment: null,
+  duplicate: 'none',
+  active_status: 3,
+  active_category: 1,
+  newest_status: 3,
+  newest_category: 1,
+  status_change: 0,
+};
+
+export const reviewByIdNotFound = {
+  error: 'Review not found.',
+};
+
+export const reviewPhenotypesOk = [
+  {
+    review_id: 101,
+    hpo_id: 'HP:0001250',
+    hpo_term: 'Seizure',
+    modifier: 'none',
+  },
+  {
+    review_id: 101,
+    hpo_id: 'HP:0001263',
+    hpo_term: 'Global developmental delay',
+    modifier: 'none',
+  },
+];
+
+export const reviewPhenotypesNotFound = {
+  error: 'Review not found.',
+};
+
+export const reviewVariationOk = [
+  {
+    review_id: 101,
+    variation_ontology_id: 'SO:0001583',
+    variation_ontology_name: 'missense_variant',
+  },
+];
+
+export const reviewVariationNotFound = {
+  error: 'Review not found.',
+};
+
+export const reviewPublicationsOk = [
+  {
+    review_id: 101,
+    pmid: 12345678,
+    title: 'A Study of Test Disease',
+    journal: 'J Test Med',
+    year: 2024,
+  },
+  {
+    review_id: 101,
+    pmid: 87654321,
+    title: 'Follow-up Report',
+    journal: 'J Test Med',
+    year: 2025,
+  },
+];
+
+export const reviewPublicationsNotFound = {
+  error: 'Review not found.',
+};
+
+export const reviewCreateOk = {
+  message: 'Review successfully created.',
+  review_id: [102],
+};
+
+export const reviewCreateBadRequest = {
+  error: 'Missing or invalid review fields.',
+};
+
+export const reviewUpdateOk = {
+  message: 'Review successfully updated.',
+};
+
+export const reviewUpdateBadRequest = {
+  error: 'Missing or invalid review fields.',
+};
+
+export const reviewApproveByIdOk = {
+  message: 'Review approved.',
+  review_id: 101,
+};
+
+export const reviewApproveByIdNotFound = {
+  error: 'Review not found.',
+};
+
+export const reviewApproveAllOk = {
+  message: 'All pending reviews approved.',
+  approved_count: 3,
+};
+
+export const reviewApproveAllForbidden = {
+  error: 'Bulk approval forbidden for non-admin.',
+};

--- a/app/src/test-utils/mocks/data/statuses.ts
+++ b/app/src/test-utils/mocks/data/statuses.ts
@@ -1,0 +1,85 @@
+// test-utils/mocks/data/statuses.ts
+/**
+ * Static fixtures mirroring the OpenAPI response shapes for status endpoints
+ * defined in api/endpoints/status_endpoints.R.
+ *
+ * Reference: api/config/openapi/schemas/inferred/api_status_GET.json,
+ * api_list_status_GET.json.
+ */
+
+export interface StatusRow {
+  status_id: number;
+  entity_id: number;
+  hgnc_id: string;
+  symbol: string;
+  disease_ontology_id_version: string;
+  disease_ontology_name: string;
+  category_id: number;
+  status_value: string;
+  status_date: string;
+  status_user_name: string;
+  status_user_role: string;
+  status_approved: number;
+  approving_user_name: string | null;
+  approving_user_role: string | null;
+  approving_user_id: number | null;
+  comment: string | null;
+}
+
+export const statusByIdOk: StatusRow = {
+  status_id: 201,
+  entity_id: 501,
+  hgnc_id: 'HGNC:12345',
+  symbol: 'TEST1',
+  disease_ontology_id_version: 'MONDO:0000123_2025-01-01',
+  disease_ontology_name: 'Test Disease',
+  category_id: 1,
+  status_value: 'Definitive',
+  status_date: '2025-06-01 12:00:00',
+  status_user_name: 'alice_admin',
+  status_user_role: 'Administrator',
+  status_approved: 0,
+  approving_user_name: null,
+  approving_user_role: null,
+  approving_user_id: null,
+  comment: null,
+};
+
+export const statusByIdNotFound = {
+  error: 'Status not found.',
+};
+
+export const statusCreateOk = {
+  message: 'Status successfully created.',
+  status_id: [202],
+};
+
+export const statusCreateBadRequest = {
+  error: 'Missing or invalid status fields.',
+};
+
+export const statusUpdateOk = {
+  message: 'Status successfully updated.',
+};
+
+export const statusUpdateBadRequest = {
+  error: 'Missing or invalid status fields.',
+};
+
+export const statusApproveByIdOk = {
+  message: 'Status approved.',
+  status_id: 201,
+};
+
+export const statusApproveByIdNotFound = {
+  error: 'Status not found.',
+};
+
+export const statusApproveAllOk = {
+  message: 'All pending statuses approved.',
+  approved_count: 5,
+};
+
+export const statusApproveAllForbidden = {
+  error: 'Bulk approval forbidden for non-admin.',
+};

--- a/app/src/test-utils/mocks/data/users.ts
+++ b/app/src/test-utils/mocks/data/users.ts
@@ -1,0 +1,164 @@
+// test-utils/mocks/data/users.ts
+/**
+ * Static fixtures mirroring the OpenAPI response shapes for user admin
+ * endpoints defined in api/endpoints/user_endpoints.R.
+ *
+ * Reference: api/config/openapi/schemas/inferred/api_user_table_GET.json,
+ * api_user_list_GET.json, api_user_role_list_GET.json.
+ */
+
+export interface UserTableRow {
+  user_id: number;
+  user_name: string;
+  email: string;
+  orcid: string | null;
+  abbreviation: string;
+  first_name: string;
+  family_name: string;
+  comment: string;
+  terms_agreed: number;
+  created_at: string;
+  user_role: string;
+  approved: number;
+}
+
+export interface PaginatedEnvelope<T> {
+  links: Array<{
+    prev: string;
+    self: string;
+    next: string;
+    last: string;
+  }>;
+  meta: Array<{
+    perPage: number;
+    currentPage: number;
+    totalPages: number;
+    prevItemID: string | number;
+    currentItemID: number;
+    nextItemID: number;
+    lastItemID: number;
+    totalItems: number;
+    fspec: unknown[];
+    executionTime: string;
+  }>;
+  data: T[];
+}
+
+export const userTableOk: PaginatedEnvelope<UserTableRow> = {
+  links: [
+    {
+      prev: '',
+      self: '/api/user/table',
+      next: '',
+      last: '/api/user/table',
+    },
+  ],
+  meta: [
+    {
+      perPage: 20,
+      currentPage: 1,
+      totalPages: 1,
+      prevItemID: '',
+      currentItemID: 1,
+      nextItemID: 2,
+      lastItemID: 2,
+      totalItems: 2,
+      fspec: [],
+      executionTime: '0.01s',
+    },
+  ],
+  data: [
+    {
+      user_id: 1,
+      user_name: 'alice_admin',
+      email: 'alice@example.org',
+      orcid: null,
+      abbreviation: 'AA',
+      first_name: 'Alice',
+      family_name: 'Admin',
+      comment: '',
+      terms_agreed: 1,
+      created_at: '2025-01-01 00:00:00',
+      user_role: 'Administrator',
+      approved: 1,
+    },
+    {
+      user_id: 2,
+      user_name: 'bob_viewer',
+      email: 'bob@example.org',
+      orcid: '0000-0002-1234-5678',
+      abbreviation: 'BV',
+      first_name: 'Bob',
+      family_name: 'Viewer',
+      comment: '',
+      terms_agreed: 1,
+      created_at: '2025-01-02 00:00:00',
+      user_role: 'Viewer',
+      approved: 1,
+    },
+  ],
+};
+
+export const userListOk = [
+  { user_id: 1, user_name: 'alice_admin', user_role: 'Administrator' },
+  { user_id: 2, user_name: 'bob_viewer', user_role: 'Viewer' },
+  { user_id: 3, user_name: 'carol_curator', user_role: 'Reviewer' },
+];
+
+export const userRoleListOk = [
+  { user_role: 'Administrator' },
+  { user_role: 'Curator' },
+  { user_role: 'Reviewer' },
+  { user_role: 'Viewer' },
+];
+
+export const userUpdateOk = {
+  message: 'User successfully updated.',
+};
+
+export const userUpdateForbidden = {
+  error: 'User update not authorized.',
+};
+
+export const userDeleteOk = {
+  message: 'User successfully deleted.',
+};
+
+export const userDeleteNotFound = {
+  error: 'User not found.',
+};
+
+export const bulkApproveOk = {
+  message: 'Bulk approval successful.',
+  approved_count: 2,
+};
+
+export const bulkApproveBadRequest = {
+  error: 'No user ids provided.',
+};
+
+export const bulkAssignRoleOk = {
+  message: 'Bulk role assignment successful.',
+  updated_count: 2,
+};
+
+export const bulkAssignRoleBadRequest = {
+  error: 'Invalid role or empty user list.',
+};
+
+export const bulkDeleteOk = {
+  message: 'Bulk delete successful.',
+  deleted_count: 2,
+};
+
+export const bulkDeleteBadRequest = {
+  error: 'No user ids provided.',
+};
+
+export const passwordUpdateOk = {
+  message: 'Password successfully changed.',
+};
+
+export const passwordUpdateConflict = {
+  error: 'Password input problem.',
+};

--- a/app/src/test-utils/mocks/handlers.spec.ts
+++ b/app/src/test-utils/mocks/handlers.spec.ts
@@ -1,0 +1,648 @@
+// test-utils/mocks/handlers.spec.ts
+/**
+ * Phase B.B1 smoke tests for the MSW handler set.
+ *
+ * Every handler listed in the Phase B.B1 locked table must have:
+ *   - a 2xx happy-path response with the declared shape
+ *   - at least one 4xx branch reachable via a distinguishable request shape
+ *     (sentinel path param `999`, a `trigger_error` query, a missing-auth
+ *     header, a `Viewer` user-role header, or a body with missing required
+ *     fields).
+ *
+ * Each `it` exercises one handler's 2xx and one 4xx trigger by calling
+ * `fetch()` directly — the server is already listening globally via
+ * `vitest.setup.ts`, so this file deliberately does not install overrides.
+ *
+ * If you're adding a handler to `handlers.ts`, add a matching `it` here.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+describe('MSW handlers — Phase B.B1 smoke tests', () => {
+  // ---------------------------------------------------------------------------
+  // Auth
+  // ---------------------------------------------------------------------------
+
+  describe('auth', () => {
+    it('POST /api/auth/authenticate returns 200 token on valid body', async () => {
+      const res = await fetch('/api/auth/authenticate', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ user_name: 'test_user', password: 'hunter2!' }),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(Array.isArray(body)).toBe(true);
+      expect(body[0]).toMatch(/^eyJ/);
+    });
+
+    it('POST /api/auth/authenticate returns 400 on too-short credentials', async () => {
+      const res = await fetch('/api/auth/authenticate', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ user_name: 'x', password: 'y' }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('POST /api/auth/authenticate returns 401 on wrong_user/wrong_pass sentinel', async () => {
+      const res = await fetch('/api/auth/authenticate', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ user_name: 'wrong_user', password: 'hunter2!' }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it('GET /api/auth/refresh returns 200 with Authorization header', async () => {
+      const res = await fetch('/api/auth/refresh', {
+        headers: { authorization: 'Bearer test-token' },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(Array.isArray(body)).toBe(true);
+    });
+
+    it('GET /api/auth/refresh returns 401 without Authorization header', async () => {
+      const res = await fetch('/api/auth/refresh');
+      expect(res.status).toBe(401);
+    });
+
+    it('GET /api/auth/signin returns 200 with Authorization header', async () => {
+      const res = await fetch('/api/auth/signin', {
+        headers: { authorization: 'Bearer test-token' },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.user_name).toEqual(['test_user']);
+    });
+
+    it('GET /api/auth/signin returns 401 without Authorization header', async () => {
+      const res = await fetch('/api/auth/signin');
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // User admin
+  // ---------------------------------------------------------------------------
+
+  describe('user admin', () => {
+    it('GET /api/user/table returns 200 paginated envelope', async () => {
+      const res = await fetch('/api/user/table');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toBeInstanceOf(Array);
+      expect(body.links).toBeInstanceOf(Array);
+      expect(body.meta).toBeInstanceOf(Array);
+    });
+
+    it('GET /api/user/table returns 400 on trigger_error=1', async () => {
+      const res = await fetch('/api/user/table?trigger_error=1');
+      expect(res.status).toBe(400);
+    });
+
+    it('GET /api/user/role_list returns 200 with Authorization', async () => {
+      const res = await fetch('/api/user/role_list', {
+        headers: { authorization: 'Bearer t' },
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('GET /api/user/role_list returns 401 without Authorization', async () => {
+      const res = await fetch('/api/user/role_list');
+      expect(res.status).toBe(401);
+    });
+
+    it('GET /api/user/list returns 200 with Authorization', async () => {
+      const res = await fetch('/api/user/list', {
+        headers: { authorization: 'Bearer t' },
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('GET /api/user/list returns 401 without Authorization', async () => {
+      const res = await fetch('/api/user/list');
+      expect(res.status).toBe(401);
+    });
+
+    it('PUT /api/user/update returns 200 on valid body', async () => {
+      const res = await fetch('/api/user/update', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ user_id: 1, user_role: 'Viewer' }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('PUT /api/user/update returns 403 on missing user_id', async () => {
+      const res = await fetch('/api/user/update', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('PUT /api/user/delete returns 200 on valid user_id', async () => {
+      const res = await fetch('/api/user/delete', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ user_id: 1 }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('PUT /api/user/delete returns 404 on sentinel 999', async () => {
+      const res = await fetch('/api/user/delete', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ user_id: 999 }),
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it('POST /api/user/bulk_approve returns 200 on non-empty user_ids', async () => {
+      const res = await fetch('/api/user/bulk_approve', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ user_ids: [1, 2] }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('POST /api/user/bulk_approve returns 400 on empty user_ids', async () => {
+      const res = await fetch('/api/user/bulk_approve', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ user_ids: [] }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('POST /api/user/bulk_assign_role returns 200 on valid body', async () => {
+      const res = await fetch('/api/user/bulk_assign_role', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ user_ids: [1, 2], user_role: 'Viewer' }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('POST /api/user/bulk_assign_role returns 400 on empty role', async () => {
+      const res = await fetch('/api/user/bulk_assign_role', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ user_ids: [1], user_role: '' }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('POST /api/user/bulk_delete returns 200 on non-empty user_ids', async () => {
+      const res = await fetch('/api/user/bulk_delete', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ user_ids: [1, 2] }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('POST /api/user/bulk_delete returns 400 on empty user_ids', async () => {
+      const res = await fetch('/api/user/bulk_delete', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ user_ids: [] }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('PUT /api/user/password/update returns 201 on valid body', async () => {
+      const res = await fetch('/api/user/password/update', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          user_id_pass_change: 1,
+          old_pass: 'OldPass1!',
+          new_pass_1: 'NewPass1!',
+          new_pass_2: 'NewPass1!',
+        }),
+      });
+      expect(res.status).toBe(201);
+    });
+
+    it('PUT /api/user/password/update returns 409 on mismatched new passwords', async () => {
+      const res = await fetch('/api/user/password/update', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          user_id_pass_change: 1,
+          old_pass: 'OldPass1!',
+          new_pass_1: 'NewPass1!',
+          new_pass_2: 'Different!',
+        }),
+      });
+      expect(res.status).toBe(409);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Review workflow
+  // ---------------------------------------------------------------------------
+
+  describe('review workflow', () => {
+    it('GET /api/review/:id returns 200 for valid id', async () => {
+      const res = await fetch('/api/review/101');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.review_id).toBe(101);
+    });
+
+    it('GET /api/review/:id returns 404 for sentinel 999', async () => {
+      const res = await fetch('/api/review/999');
+      expect(res.status).toBe(404);
+    });
+
+    it('GET /api/review/:id/phenotypes returns 200 for valid id', async () => {
+      const res = await fetch('/api/review/101/phenotypes');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(Array.isArray(body)).toBe(true);
+    });
+
+    it('GET /api/review/:id/phenotypes returns 404 for sentinel 999', async () => {
+      const res = await fetch('/api/review/999/phenotypes');
+      expect(res.status).toBe(404);
+    });
+
+    it('GET /api/review/:id/variation returns 200 for valid id', async () => {
+      const res = await fetch('/api/review/101/variation');
+      expect(res.status).toBe(200);
+    });
+
+    it('GET /api/review/:id/variation returns 404 for sentinel 999', async () => {
+      const res = await fetch('/api/review/999/variation');
+      expect(res.status).toBe(404);
+    });
+
+    it('GET /api/review/:id/publications returns 200 for valid id', async () => {
+      const res = await fetch('/api/review/101/publications');
+      expect(res.status).toBe(200);
+    });
+
+    it('GET /api/review/:id/publications returns 404 for sentinel 999', async () => {
+      const res = await fetch('/api/review/999/publications');
+      expect(res.status).toBe(404);
+    });
+
+    it('POST /api/review/create returns 201 on valid body', async () => {
+      const res = await fetch('/api/review/create', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ entity_id: 501, synopsis: 'ok' }),
+      });
+      expect(res.status).toBe(201);
+    });
+
+    it('POST /api/review/create returns 400 on missing entity_id', async () => {
+      const res = await fetch('/api/review/create', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ synopsis: 'ok' }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('PUT /api/review/update returns 200 on valid body', async () => {
+      const res = await fetch('/api/review/update', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ review_id: 101, synopsis: 'ok' }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('PUT /api/review/update returns 400 on missing review_id', async () => {
+      const res = await fetch('/api/review/update', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ synopsis: 'ok' }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('PUT /api/review/approve/:id returns 200 for valid id', async () => {
+      const res = await fetch('/api/review/approve/101', { method: 'PUT' });
+      expect(res.status).toBe(200);
+    });
+
+    it('PUT /api/review/approve/:id returns 404 for sentinel 999', async () => {
+      const res = await fetch('/api/review/approve/999', { method: 'PUT' });
+      expect(res.status).toBe(404);
+    });
+
+    it('PUT /api/review/approve/all returns 200 for admin', async () => {
+      const res = await fetch('/api/review/approve/all', {
+        method: 'PUT',
+        headers: { 'x-user-role': 'Administrator' },
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('PUT /api/review/approve/all returns 403 for Viewer', async () => {
+      const res = await fetch('/api/review/approve/all', {
+        method: 'PUT',
+        headers: { 'x-user-role': 'Viewer' },
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Status workflow
+  // ---------------------------------------------------------------------------
+
+  describe('status workflow', () => {
+    it('GET /api/status/:id returns 200 for valid id', async () => {
+      const res = await fetch('/api/status/201');
+      expect(res.status).toBe(200);
+    });
+
+    it('GET /api/status/:id returns 404 for sentinel 999', async () => {
+      const res = await fetch('/api/status/999');
+      expect(res.status).toBe(404);
+    });
+
+    it('POST /api/status/create returns 201 on valid body', async () => {
+      const res = await fetch('/api/status/create', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ entity_id: 501, category_id: 1 }),
+      });
+      expect(res.status).toBe(201);
+    });
+
+    it('POST /api/status/create returns 400 on missing category_id', async () => {
+      const res = await fetch('/api/status/create', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ entity_id: 501 }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('PUT /api/status/update returns 200 on valid body', async () => {
+      const res = await fetch('/api/status/update', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ status_id: 201, category_id: 2 }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('PUT /api/status/update returns 400 on missing status_id', async () => {
+      const res = await fetch('/api/status/update', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ category_id: 2 }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('PUT /api/status/approve/:id returns 200 for valid id', async () => {
+      const res = await fetch('/api/status/approve/201', { method: 'PUT' });
+      expect(res.status).toBe(200);
+    });
+
+    it('PUT /api/status/approve/:id returns 404 for sentinel 999', async () => {
+      const res = await fetch('/api/status/approve/999', { method: 'PUT' });
+      expect(res.status).toBe(404);
+    });
+
+    it('PUT /api/status/approve/all returns 200 for admin', async () => {
+      const res = await fetch('/api/status/approve/all', {
+        method: 'PUT',
+        headers: { 'x-user-role': 'Administrator' },
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('PUT /api/status/approve/all returns 403 for Viewer', async () => {
+      const res = await fetch('/api/status/approve/all', {
+        method: 'PUT',
+        headers: { 'x-user-role': 'Viewer' },
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Entity curation
+  // ---------------------------------------------------------------------------
+
+  describe('entity curation', () => {
+    it('GET /api/entity/:sysndd_id returns 200 for valid id', async () => {
+      const res = await fetch('/api/entity/501');
+      expect(res.status).toBe(200);
+    });
+
+    it('GET /api/entity/:sysndd_id returns 404 for sentinel 999', async () => {
+      const res = await fetch('/api/entity/999');
+      expect(res.status).toBe(404);
+    });
+
+    it('POST /api/entity/create returns 201 on valid body', async () => {
+      const res = await fetch('/api/entity/create', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          hgnc_id: 'HGNC:12345',
+          disease_ontology_id_version: 'MONDO:0000123_2025-01-01',
+        }),
+      });
+      expect(res.status).toBe(201);
+    });
+
+    it('POST /api/entity/create returns 400 on missing hgnc_id', async () => {
+      const res = await fetch('/api/entity/create', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ disease_ontology_id_version: 'MONDO:0000123_2025-01-01' }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('POST /api/entity/rename returns 200 on valid body', async () => {
+      const res = await fetch('/api/entity/rename', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ sysndd_id: 501, new_symbol: 'TEST2' }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('POST /api/entity/rename returns 400 on missing new_symbol', async () => {
+      const res = await fetch('/api/entity/rename', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ sysndd_id: 501 }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('POST /api/entity/deactivate returns 200 on valid body', async () => {
+      const res = await fetch('/api/entity/deactivate', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ sysndd_id: 501 }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('POST /api/entity/deactivate returns 400 on missing sysndd_id', async () => {
+      const res = await fetch('/api/entity/deactivate', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('GET /api/entity/:sysndd_id/review returns 200 for valid id', async () => {
+      const res = await fetch('/api/entity/501/review');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(Array.isArray(body)).toBe(true);
+    });
+
+    it('GET /api/entity/:sysndd_id/review returns 404 for sentinel 999', async () => {
+      const res = await fetch('/api/entity/999/review');
+      expect(res.status).toBe(404);
+    });
+
+    it('GET /api/entity/:sysndd_id/status returns 200 for valid id', async () => {
+      const res = await fetch('/api/entity/501/status');
+      expect(res.status).toBe(200);
+    });
+
+    it('GET /api/entity/:sysndd_id/status returns 404 for sentinel 999', async () => {
+      const res = await fetch('/api/entity/999/status');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Annotation jobs
+  // ---------------------------------------------------------------------------
+
+  describe('annotation jobs', () => {
+    it('GET /api/jobs/history returns 200 for admin', async () => {
+      const res = await fetch('/api/jobs/history', {
+        headers: { 'x-user-role': 'Administrator' },
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data).toBeInstanceOf(Array);
+    });
+
+    it('GET /api/jobs/history returns 403 for Viewer', async () => {
+      const res = await fetch('/api/jobs/history', {
+        headers: { 'x-user-role': 'Viewer' },
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('GET /api/jobs/:job_id/status returns 200 for valid job_id', async () => {
+      const res = await fetch('/api/jobs/hgnc-update-2025-06-01/status');
+      expect(res.status).toBe(200);
+    });
+
+    it('GET /api/jobs/:job_id/status returns 404 for missing-job sentinel', async () => {
+      const res = await fetch('/api/jobs/missing-job/status');
+      expect(res.status).toBe(404);
+    });
+
+    it('POST /api/jobs/hgnc_update/submit returns 202 for admin', async () => {
+      const res = await fetch('/api/jobs/hgnc_update/submit', {
+        method: 'POST',
+        headers: { 'x-user-role': 'Administrator' },
+      });
+      expect(res.status).toBe(202);
+    });
+
+    it('POST /api/jobs/hgnc_update/submit returns 403 for Viewer', async () => {
+      const res = await fetch('/api/jobs/hgnc_update/submit', {
+        method: 'POST',
+        headers: { 'x-user-role': 'Viewer' },
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('POST /api/jobs/ontology_update/submit returns 202 for admin', async () => {
+      const res = await fetch('/api/jobs/ontology_update/submit', {
+        method: 'POST',
+        headers: { 'x-user-role': 'Administrator' },
+      });
+      expect(res.status).toBe(202);
+    });
+
+    it('POST /api/jobs/ontology_update/submit returns 403 for Viewer', async () => {
+      const res = await fetch('/api/jobs/ontology_update/submit', {
+        method: 'POST',
+        headers: { 'x-user-role': 'Viewer' },
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('POST /api/jobs/comparisons_update/submit returns 202 for admin', async () => {
+      const res = await fetch('/api/jobs/comparisons_update/submit', {
+        method: 'POST',
+        headers: { 'x-user-role': 'Administrator' },
+      });
+      expect(res.status).toBe(202);
+    });
+
+    it('POST /api/jobs/comparisons_update/submit returns 403 for Viewer', async () => {
+      const res = await fetch('/api/jobs/comparisons_update/submit', {
+        method: 'POST',
+        headers: { 'x-user-role': 'Viewer' },
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it('POST /api/jobs/clustering/submit returns 202 with algorithm', async () => {
+      const res = await fetch('/api/jobs/clustering/submit', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ algorithm: 'louvain' }),
+      });
+      expect(res.status).toBe(202);
+    });
+
+    it('POST /api/jobs/clustering/submit returns 400 without algorithm', async () => {
+      const res = await fetch('/api/jobs/clustering/submit', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('POST /api/jobs/phenotype_clustering/submit returns 202 with algorithm', async () => {
+      const res = await fetch('/api/jobs/phenotype_clustering/submit', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ algorithm: 'kmeans' }),
+      });
+      expect(res.status).toBe(202);
+    });
+
+    it('POST /api/jobs/phenotype_clustering/submit returns 400 without algorithm', async () => {
+      const res = await fetch('/api/jobs/phenotype_clustering/submit', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/app/src/test-utils/mocks/handlers.ts
+++ b/app/src/test-utils/mocks/handlers.ts
@@ -2,8 +2,26 @@
 /**
  * MSW request handlers for API mocking in tests.
  *
- * These handlers intercept HTTP requests and return mock responses.
- * Add handlers for API endpoints your tests need.
+ * Phase B.B1 (v11.0): handler set expanded to cover the locked table for every
+ * real axios call site in the six top curate/admin views — see
+ * `.plans/v11.0/phase-b.md` §3 Phase B.B1.  Each handler is documented with the
+ * OpenAPI path it mirrors (§4.3) so the static verifier
+ * (`scripts/verify-msw-against-openapi.sh`) can cross-reference the handler
+ * against `api/endpoints/*.R` annotations.
+ *
+ * 2xx / 4xx selection: each handler returns its declared 2xx happy-path shape
+ * by default and branches to a 4xx shape when the request carries a
+ * distinguishable error trigger (a sentinel path param, query, or request-body
+ * field — e.g. `id === '999'`, `?trigger_error=1`, or `{ user_name: '' }`).
+ * Tests that want the error branch can either hit the sentinel shape directly
+ * or call `server.use(...)` to install a per-test override.
+ *
+ * Adding a new handler?  Follow the same pattern:
+ *   1. Add the fixture to `data/<family>.ts` (≤300 LoC per file).
+ *   2. Add the handler here with a `// OpenAPI: <METHOD> /api/<path>` comment.
+ *   3. Add a smoke test to `handlers.spec.ts` covering 2xx and 4xx.
+ *   4. Run `scripts/verify-msw-against-openapi.sh` to confirm the underlying
+ *      plumber annotation exists in `api/endpoints/*.R`.
  *
  * @example
  * // In a test file, override a handler:
@@ -12,7 +30,7 @@
  *
  * it('handles error response', async () => {
  *   server.use(
- *     http.get('/api/genes/:id', () => {
+ *     http.get('/api/entity/:id', () => {
  *       return HttpResponse.json({ error: 'Not found' }, { status: 404 });
  *     })
  *   );
@@ -22,66 +40,527 @@
 
 import { http, HttpResponse } from 'msw';
 
+import {
+  signinOk,
+  signinUnauthorized,
+  authenticateTokenOk,
+  authenticateBadRequest,
+  authenticateUnauthorized,
+  refreshTokenOk,
+  refreshTokenUnauthorized,
+} from './data/auth';
+import {
+  userTableOk,
+  userListOk,
+  userRoleListOk,
+  userUpdateOk,
+  userUpdateForbidden,
+  userDeleteOk,
+  userDeleteNotFound,
+  bulkApproveOk,
+  bulkApproveBadRequest,
+  bulkAssignRoleOk,
+  bulkAssignRoleBadRequest,
+  bulkDeleteOk,
+  bulkDeleteBadRequest,
+  passwordUpdateOk,
+  passwordUpdateConflict,
+} from './data/users';
+import {
+  reviewByIdOk,
+  reviewByIdNotFound,
+  reviewPhenotypesOk,
+  reviewPhenotypesNotFound,
+  reviewVariationOk,
+  reviewVariationNotFound,
+  reviewPublicationsOk,
+  reviewPublicationsNotFound,
+  reviewCreateOk,
+  reviewCreateBadRequest,
+  reviewUpdateOk,
+  reviewUpdateBadRequest,
+  reviewApproveByIdOk,
+  reviewApproveByIdNotFound,
+  reviewApproveAllOk,
+  reviewApproveAllForbidden,
+} from './data/reviews';
+import {
+  statusByIdOk,
+  statusByIdNotFound,
+  statusCreateOk,
+  statusCreateBadRequest,
+  statusUpdateOk,
+  statusUpdateBadRequest,
+  statusApproveByIdOk,
+  statusApproveByIdNotFound,
+  statusApproveAllOk,
+  statusApproveAllForbidden,
+} from './data/statuses';
+import {
+  entityByIdOk,
+  entityByIdNotFound,
+  entityCreateOk,
+  entityCreateBadRequest,
+  entityRenameOk,
+  entityRenameBadRequest,
+  entityDeactivateOk,
+  entityDeactivateBadRequest,
+  entityReviewListOk,
+  entityReviewListNotFound,
+  entityStatusListOk,
+  entityStatusListNotFound,
+} from './data/entities';
+import {
+  jobsHistoryOk,
+  jobsHistoryForbidden,
+  jobStatusOk,
+  jobStatusNotFound,
+  hgncUpdateSubmitOk,
+  hgncUpdateSubmitForbidden,
+  ontologyUpdateSubmitOk,
+  ontologyUpdateSubmitForbidden,
+  comparisonsUpdateSubmitOk,
+  comparisonsUpdateSubmitForbidden,
+  clusteringSubmitOk,
+  clusteringSubmitBadRequest,
+  phenotypeClusteringSubmitOk,
+  phenotypeClusteringSubmitBadRequest,
+} from './data/jobs';
+
 /**
- * Default handlers for common API endpoints
+ * Parse a JSON body from a request, returning an empty object on failure.
+ * Handlers can then probe fields (e.g. `body.user_name`) for 4xx triggers
+ * without worrying about parse errors.
+ */
+const readJsonBody = async (request: Request): Promise<Record<string, unknown>> => {
+  try {
+    const parsed = await request.clone().json();
+    if (parsed && typeof parsed === 'object') {
+      return parsed as Record<string, unknown>;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+};
+
+/**
+ * Default handlers for the curate/admin view axios call sites (Phase B.B1).
  */
 export const handlers = [
-  // Auth endpoint - used by Navbar component
-  http.get('/api/auth/signin', () => {
-    return HttpResponse.json({
-      user_name: ['test_user'],
-      user_role: ['Viewer'],
-    });
+  // ---------------------------------------------------------------------------
+  // Auth (post Phase A1 shapes)
+  // ---------------------------------------------------------------------------
+
+  // OpenAPI: POST /api/auth/authenticate
+  // api/endpoints/authentication_endpoints.R @post authenticate
+  // Body: { user_name: string, password: string }  (A1: JSON body, not query)
+  http.post('/api/auth/authenticate', async ({ request }) => {
+    const body = await readJsonBody(request);
+    const userName = typeof body.user_name === 'string' ? body.user_name : '';
+    const password = typeof body.password === 'string' ? body.password : '';
+
+    if (userName.length < 5 || userName.length > 20 || password.length < 5 || password.length > 50) {
+      return HttpResponse.text(authenticateBadRequest, { status: 400 });
+    }
+    if (userName === 'wrong_user' || password === 'wrong_pass') {
+      return HttpResponse.text(authenticateUnauthorized, { status: 401 });
+    }
+    return HttpResponse.json(authenticateTokenOk);
   }),
 
-  // Gene endpoint example
-  http.get('/api/genes/:symbol', ({ params }) => {
-    const { symbol } = params;
-    return HttpResponse.json({
-      symbol,
-      hgnc_id: 12345,
-      name: `Test Gene ${symbol}`,
-      entities: [],
-    });
+  // OpenAPI: GET /api/auth/refresh
+  // api/endpoints/authentication_endpoints.R @get refresh
+  http.get('/api/auth/refresh', ({ request }) => {
+    if (!request.headers.get('authorization')) {
+      return HttpResponse.json(refreshTokenUnauthorized, { status: 401 });
+    }
+    return HttpResponse.json(refreshTokenOk);
   }),
 
-  // Entity endpoint example
-  http.get('/api/entity/:id', ({ params }) => {
-    const { id } = params;
-    return HttpResponse.json({
-      entity_id: id,
-      symbol: 'TEST1',
-      disease_ontology_id: 'OMIM:123456',
-      category_id: 1,
-    });
+  // OpenAPI: GET /api/auth/signin
+  // api/endpoints/authentication_endpoints.R @get signin
+  http.get('/api/auth/signin', ({ request }) => {
+    if (!request.headers.get('authorization')) {
+      return HttpResponse.json(signinUnauthorized, { status: 401 });
+    }
+    return HttpResponse.json(signinOk);
   }),
 
-  // Search endpoint example
-  http.get('/api/search', ({ request }) => {
+  // ---------------------------------------------------------------------------
+  // User admin  (ManageUser.vue)
+  // ---------------------------------------------------------------------------
+
+  // OpenAPI: GET /api/user/table
+  // api/endpoints/user_endpoints.R @get table
+  http.get('/api/user/table', ({ request }) => {
     const url = new URL(request.url);
-    const query = url.searchParams.get('query') || '';
-    return HttpResponse.json({
-      results: [
-        { type: 'gene', symbol: 'TEST1', match: query },
-        { type: 'disease', name: 'Test Disease', match: query },
-      ],
-      total: 2,
-    });
+    if (url.searchParams.get('trigger_error') === '1') {
+      return HttpResponse.json({ error: 'Invalid table query.' }, { status: 400 });
+    }
+    return HttpResponse.json(userTableOk);
   }),
 
-  // Internet Archive endpoint (used by HelperBadge)
-  http.get('/api/external/internet_archive', () => {
-    return HttpResponse.json({
-      job_id: 'test-job-123',
-      status: 'pending',
-    });
+  // OpenAPI: GET /api/user/role_list
+  // api/endpoints/user_endpoints.R @get role_list
+  http.get('/api/user/role_list', ({ request }) => {
+    if (!request.headers.get('authorization')) {
+      return HttpResponse.json({ error: 'Not authorised.' }, { status: 401 });
+    }
+    return HttpResponse.json(userRoleListOk);
   }),
 
-  // Generic error handler for unhandled requests during development
-  // Remove or modify this in production tests
-  http.get('/api/*', ({ request }) => {
-    console.warn(`Unhandled API request: ${request.url}`);
-    return HttpResponse.json({ error: 'Not mocked', url: request.url }, { status: 500 });
+  // OpenAPI: GET /api/user/list
+  // api/endpoints/user_endpoints.R @get list
+  http.get('/api/user/list', ({ request }) => {
+    if (!request.headers.get('authorization')) {
+      return HttpResponse.json({ error: 'Not authorised.' }, { status: 401 });
+    }
+    return HttpResponse.json(userListOk);
+  }),
+
+  // OpenAPI: PUT /api/user/update
+  // api/endpoints/user_endpoints.R @put update
+  // Body: { user_id: number, ... }
+  http.put('/api/user/update', async ({ request }) => {
+    const body = await readJsonBody(request);
+    if (!body.user_id || body.user_id === 0) {
+      return HttpResponse.json(userUpdateForbidden, { status: 403 });
+    }
+    return HttpResponse.json(userUpdateOk);
+  }),
+
+  // OpenAPI: PUT /api/user/delete  (SPEC BUG — real annotation is @delete delete;
+  //                                 see scripts/msw-openapi-exceptions.txt)
+  // api/endpoints/user_endpoints.R @delete delete (at line 773)
+  http.put('/api/user/delete', async ({ request }) => {
+    const body = await readJsonBody(request);
+    if (!body.user_id || body.user_id === 999) {
+      return HttpResponse.json(userDeleteNotFound, { status: 404 });
+    }
+    return HttpResponse.json(userDeleteOk);
+  }),
+
+  // OpenAPI: POST /api/user/bulk_approve
+  // api/endpoints/user_endpoints.R @post bulk_approve
+  // Body: { user_ids: number[] }
+  http.post('/api/user/bulk_approve', async ({ request }) => {
+    const body = await readJsonBody(request);
+    const ids = Array.isArray(body.user_ids) ? body.user_ids : [];
+    if (ids.length === 0) {
+      return HttpResponse.json(bulkApproveBadRequest, { status: 400 });
+    }
+    return HttpResponse.json(bulkApproveOk);
+  }),
+
+  // OpenAPI: POST /api/user/bulk_assign_role
+  // api/endpoints/user_endpoints.R @post bulk_assign_role
+  // Body: { user_ids: number[], user_role: string }
+  http.post('/api/user/bulk_assign_role', async ({ request }) => {
+    const body = await readJsonBody(request);
+    const ids = Array.isArray(body.user_ids) ? body.user_ids : [];
+    const role = typeof body.user_role === 'string' ? body.user_role : '';
+    if (ids.length === 0 || role === '') {
+      return HttpResponse.json(bulkAssignRoleBadRequest, { status: 400 });
+    }
+    return HttpResponse.json(bulkAssignRoleOk);
+  }),
+
+  // OpenAPI: POST /api/user/bulk_delete
+  // api/endpoints/user_endpoints.R @post bulk_delete
+  // Body: { user_ids: number[] }
+  http.post('/api/user/bulk_delete', async ({ request }) => {
+    const body = await readJsonBody(request);
+    const ids = Array.isArray(body.user_ids) ? body.user_ids : [];
+    if (ids.length === 0) {
+      return HttpResponse.json(bulkDeleteBadRequest, { status: 400 });
+    }
+    return HttpResponse.json(bulkDeleteOk);
+  }),
+
+  // OpenAPI: PUT /api/user/password/update
+  // api/endpoints/user_endpoints.R @put password/update  (Phase A1 body shape)
+  // Body: { user_id_pass_change: number, old_pass: string,
+  //         new_pass_1: string, new_pass_2: string }
+  http.put('/api/user/password/update', async ({ request }) => {
+    const body = await readJsonBody(request);
+    const id = typeof body.user_id_pass_change === 'number' ? body.user_id_pass_change : 0;
+    const oldPass = typeof body.old_pass === 'string' ? body.old_pass : '';
+    const newPass1 = typeof body.new_pass_1 === 'string' ? body.new_pass_1 : '';
+    const newPass2 = typeof body.new_pass_2 === 'string' ? body.new_pass_2 : '';
+
+    if (id === 0 || oldPass === '' || newPass1 === '' || newPass1 !== newPass2) {
+      return HttpResponse.json(passwordUpdateConflict, { status: 409 });
+    }
+    return HttpResponse.json(passwordUpdateOk, { status: 201 });
+  }),
+
+  // ---------------------------------------------------------------------------
+  // Review workflow  (ApproveReview.vue, Review.vue)
+  // ---------------------------------------------------------------------------
+
+  // OpenAPI: GET /api/review/:id
+  // api/endpoints/review_endpoints.R @get /<review_id_requested>
+  http.get('/api/review/:id', ({ params }) => {
+    if (params.id === '999') {
+      return HttpResponse.json(reviewByIdNotFound, { status: 404 });
+    }
+    return HttpResponse.json(reviewByIdOk);
+  }),
+
+  // OpenAPI: GET /api/review/:id/phenotypes
+  // api/endpoints/review_endpoints.R @get /<review_id_requested>/phenotypes
+  http.get('/api/review/:id/phenotypes', ({ params }) => {
+    if (params.id === '999') {
+      return HttpResponse.json(reviewPhenotypesNotFound, { status: 404 });
+    }
+    return HttpResponse.json(reviewPhenotypesOk);
+  }),
+
+  // OpenAPI: GET /api/review/:id/variation
+  // api/endpoints/review_endpoints.R @get /<review_id_requested>/variation
+  http.get('/api/review/:id/variation', ({ params }) => {
+    if (params.id === '999') {
+      return HttpResponse.json(reviewVariationNotFound, { status: 404 });
+    }
+    return HttpResponse.json(reviewVariationOk);
+  }),
+
+  // OpenAPI: GET /api/review/:id/publications
+  // api/endpoints/review_endpoints.R @get /<review_id_requested>/publications
+  http.get('/api/review/:id/publications', ({ params }) => {
+    if (params.id === '999') {
+      return HttpResponse.json(reviewPublicationsNotFound, { status: 404 });
+    }
+    return HttpResponse.json(reviewPublicationsOk);
+  }),
+
+  // OpenAPI: POST /api/review/create
+  // api/endpoints/review_endpoints.R @post /create
+  http.post('/api/review/create', async ({ request }) => {
+    const body = await readJsonBody(request);
+    if (!body.entity_id || !body.synopsis) {
+      return HttpResponse.json(reviewCreateBadRequest, { status: 400 });
+    }
+    return HttpResponse.json(reviewCreateOk, { status: 201 });
+  }),
+
+  // OpenAPI: PUT /api/review/update
+  // api/endpoints/review_endpoints.R @put /update
+  http.put('/api/review/update', async ({ request }) => {
+    const body = await readJsonBody(request);
+    if (!body.review_id) {
+      return HttpResponse.json(reviewUpdateBadRequest, { status: 400 });
+    }
+    return HttpResponse.json(reviewUpdateOk);
+  }),
+
+  // OpenAPI: PUT /api/review/approve/all  (SPEC BUG — no bulk approve endpoint
+  //                                        exists in review_endpoints.R; see
+  //                                        scripts/msw-openapi-exceptions.txt)
+  // Registered BEFORE `/approve/:id` so the literal match wins over the
+  // parameterised one in MSW's first-match-wins ordering.
+  http.put('/api/review/approve/all', ({ request }) => {
+    if (request.headers.get('x-user-role') === 'Viewer') {
+      return HttpResponse.json(reviewApproveAllForbidden, { status: 403 });
+    }
+    return HttpResponse.json(reviewApproveAllOk);
+  }),
+
+  // OpenAPI: PUT /api/review/approve/:id
+  // api/endpoints/review_endpoints.R @put /approve/<review_id_requested>
+  http.put('/api/review/approve/:id', ({ params }) => {
+    if (params.id === '999') {
+      return HttpResponse.json(reviewApproveByIdNotFound, { status: 404 });
+    }
+    return HttpResponse.json(reviewApproveByIdOk);
+  }),
+
+  // ---------------------------------------------------------------------------
+  // Status workflow  (ApproveStatus.vue, ApproveReview.vue)
+  // ---------------------------------------------------------------------------
+
+  // OpenAPI: GET /api/status/:id
+  // api/endpoints/status_endpoints.R @get /<status_id_requested>
+  http.get('/api/status/:id', ({ params }) => {
+    if (params.id === '999') {
+      return HttpResponse.json(statusByIdNotFound, { status: 404 });
+    }
+    return HttpResponse.json(statusByIdOk);
+  }),
+
+  // OpenAPI: POST /api/status/create
+  // api/endpoints/status_endpoints.R @post /create
+  http.post('/api/status/create', async ({ request }) => {
+    const body = await readJsonBody(request);
+    if (!body.entity_id || !body.category_id) {
+      return HttpResponse.json(statusCreateBadRequest, { status: 400 });
+    }
+    return HttpResponse.json(statusCreateOk, { status: 201 });
+  }),
+
+  // OpenAPI: PUT /api/status/update
+  // api/endpoints/status_endpoints.R @put /update
+  http.put('/api/status/update', async ({ request }) => {
+    const body = await readJsonBody(request);
+    if (!body.status_id) {
+      return HttpResponse.json(statusUpdateBadRequest, { status: 400 });
+    }
+    return HttpResponse.json(statusUpdateOk);
+  }),
+
+  // OpenAPI: PUT /api/status/approve/all  (SPEC BUG — no bulk approve endpoint
+  //                                        exists in status_endpoints.R; see
+  //                                        scripts/msw-openapi-exceptions.txt)
+  // Registered BEFORE `/approve/:id` so the literal match wins over the
+  // parameterised one in MSW's first-match-wins ordering.
+  http.put('/api/status/approve/all', ({ request }) => {
+    if (request.headers.get('x-user-role') === 'Viewer') {
+      return HttpResponse.json(statusApproveAllForbidden, { status: 403 });
+    }
+    return HttpResponse.json(statusApproveAllOk);
+  }),
+
+  // OpenAPI: PUT /api/status/approve/:id
+  // api/endpoints/status_endpoints.R @put /approve/<status_id_requested>
+  http.put('/api/status/approve/:id', ({ params }) => {
+    if (params.id === '999') {
+      return HttpResponse.json(statusApproveByIdNotFound, { status: 404 });
+    }
+    return HttpResponse.json(statusApproveByIdOk);
+  }),
+
+  // ---------------------------------------------------------------------------
+  // Entity curation  (ModifyEntity.vue, Review.vue)
+  // ---------------------------------------------------------------------------
+
+  // OpenAPI: GET /api/entity/:sysndd_id  (SPEC BUG — no bare @get /<sysndd_id>
+  //                                        annotation exists in
+  //                                        entity_endpoints.R; only `/` and
+  //                                        `/<sysndd_id>/<sub>`. See
+  //                                        scripts/msw-openapi-exceptions.txt)
+  http.get('/api/entity/:sysndd_id', ({ params }) => {
+    if (params.sysndd_id === '999') {
+      return HttpResponse.json(entityByIdNotFound, { status: 404 });
+    }
+    return HttpResponse.json(entityByIdOk);
+  }),
+
+  // OpenAPI: POST /api/entity/create
+  // api/endpoints/entity_endpoints.R @post /create
+  http.post('/api/entity/create', async ({ request }) => {
+    const body = await readJsonBody(request);
+    if (!body.hgnc_id || !body.disease_ontology_id_version) {
+      return HttpResponse.json(entityCreateBadRequest, { status: 400 });
+    }
+    return HttpResponse.json(entityCreateOk, { status: 201 });
+  }),
+
+  // OpenAPI: POST /api/entity/rename
+  // api/endpoints/entity_endpoints.R @post /rename
+  http.post('/api/entity/rename', async ({ request }) => {
+    const body = await readJsonBody(request);
+    if (!body.sysndd_id || !body.new_symbol) {
+      return HttpResponse.json(entityRenameBadRequest, { status: 400 });
+    }
+    return HttpResponse.json(entityRenameOk);
+  }),
+
+  // OpenAPI: POST /api/entity/deactivate
+  // api/endpoints/entity_endpoints.R @post /deactivate
+  http.post('/api/entity/deactivate', async ({ request }) => {
+    const body = await readJsonBody(request);
+    if (!body.sysndd_id) {
+      return HttpResponse.json(entityDeactivateBadRequest, { status: 400 });
+    }
+    return HttpResponse.json(entityDeactivateOk);
+  }),
+
+  // OpenAPI: GET /api/entity/:sysndd_id/review
+  // api/endpoints/entity_endpoints.R @get /<sysndd_id>/review
+  http.get('/api/entity/:sysndd_id/review', ({ params }) => {
+    if (params.sysndd_id === '999') {
+      return HttpResponse.json(entityReviewListNotFound, { status: 404 });
+    }
+    return HttpResponse.json(entityReviewListOk);
+  }),
+
+  // OpenAPI: GET /api/entity/:sysndd_id/status
+  // api/endpoints/entity_endpoints.R @get /<sysndd_id>/status
+  http.get('/api/entity/:sysndd_id/status', ({ params }) => {
+    if (params.sysndd_id === '999') {
+      return HttpResponse.json(entityStatusListNotFound, { status: 404 });
+    }
+    return HttpResponse.json(entityStatusListOk);
+  }),
+
+  // ---------------------------------------------------------------------------
+  // Annotation jobs  (ManageAnnotations.vue)
+  // ---------------------------------------------------------------------------
+
+  // OpenAPI: GET /api/jobs/history
+  // api/endpoints/jobs_endpoints.R @get /history
+  http.get('/api/jobs/history', ({ request }) => {
+    if (request.headers.get('x-user-role') === 'Viewer') {
+      return HttpResponse.json(jobsHistoryForbidden, { status: 403 });
+    }
+    return HttpResponse.json(jobsHistoryOk);
+  }),
+
+  // OpenAPI: GET /api/jobs/:job_id/status
+  // api/endpoints/jobs_endpoints.R @get /<job_id>/status
+  http.get('/api/jobs/:job_id/status', ({ params }) => {
+    if (params.job_id === 'missing-job') {
+      return HttpResponse.json(jobStatusNotFound, { status: 404 });
+    }
+    return HttpResponse.json(jobStatusOk);
+  }),
+
+  // OpenAPI: POST /api/jobs/hgnc_update/submit
+  // api/endpoints/jobs_endpoints.R @post /hgnc_update/submit
+  http.post('/api/jobs/hgnc_update/submit', ({ request }) => {
+    if (request.headers.get('x-user-role') === 'Viewer') {
+      return HttpResponse.json(hgncUpdateSubmitForbidden, { status: 403 });
+    }
+    return HttpResponse.json(hgncUpdateSubmitOk, { status: 202 });
+  }),
+
+  // OpenAPI: POST /api/jobs/ontology_update/submit
+  // api/endpoints/jobs_endpoints.R @post /ontology_update/submit
+  http.post('/api/jobs/ontology_update/submit', ({ request }) => {
+    if (request.headers.get('x-user-role') === 'Viewer') {
+      return HttpResponse.json(ontologyUpdateSubmitForbidden, { status: 403 });
+    }
+    return HttpResponse.json(ontologyUpdateSubmitOk, { status: 202 });
+  }),
+
+  // OpenAPI: POST /api/jobs/comparisons_update/submit
+  // api/endpoints/jobs_endpoints.R @post /comparisons_update/submit
+  http.post('/api/jobs/comparisons_update/submit', ({ request }) => {
+    if (request.headers.get('x-user-role') === 'Viewer') {
+      return HttpResponse.json(comparisonsUpdateSubmitForbidden, { status: 403 });
+    }
+    return HttpResponse.json(comparisonsUpdateSubmitOk, { status: 202 });
+  }),
+
+  // OpenAPI: POST /api/jobs/clustering/submit
+  // api/endpoints/jobs_endpoints.R @post /clustering/submit
+  http.post('/api/jobs/clustering/submit', async ({ request }) => {
+    const body = await readJsonBody(request);
+    if (!body.algorithm) {
+      return HttpResponse.json(clusteringSubmitBadRequest, { status: 400 });
+    }
+    return HttpResponse.json(clusteringSubmitOk, { status: 202 });
+  }),
+
+  // OpenAPI: POST /api/jobs/phenotype_clustering/submit
+  // api/endpoints/jobs_endpoints.R @post /phenotype_clustering/submit
+  http.post('/api/jobs/phenotype_clustering/submit', async ({ request }) => {
+    const body = await readJsonBody(request);
+    if (!body.algorithm) {
+      return HttpResponse.json(phenotypeClusteringSubmitBadRequest, { status: 400 });
+    }
+    return HttpResponse.json(phenotypeClusteringSubmitOk, { status: 202 });
   }),
 ];
 

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -28,11 +28,13 @@ export default mergeConfig(
           '**/test-utils/**',
           '**/types/**',
         ],
+        // Phase B.B1 bumped these from 40 → 45 in line with §3 Phase B.B1.
+        // Phase C will bump them again once the view-level spec suite lands.
         thresholds: {
-          lines: 40,
-          functions: 40,
-          branches: 40,
-          statements: 40,
+          lines: 45,
+          functions: 45,
+          branches: 45,
+          statements: 45,
         },
       },
     },

--- a/app/vitest.setup.ts
+++ b/app/vitest.setup.ts
@@ -56,9 +56,14 @@ Object.defineProperty(window, 'localStorage', { value: localStorageMock });
 
 import { server } from './src/test-utils/mocks/server';
 
-// Start MSW server before all tests
+// Start MSW server before all tests.
+// Phase B.B1: `onUnhandledRequest: 'error'` — any spec that reaches an
+// un-mocked API path fails loudly instead of silently hitting the real
+// network. If a new spec needs a handler that isn't in
+// src/test-utils/mocks/handlers.ts, add it there first (with a 2xx + 4xx
+// branch and an OpenAPI path comment); do not weaken this back to 'warn'.
 beforeAll(() => {
-  server.listen({ onUnhandledRequest: 'warn' });
+  server.listen({ onUnhandledRequest: 'error' });
 });
 
 // =============================================================================

--- a/scripts/msw-openapi-exceptions.txt
+++ b/scripts/msw-openapi-exceptions.txt
@@ -1,0 +1,36 @@
+# scripts/msw-openapi-exceptions.txt
+#
+# Phase B.B1 allow-list for MSW handlers whose path+method pair is listed in
+# the locked Phase B.B1 handler table (.plans/v11.0/phase-b.md §3 Phase B.B1)
+# but does NOT have a matching @get/@post/@put/@delete annotation in the
+# corresponding api/endpoints/*.R file.
+#
+# Each line is: METHOD /api/<path>#reason
+# Lines starting with `#` are comments. Case-sensitive on the METHOD.
+#
+# The table in §3 Phase B.B1 is marked "DO NOT REOPEN" in the spec — these
+# drifts are deliberate, documented spec bugs carried forward so downstream
+# view-level specs can still mount against the mock shape they expect. The
+# underlying R endpoint must be added or the locked table must be re-opened
+# in a later phase before this allow-list can shrink.
+#
+# ---------------------------------------------------------------------------
+# Current exceptions (4 entries):
+# ---------------------------------------------------------------------------
+
+# Spec table says PUT /api/user/delete; real annotation is @delete delete
+# (api/endpoints/user_endpoints.R:773). Drift: HTTP method.
+PUT /api/user/delete#spec bug: real endpoint is DELETE, not PUT (user_endpoints.R:773)
+
+# Spec table says PUT /api/review/approve/all; no bulk approve endpoint
+# exists in api/endpoints/review_endpoints.R. Only PUT /approve/<id>.
+PUT /api/review/approve/all#spec bug: no bulk-approve annotation in review_endpoints.R
+
+# Spec table says PUT /api/status/approve/all; no bulk approve endpoint
+# exists in api/endpoints/status_endpoints.R. Only PUT /approve/<id>.
+PUT /api/status/approve/all#spec bug: no bulk-approve annotation in status_endpoints.R
+
+# Spec table says GET /api/entity/<sysndd_id>; entity_endpoints.R defines only
+# @get / (list) and @get /<sysndd_id>/<sub> paths. There is no bare
+# @get /<sysndd_id> annotation on master.
+GET /api/entity/:sysndd_id#spec bug: no bare @get /<sysndd_id> annotation in entity_endpoints.R

--- a/scripts/verify-msw-against-openapi.sh
+++ b/scripts/verify-msw-against-openapi.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+#
+# scripts/verify-msw-against-openapi.sh
+#
+# Phase B.B1 (v11.0): statically verifies that every MSW handler in
+# app/src/test-utils/mocks/handlers.ts targets a real plumber annotation
+# (@get/@post/@put/@delete) in the corresponding api/endpoints/*.R file.
+#
+# Fails loudly when a handler drifts away from the real API. Pair this with
+# `onUnhandledRequest: 'error'` in vitest.setup.ts — together they give us
+# "MSW is always a faithful mirror of the live API". If you intentionally
+# mock an endpoint the R API does not expose (e.g. the handler table in
+# .plans/v11.0/phase-b.md lists it as a known spec bug), add an explicit
+# entry to scripts/msw-openapi-exceptions.txt.
+#
+# Usage:
+#   scripts/verify-msw-against-openapi.sh [--help]
+#
+# Wired into: `make lint-app` via the root Makefile.
+#
+# Exit codes:
+#   0 — every handler maps to a real plumber annotation (or to an exception)
+#   1 — at least one handler drifted and is not in the exception file
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+HANDLERS_FILE="${REPO_ROOT}/app/src/test-utils/mocks/handlers.ts"
+ENDPOINTS_DIR="${REPO_ROOT}/api/endpoints"
+EXCEPTIONS_FILE="${SCRIPT_DIR}/msw-openapi-exceptions.txt"
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  sed -n '3,30p' "$0"
+  exit 0
+fi
+
+if [[ ! -f "${HANDLERS_FILE}" ]]; then
+  echo "verify-msw-against-openapi: handlers.ts not found at ${HANDLERS_FILE}" >&2
+  exit 1
+fi
+
+if [[ ! -d "${ENDPOINTS_DIR}" ]]; then
+  echo "verify-msw-against-openapi: endpoints dir not found at ${ENDPOINTS_DIR}" >&2
+  exit 1
+fi
+
+# Mount-point → endpoint file map (from api/start_sysndd_api.R pr_mount calls).
+# Longest prefixes first so `/api/auth` wins over any shorter match.
+declare -a MOUNTS=(
+  "/api/statistics:statistics_endpoints.R"
+  "/api/comparisons:comparisons_endpoints.R"
+  "/api/publication:publication_endpoints.R"
+  "/api/phenotype:phenotype_endpoints.R"
+  "/api/re_review:re_review_endpoints.R"
+  "/api/external:external_endpoints.R"
+  "/api/ontology:ontology_endpoints.R"
+  "/api/analysis:analysis_endpoints.R"
+  "/api/version:version_endpoints.R"
+  "/api/logging:logging_endpoints.R"
+  "/api/variant:variant_endpoints.R"
+  "/api/backup:backup_endpoints.R"
+  "/api/search:search_endpoints.R"
+  "/api/health:health_endpoints.R"
+  "/api/entity:entity_endpoints.R"
+  "/api/review:review_endpoints.R"
+  "/api/status:status_endpoints.R"
+  "/api/panels:panels_endpoints.R"
+  "/api/admin:admin_endpoints.R"
+  "/api/about:about_endpoints.R"
+  "/api/gene:gene_endpoints.R"
+  "/api/jobs:jobs_endpoints.R"
+  "/api/hash:hash_endpoints.R"
+  "/api/logs:logging_endpoints.R"
+  "/api/list:list_endpoints.R"
+  "/api/user:user_endpoints.R"
+  "/api/auth:authentication_endpoints.R"
+  "/api/llm:llm_admin_endpoints.R"
+)
+
+# --- Load exceptions ---------------------------------------------------------
+declare -A EXCEPTIONS
+if [[ -f "${EXCEPTIONS_FILE}" ]]; then
+  while IFS= read -r line; do
+    [[ -z "${line// }" ]] && continue
+    [[ "${line:0:1}" == "#" ]] && continue
+    # Format: METHOD /api/<path>#reason
+    key="${line%%#*}"
+    # Trim trailing spaces on key
+    key="${key%"${key##*[![:space:]]}"}"
+    EXCEPTIONS["${key}"]=1
+  done < "${EXCEPTIONS_FILE}"
+fi
+
+# --- Extract handlers from handlers.ts --------------------------------------
+# Match lines like:   http.get('/api/auth/signin', ... )
+# Captures METHOD and PATH. Skips commented-out lines (leading //).
+mapfile -t HANDLER_LINES < <(
+  grep -nE "^[[:space:]]*http\.(get|post|put|delete|patch)\('/api/" "${HANDLERS_FILE}" || true
+)
+
+if [[ ${#HANDLER_LINES[@]} -eq 0 ]]; then
+  echo "verify-msw-against-openapi: no handlers found in ${HANDLERS_FILE}" >&2
+  exit 1
+fi
+
+# --- Helper: given a handler path, find the endpoint file --------------------
+resolve_endpoint_file() {
+  local path="$1"
+  for entry in "${MOUNTS[@]}"; do
+    local prefix="${entry%%:*}"
+    local file="${entry##*:}"
+    if [[ "${path}" == "${prefix}" || "${path}" == "${prefix}/"* ]]; then
+      echo "${file}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# --- Helper: normalize path params -------------------------------------------
+# Convert "/api/review/:id/phenotypes"  → sub = "/<param>/phenotypes"
+# Convert "/api/user/bulk_approve"      → sub = "/bulk_approve"
+# Convert "/api/review/approve/:id"     → sub = "/approve/<param>"
+normalize_subpath() {
+  local path="$1"
+  local prefix="$2"
+  local sub="${path#"${prefix}"}"
+  # Replace ":<name>" with a plumber-style placeholder
+  echo "${sub}" | sed -E 's#:[A-Za-z_][A-Za-z0-9_]*#<param>#g'
+}
+
+# --- Helper: check that R file has an annotation for method+subpath ---------
+# Plumber annotations look like:
+#   #* @get signin
+#   #* @put /update
+#   #* @get /<sysndd_id>/phenotypes
+#   #* @get <user_id>/contributions
+#   #* @delete delete
+# We normalize both sides to compare robustly:
+#   - strip a leading "/"
+#   - replace any `<name>` placeholder with `<param>`
+#   - lowercase the method
+normalize_annotation_path() {
+  local raw="$1"
+  local stripped="${raw#/}"
+  echo "${stripped}" | sed -E 's#<[A-Za-z_][A-Za-z0-9_]*>#<param>#g'
+}
+
+has_annotation() {
+  local endpoint_file="$1"
+  local method="$2"
+  local subpath="$3"
+
+  local want
+  want="$(normalize_annotation_path "${subpath}")"
+
+  # Empty subpath corresponds to "/" — plumber files use "@get /"
+  if [[ -z "${want}" ]]; then
+    want="/"
+  fi
+
+  # Pull every annotation line and normalize
+  while IFS= read -r line; do
+    # Line looks like: "#* @get /<review_id_requested>/phenotypes"
+    # Strip leading "#* @", then split on whitespace into [method, path]
+    local trimmed="${line#*@}"
+    local ann_method="${trimmed%% *}"
+    local ann_path="${trimmed#* }"
+    # Guard against annotations with no path (e.g., "@tag review")
+    if [[ "${ann_method}" == "${ann_path}" ]]; then
+      continue
+    fi
+    if [[ "${ann_method,,}" != "${method,,}" ]]; then
+      continue
+    fi
+    local ann_norm
+    ann_norm="$(normalize_annotation_path "${ann_path%% *}")"
+    # ann_norm empty => "/"
+    if [[ -z "${ann_norm}" ]]; then
+      ann_norm="/"
+    fi
+    if [[ "${ann_norm}" == "${want}" ]]; then
+      return 0
+    fi
+  done < <(grep -E "^#\*[[:space:]]+@(get|post|put|delete|patch)[[:space:]]" "${endpoint_file}" || true)
+
+  return 1
+}
+
+# --- Main loop ---------------------------------------------------------------
+fail_count=0
+handler_count=0
+
+for record in "${HANDLER_LINES[@]}"; do
+  # record format:  <lineno>:<content>
+  content="${record#*:}"
+  method="$(echo "${content}" | sed -nE "s#^[[:space:]]*http\.(get|post|put|delete|patch)\('/api/.*#\1#p")"
+  path="$(echo "${content}" | sed -nE "s#^[[:space:]]*http\.(get|post|put|delete|patch)\('(/api/[^']*)'.*#\2#p")"
+
+  if [[ -z "${method}" || -z "${path}" ]]; then
+    continue
+  fi
+
+  handler_count=$((handler_count + 1))
+  method_upper="$(echo "${method}" | tr '[:lower:]' '[:upper:]')"
+  key="${method_upper} ${path}"
+
+  # 1. Allowed via exception?
+  if [[ -n "${EXCEPTIONS[${key}]+x}" ]]; then
+    continue
+  fi
+
+  # 2. Resolve endpoint file
+  if ! endpoint_basename="$(resolve_endpoint_file "${path}")"; then
+    echo "FAIL: ${key} — no /api/* mount prefix matches (unknown resource)" >&2
+    fail_count=$((fail_count + 1))
+    continue
+  fi
+  endpoint_file="${ENDPOINTS_DIR}/${endpoint_basename}"
+  if [[ ! -f "${endpoint_file}" ]]; then
+    echo "FAIL: ${key} — resolved endpoint file does not exist: ${endpoint_file}" >&2
+    fail_count=$((fail_count + 1))
+    continue
+  fi
+
+  # 3. Extract the sub-path (after the mount prefix) and check annotation
+  prefix=""
+  for entry in "${MOUNTS[@]}"; do
+    p="${entry%%:*}"
+    if [[ "${path}" == "${p}" || "${path}" == "${p}/"* ]]; then
+      prefix="${p}"
+      break
+    fi
+  done
+  subpath="$(normalize_subpath "${path}" "${prefix}")"
+
+  if ! has_annotation "${endpoint_file}" "${method}" "${subpath}"; then
+    echo "FAIL: ${key} — no matching @${method} ${subpath} annotation in ${endpoint_basename}" >&2
+    echo "      (add an exception in scripts/msw-openapi-exceptions.txt if this is a known spec-table bug)" >&2
+    fail_count=$((fail_count + 1))
+  fi
+done
+
+if [[ ${fail_count} -gt 0 ]]; then
+  echo "" >&2
+  echo "verify-msw-against-openapi: ${fail_count} handler(s) drifted out of ${handler_count} total" >&2
+  exit 1
+fi
+
+echo "verify-msw-against-openapi: ${handler_count} handler(s) OK"
+exit 0


### PR DESCRIPTION
## Summary

Phase B.B1 — MSW handler expansion per `.plans/v11.0/phase-b.md` §3 Phase B.B1.

- Add **38 handlers** covering every real axios call site in the six curate/admin top views (auth, user admin, review workflow, status workflow, entity curation, annotation jobs). Handler count matches the locked table in the spec exactly.
- Each handler has a 2xx happy path and at least one 4xx branch reachable via a distinguishable request shape (sentinel path param `999`, `trigger_error=1` query, missing Authorization header, Viewer user-role header, or missing-required-field body). Every handler is documented with an `OpenAPI: <METHOD> /api/<path>` code comment back-referencing the plumber annotation in `api/endpoints/*.R`.
- Static mock fixtures split into `app/src/test-utils/mocks/data/{auth,users,reviews,statuses,entities,jobs}.ts`, all ≤ 164 LoC (well under the 300 LoC cap). TypeScript interfaces mirror the shapes in `api/config/openapi/schemas/inferred/`, preserving R/Plumber's one-element-array scalar convention.
- `app/src/test-utils/mocks/handlers.spec.ts` smoke-tests every handler with both 2xx and 4xx assertions — **77 tests**, all green.
- Flip `onUnhandledRequest: 'warn'` → `'error'` in `app/vitest.setup.ts`. Full existing vitest suite (23 files, 321 tests) remains green because existing specs mock axios directly rather than reaching MSW.
- Bump coverage thresholds from 40 → 45 for lines/functions/branches/statements in `app/vitest.config.ts`.
- New `scripts/verify-msw-against-openapi.sh` parses every `http.<method>('/api/...')` in `handlers.ts` and asserts a matching `@get/@post/@put/@delete` annotation in the mounted `api/endpoints/*.R` file. Mount mapping is cribbed from `pr_mount()` calls in `api/start_sysndd_api.R`. Wired into `make lint-app` after eslint.
- Known spec-table drifts whitelisted in `scripts/msw-openapi-exceptions.txt` (4 entries — flagged as spec bugs, see below).

## Auth shapes (post Phase A1)

- `POST /api/auth/authenticate` — JSON body `{user_name, password}`, returns JWT token string wrapped as a one-element array. Matches `api/endpoints/authentication_endpoints.R` `@post authenticate`.
- `PUT /api/user/password/update` — JSON body `{user_id_pass_change, old_pass, new_pass_1, new_pass_2}`. Matches `api/endpoints/user_endpoints.R` `@put password/update`.

(The spec text referred to `auth_endpoints.R`; the real file is `authentication_endpoints.R`. Flagged here; the spec did not require a rename.)

## Known spec-table drifts (documented in `scripts/msw-openapi-exceptions.txt`)

The Phase B.B1 locked handler table is marked "DO NOT REOPEN", so these four handlers are mocked as-listed but the underlying endpoints do not (yet) exist on master. They are carried forward for downstream Phase C view specs and re-opened in a later phase:

| Handler | Drift |
|---|---|
| `PUT /api/user/delete` | Real annotation is `@delete delete` in `user_endpoints.R:773` |
| `PUT /api/review/approve/all` | No bulk-approve endpoint in `review_endpoints.R` (only `@put /approve/<id>`) |
| `PUT /api/status/approve/all` | No bulk-approve endpoint in `status_endpoints.R` (only `@put /approve/<id>`) |
| `GET /api/entity/:sysndd_id` | No bare `@get /<sysndd_id>` in `entity_endpoints.R` (only `/` and `/<sysndd_id>/<sub>`) |

## verify-msw-against-openapi.sh — fake-path rejection evidence

Confirmed during development by temporarily injecting synthetic fake handlers:

**Case 1 — unknown resource** (injected `http.get('/api/fake/nonexistent_endpoint', ...)`)
```
FAIL: GET /api/fake/nonexistent_endpoint — no /api/* mount prefix matches (unknown resource)

verify-msw-against-openapi: 1 handler(s) drifted out of 39 total
EXIT=1
```

**Case 2 — real mount, bogus sub-path** (injected `http.get('/api/auth/totally_fake', ...)`)
```
FAIL: GET /api/auth/totally_fake — no matching @get /totally_fake annotation in authentication_endpoints.R
      (add an exception in scripts/msw-openapi-exceptions.txt if this is a known spec-table bug)

verify-msw-against-openapi: 1 handler(s) drifted out of 39 total
EXIT=1
```

Both fakes removed before committing; `./scripts/verify-msw-against-openapi.sh` now reports `38 handler(s) OK`.

## Local gate results

| Command | Result |
|---|---|
| `cd app && npm run lint` | exit 0 |
| `cd app && npm run type-check` | exit 0 |
| `cd app && npm run test:unit` | exit 0 — 23 files, 321 tests |
| `make lint-app` (includes `verify-msw-against-openapi.sh`) | exit 0 — 38 handler(s) OK |

## Host-env caveats

Per CLAUDE.md "Host-Env Workaround: Conda R on Ubuntu Questing (25.10)":

- `make install-dev` and `make doctor` fail on this host at the R-side checks because renv bootstraps BiocManager from Posit PPM which has no `questing` binary repo. Phase A7 is the canonical fix. **B1 changes no R code**, so this does not affect correctness of the PR — rely on CI (ubuntu-latest) for the R side.
- `make test-api` is deferred to CI for the same reason (documented in CLAUDE.md).
- `make lint-app`, `npm run type-check`, `npm run test:unit` all pass locally because they are Node-only.

## Test plan

- [ ] Confirm CI `app`-related jobs (lint, type-check, test:unit, build) are green.
- [ ] Confirm CI `api`-related jobs remain untouched (B1 changes no R code).
- [ ] Sanity-check that the new `verify-msw-against-openapi.sh` runs as part of `make lint-app` in CI (if CI invokes `make lint-app` directly) — otherwise it will be picked up once Phase B.B4 lands the smoke-test job.
- [ ] Downstream Phase C view specs will consume these handlers; any shape drift will show up loudly in Phase C's red runs.