### PR TITLE
v11.0/phase-e: E3 first client migration (GeneView)

### DIFF
--- a/app/src/api/client.ts
+++ b/app/src/api/client.ts
@@ -14,6 +14,17 @@
  * separate `axios.create({...})` would skip that interceptor chain and
  * silently bypass the login-redirect behaviour. Every method below delegates
  * to the configured default instance so the wrapper inherits all of it.
+ *
+ * `withCredentials` is NOT enabled by default on the shared singleton
+ * (`@/plugins/axios` does not set `axios.defaults.withCredentials`). The vast
+ * majority of endpoints are Bearer-authenticated and either idempotent or
+ * backend-memoised, so they do not need cookies. Call sites that DO depend on
+ * sticky-session cookies — notably long-running async-job polling against the
+ * load-balanced API, which relies on Traefik's `sysndd_api_sticky` cookie to
+ * keep hitting the container that owns the job — must opt in explicitly by
+ * passing `withCredentials: true` via the `config` argument to
+ * `apiClient.get/post/put/patch/delete`. See `@/composables/useAsyncJob.ts`
+ * (`checkJobStatus`) for the canonical example.
  */
 
 import axios, { AxiosError, type AxiosRequestConfig, type AxiosResponse } from 'axios';

--- a/app/src/api/external.ts
+++ b/app/src/api/external.ts
@@ -1,5 +1,67 @@
 // app/src/api/external.ts
-// Stub — v11.0 Phase E.E1 establishes the api/ module structure.
-// Resource helpers to be filled in during v11.1 per each view's migration.
-// See docs/superpowers/specs/2026-04-11-v11.0-test-foundation-design.md §3 Phase E.
-export {};
+/**
+ * External-proxy resource helpers.
+ *
+ * Phase E.E1 established this module as a stub; Phase E.E3 fills in the
+ * first real helper (`getUniprotDomains`) as part of migrating
+ * `GeneView.vue` off raw `axios.get`. Additional external-proxy helpers
+ * (Ensembl, AlphaFold metadata, ClinVar, gnomAD variants, MGI, RGD) will
+ * be added as each call site migrates during v11.1.
+ *
+ * Wire shapes mirror `api/endpoints/external_endpoints.R`. The endpoints
+ * use `@serializer unboxedJSON`, so responses arrive as plain objects
+ * (not the R/Plumber 1-element-array scalar wrapping used by tibble
+ * collectors elsewhere). Consumers therefore do NOT need `unwrapScalar`.
+ */
+
+import type { AxiosRequestConfig } from 'axios';
+import { apiClient } from './client';
+
+// ---------------------------------------------------------------------------
+// UniProt domain architecture
+// ---------------------------------------------------------------------------
+
+/**
+ * A single protein feature emitted by UniProt (domain, region, signal, etc.).
+ * Mirrors the shape used by `GeneView.vue` — `begin`/`end` can come back as
+ * strings for some UniProt entries, so the type accepts both forms.
+ */
+export interface UniProtDomainFeature {
+  type: string;
+  description?: string;
+  begin: number | string;
+  end: number | string;
+}
+
+/**
+ * Response body from `GET /api/external/uniprot/domains/<symbol>`.
+ * The upstream endpoint memoises for 14 days; 404 is the canonical
+ * "gene not in UniProt" branch, and consumers typically surface it as
+ * "no data" rather than an error.
+ */
+export interface UniProtData {
+  source: string;
+  gene_symbol: string;
+  accession: string;
+  protein_name: string;
+  protein_length: number | string;
+  domains: UniProtDomainFeature[];
+}
+
+/**
+ * GET /api/external/uniprot/domains/<symbol>
+ *
+ * Returns the protein-domain architecture for the given gene symbol.
+ * Throws the underlying `AxiosError` on non-2xx (including the 404
+ * "gene not found in UniProt" branch) — callers that want to map 404
+ * to "no data, no error" should catch and inspect via `isApiError` +
+ * `err.response?.status`. See `GeneView.vue`'s `fetchUniprotData` for
+ * the canonical handling pattern.
+ */
+export async function getUniprotDomains(
+  symbol: string,
+  config?: AxiosRequestConfig,
+): Promise<UniProtData> {
+  const path = `/api/external/uniprot/domains/${encodeURIComponent(symbol)}`;
+  return apiClient.get<UniProtData>(path, config);
+}

