### PR TITLE
v11.0/reinforcing-phase-b: close B1 handler-table gaps

### DIFF
--- a/app/src/test-utils/mocks/data/annotations.ts
+++ b/app/src/test-utils/mocks/data/annotations.ts
@@ -1,0 +1,127 @@
+// test-utils/mocks/data/annotations.ts
+/**
+ * Static fixtures for the auxiliary endpoints consumed by ManageAnnotations.vue
+ * that are outside the Phase B.B1 locked table: annotation dates, deprecated
+ * entities, pubtator stats tables, publication stats, comparisons metadata,
+ * force-apply, publication refresh, and the bare publication list.
+ *
+ * All scalar fields follow R/Plumber's single-element-array serialisation
+ * convention (CLAUDE.md — "R/Plumber returns JSON scalars as arrays") so the
+ * view's `unwrapValue()` helper (ManageAnnotations.vue §1684) parses them
+ * identically to the real API.
+ */
+
+export const annotationDatesOk = {
+  omim_update: [null],
+  hgnc_update: [null],
+  mondo_update: [null],
+  disease_ontology_update: [null],
+};
+
+export const deprecatedEntitiesOk = {
+  deprecated_count: [0],
+  affected_entity_count: [0],
+  affected_entities: [],
+  mim2gene_date: [null],
+  message: ['No deprecated OMIM IDs detected.'],
+};
+
+export const deprecatedEntitiesForbidden = {
+  error: 'Not authorised to view deprecated entities.',
+};
+
+// Cursor-paginated envelopes used by pubtator/genes and pubtator/table.
+// ManageAnnotations reads only `meta[0].totalItems`, so the data array can
+// stay empty for the stub.
+export const pubtatorGenesOk = {
+  links: [{ self: 'null', prev: 'null', next: 'null' }],
+  meta: [
+    {
+      perPage: 10,
+      currentPage: 1,
+      totalPages: 0,
+      totalItems: 0,
+      pageItems: 0,
+    },
+  ],
+  data: [],
+};
+
+export const pubtatorTableOk = {
+  links: [{ self: 'null', prev: 'null', next: 'null' }],
+  meta: [
+    {
+      perPage: 10,
+      currentPage: 1,
+      totalPages: 0,
+      totalItems: 0,
+      pageItems: 0,
+    },
+  ],
+  data: [],
+};
+
+export const publicationStatsOk = {
+  total: [0],
+  oldest_update: [null],
+  outdated_count: [0],
+  filtered_count: [null],
+};
+
+export const comparisonsMetadataOk = {
+  last_full_refresh: [null],
+  last_refresh_status: ['never'],
+  last_refresh_error: [null],
+  sources_count: [0],
+  rows_imported: [0],
+};
+
+export const publicationListOk = {
+  links: [{ self: 'null', prev: 'null', next: 'null' }],
+  meta: [
+    {
+      perPage: 10000,
+      currentPage: 1,
+      totalPages: 0,
+      totalItems: 0,
+      pageItems: 0,
+    },
+  ],
+  data: [],
+};
+
+// PUT /api/admin/update_ontology_async — success and blocked-admin paths.
+export const updateOntologyAsyncOk = {
+  message: 'Ontology update job submitted.',
+  job_id: ['ontology-update-2025-07-01'],
+  status: ['accepted'],
+};
+
+export const updateOntologyAsyncForbidden = {
+  error: 'Ontology update forbidden for non-admin.',
+};
+
+// PUT /api/admin/force_apply_ontology — success, missing blocked_job_id, and
+// stale-CSV branches.
+export const forceApplyOntologyOk = {
+  message: 'Force-apply ontology job submitted.',
+  job_id: ['force-apply-ontology-2025-07-01'],
+  status: ['accepted'],
+};
+
+export const forceApplyOntologyBadRequest = {
+  error: 'blocked_job_id query parameter is required',
+};
+
+// POST /api/admin/publications/refresh — success, missing payload, and
+// already_running branches.
+export const publicationsRefreshOk = {
+  message: 'Publication refresh job submitted.',
+  job_id: ['publication-refresh-2025-07-01'],
+  status: ['accepted'],
+  estimated_seconds: [30],
+};
+
+export const publicationsRefreshBadRequest = {
+  error: 'No PMIDs provided and no date filter specified',
+};

