### PR TITLE
v11.0/phase-d: D5 pagination sweep on 9 list endpoints

### DIFF
--- a/api/endpoints/backup_endpoints.R
+++ b/api/endpoints/backup_endpoints.R
@@ -40,7 +40,13 @@
 #* @param offset:int Number of items to skip (default: 0)
 #*
 #* @get /list
-function(req, res, limit = 50, offset = 0, sort = "newest") {
+function(req, res, limit = 50, offset = 0, sort = "newest", page = NULL) {
+  # Backward compatibility: convert page-based to offset-based pagination
+  if (!is.null(page)) {
+    page <- as.integer(page)
+    offset <- (page - 1L) * as.integer(limit)
+  }
+
   # Require Administrator role
   require_role(req, res, "Administrator")
 

--- a/api/endpoints/backup_endpoints.R
+++ b/api/endpoints/backup_endpoints.R
@@ -22,16 +22,17 @@
 #* Requires Administrator role.
 #*
 #* # `Parameters`
-#* - page: Integer - Page number (default: 1)
+#* - limit: Integer - Maximum number of items per page (default: 50, max: 500)
+#* - offset: Integer - Number of items to skip (default: 0)
+#* - page: Integer - Page number, backward-compatible alias (default: 1);
+#*   converted to offset internally. Ignored when limit/offset are provided.
 #* - sort: String - Sort order: "newest" (default) or "oldest"
 #*
 #* # `Response`
 #* Paginated response with:
 #* - data: Array of backup objects (filename, size_bytes, created_at, table_count)
-#* - total: Total number of backups
-#* - page: Current page number
-#* - page_size: Number of items per page (20)
-#* - meta: Directory metadata (total_count, total_size_bytes)
+#* - links: Object with `next` URL string (or null when no more pages)
+#* - meta: Object with total, limit, offset, page, page_size, directory metadata
 #*
 #* @tag backup
 #* @serializer json list(na="string")

--- a/api/endpoints/backup_endpoints.R
+++ b/api/endpoints/backup_endpoints.R
@@ -40,15 +40,23 @@
 #* @param offset:int Number of items to skip (default: 0)
 #*
 #* @get /list
-function(req, res, limit = 50, offset = 0, sort = "newest", page = NULL) {
-  # Backward compatibility: convert page-based to offset-based pagination
-  if (!is.null(page)) {
-    page <- as.integer(page)
-    offset <- (page - 1L) * as.integer(limit)
-  }
-
+function(req, res, page = 1, sort = "newest", limit = NULL, offset = NULL) {
   # Require Administrator role
   require_role(req, res, "Administrator")
+
+  # Pagination: support both page-based (legacy) and limit/offset (new).
+  # If limit/offset provided, use them; otherwise convert page to offset.
+  page_size <- 20L
+  if (!is.null(limit)) {
+    limit  <- min(as.integer(limit), 500L)
+    offset <- if (!is.null(offset)) as.integer(offset) else 0L
+    page_size <- limit
+  } else {
+    page <- suppressWarnings(as.integer(page))
+    if (is.na(page) || page < 1) page <- 1
+    limit  <- page_size
+    offset <- (page - 1L) * page_size
+  }
 
   # Validate sort parameter
   if (!sort %in% c("newest", "oldest")) {
@@ -69,19 +77,34 @@ function(req, res, limit = 50, offset = 0, sort = "newest", page = NULL) {
       if (sort == "oldest") {
         backups <- dplyr::arrange(backups, created_at)
       }
-      # else keep default: newest first (already sorted by list_backup_files)
 
-      # Apply offset-based pagination using helper
-      pag <- paginate_offset(backups, limit = limit, offset = offset)
+      # Inline pagination (no external helper dependency)
+      total <- nrow(backups)
+      if (total == 0) {
+        data <- backups
+      } else {
+        start_idx <- offset + 1L
+        end_idx   <- min(offset + limit, total)
+        data <- if (start_idx > total) backups[0, ] else dplyr::slice(backups, start_idx:end_idx)
+      }
+      next_offset <- offset + limit
+      next_link   <- if (next_offset < total) paste0("?limit=", limit, "&offset=", next_offset) else NULL
 
       # Get directory metadata
       dir_meta <- get_backup_metadata("/backup")
 
       # Return paginated response
       list(
-        data = pag$data,
-        links = pag$links,
-        meta = c(pag$meta, list(directory = dir_meta))
+        data  = data,
+        links = list("next" = next_link),
+        meta  = list(
+          total     = total,
+          limit     = limit,
+          offset    = offset,
+          page      = floor(offset / page_size) + 1L,
+          page_size = page_size,
+          directory = dir_meta
+        )
       )
     },
     error = function(e) {

--- a/api/endpoints/backup_endpoints.R
+++ b/api/endpoints/backup_endpoints.R
@@ -36,16 +36,13 @@
 #* @tag backup
 #* @serializer json list(na="string")
 #*
+#* @param limit:int Maximum number of items per page (default: 50, max: 500)
+#* @param offset:int Number of items to skip (default: 0)
+#*
 #* @get /list
-function(req, res, page = 1, sort = "newest") {
+function(req, res, limit = 50, offset = 0, sort = "newest") {
   # Require Administrator role
   require_role(req, res, "Administrator")
-
-  # Validate and coerce page parameter
-  page <- suppressWarnings(as.integer(page))
-  if (is.na(page) || page < 1) {
-    page <- 1
-  }
 
   # Validate sort parameter
   if (!sort %in% c("newest", "oldest")) {
@@ -56,9 +53,6 @@ function(req, res, page = 1, sort = "newest") {
       valid_values = c("newest", "oldest")
     ))
   }
-
-  # Page size per CONTEXT.md
-  page_size <- 20
 
   # Get backup list from business logic
   tryCatch(
@@ -71,35 +65,17 @@ function(req, res, page = 1, sort = "newest") {
       }
       # else keep default: newest first (already sorted by list_backup_files)
 
-      # Calculate pagination
-      total <- nrow(backups)
-      offset <- (page - 1) * page_size
-
-      # Slice data for current page
-      if (total == 0) {
-        data <- backups # Empty tibble with correct structure
-      } else {
-        start_idx <- offset + 1
-        end_idx <- min(offset + page_size, total)
-
-        if (start_idx > total) {
-          # Page beyond available data - return empty
-          data <- backups[0, ]
-        } else {
-          data <- dplyr::slice(backups, start_idx:end_idx)
-        }
-      }
+      # Apply offset-based pagination using helper
+      pag <- paginate_offset(backups, limit = limit, offset = offset)
 
       # Get directory metadata
-      meta <- get_backup_metadata("/backup")
+      dir_meta <- get_backup_metadata("/backup")
 
       # Return paginated response
       list(
-        data = data,
-        total = total,
-        page = page,
-        page_size = page_size,
-        meta = meta
+        data = pag$data,
+        links = pag$links,
+        meta = c(pag$meta, list(directory = dir_meta))
       )
     },
     error = function(e) {

--- a/api/endpoints/backup_endpoints.R
+++ b/api/endpoints/backup_endpoints.R
@@ -94,18 +94,19 @@ function(req, res, page = 1, sort = "newest", limit = NULL, offset = NULL) {
       # Get directory metadata
       dir_meta <- get_backup_metadata("/backup")
 
-      # Return paginated response
+      # Return paginated response.
+      # Top-level legacy fields (total/page/page_size) are preserved for
+      # backward compatibility with existing callers. `links` and `limit`/
+      # `offset` are added for the new pagination contract.
       list(
-        data  = data,
-        links = list("next" = next_link),
-        meta  = list(
-          total     = total,
-          limit     = limit,
-          offset    = offset,
-          page      = floor(offset / page_size) + 1L,
-          page_size = page_size,
-          directory = dir_meta
-        )
+        data      = data,
+        total     = total,
+        page      = floor(offset / page_size) + 1L,
+        page_size = page_size,
+        limit     = limit,
+        offset    = offset,
+        links     = list("next" = next_link),
+        meta      = dir_meta
       )
     },
     error = function(e) {

--- a/api/endpoints/comparisons_endpoints.R
+++ b/api/endpoints/comparisons_endpoints.R
@@ -28,8 +28,11 @@
 #* @tag comparisons
 #* @serializer json list(na="string")
 #*
+#* @param limit:int Maximum number of items per page (default: 50, max: 500).
+#* @param offset:int Number of items to skip (default: 0).
+#*
 #* @get options
-function() {
+function(limit = 50, offset = 0) {
   # Connect to database and fetch data from ndd_database_comparison_view
   ndd_database_comparison_view <- pool %>%
     tbl("ndd_database_comparison_view") %>%
@@ -63,13 +66,14 @@ function() {
     unique() %>%
     arrange(pathogenicity_mode)
 
-  # Return the combined data as a list
-  list(
-    list = list_df,
-    inheritance = inheritance_df,
-    category = category_df,
-    pathogenicity_mode = pathogenicity_mode_df
+  # Combine into a flat tibble for consistent pagination
+  options_tbl <- tibble::tibble(
+    option_group = c("list", "inheritance", "category", "pathogenicity_mode"),
+    values = list(list_df, inheritance_df, category_df, pathogenicity_mode_df)
   )
+
+  # Apply offset-based pagination
+  paginate_offset(options_tbl, limit = limit, offset = offset)
 }
 
 
@@ -94,9 +98,11 @@ function() {
 #*
 #* @param fields Comma-separated list of fields (databases) to include.
 #* @param definitive_only If TRUE, filter each source to only show Definitive entries.
+#* @param limit:int Maximum number of rows per page (default: 50, max: 500).
+#* @param offset:int Number of rows to skip (default: 0).
 #*
 #* @get upset
-function(res, fields = "", definitive_only = "false") {
+function(res, fields = "", definitive_only = "false", limit = 50, offset = 0) {
   ndd_database_comp_gene_list <- pool %>%
     tbl("ndd_database_comparison_view") %>%
     collect()
@@ -138,8 +144,8 @@ function(res, fields = "", definitive_only = "false") {
     ungroup() %>%
     mutate(sets = strsplit(sets, ","))
 
-  # Return the result
-  comparison_upset_data
+  # Apply offset-based pagination
+  paginate_offset(comparison_upset_data, limit = limit, offset = offset)
 }
 
 
@@ -158,8 +164,11 @@ function(res, fields = "", definitive_only = "false") {
 #* @tag comparisons
 #* @serializer json list(na="string")
 #*
+#* @param limit:int Maximum number of rows per page (default: 50, max: 500).
+#* @param offset:int Number of rows to skip (default: 0).
+#*
 #* @get similarity
-function() {
+function(limit = 50, offset = 0) {
   # Gather data and transform to wide binary matrix
   ndd_database_comparison_matrix <- pool %>%
     tbl("ndd_database_comparison_view") %>%
@@ -177,8 +186,8 @@ function() {
   ndd_database_comp_sim_melted <- melt(ndd_database_comp_sim) %>%
     select(x = Var1, y = Var2, value)
 
-  # Return the result
-  ndd_database_comp_sim_melted
+  # Apply offset-based pagination
+  paginate_offset(ndd_database_comp_sim_melted, limit = limit, offset = offset)
 }
 
 

--- a/api/endpoints/llm_admin_endpoints.R
+++ b/api/endpoints/llm_admin_endpoints.R
@@ -247,7 +247,7 @@ function(req, res, cluster_type = NULL, validation_status = NULL, limit = 50, of
 
   list(
     data  = result$data,
-    links = list(next = next_link),
+    links = list("next" = next_link),
     meta  = list(total = total, limit = limit, offset = offset)
   )
 }
@@ -556,7 +556,7 @@ function(req, res, cluster_type = NULL, status = NULL, from_date = NULL, to_date
 
   list(
     data  = result$data,
-    links = list(next = next_link),
+    links = list("next" = next_link),
     meta  = list(total = total, limit = limit, offset = offset)
   )
 }

--- a/api/endpoints/llm_admin_endpoints.R
+++ b/api/endpoints/llm_admin_endpoints.R
@@ -217,15 +217,17 @@ function(req, res) {
 function(req, res, cluster_type = NULL, validation_status = NULL, limit = 50, offset = 0) {
   require_role(req, res, "Administrator")
 
-  # Convert to integer (Plumber passes query params as strings)
-  limit  <- as.integer(limit)
-  offset <- as.integer(offset)
+  # Convert & clamp pagination inputs
+  limit  <- min(max(as.integer(limit), 1L), 500L)
+  offset <- max(as.integer(offset), 0L)
 
   # Convert empty strings to NULL
   if (!is.null(cluster_type) && cluster_type == "") cluster_type <- NULL
   if (!is.null(validation_status) && validation_status == "") validation_status <- NULL
 
-  # Delegate to repository; translate limit/offset to page/per_page for existing function
+  # Translate limit/offset to page/per_page for existing repository function.
+  # NOTE: page translation is only exact when offset is a multiple of limit;
+  # non-aligned offsets are rounded down to the nearest page boundary.
   page     <- floor(offset / max(limit, 1L)) + 1L
   per_page <- limit
 
@@ -237,7 +239,9 @@ function(req, res, cluster_type = NULL, validation_status = NULL, limit = 50, of
   )
 
   # Re-wrap into standard pagination envelope
-  total <- if (!is.null(result$total)) result$total else length(result$data)
+  total <- if (!is.null(result$total)) result$total else {
+    if (is.data.frame(result$data)) nrow(result$data) else length(result$data)
+  }
   next_offset <- offset + limit
   next_link <- if (next_offset < total) {
     paste0("?limit=", limit, "&offset=", next_offset)
@@ -522,9 +526,9 @@ function(req, res, cluster_type = NULL, status = NULL, from_date = NULL, to_date
          limit = 50, offset = 0) {
   require_role(req, res, "Administrator")
 
-  # Convert to integer
-  limit  <- as.integer(limit)
-  offset <- as.integer(offset)
+  # Convert & clamp pagination inputs
+  limit  <- min(max(as.integer(limit), 1L), 500L)
+  offset <- max(as.integer(offset), 0L)
 
   # Convert empty strings to NULL
   if (!is.null(cluster_type) && cluster_type == "") cluster_type <- NULL
@@ -532,7 +536,9 @@ function(req, res, cluster_type = NULL, status = NULL, from_date = NULL, to_date
   if (!is.null(from_date) && from_date == "") from_date <- NULL
   if (!is.null(to_date) && to_date == "") to_date <- NULL
 
-  # Translate limit/offset to page/per_page for existing repository function
+  # Translate limit/offset to page/per_page for existing repository function.
+  # NOTE: page translation is only exact when offset is a multiple of limit;
+  # non-aligned offsets are rounded down to the nearest page boundary.
   page     <- floor(offset / max(limit, 1L)) + 1L
   per_page <- limit
 
@@ -546,7 +552,9 @@ function(req, res, cluster_type = NULL, status = NULL, from_date = NULL, to_date
   )
 
   # Re-wrap into standard pagination envelope
-  total <- if (!is.null(result$total)) result$total else length(result$data)
+  total <- if (!is.null(result$total)) result$total else {
+    if (is.data.frame(result$data)) nrow(result$data) else length(result$data)
+  }
   next_offset <- offset + limit
   next_link <- if (next_offset < total) {
     paste0("?limit=", limit, "&offset=", next_offset)

--- a/api/endpoints/llm_admin_endpoints.R
+++ b/api/endpoints/llm_admin_endpoints.R
@@ -200,37 +200,55 @@ function(req, res) {
 #* # `Query Parameters`
 #* @param cluster_type:character Filter by "functional" or "phenotype"
 #* @param validation_status:character Filter by "pending", "validated", "rejected"
-#* @param page:int Page number (1-indexed, default: 1)
-#* @param per_page:int Entries per page (default: 20)
+#* @param limit:int Maximum number of items per page (default: 50, max: 500)
+#* @param offset:int Number of items to skip (default: 0)
 #*
 #* # `Authorization`
 #* Restricted to Administrator role.
 #*
 #* # `Return`
 #* - data: Array of cache entries
-#* - total: Integer, total matching entries
-#* - page: Integer, current page
-#* - per_page: Integer, entries per page
+#* - links: Object with next URL (or null)
+#* - meta: Object with total, limit, offset
 #*
 #* @tag llm-admin
 #* @serializer json list(na="string")
 #* @get /cache/summaries
-function(req, res, cluster_type = NULL, validation_status = NULL, page = 1, per_page = 20) {
+function(req, res, cluster_type = NULL, validation_status = NULL, limit = 50, offset = 0) {
   require_role(req, res, "Administrator")
 
   # Convert to integer (Plumber passes query params as strings)
-  page <- as.integer(page)
-  per_page <- as.integer(per_page)
+  limit  <- as.integer(limit)
+  offset <- as.integer(offset)
 
   # Convert empty strings to NULL
   if (!is.null(cluster_type) && cluster_type == "") cluster_type <- NULL
   if (!is.null(validation_status) && validation_status == "") validation_status <- NULL
 
-  get_cached_summaries_paginated(
+  # Delegate to repository; translate limit/offset to page/per_page for existing function
+  page     <- floor(offset / max(limit, 1L)) + 1L
+  per_page <- limit
+
+  result <- get_cached_summaries_paginated(
     cluster_type = cluster_type,
     validation_status = validation_status,
     page = page,
     per_page = per_page
+  )
+
+  # Re-wrap into standard pagination envelope
+  total <- if (!is.null(result$total)) result$total else length(result$data)
+  next_offset <- offset + limit
+  next_link <- if (next_offset < total) {
+    paste0("?limit=", limit, "&offset=", next_offset)
+  } else {
+    NULL
+  }
+
+  list(
+    data  = result$data,
+    links = list(next = next_link),
+    meta  = list(total = total, limit = limit, offset = offset)
   )
 }
 
@@ -486,28 +504,27 @@ function(req, res, cluster_type = "all", force = FALSE) {
 #* @param status:character Filter by "success", "validation_failed", "api_error", "timeout"
 #* @param from_date:character Start date filter (YYYY-MM-DD)
 #* @param to_date:character End date filter (YYYY-MM-DD)
-#* @param page:int Page number (1-indexed, default: 1)
-#* @param per_page:int Entries per page (default: 50)
+#* @param limit:int Maximum number of items per page (default: 50, max: 500)
+#* @param offset:int Number of items to skip (default: 0)
 #*
 #* # `Authorization`
 #* Restricted to Administrator role.
 #*
 #* # `Return`
 #* - data: Array of log entries
-#* - total: Integer, total matching entries
-#* - page: Integer, current page
-#* - per_page: Integer, entries per page
+#* - links: Object with next URL (or null)
+#* - meta: Object with total, limit, offset
 #*
 #* @tag llm-admin
 #* @serializer json list(na="string")
 #* @get /logs
 function(req, res, cluster_type = NULL, status = NULL, from_date = NULL, to_date = NULL,
-         page = 1, per_page = 50) {
+         limit = 50, offset = 0) {
   require_role(req, res, "Administrator")
 
   # Convert to integer
-  page <- as.integer(page)
-  per_page <- as.integer(per_page)
+  limit  <- as.integer(limit)
+  offset <- as.integer(offset)
 
   # Convert empty strings to NULL
   if (!is.null(cluster_type) && cluster_type == "") cluster_type <- NULL
@@ -515,13 +532,32 @@ function(req, res, cluster_type = NULL, status = NULL, from_date = NULL, to_date
   if (!is.null(from_date) && from_date == "") from_date <- NULL
   if (!is.null(to_date) && to_date == "") to_date <- NULL
 
-  get_generation_logs_paginated(
+  # Translate limit/offset to page/per_page for existing repository function
+  page     <- floor(offset / max(limit, 1L)) + 1L
+  per_page <- limit
+
+  result <- get_generation_logs_paginated(
     cluster_type = cluster_type,
     status = status,
     from_date = from_date,
     to_date = to_date,
     page = page,
     per_page = per_page
+  )
+
+  # Re-wrap into standard pagination envelope
+  total <- if (!is.null(result$total)) result$total else length(result$data)
+  next_offset <- offset + limit
+  next_link <- if (next_offset < total) {
+    paste0("?limit=", limit, "&offset=", next_offset)
+  } else {
+    NULL
+  }
+
+  list(
+    data  = result$data,
+    links = list(next = next_link),
+    meta  = list(total = total, limit = limit, offset = offset)
   )
 }
 

--- a/api/endpoints/llm_admin_endpoints.R
+++ b/api/endpoints/llm_admin_endpoints.R
@@ -239,7 +239,9 @@ function(req, res, cluster_type = NULL, validation_status = NULL, limit = 50, of
   )
 
   # Re-wrap into standard pagination envelope
-  total <- if (!is.null(result$total)) result$total else {
+  total <- if (!is.null(result$total)) {
+    result$total
+  } else {
     if (is.data.frame(result$data)) nrow(result$data) else length(result$data)
   }
   next_offset <- offset + limit
@@ -552,7 +554,9 @@ function(req, res, cluster_type = NULL, status = NULL, from_date = NULL, to_date
   )
 
   # Re-wrap into standard pagination envelope
-  total <- if (!is.null(result$total)) result$total else {
+  total <- if (!is.null(result$total)) {
+    result$total
+  } else {
     if (is.data.frame(result$data)) nrow(result$data) else length(result$data)
   }
   next_offset <- offset + limit

--- a/api/endpoints/panels_endpoints.R
+++ b/api/endpoints/panels_endpoints.R
@@ -23,8 +23,12 @@
 #*
 #* @tag panels
 #* @serializer json list(na="string")
+#*
+#* @param limit:int Maximum number of option groups (default: 50, max: 500).
+#* @param offset:int Number of option groups to skip (default: 0).
+#*
 #* @get options
-function() {
+function(limit = 50, offset = 0) {
   categories_list <- pool %>%
     tbl("ndd_entity_status_categories_list") %>%
     select(category) %>%
@@ -49,7 +53,8 @@ function() {
     )
   )
 
-  options
+  # Apply offset-based pagination
+  paginate_offset(options, limit = limit, offset = offset)
 }
 
 

--- a/api/endpoints/re_review_endpoints.R
+++ b/api/endpoints/re_review_endpoints.R
@@ -468,8 +468,11 @@ function(req, res, re_review_batch) {
 #* @tag re_review
 #* @serializer json list(na="string")
 #*
+#* @param limit:int Maximum number of items per page (default: 50, max: 500)
+#* @param offset:int Number of items to skip (default: 0)
+#*
 #* @get assignment_table
-function(req, res) {
+function(req, res, limit = 50, offset = 0) {
   require_role(req, res, "Curator")
 
   user <- req$user_id
@@ -512,7 +515,8 @@ function(req, res) {
     ) %>%
     arrange(user_id)
 
-  re_review_assign_table_user
+  # Apply offset-based pagination
+  paginate_offset(re_review_assign_table_user, limit = limit, offset = offset)
 }
 
 

--- a/api/endpoints/search_endpoints.R
+++ b/api/endpoints/search_endpoints.R
@@ -25,9 +25,11 @@
 #*
 #* @param searchterm The search query.
 #* @param helper Logical controlling the output format.
+#* @param limit:int Maximum number of results (default: 50, max: 500).
+#* @param offset:int Number of results to skip (default: 0).
 #*
 #* @get <searchterm>
-function(searchterm, helper = TRUE) {
+function(searchterm, helper = TRUE, limit = 50, offset = 0) {
   helper <- as.logical(helper)
   searchterm <- URLdecode(searchterm) %>%
     str_squish()
@@ -91,9 +93,10 @@ function(searchterm, helper = TRUE) {
         names_from = "results",
         values_from = "values"
       )
-  } else {
-    sysndd_db_entity_search_return
   }
+
+  # Apply offset-based pagination
+  paginate_offset(sysndd_db_entity_search_return, limit = limit, offset = offset)
 }
 
 
@@ -110,9 +113,11 @@ function(searchterm, helper = TRUE) {
 #*
 #* @param searchterm The query string.
 #* @param tree Logical controlling output format.
+#* @param limit:int Maximum number of results (default: 50, max: 500).
+#* @param offset:int Number of results to skip (default: 0).
 #*
 #* @get ontology/<searchterm>
-function(searchterm, tree = FALSE) {
+function(searchterm, tree = FALSE, limit = 50, offset = 0) {
   tree <- as.logical(tree)
   searchterm <- URLdecode(searchterm) %>%
     str_squish()
@@ -164,7 +169,8 @@ function(searchterm, tree = FALSE) {
       )
   }
 
-  do_set_search_return_helper
+  # Apply offset-based pagination
+  paginate_offset(do_set_search_return_helper, limit = limit, offset = offset)
 }
 
 
@@ -180,9 +186,11 @@ function(searchterm, tree = FALSE) {
 #*
 #* @param searchterm The query string.
 #* @param tree Logical controlling output format.
+#* @param limit:int Maximum number of results (default: 50, max: 500).
+#* @param offset:int Number of results to skip (default: 0).
 #*
 #* @get gene/<searchterm>
-function(searchterm, tree = FALSE) {
+function(searchterm, tree = FALSE, limit = 50, offset = 0) {
   tree <- as.logical(tree)
   searchterm <- URLdecode(searchterm) %>%
     str_squish()
@@ -233,7 +241,8 @@ function(searchterm, tree = FALSE) {
       )
   }
 
-  nal_set_search_return_helper
+  # Apply offset-based pagination
+  paginate_offset(nal_set_search_return_helper, limit = limit, offset = offset)
 }
 
 
@@ -249,9 +258,11 @@ function(searchterm, tree = FALSE) {
 #*
 #* @param searchterm The query string.
 #* @param tree Logical controlling output format.
+#* @param limit:int Maximum number of results (default: 50, max: 500).
+#* @param offset:int Number of results to skip (default: 0).
 #*
 #* @get inheritance/<searchterm>
-function(searchterm, tree = FALSE) {
+function(searchterm, tree = FALSE, limit = 50, offset = 0) {
   tree <- as.logical(tree)
   searchterm <- URLdecode(searchterm) %>%
     str_squish()
@@ -305,5 +316,6 @@ function(searchterm, tree = FALSE) {
       )
   }
 
-  moi_list_search_return_helper
+  # Apply offset-based pagination
+  paginate_offset(moi_list_search_return_helper, limit = limit, offset = offset)
 }

--- a/api/endpoints/variant_endpoints.R
+++ b/api/endpoints/variant_endpoints.R
@@ -90,10 +90,14 @@ function(req,
 #*
 #* @param filter:str A string representing a filter query to use
 #*                  when selecting data from the database.
+#* @param limit:int Maximum number of rows per page (default: 50, max: 500).
+#* @param offset:int Number of rows to skip (default: 0).
 #*
 #* @get correlation
 function(res,
-         filter = "contains(ndd_phenotype_word,Yes),any(category,Definitive)") {
+         filter = "contains(ndd_phenotype_word,Yes),any(category,Definitive)",
+         limit = 50,
+         offset = 0) {
   # 1) Use helper to get a data frame with columns (entity_id, modifier_variant_id, etc.)
   variant_entities_data <- generate_variant_entities_list(filter = filter)$data %>%
     # Convert comma-separated variant IDs to separate rows
@@ -159,7 +163,8 @@ function(res,
       value
     )
 
-  variants_corr_melted_ids
+  # Apply offset-based pagination
+  paginate_offset(variants_corr_melted_ids, limit = limit, offset = offset)
 }
 
 
@@ -179,10 +184,14 @@ function(res,
 #* @serializer json list(na="string")
 #*
 #* @param filter:str Filter expression to restrict the entity set.
+#* @param limit:int Maximum number of items per page (default: 50, max: 500).
+#* @param offset:int Number of items to skip (default: 0).
 #*
 #* @get count
 function(res,
-         filter = "contains(ndd_phenotype_word,Yes),any(category,Definitive)") {
+         filter = "contains(ndd_phenotype_word,Yes),any(category,Definitive)",
+         limit = 50,
+         offset = 0) {
   # 1) Use helper to get entity-variant associations
   variant_entities_data <- generate_variant_entities_list(filter = filter)$data %>%
     separate_rows(modifier_variant_id, sep = ",") %>%
@@ -209,5 +218,6 @@ function(res,
     # rename for clarity: we store vario_id + variant_name + count
     select(vario_id, variant_name, count = n)
 
-  db_variants_count
+  # Apply offset-based pagination
+  paginate_offset(db_variants_count, limit = limit, offset = offset)
 }

--- a/api/functions/pagination-helpers.R
+++ b/api/functions/pagination-helpers.R
@@ -159,7 +159,15 @@ paginate_offset <- function(data, limit = 50, offset = 0, base_url = NULL) {
   # Build next link
   next_offset <- offset + limit
   if (next_offset < total && !is.null(base_url)) {
-    next_link <- paste0(base_url, "&limit=", limit, "&offset=", next_offset)
+    # Detect correct query-string separator for base_url
+    query_sep <- if (grepl("\\?$|&$", base_url)) {
+      ""
+    } else if (grepl("\\?", base_url)) {
+      "&"
+    } else {
+      "?"
+    }
+    next_link <- paste0(base_url, query_sep, "limit=", limit, "&offset=", next_offset)
   } else if (next_offset < total) {
     next_link <- paste0("?limit=", limit, "&offset=", next_offset)
   } else {

--- a/api/functions/pagination-helpers.R
+++ b/api/functions/pagination-helpers.R
@@ -168,7 +168,7 @@ paginate_offset <- function(data, limit = 50, offset = 0, base_url = NULL) {
 
   list(
     data  = sliced,
-    links = list(next = next_link),
+    links = list(`next` = next_link),
     meta  = list(total = total, limit = limit, offset = offset)
   )
 }

--- a/api/functions/pagination-helpers.R
+++ b/api/functions/pagination-helpers.R
@@ -112,3 +112,63 @@ generate_cursor_pag_inf_safe <- function(
     pagination_identifier
   )
 }
+
+
+#' Offset-based Pagination
+#'
+#' Applies simple offset/limit pagination to a data frame or tibble.
+#' Returns a standardised response envelope with data, links, and meta.
+#'
+#' @param data A data frame or tibble to paginate.
+#' @param limit Maximum number of rows to return (default 50, max 500).
+#' @param offset Number of rows to skip (default 0).
+#' @param base_url Base URL for building links.next (optional).
+#'
+#' @return A list with:
+#'   \item{data}{The sliced data frame.}
+#'   \item{links}{A list with \code{next} (URL string or NULL).}
+#'   \item{meta}{A list with \code{total}, \code{limit}, and \code{offset}.}
+#'
+#' @examples
+#' paginate_offset(mtcars, limit = 10, offset = 0)
+paginate_offset <- function(data, limit = 50, offset = 0, base_url = NULL) {
+  # Coerce & validate
+  limit  <- suppressWarnings(as.integer(limit))
+  offset <- suppressWarnings(as.integer(offset))
+
+  if (is.na(limit) || limit < 1)   limit  <- 50L
+  if (is.na(offset) || offset < 0) offset <- 0L
+
+  # Cap at PAGINATION_MAX_SIZE
+  if (limit > PAGINATION_MAX_SIZE) {
+    limit <- PAGINATION_MAX_SIZE
+  }
+
+  total <- nrow(data)
+
+  # Slice the data
+  start_row <- offset + 1L
+  end_row   <- min(offset + limit, total)
+
+  if (start_row > total) {
+    sliced <- data[0, , drop = FALSE]
+  } else {
+    sliced <- data[start_row:end_row, , drop = FALSE]
+  }
+
+  # Build next link
+  next_offset <- offset + limit
+  if (next_offset < total && !is.null(base_url)) {
+    next_link <- paste0(base_url, "&limit=", limit, "&offset=", next_offset)
+  } else if (next_offset < total) {
+    next_link <- paste0("?limit=", limit, "&offset=", next_offset)
+  } else {
+    next_link <- NULL
+  }
+
+  list(
+    data  = sliced,
+    links = list(next = next_link),
+    meta  = list(total = total, limit = limit, offset = offset)
+  )
+}

--- a/api/tests/testthat/test-pagination-contract.R
+++ b/api/tests/testthat/test-pagination-contract.R
@@ -1,0 +1,332 @@
+# tests/testthat/test-pagination-contract.R
+# Contract tests for D5 pagination sweep
+#
+# Verifies that:
+# 1. paginate_offset() helper produces correct envelope shape
+# 2. All target endpoint files declare limit/offset params on GET list handlers
+#
+# Run with:
+#   Rscript -e "testthat::test_file('tests/testthat/test-pagination-contract.R')"
+
+library(testthat)
+library(tibble)
+
+# Source the pagination helpers
+source_api_file("functions/pagination-helpers.R", local = FALSE)
+
+# =============================================================================
+# paginate_offset() unit tests
+# =============================================================================
+
+test_that("paginate_offset returns correct envelope shape", {
+  data <- tibble(id = 1:100, value = letters[rep(1:26, length.out = 100)])
+  result <- paginate_offset(data, limit = 10, offset = 0)
+
+  expect_true(is.list(result))
+  expect_named(result, c("data", "links", "meta"))
+  expect_true(is.data.frame(result$data))
+  expect_true(is.list(result$links))
+  expect_true(is.list(result$meta))
+})
+
+test_that("paginate_offset meta contains total, limit, offset", {
+
+  data <- tibble(id = 1:100)
+  result <- paginate_offset(data, limit = 10, offset = 0)
+
+  expect_equal(result$meta$total, 100)
+  expect_equal(result$meta$limit, 10)
+  expect_equal(result$meta$offset, 0)
+})
+
+test_that("paginate_offset slices data correctly", {
+  data <- tibble(id = 1:100)
+
+  # First page
+
+  result <- paginate_offset(data, limit = 10, offset = 0)
+  expect_equal(nrow(result$data), 10)
+  expect_equal(result$data$id[1], 1)
+  expect_equal(result$data$id[10], 10)
+
+  # Second page
+  result2 <- paginate_offset(data, limit = 10, offset = 10)
+  expect_equal(nrow(result2$data), 10)
+  expect_equal(result2$data$id[1], 11)
+  expect_equal(result2$data$id[10], 20)
+
+  # Last partial page
+  result3 <- paginate_offset(data, limit = 10, offset = 95)
+  expect_equal(nrow(result3$data), 5)
+  expect_equal(result3$data$id[1], 96)
+})
+
+test_that("paginate_offset links.next is present when more data exists", {
+  data <- tibble(id = 1:100)
+  result <- paginate_offset(data, limit = 10, offset = 0)
+
+  expect_false(is.null(result$links[["next"]]))
+  expect_match(result$links[["next"]], "limit=10")
+  expect_match(result$links[["next"]], "offset=10")
+})
+
+test_that("paginate_offset links.next is NULL on last page", {
+  data <- tibble(id = 1:100)
+  result <- paginate_offset(data, limit = 10, offset = 90)
+
+  expect_null(result$links[["next"]])
+})
+
+test_that("paginate_offset links.next is NULL when data fits in one page", {
+  data <- tibble(id = 1:5)
+  result <- paginate_offset(data, limit = 50, offset = 0)
+
+  expect_null(result$links[["next"]])
+})
+
+test_that("paginate_offset handles empty data frame", {
+  data <- tibble(id = integer(0))
+  result <- paginate_offset(data, limit = 10, offset = 0)
+
+  expect_equal(nrow(result$data), 0)
+  expect_equal(result$meta$total, 0)
+  expect_null(result$links[["next"]])
+})
+
+test_that("paginate_offset defaults limit to 50 for invalid values", {
+  data <- tibble(id = 1:100)
+
+  result <- paginate_offset(data, limit = -1, offset = 0)
+  expect_equal(result$meta$limit, 50)
+
+  result2 <- paginate_offset(data, limit = "abc", offset = 0)
+  expect_equal(result2$meta$limit, 50)
+})
+
+test_that("paginate_offset caps limit at PAGINATION_MAX_SIZE", {
+  data <- tibble(id = 1:1000)
+  result <- paginate_offset(data, limit = 9999, offset = 0)
+
+  expect_equal(result$meta$limit, PAGINATION_MAX_SIZE)
+  expect_equal(nrow(result$data), PAGINATION_MAX_SIZE)
+})
+
+test_that("paginate_offset defaults offset to 0 for invalid values", {
+  data <- tibble(id = 1:100)
+
+  result <- paginate_offset(data, limit = 10, offset = -5)
+  expect_equal(result$meta$offset, 0)
+})
+
+test_that("paginate_offset returns empty data for offset beyond range", {
+  data <- tibble(id = 1:10)
+  result <- paginate_offset(data, limit = 10, offset = 100)
+
+  expect_equal(nrow(result$data), 0)
+  expect_equal(result$meta$total, 10)
+})
+
+test_that("paginate_offset includes base_url in links.next when provided", {
+  data <- tibble(id = 1:100)
+  result <- paginate_offset(data, limit = 10, offset = 0,
+                            base_url = "/api/example?sort=id")
+
+  expect_match(result$links[["next"]], "^/api/example\\?sort=id&limit=10&offset=10$")
+})
+
+
+# =============================================================================
+# Endpoint signature verification
+# =============================================================================
+# Parse each target endpoint file and verify that GET handlers accepting list
+# data declare `limit` and `offset` parameters.
+
+#' Extract function signatures from a plumber endpoint file
+#'
+#' Reads the file, finds function declarations preceded by @get annotations,
+#' and returns the parameter names for each.
+#'
+#' @param file_path Relative path from api/ directory
+#' @return Named list: route -> character vector of param names
+extract_get_handler_params <- function(file_path) {
+  api_dir <- get_api_dir()
+  full_path <- file.path(api_dir, file_path)
+  lines <- readLines(full_path, warn = FALSE)
+
+  handlers <- list()
+  i <- 1
+  while (i <= length(lines)) {
+    line <- trimws(lines[i])
+
+    # Detect @get annotation
+    if (grepl("^#\\*\\s*@get\\s+", line)) {
+      route <- sub("^#\\*\\s*@get\\s+", "", line)
+
+      # Scan forward for the function() declaration
+      j <- i + 1
+      while (j <= length(lines) && !grepl("^function\\s*\\(", trimws(lines[j]))) {
+        j <- j + 1
+      }
+
+      if (j <= length(lines)) {
+        # Gather the full function signature (may span multiple lines)
+        sig <- ""
+        k <- j
+        while (k <= length(lines) && !grepl("\\{", lines[k])) {
+          sig <- paste0(sig, lines[k])
+          k <- k + 1
+        }
+        sig <- paste0(sig, lines[min(k, length(lines))])
+
+        # Extract parameter names from function(param1, param2 = default, ...)
+        params_str <- sub(".*function\\s*\\(", "", sig)
+        params_str <- sub("\\)\\s*\\{.*", "", params_str)
+        params <- trimws(strsplit(params_str, ",")[[1]])
+        param_names <- sub("\\s*=.*", "", params)
+        param_names <- sub("^`", "", param_names)
+        param_names <- sub("`$", "", param_names)
+        param_names <- param_names[param_names != "" & param_names != "..."]
+
+        handlers[[route]] <- param_names
+      }
+      i <- j + 1
+    } else {
+      i <- i + 1
+    }
+  }
+  handlers
+}
+
+
+# --- backup_endpoints.R: GET /list ---
+test_that("backup GET /list accepts limit and offset", {
+  handlers <- extract_get_handler_params("endpoints/backup_endpoints.R")
+  expect_true("/list" %in% names(handlers),
+              info = "GET /list handler not found in backup_endpoints.R")
+  params <- handlers[["/list"]]
+  expect_true("limit" %in% params, info = "limit param missing from GET /list")
+  expect_true("offset" %in% params, info = "offset param missing from GET /list")
+})
+
+# --- llm_admin_endpoints.R: GET /cache/summaries, GET /logs ---
+test_that("llm_admin GET /cache/summaries accepts limit and offset", {
+  handlers <- extract_get_handler_params("endpoints/llm_admin_endpoints.R")
+  expect_true("/cache/summaries" %in% names(handlers),
+              info = "GET /cache/summaries handler not found")
+  params <- handlers[["/cache/summaries"]]
+  expect_true("limit" %in% params, info = "limit param missing from GET /cache/summaries")
+  expect_true("offset" %in% params, info = "offset param missing from GET /cache/summaries")
+})
+
+test_that("llm_admin GET /logs accepts limit and offset", {
+  handlers <- extract_get_handler_params("endpoints/llm_admin_endpoints.R")
+  expect_true("/logs" %in% names(handlers),
+              info = "GET /logs handler not found")
+  params <- handlers[["/logs"]]
+  expect_true("limit" %in% params, info = "limit param missing from GET /logs")
+  expect_true("offset" %in% params, info = "offset param missing from GET /logs")
+})
+
+# --- re_review_endpoints.R: GET assignment_table ---
+test_that("re_review GET assignment_table accepts limit and offset", {
+  handlers <- extract_get_handler_params("endpoints/re_review_endpoints.R")
+  expect_true("assignment_table" %in% names(handlers),
+              info = "GET assignment_table handler not found")
+  params <- handlers[["assignment_table"]]
+  expect_true("limit" %in% params, info = "limit param missing from GET assignment_table")
+  expect_true("offset" %in% params, info = "offset param missing from GET assignment_table")
+})
+
+# --- search_endpoints.R: 4 search GET endpoints ---
+test_that("search GET <searchterm> accepts limit and offset", {
+  handlers <- extract_get_handler_params("endpoints/search_endpoints.R")
+  expect_true("<searchterm>" %in% names(handlers),
+              info = "GET <searchterm> handler not found")
+  params <- handlers[["<searchterm>"]]
+  expect_true("limit" %in% params, info = "limit param missing from GET <searchterm>")
+  expect_true("offset" %in% params, info = "offset param missing from GET <searchterm>")
+})
+
+test_that("search GET ontology/<searchterm> accepts limit and offset", {
+  handlers <- extract_get_handler_params("endpoints/search_endpoints.R")
+  expect_true("ontology/<searchterm>" %in% names(handlers),
+              info = "GET ontology/<searchterm> handler not found")
+  params <- handlers[["ontology/<searchterm>"]]
+  expect_true("limit" %in% params)
+  expect_true("offset" %in% params)
+})
+
+test_that("search GET gene/<searchterm> accepts limit and offset", {
+  handlers <- extract_get_handler_params("endpoints/search_endpoints.R")
+  expect_true("gene/<searchterm>" %in% names(handlers),
+              info = "GET gene/<searchterm> handler not found")
+  params <- handlers[["gene/<searchterm>"]]
+  expect_true("limit" %in% params)
+  expect_true("offset" %in% params)
+})
+
+test_that("search GET inheritance/<searchterm> accepts limit and offset", {
+  handlers <- extract_get_handler_params("endpoints/search_endpoints.R")
+  expect_true("inheritance/<searchterm>" %in% names(handlers),
+              info = "GET inheritance/<searchterm> handler not found")
+  params <- handlers[["inheritance/<searchterm>"]]
+  expect_true("limit" %in% params)
+  expect_true("offset" %in% params)
+})
+
+# --- variant_endpoints.R: GET correlation, GET count ---
+test_that("variant GET correlation accepts limit and offset", {
+  handlers <- extract_get_handler_params("endpoints/variant_endpoints.R")
+  expect_true("correlation" %in% names(handlers),
+              info = "GET correlation handler not found")
+  params <- handlers[["correlation"]]
+  expect_true("limit" %in% params, info = "limit param missing from GET correlation")
+  expect_true("offset" %in% params, info = "offset param missing from GET correlation")
+})
+
+test_that("variant GET count accepts limit and offset", {
+  handlers <- extract_get_handler_params("endpoints/variant_endpoints.R")
+  expect_true("count" %in% names(handlers),
+              info = "GET count handler not found")
+  params <- handlers[["count"]]
+  expect_true("limit" %in% params, info = "limit param missing from GET count")
+  expect_true("offset" %in% params, info = "offset param missing from GET count")
+})
+
+# --- panels_endpoints.R: GET options ---
+test_that("panels GET options accepts limit and offset", {
+  handlers <- extract_get_handler_params("endpoints/panels_endpoints.R")
+  expect_true("options" %in% names(handlers),
+              info = "GET options handler not found")
+  params <- handlers[["options"]]
+  expect_true("limit" %in% params, info = "limit param missing from GET options")
+  expect_true("offset" %in% params, info = "offset param missing from GET options")
+})
+
+# --- comparisons_endpoints.R: GET options, GET upset, GET similarity ---
+test_that("comparisons GET options accepts limit and offset", {
+  handlers <- extract_get_handler_params("endpoints/comparisons_endpoints.R")
+  expect_true("options" %in% names(handlers),
+              info = "GET options handler not found in comparisons")
+  params <- handlers[["options"]]
+  expect_true("limit" %in% params, info = "limit param missing from comparisons GET options")
+  expect_true("offset" %in% params, info = "offset param missing from comparisons GET options")
+})
+
+test_that("comparisons GET upset accepts limit and offset", {
+  handlers <- extract_get_handler_params("endpoints/comparisons_endpoints.R")
+  expect_true("upset" %in% names(handlers),
+              info = "GET upset handler not found")
+  params <- handlers[["upset"]]
+  expect_true("limit" %in% params)
+  expect_true("offset" %in% params)
+})
+
+test_that("comparisons GET similarity accepts limit and offset", {
+  handlers <- extract_get_handler_params("endpoints/comparisons_endpoints.R")
+  expect_true("similarity" %in% names(handlers),
+              info = "GET similarity handler not found")
+  params <- handlers[["similarity"]]
+  expect_true("limit" %in% params)
+  expect_true("offset" %in% params)
+})


### PR DESCRIPTION
## Summary

- **New `paginate_offset()` helper** in `api/functions/pagination-helpers.R` providing offset/limit pagination with a standardized response envelope (`{data, links.next, meta{total, limit, offset}}`), capped at `PAGINATION_MAX_SIZE` (500).
- **14 GET endpoints across 7 endpoint files** now accept `limit` (default 50) and `offset` (default 0) query parameters:
  - `backup_endpoints.R`: GET /list
  - `llm_admin_endpoints.R`: GET /cache/summaries, GET /logs
  - `re_review_endpoints.R`: GET /assignment_table
  - `search_endpoints.R`: GET entity, GET ontology, GET gene, GET inheritance (4 routes)
  - `variant_endpoints.R`: GET /correlation, GET /count
  - `panels_endpoints.R`: GET /options
  - `comparisons_endpoints.R`: GET /options, GET /upset, GET /similarity
- **2 files intentionally untouched** (`about_endpoints.R`, `hash_endpoints.R`) -- no GET endpoints return list data (about returns single documents; hash has only POST).
- Endpoints that already had cursor-based pagination (`re_review GET /table`, `variant GET /browse`, `panels GET /browse`, `comparisons GET /browse`) retain their existing `page_after`/`page_size` interface.
- **New test file** `test-pagination-contract.R` with 26 tests verifying helper correctness and static endpoint signature extraction confirming all target handlers accept `limit`/`offset`.

## Test plan

- [x] `test-pagination-contract.R` passes (26/26) -- run via `Rscript --no-init-file` with minimal dependencies
- [ ] Existing pre-existing test suite unaffected (no test files modified)
- [ ] Manual smoke: call a paginated endpoint with `?limit=5&offset=0` and verify `links.next` is present
- [ ] Manual smoke: call with no params and verify default first-page behavior (backward compatible)