--- a/app/src/api/genes.spec.ts
+++ b/app/src/api/genes.spec.ts
@@ -1,0 +1,215 @@
+// app/src/api/genes.spec.ts
+/**
+ * Phase E.E3 unit tests for the typed gene and uniprot-domains helpers.
+ *
+ * Covers:
+ *   - `getGene(gene_input, input_type)`
+ *   - `getGeneBySymbol(symbol)`
+ *   - `listGenes(params)`
+ *   - `getUniprotDomains(symbol)` (from api/external.ts)
+ *
+ * MSW handlers live in `@/test-utils/mocks/handlers` (registered with the
+ * global server in `vitest.setup.ts`) and the fixtures live in
+ * `@/test-utils/mocks/data/genes`. See `.plans/v11.0/phase-e.md` §3 Phase
+ * E.E3 for the migration rationale; these tests lock in the wire shapes
+ * before rewriting `GeneView.vue`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { getGene, getGeneBySymbol, listGenes } from './genes';
+import { getUniprotDomains } from './external';
+import { isApiError } from './client';
+import { server } from '@/test-utils/mocks/server';
+import {
+  geneLookupOk,
+  geneListOk,
+  uniprotDomainsOk,
+  UNIPROT_NOT_FOUND_SYMBOL,
+} from '@/test-utils/mocks/data/genes';
+
+describe('api/genes — typed helpers', () => {
+  // ---------------------------------------------------------------------------
+  // getGene
+  // ---------------------------------------------------------------------------
+
+  describe('getGene', () => {
+    it('returns the 1-row lookup array for a valid HGNC id', async () => {
+      const rows = await getGene('HGNC:4586', 'hgnc');
+
+      expect(Array.isArray(rows)).toBe(true);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].symbol).toEqual(geneLookupOk[0].symbol);
+      expect(rows[0].hgnc_id).toEqual(['HGNC:4586']);
+      // Phase A A2 regression guard: gnomad_constraints arrives as a scalar
+      // JSON string (NOT a pipe-split array).
+      expect(typeof rows[0].gnomad_constraints).toBe('string');
+    });
+
+    it('defaults input_type to "hgnc" when omitted', async () => {
+      let observedInputType: string | null = null;
+      server.use(
+        http.get('/api/gene/:gene_input', ({ request }) => {
+          observedInputType = new URL(request.url).searchParams.get('input_type');
+          return HttpResponse.json(geneLookupOk);
+        }),
+      );
+
+      await getGene('HGNC:4586');
+      expect(observedInputType).toBe('hgnc');
+    });
+
+    it('sends input_type=symbol when explicitly requested', async () => {
+      let observedInputType: string | null = null;
+      server.use(
+        http.get('/api/gene/:gene_input', ({ request }) => {
+          observedInputType = new URL(request.url).searchParams.get('input_type');
+          return HttpResponse.json(geneLookupOk);
+        }),
+      );
+
+      await getGene('GRIN2B', 'symbol');
+      expect(observedInputType).toBe('symbol');
+    });
+
+    it('returns an empty array for the UNKNOWN_GENE sentinel', async () => {
+      const rows = await getGene('UNKNOWN_GENE', 'symbol');
+      expect(Array.isArray(rows)).toBe(true);
+      expect(rows).toHaveLength(0);
+    });
+
+    it('URL-encodes the gene_input path param', async () => {
+      let observedPath: string | null = null;
+      server.use(
+        http.get('/api/gene/:gene_input', ({ params, request }) => {
+          observedPath = new URL(request.url).pathname;
+          // Also confirm MSW decoded the path param back to the raw value.
+          expect(params.gene_input).toBe('HGNC:4586');
+          return HttpResponse.json(geneLookupOk);
+        }),
+      );
+
+      await getGene('HGNC:4586', 'hgnc');
+      // `:` must be percent-encoded in the outgoing URL — otherwise callers
+      // with symbols containing reserved characters would drop path segments.
+      expect(observedPath).toBe('/api/gene/HGNC%3A4586');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getGeneBySymbol
+  // ---------------------------------------------------------------------------
+
+  describe('getGeneBySymbol', () => {
+    it('wraps getGene with input_type=symbol', async () => {
+      let observedInputType: string | null = null;
+      let observedSymbol: string | null = null;
+      server.use(
+        http.get('/api/gene/:gene_input', ({ params, request }) => {
+          observedSymbol = String(params.gene_input);
+          observedInputType = new URL(request.url).searchParams.get('input_type');
+          return HttpResponse.json(geneLookupOk);
+        }),
+      );
+
+      const rows = await getGeneBySymbol('GRIN2B');
+      expect(observedSymbol).toBe('GRIN2B');
+      expect(observedInputType).toBe('symbol');
+      expect(rows).toHaveLength(1);
+      expect(rows[0].symbol).toEqual(['GRIN2B']);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // listGenes
+  // ---------------------------------------------------------------------------
+
+  describe('listGenes', () => {
+    it('returns the cursor-paginated envelope', async () => {
+      const envelope = await listGenes({ page_size: '10' });
+
+      expect(envelope).toHaveProperty('data');
+      expect(envelope).toHaveProperty('meta');
+      expect(envelope).toHaveProperty('links');
+      expect(Array.isArray(envelope.data)).toBe(true);
+      expect(envelope.data).toHaveLength(geneListOk.data.length);
+      expect(envelope.data[0].symbol).toEqual(geneListOk.data[0].symbol);
+    });
+
+    it('forwards all listing params to the query string', async () => {
+      let observedQuery: URLSearchParams | null = null;
+      server.use(
+        http.get('/api/gene', ({ request }) => {
+          observedQuery = new URL(request.url).searchParams;
+          return HttpResponse.json(geneListOk);
+        }),
+      );
+
+      await listGenes({
+        sort: 'symbol',
+        filter: 'contains(symbol,GR)',
+        fields: 'hgnc_id,symbol',
+        page_after: 'HGNC:4586',
+        page_size: '25',
+        fspec: 'default',
+      });
+
+      expect(observedQuery).not.toBeNull();
+      const q = observedQuery as unknown as URLSearchParams;
+      expect(q.get('sort')).toBe('symbol');
+      expect(q.get('filter')).toBe('contains(symbol,GR)');
+      expect(q.get('fields')).toBe('hgnc_id,symbol');
+      expect(q.get('page_after')).toBe('HGNC:4586');
+      expect(q.get('page_size')).toBe('25');
+      expect(q.get('fspec')).toBe('default');
+    });
+
+    it('works with no params (defaults)', async () => {
+      const envelope = await listGenes();
+      expect(envelope).toHaveProperty('data');
+    });
+  });
+});
+
+describe('api/external — getUniprotDomains', () => {
+  it('returns the UniProt domains payload on 200', async () => {
+    const data = await getUniprotDomains('GRIN2B');
+
+    expect(data.source).toBe('uniprot');
+    expect(data.gene_symbol).toBe(uniprotDomainsOk.gene_symbol);
+    expect(data.accession).toBe(uniprotDomainsOk.accession);
+    expect(Array.isArray(data.domains)).toBe(true);
+    expect(data.domains.length).toBeGreaterThan(0);
+    expect(data.domains[0]).toHaveProperty('type');
+    expect(data.domains[0]).toHaveProperty('begin');
+    expect(data.domains[0]).toHaveProperty('end');
+  });
+
+  it('URL-encodes the symbol path param', async () => {
+    let observedPath: string | null = null;
+    server.use(
+      http.get('/api/external/uniprot/domains/:symbol', ({ request }) => {
+        observedPath = new URL(request.url).pathname;
+        return HttpResponse.json(uniprotDomainsOk);
+      }),
+    );
+
+    await getUniprotDomains('GRIN 2B');
+    expect(observedPath).toBe('/api/external/uniprot/domains/GRIN%202B');
+  });
+
+  it('rejects with an AxiosError on the 404 sentinel branch', async () => {
+    let caught: unknown;
+    try {
+      await getUniprotDomains(UNIPROT_NOT_FOUND_SYMBOL);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeDefined();
+    expect(isApiError(caught)).toBe(true);
+    if (isApiError(caught)) {
+      expect(caught.response?.status).toBe(404);
+    }
+  });
+});

--- a/app/src/test-utils/mocks/data/genes.ts
+++ b/app/src/test-utils/mocks/data/genes.ts
@@ -1,0 +1,134 @@
+// test-utils/mocks/data/genes.ts
+/**
+ * Static fixtures for gene and UniProt-domains endpoints used by the
+ * Phase E.E3 migration of `GeneView.vue` off raw axios.get onto the typed
+ * `api/genes.ts` + `api/external.ts` helpers.
+ *
+ * Wire shapes mirror:
+ *   - api/endpoints/gene_endpoints.R @get /<gene_input>  — returns a `tibble`
+ *     collected to JSON (1-row array when the gene exists, empty `[]` when
+ *     not found). Each string column is pipe-split into a `string[]`.
+ *   - api/endpoints/gene_endpoints.R @get /            — cursor-paginated
+ *     `{meta, data, links}` envelope.
+ *   - api/endpoints/external_endpoints.R @get uniprot/domains/<symbol>  —
+ *     unboxedJSON serializer; the body is a plain object with a `domains`
+ *     array. 404 uses the `application/problem+json` error shape.
+ *
+ * Sentinel path params:
+ *   - gene symbol `UNKNOWN_GENE` → `/api/gene/:id` returns `[]` (empty lookup).
+ *   - gene symbol `NO_UNIPROT`   → `/api/external/uniprot/domains/:symbol`
+ *     returns a 404 (mirrors the "gene not in UniProt" branch of the real
+ *     endpoint).
+ */
+
+import type { GeneApiData } from '@/types/gene';
+
+// ---------------------------------------------------------------------------
+// /api/gene/:id
+// ---------------------------------------------------------------------------
+
+/** Default 1-row lookup result returned for any input_type=hgnc|symbol. */
+export const geneLookupOk: GeneApiData[] = [
+  {
+    hgnc_id: ['HGNC:4586'],
+    symbol: ['GRIN2B'],
+    name: ['glutamate ionotropic receptor NMDA type subunit 2B'],
+    entrez_id: ['2904'],
+    ensembl_gene_id: ['ENSG00000273079'],
+    ucsc_id: ['uc001qvj.4'],
+    ccds_id: ['CCDS8573'],
+    uniprot_ids: ['Q13224'],
+    omim_id: ['138252'],
+    mane_select: ['NM_000834.5'],
+    mgd_id: ['MGI:95821'],
+    rgd_id: ['RGD:620630'],
+    STRING_id: ['9606.ENSP00000477455'],
+    bed_hg38: ['chr12:13437873-13982410'],
+    gnomad_constraints: '{"pli":0.99,"loeuf":0.18,"mis_z":5.4,"syn_z":0.4}',
+    alphafold_id: ['AF-Q13224-F1'],
+  },
+];
+
+/** Empty-lookup branch: the real endpoint returns `[]` for unknown input. */
+export const geneLookupEmpty: GeneApiData[] = [];
+
+// ---------------------------------------------------------------------------
+// /api/gene (cursor-paginated listing)
+// ---------------------------------------------------------------------------
+
+export interface GeneListEnvelope {
+  meta: unknown[];
+  data: GeneApiData[];
+  links: unknown[];
+}
+
+export const geneListOk: GeneListEnvelope = {
+  meta: [{ page_size: 10, total: 2 }],
+  data: [
+    geneLookupOk[0],
+    {
+      hgnc_id: ['HGNC:4851'],
+      symbol: ['HNRNPU'],
+      name: ['heterogeneous nuclear ribonucleoprotein U'],
+      entrez_id: ['3192'],
+      ensembl_gene_id: ['ENSG00000153187'],
+      ucsc_id: ['uc001htx.3'],
+      ccds_id: ['CCDS1578'],
+      uniprot_ids: ['Q00839'],
+      omim_id: ['602869'],
+      mane_select: ['NM_031844.3'],
+      mgd_id: ['MGI:105052'],
+      rgd_id: ['RGD:1305876'],
+      STRING_id: ['9606.ENSP00000283179'],
+      bed_hg38: ['chr1:244839603-244856519'],
+      gnomad_constraints: null,
+      alphafold_id: ['AF-Q00839-F1'],
+    },
+  ],
+  links: [{ self: '/api/gene?page_size=10' }],
+};
+
+// ---------------------------------------------------------------------------
+// /api/external/uniprot/domains/:symbol
+// ---------------------------------------------------------------------------
+
+export interface UniProtDomainFeatureFixture {
+  type: string;
+  description?: string;
+  begin: number | string;
+  end: number | string;
+}
+
+export interface UniProtDataFixture {
+  source: string;
+  gene_symbol: string;
+  accession: string;
+  protein_name: string;
+  protein_length: number | string;
+  domains: UniProtDomainFeatureFixture[];
+}
+
+export const uniprotDomainsOk: UniProtDataFixture = {
+  source: 'uniprot',
+  gene_symbol: 'GRIN2B',
+  accession: 'Q13224',
+  protein_name: 'Glutamate receptor ionotropic, NMDA 2B',
+  protein_length: 1484,
+  domains: [
+    { type: 'DOMAIN', description: 'Lig_chan-Glu_bd', begin: 557, end: 780 },
+    { type: 'DOMAIN', description: 'ANF_receptor', begin: 27, end: 387 },
+    { type: 'REGION', description: 'Cytoplasmic tail', begin: 839, end: 1484 },
+  ],
+};
+
+/** Sentinel gene symbol that triggers the 404 branch. */
+export const UNIPROT_NOT_FOUND_SYMBOL = 'NO_UNIPROT';
+
+export const uniprotDomainsNotFound = {
+  type: 'about:blank',
+  title: 'Gene not found in UniProt',
+  status: 404,
+  detail: 'Gene NO_UNIPROT not found in UniProt',
+  instance: '/api/external/uniprot/domains/NO_UNIPROT',
+  source: 'uniprot',
+};