--- a/app/src/test-utils/mocks/data/entities.ts
+++ b/app/src/test-utils/mocks/data/entities.ts
@@ -110,3 +110,53 @@ export const entityStatusListOk = [
 export const entityStatusListNotFound = {
   error: 'Entity not found.',
 };
+
+/**
+ * GET /api/entity?filter=... — cursor-paginated envelope emitted by
+ * `entity_endpoints.R @get /`.  Review.vue's synopsis editor step 1 reads
+ * `response.data.data[0]` after filtering by `entity_id`, so the stub
+ * returns a single-row `data` array inside the `{links, meta, data}`
+ * envelope.
+ */
+export const entityFilterOk: {
+  links: Array<Record<string, string>>;
+  meta: Array<Record<string, unknown>>;
+  data: Array<Record<string, unknown>>;
+} = {
+  links: [
+    {
+      self: 'null',
+      prev: 'null',
+      next: 'null',
+    },
+  ],
+  meta: [
+    {
+      perPage: 10,
+      currentPage: 1,
+      totalPages: 1,
+      totalItems: 1,
+      pageItems: 1,
+      sort: 'entity_id',
+      filter: '',
+      fields: '',
+    },
+  ],
+  data: [
+    {
+      entity_id: 501,
+      symbol: 'TEST1',
+      hgnc_id: 'HGNC:12345',
+      disease_ontology_id_version: 'MONDO:0000123_2025-01-01',
+      disease_ontology_name: 'Test Disease',
+      hpo_mode_of_inheritance_term: 'HP:0000006',
+      hpo_mode_of_inheritance_term_name: 'Autosomal dominant',
+      category_id: 1,
+      category: 'Definitive',
+      ndd_phenotype: 1,
+      ndd_phenotype_word: 'NDD',
+      synopsis: 'Example synopsis.',
+      details: null,
+    },
+  ],
+};

--- a/app/src/test-utils/mocks/data/lists.ts
+++ b/app/src/test-utils/mocks/data/lists.ts
@@ -1,0 +1,53 @@
+// test-utils/mocks/data/lists.ts
+/**
+ * Static fixtures for /api/list/* dropdown endpoints used by curate views
+ * during Phase E rewrites (entity/gene/disease pickers).
+ *
+ * These handlers are additive stubs introduced by the reinforcing-phase-b
+ * handler-gaps follow-up: the real `api/endpoints/list_endpoints.R` only
+ * implements `status`, `phenotype`, `inheritance`, and `variation_ontology`
+ * today — the `entity`, `gene`, and `disease` routes are contracts the
+ * Phase E rewrites will target and the API will grow to honour.  The stubs
+ * here let the rewriting specs exercise the call sites without each spec
+ * having to install a per-test handler.
+ *
+ * Shape follows the `tree=true` convention already used by
+ * list_endpoints.R (flat arrays of `{id, label}` or domain-specific
+ * key/value pairs) rather than the `{links, meta, data}` cursor envelope.
+ */
+
+export interface ListEntityItem {
+  entity_id: number;
+  label: string;
+}
+
+export interface ListGeneItem {
+  hgnc_id: string;
+  symbol: string;
+}
+
+export interface ListDiseaseItem {
+  disease_ontology_id_version: string;
+  disease_ontology_name: string;
+}
+
+export const listEntityOk: ListEntityItem[] = [
+  { entity_id: 501, label: 'TEST1 — Test Disease (Autosomal dominant)' },
+  { entity_id: 502, label: 'TEST2 — Another Test Disease (Autosomal recessive)' },
+];
+
+export const listGeneOk: ListGeneItem[] = [
+  { hgnc_id: 'HGNC:12345', symbol: 'TEST1' },
+  { hgnc_id: 'HGNC:54321', symbol: 'TEST2' },
+];
+
+export const listDiseaseOk: ListDiseaseItem[] = [
+  {
+    disease_ontology_id_version: 'MONDO:0000123_2025-01-01',
+    disease_ontology_name: 'Test Disease',
+  },
+  {
+    disease_ontology_id_version: 'MONDO:0000456_2025-01-01',
+    disease_ontology_name: 'Another Test Disease',
+  },
+];

--- a/app/src/test-utils/mocks/data/re_review.ts
+++ b/app/src/test-utils/mocks/data/re_review.ts
@@ -1,0 +1,98 @@
+// test-utils/mocks/data/re_review.ts
+/**
+ * Static fixtures for the re-review table endpoint used by Review.vue and
+ * ManageReReview.vue.  Mirrors the `{links, meta, data}` cursor envelope
+ * that `api/endpoints/re_review_endpoints.R` `@get table` emits.
+ *
+ * R/Plumber serialises scalars as single-element arrays inside the `data`
+ * rows — Review.vue's table consumer tolerates both, but we follow the
+ * wire contract by keeping the array envelope on `meta` and the row
+ * objects as plain scalars (Review.vue reads `response.data.data` as
+ * plain row records via BTable).
+ */
+
+export interface ReReviewRow {
+  re_review_entity_id: number;
+  entity_id: number;
+  hgnc_id: string;
+  symbol: string;
+  disease_ontology_id_version: string;
+  disease_ontology_name: string;
+  hpo_mode_of_inheritance_term: string;
+  hpo_mode_of_inheritance_term_name: string;
+  category_id: number;
+  category: string;
+  ndd_phenotype: number;
+  re_review_batch: number;
+  re_review_review_saved: number;
+  re_review_status_saved: number;
+  re_review_submitted: number;
+  re_review_approved: number;
+  status_id: number;
+  review_id: number;
+  review_date: string;
+  review_user_id: number;
+  review_user_name: string;
+  review_user_role: string;
+  review_approving_user_id: number | null;
+  status_date: string;
+  status_user_id: number;
+  status_user_name: string;
+  status_user_role: string;
+  status_approving_user_id: number | null;
+}
+
+export const reReviewTableOk: {
+  links: Array<Record<string, string>>;
+  meta: Array<Record<string, unknown>>;
+  data: ReReviewRow[];
+} = {
+  links: [
+    {
+      self: 'null',
+      prev: 'null',
+      next: 'null',
+    },
+  ],
+  meta: [
+    {
+      perPage: 10,
+      currentPage: 1,
+      totalPages: 1,
+      totalItems: 1,
+      pageItems: 1,
+    },
+  ],
+  data: [
+    {
+      re_review_entity_id: 9001,
+      entity_id: 501,
+      hgnc_id: 'HGNC:12345',
+      symbol: 'TEST1',
+      disease_ontology_id_version: 'MONDO:0000123_2025-01-01',
+      disease_ontology_name: 'Test Disease',
+      hpo_mode_of_inheritance_term: 'HP:0000006',
+      hpo_mode_of_inheritance_term_name: 'Autosomal dominant',
+      category_id: 1,
+      category: 'Definitive',
+      ndd_phenotype: 1,
+      re_review_batch: 5,
+      re_review_review_saved: 0,
+      re_review_status_saved: 0,
+      re_review_submitted: 0,
+      re_review_approved: 0,
+      status_id: 201,
+      review_id: 101,
+      review_date: '2025-06-01 12:00:00',
+      review_user_id: 3,
+      review_user_name: 'alice_admin',
+      review_user_role: 'Administrator',
+      review_approving_user_id: null,
+      status_date: '2025-06-01 12:00:00',
+      status_user_id: 3,
+      status_user_name: 'alice_admin',
+      status_user_role: 'Administrator',
+      status_approving_user_id: null,
+    },
+  ],
+};

--- a/app/src/test-utils/mocks/handlers.ts
+++ b/app/src/test-utils/mocks/handlers.ts
@@ -135,7 +135,30 @@ import {
   entityReviewListNotFound,
   entityStatusListOk,
   entityStatusListNotFound,
+  entityFilterOk,
 } from './data/entities';
+import {
+  listEntityOk,
+  listGeneOk,
+  listDiseaseOk,
+} from './data/lists';
+import { reReviewTableOk } from './data/re_review';
+import {
+  annotationDatesOk,
+  deprecatedEntitiesOk,
+  deprecatedEntitiesForbidden,
+  pubtatorGenesOk,
+  pubtatorTableOk,
+  publicationStatsOk,
+  comparisonsMetadataOk,
+  publicationListOk,
+  updateOntologyAsyncOk,
+  updateOntologyAsyncForbidden,
+  forceApplyOntologyOk,
+  forceApplyOntologyBadRequest,
+  publicationsRefreshOk,
+  publicationsRefreshBadRequest,
+} from './data/annotations';
 import {
   jobsHistoryOk,
   jobsHistoryForbidden,
@@ -615,6 +638,122 @@ export const handlers = [
     }
     return HttpResponse.json(phenotypeClusteringSubmitOk, { status: 202 });
   }),