--- a/app/src/test-utils/mocks/handlers.ts
+++ b/app/src/test-utils/mocks/handlers.ts
@@ -142,6 +142,14 @@ import {
   listGeneOk,
   listDiseaseOk,
 } from './data/lists';
+import {
+  geneLookupOk,
+  geneLookupEmpty,
+  geneListOk,
+  uniprotDomainsOk,
+  uniprotDomainsNotFound,
+  UNIPROT_NOT_FOUND_SYMBOL,
+} from './data/genes';
 import { reReviewTableOk } from './data/re_review';
 import {
   annotationDatesOk,
@@ -754,6 +762,49 @@ export const handlers = [
   // OpenAPI: GET /api/comparisons/metadata
   // api/endpoints/comparisons_endpoints.R @get /metadata
   http.get('/api/comparisons/metadata', () => HttpResponse.json(comparisonsMetadataOk)),
+
+  // ---------------------------------------------------------------------------
+  // Phase E.E3 — GeneView.vue migration (first-client-migration)
+  //
+  // These handlers back the `api/genes.ts` + `api/external.ts` typed helpers
+  // that Phase E.E3 introduces to replace the raw `axios.get` calls in
+  // `GeneView.vue`. Registered here so the `genes.spec.ts` helper unit tests
+  // and any future GeneView.vue component spec can rely on MSW interception.
+  // See `.plans/v11.0/phase-e.md` §3 Phase E.E3 exit criterion #14.
+  // ---------------------------------------------------------------------------
+
+  // OpenAPI: GET /api/gene  (cursor-paginated listing)
+  // api/endpoints/gene_endpoints.R @get /
+  // Registered BEFORE `/api/gene/:gene_input` so the literal match wins over
+  // the parameterised one in MSW's first-match-wins ordering.
+  http.get('/api/gene', () => HttpResponse.json(geneListOk)),
+
+  // OpenAPI: GET /api/gene/:gene_input?input_type=hgnc|symbol
+  // api/endpoints/gene_endpoints.R @get /<gene_input>
+  //
+  // Wire shape: 1-row array when found, empty `[]` when unknown. `GeneView`
+  // dispatches two lookups in parallel (hgnc + symbol) and picks whichever
+  // comes back with rows. Use the sentinel value `UNKNOWN_GENE` to trigger
+  // the empty branch regardless of input_type.
+  http.get('/api/gene/:gene_input', ({ params }) => {
+    if (params.gene_input === 'UNKNOWN_GENE') {
+      return HttpResponse.json(geneLookupEmpty);
+    }
+    return HttpResponse.json(geneLookupOk);
+  }),
+
+  // OpenAPI: GET /api/external/uniprot/domains/:symbol
+  // api/endpoints/external_endpoints.R @get uniprot/domains/<symbol>
+  //
+  // 404 branch uses the sentinel symbol `NO_UNIPROT` (mirrors the "gene not
+  // in UniProt" path of the real endpoint). The body follows the
+  // `application/problem+json` shape the endpoint emits on error.
+  http.get('/api/external/uniprot/domains/:symbol', ({ params }) => {
+    if (params.symbol === UNIPROT_NOT_FOUND_SYMBOL) {
+      return HttpResponse.json(uniprotDomainsNotFound, { status: 404 });
+    }
+    return HttpResponse.json(uniprotDomainsOk);
+  }),
 ];
 
 export default handlers;

--- a/app/src/views/pages/GeneView.vue
+++ b/app/src/views/pages/GeneView.vue
@@ -276,7 +276,7 @@ async function loadGeneInfo() {
       geneData.value = hgncRows;
     }
   } catch (e) {
-    makeToast(e as string, 'Error', 'danger');
+    makeToast(e, 'Error', 'danger');
   }
   loading.value = false;
 