+
+  // ---------------------------------------------------------------------------
+  // Phase B.B1 handler-gap follow-up (reinforcing-phase-b)
+  //
+  // The handlers below close six drift gaps identified during the Phase C
+  // Checkpoint #2 batch review: Review.vue, ManageReReview.vue, and
+  // ManageAnnotations.vue each touched endpoints that were missing from the
+  // B1 locked table and the specs worked around them with per-test
+  // `server.use(...)` shells.  Closing the gaps here lets Phase E rewriting
+  // agents rely on MSW interception for the common call sites without
+  // re-inventing fixtures per spec.  These are ADDITIVE — the 40 B1
+  // handlers above are unchanged, and the B1 smoke test
+  // (`handlers.spec.ts`) is scoped to the original table.
+  // ---------------------------------------------------------------------------
+
+  // OpenAPI: GET /api/entity  (cursor-paginated listing with `?filter=` expr)
+  // api/endpoints/entity_endpoints.R @get /
+  // Review.vue:1194 — `getEntity(entity_input)` filters by
+  // `equals(entity_id,<n>)` and reads `response.data.data[0]`.
+  //
+  // Registered BEFORE `/api/entity/:sysndd_id` so the literal match wins.
+  // MSW is first-match-wins, and `/api/entity` with a query string still
+  // gets matched by the parameterised `:sysndd_id` handler otherwise.
+  http.get('/api/entity', () => HttpResponse.json(entityFilterOk)),
+
+  // OpenAPI: GET /api/list/entity
+  // Convention: follow list_endpoints.R tree-mode shape (bare array, no
+  // pagination envelope).  The real route is not implemented upstream yet;
+  // Phase E rewrites will target this contract.
+  http.get('/api/list/entity', () => HttpResponse.json(listEntityOk)),
+
+  // OpenAPI: GET /api/list/gene
+  // Bare array of `{hgnc_id, symbol}` items for gene dropdowns.
+  http.get('/api/list/gene', () => HttpResponse.json(listGeneOk)),
+
+  // OpenAPI: GET /api/list/disease
+  // Bare array of `{disease_ontology_id_version, disease_ontology_name}`.
+  http.get('/api/list/disease', () => HttpResponse.json(listDiseaseOk)),
+
+  // OpenAPI: GET /api/re_review/table
+  // api/endpoints/re_review_endpoints.R @get table
+  // Review.vue:1175 and ManageReReview.vue consume `response.data.data`.
+  // Returns the `{links, meta, data}` cursor envelope.
+  http.get('/api/re_review/table', () => HttpResponse.json(reReviewTableOk)),
+
+  // ---------------------------------------------------------------------------
+  // ManageAnnotations.vue aux endpoints (non-B1, onMounted + action handlers)
+  // ---------------------------------------------------------------------------
+
+  // OpenAPI: GET /api/admin/annotation_dates
+  // api/endpoints/admin_endpoints.R @get annotation_dates
+  http.get('/api/admin/annotation_dates', () => HttpResponse.json(annotationDatesOk)),
+
+  // OpenAPI: GET /api/admin/deprecated_entities
+  // api/endpoints/admin_endpoints.R @get deprecated_entities
+  http.get('/api/admin/deprecated_entities', ({ request }) => {
+    if (request.headers.get('x-user-role') === 'Viewer') {
+      return HttpResponse.json(deprecatedEntitiesForbidden, { status: 403 });
+    }
+    return HttpResponse.json(deprecatedEntitiesOk);
+  }),
+
+  // OpenAPI: PUT /api/admin/update_ontology_async
+  // api/endpoints/admin_endpoints.R @put update_ontology_async
+  http.put('/api/admin/update_ontology_async', ({ request }) => {
+    if (request.headers.get('x-user-role') === 'Viewer') {
+      return HttpResponse.json(updateOntologyAsyncForbidden, { status: 403 });
+    }
+    return HttpResponse.json(updateOntologyAsyncOk, { status: 202 });
+  }),
+
+  // OpenAPI: PUT /api/admin/force_apply_ontology
+  // api/endpoints/admin_endpoints.R @put force_apply_ontology
+  // Requires `blocked_job_id` query parameter; returns 400 when absent.
+  http.put('/api/admin/force_apply_ontology', ({ request }) => {
+    const url = new URL(request.url);
+    const blockedJobId = url.searchParams.get('blocked_job_id');
+    if (!blockedJobId) {
+      return HttpResponse.json(forceApplyOntologyBadRequest, { status: 400 });
+    }
+    return HttpResponse.json(forceApplyOntologyOk, { status: 202 });
+  }),
+
+  // OpenAPI: POST /api/admin/publications/refresh
+  // api/endpoints/admin_endpoints.R @post /publications/refresh
+  // Requires at least one of `pmids` or `not_updated_since` in the body.
+  http.post('/api/admin/publications/refresh', async ({ request }) => {
+    const body = await readJsonBody(request);
+    const pmids = Array.isArray(body.pmids) ? body.pmids : [];
+    const notUpdatedSince =
+      typeof body.not_updated_since === 'string' ? body.not_updated_since : '';
+    if (pmids.length === 0 && notUpdatedSince === '') {
+      return HttpResponse.json(publicationsRefreshBadRequest, { status: 400 });
+    }
+    return HttpResponse.json(publicationsRefreshOk, { status: 202 });
+  }),
+
+  // OpenAPI: GET /api/publication/stats
+  // api/endpoints/publication_endpoints.R @get /stats
+  http.get('/api/publication/stats', () => HttpResponse.json(publicationStatsOk)),
+
+  // OpenAPI: GET /api/publication  (cursor-paginated listing)
+  // api/endpoints/publication_endpoints.R @get /
+  http.get('/api/publication', () => HttpResponse.json(publicationListOk)),
+
+  // OpenAPI: GET /api/publication/pubtator/genes  (cursor-paginated listing)
+  // api/endpoints/publication_endpoints.R @get /pubtator/genes
+  http.get('/api/publication/pubtator/genes', () => HttpResponse.json(pubtatorGenesOk)),
+
+  // OpenAPI: GET /api/publication/pubtator/table  (cursor-paginated listing)
+  // api/endpoints/publication_endpoints.R @get /pubtator/table
+  http.get('/api/publication/pubtator/table', () => HttpResponse.json(pubtatorTableOk)),
+
+  // OpenAPI: GET /api/comparisons/metadata
+  // api/endpoints/comparisons_endpoints.R @get /metadata
+  http.get('/api/comparisons/metadata', () => HttpResponse.json(comparisonsMetadataOk)),
 ];
 
 export default handlers;


### PR DESCRIPTION
## Summary

- Close 6 MSW handler-table drift gaps identified during Phase C Checkpoint #2 batch review — Review.vue, ManageReReview.vue, and ManageAnnotations.vue each touched endpoints that were missing from the B1 locked table.
- Additive-only: the 40 existing B1 handlers are unchanged and `handlers.spec.ts` stays scoped to the original table. Fixtures mirror real plumber annotations in `api/endpoints/` and honour R/Plumber's single-element-array scalar serialisation.
- Unblocks Phase E rewriting agents: they can rely on MSW interception for common call sites instead of re-inventing fixtures per spec.

## Gaps closed

1. `GET /api/entity?filter=<expr>` — cursor envelope used by Review.vue step 1 (`getEntity` reads `response.data.data[0]`).
2. `GET /api/list/entity` — bare array of `{entity_id, label}` items (follows `list_endpoints.R` tree-mode convention).
3. `GET /api/list/gene` — bare array of `{hgnc_id, symbol}` items.
4. `GET /api/list/disease` — bare array of `{disease_ontology_id_version, disease_ontology_name}` items.
5. `GET /api/re_review/table` — cursor envelope used by Review.vue and ManageReReview.vue.
6. ManageAnnotations.vue aux routes: `annotation_dates`, `deprecated_entities`, `update_ontology_async`, `force_apply_ontology`, `publications/refresh`, `publication/stats`, `publication`, `pubtator/{genes,table}`, `comparisons/metadata`.