--- a/app/src/views/pages/GeneView.vue
+++ b/app/src/views/pages/GeneView.vue
@@ -136,7 +136,9 @@ import { useHead } from '@unhead/vue';
 import { useToast } from '@/composables';
 import { useGeneExternalData } from '@/composables/useGeneExternalData';
 import { useModelOrganismData } from '@/composables/useModelOrganismData';
-import axios from 'axios';
+import { getGene, getGeneBySymbol } from '@/api/genes';
+import { getUniprotDomains, type UniProtData } from '@/api/external';
+import { isApiError } from '@/api/client';
 import GeneBadge from '@/components/ui/GeneBadge.vue';
 import IdentifierCard from '@/components/gene/IdentifierCard.vue';
 import ClinicalResourcesCard from '@/components/gene/ClinicalResourcesCard.vue';
@@ -147,27 +149,9 @@ import GenomicVisualizationTabs from '@/components/gene/GenomicVisualizationTabs
 import TablesEntities from '@/components/tables/TablesEntities.vue';
 import type { GeneApiData } from '@/types/gene';
 
-/**
- * UniProt domain feature from the API response
- */
-interface UniProtDomainFeature {
-  type: string;
-  description?: string;
-  begin: number | string;
-  end: number | string;
-}
-
-/**
- * UniProt API response structure from /api/external/uniprot/domains/<symbol>
- */
-interface UniProtData {
-  source: string;
-  gene_symbol: string;
-  accession: string;
-  protein_name: string;
-  protein_length: number | string;
-  domains: UniProtDomainFeature[];
-}
+// UniProtData + UniProtDomainFeature are now exported from `@/api/external`
+// (Phase E.E3 migration). Importing them keeps one source of truth between
+// the api/ helper and this view's prop-forwarding to GenomicVisualizationTabs.
 
 const route = useRoute();
 const router = useRouter();
@@ -230,22 +214,16 @@ async function fetchUniprotData(): Promise<void> {
   uniprotError.value = null;
 
   try {
-    const apiBase = import.meta.env.VITE_API_URL;
-    const response = await axios.get(
-      `${apiBase}/api/external/uniprot/domains/${geneSymbol.value}`,
-      {
-        withCredentials: true,
-      }
-    );
+    const data = await getUniprotDomains(geneSymbol.value);
 
     // Check for valid response with domains
-    if (response.data && response.data.domains) {
-      uniprotData.value = response.data;
+    if (data && data.domains) {
+      uniprotData.value = data;
     } else {
       uniprotData.value = null;
     }
   } catch (err) {
-    if (axios.isAxiosError(err) && err.response?.status === 404) {
+    if (isApiError(err) && err.response?.status === 404) {
       // Gene not found in UniProt - not an error, just no data
       uniprotData.value = null;
       uniprotError.value = null;
@@ -278,23 +256,24 @@ async function retryAllExternalData(): Promise<void> {
 async function loadGeneInfo() {
   loading.value = true;
   const symbol = route.params.symbol as string;
-  const apiBase = import.meta.env.VITE_API_URL;
-  const apiGeneURL = `${apiBase}/api/gene/${symbol}?input_type=hgnc`;
-  const apiGeneSymbolURL = `${apiBase}/api/gene/${symbol}?input_type=symbol`;
 
   try {
-    // Parallel fetch: both gene API calls run concurrently
-    const [responseGene, responseSymbol] = await Promise.all([
-      axios.get(apiGeneURL, { withCredentials: true }),
-      axios.get(apiGeneSymbolURL, { withCredentials: true }),
+    // Parallel fetch: both gene API calls run concurrently. `getGene` /
+    // `getGeneBySymbol` (from `@/api/genes`) return the 1-row-array lookup
+    // shape directly — the legacy `?input_type=...` query string is folded
+    // into the helper signature, and the `apiBase` prepend is handled by
+    // the configured axios singleton under `@/plugins/axios`.
+    const [hgncRows, symbolRows] = await Promise.all([
+      getGene(symbol, 'hgnc'),
+      getGeneBySymbol(symbol),
     ]);
 
-    if (responseGene.data.length === 0 && responseSymbol.data.length === 0) {
+    if (hgncRows.length === 0 && symbolRows.length === 0) {
       router.push('/PageNotFound');
-    } else if (responseGene.data.length === 0) {
-      geneData.value = responseSymbol.data;
+    } else if (hgncRows.length === 0) {
+      geneData.value = symbolRows;
     } else {
-      geneData.value = responseGene.data;
+      geneData.value = hgncRows;
     }
   } catch (e) {
     makeToast(e as string, 'Error', 'danger');


### PR DESCRIPTION
## Summary
- Migrates `GeneView.vue` from raw `axios.get` to `api/client.ts` helpers
- Adds `getUniprotDomains()` + `UniProtData` / `UniProtDomainFeature` types to `api/external.ts` (was stub-only from E1)
- Adds `api/genes.spec.ts` covering `getGene`, `getGeneBySymbol`, `listGenes`, and `getUniprotDomains`
- Adds MSW fixtures + handlers for `/api/gene`, `/api/gene/:id`, and `/api/external/uniprot/domains/:symbol`
- Zero `axios.get` remaining in `GeneView.vue`

See `.plans/v11.0/phase-e.md` §3 Phase E.E3 exit criterion 14 (template migration). Intentionally no `Closes #<n>` keyword — this PR advances a phase plan, not a GitHub issue.

## Verification
- `cd app && npm run type-check` OK
- `cd app && npm run lint` OK
- `cd app && npm run test:unit` OK (462 passed, +12 new from genes.spec.ts)
- `grep -n "axios\.get" app/src/views/pages/GeneView.vue` returns 0
- Host `make ci-local` skipped per CLAUDE.md Conda-R workaround (frontend-only change).

## Test plan
- [ ] CI green
- [ ] Manual gene-page smoke test (click through to a gene page; external cards load)