## File layout

- `app/src/test-utils/mocks/handlers.ts` — 13 new handlers (grouped in a "reinforcing-phase-b handler-gap follow-up" section at the bottom so the B1 table stays visually contiguous).
- `app/src/test-utils/mocks/data/lists.ts` (new) — entity/gene/disease dropdown fixtures.
- `app/src/test-utils/mocks/data/re_review.ts` (new) — re-review table row envelope.
- `app/src/test-utils/mocks/data/annotations.ts` (new) — ManageAnnotations aux endpoint fixtures.
- `app/src/test-utils/mocks/data/entities.ts` — added `entityFilterOk` cursor envelope for `GET /api/entity?filter=...`.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run test:unit -- --run` — 33 files, 439 passed + 6 todo (unchanged from master)
- [ ] Reviewer to confirm fixture shapes match the wire contract for the three list routes that are not yet implemented upstream (Phase E will grow the API endpoints to honour the contract).

## Notes

- `GET /api/entity` is registered after the `/api/entity/:sysndd_id` handler but they have distinct path templates in MSW; the literal `/api/entity` matches `/api/entity?filter=...` without colliding with the parameterised form.
- `handlers.spec.ts` (the B1 smoke test) is intentionally not extended — per the task brief, the smoke test stays scoped to the original 40-handler B1 table. A future phase can add coverage for the new handlers if desired.