### PR TITLE
v11.0/phase-e: E2 ts-strictness-scopes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,9 @@ jobs:
       - name: Run TypeScript check
         run: npm run type-check
 
+      - name: Run TypeScript check (strict scopes)
+        run: npm run type-check:strict
+
       - name: Run Vitest tests
         run: npm run test:unit
 

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ pre-commit: ## [quality] Run all quality checks before committing
 
 ci-local: ## [quality] Run CI checks locally (lint + test with DB - mirrors GitHub Actions)
 	@printf "$(CYAN)==> Running CI checks locally (mirrors GitHub Actions)...$(RESET)\n"
-	@printf "\n$(CYAN)[1/5] Starting test database...$(RESET)\n"
+	@printf "\n$(CYAN)[1/6] Starting test database...$(RESET)\n"
 	@cd $(ROOT_DIR) && docker compose -f docker-compose.dev.yml up -d mysql-test && \
 		printf "$(GREEN)✓ Test database started$(RESET)\n" || \
 		(printf "$(RED)✗ Failed to start test database$(RESET)\n" && exit 1)
@@ -193,14 +193,17 @@ ci-local: ## [quality] Run CI checks locally (lint + test with DB - mirrors GitH
 		sleep 1; \
 		SECONDS=$$((SECONDS+1)); \
 	done
-	@printf "\n$(CYAN)[2/5] Linting R code...$(RESET)\n"
+	@printf "\n$(CYAN)[2/6] Linting R code...$(RESET)\n"
 	@$(MAKE) lint-api || ($(MAKE) _ci-cleanup && exit 1)
-	@printf "\n$(CYAN)[3/5] Linting frontend code...$(RESET)\n"
+	@printf "\n$(CYAN)[3/6] Linting frontend code...$(RESET)\n"
 	@$(MAKE) lint-app || ($(MAKE) _ci-cleanup && exit 1)
-	@printf "\n$(CYAN)[4/5] Type-checking frontend...$(RESET)\n"
+	@printf "\n$(CYAN)[4/6] Type-checking frontend...$(RESET)\n"
 	@cd $(ROOT_DIR)/app && npm run type-check || ($(MAKE) _ci-cleanup && exit 1)
 	@printf "$(GREEN)✓ Type check passed$(RESET)\n"
-	@printf "\n$(CYAN)[5/5] Running R API tests (with database)...$(RESET)\n"
+	@printf "\n$(CYAN)[5/6] Type-checking frontend (strict scopes)...$(RESET)\n"
+	@cd $(ROOT_DIR)/app && npm run type-check:strict || ($(MAKE) _ci-cleanup && exit 1)
+	@printf "$(GREEN)✓ Strict type check passed$(RESET)\n"
+	@printf "\n$(CYAN)[6/6] Running R API tests (with database)...$(RESET)\n"
 	@cd $(ROOT_DIR)/api && \
 		MYSQL_HOST=127.0.0.1 MYSQL_PORT=7655 MYSQL_DATABASE=sysndd_db_test \
 		MYSQL_USER=bernt MYSQL_PASSWORD=Nur7DoofeFliegen. \

--- a/app/package.json
+++ b/app/package.json
@@ -11,6 +11,7 @@
     "build:docker": "vite build --mode docker",
     "build:production": "vite build --mode production",
     "type-check": "vue-tsc --noEmit",
+    "type-check:strict": "node scripts/type-check-strict.js",
     "lint": "eslint . --ext .vue,.js,.ts,.tsx",
     "lint:fix": "eslint . --ext .vue,.js,.ts,.tsx --fix",
     "format": "prettier --write \"src/**/*.{js,ts,vue,json,css,scss}\"",

--- a/app/scripts/type-check-strict.js
+++ b/app/scripts/type-check-strict.js
@@ -77,6 +77,24 @@ for (const scope of scopes) {
     { cwd: appDir, encoding: 'utf8' }
   );
 
+  // Spawn failed outright (e.g. npx not on PATH, ENOENT, permission denied).
+  // `result.status` is null in this case, so fall-through would surface as
+  // "UNEXPECTED TOOL FAILURE (vue-tsc exit null)" and bury the real cause.
+  if (result.error) {
+    console.error(`[type-check:strict] ${scope.name}: SPAWN FAILED — ${result.error.message}`);
+    console.error(result.error.stack ?? '(no stack)');
+    failed = true;
+    continue;
+  }
+  // Process was terminated by a signal (e.g. SIGKILL from OOM killer).
+  // Again, `result.status` is null here, so we need to surface the signal
+  // explicitly before the generic guard below misreports it.
+  if (result.signal) {
+    console.error(`[type-check:strict] ${scope.name}: KILLED BY SIGNAL ${result.signal}`);
+    failed = true;
+    continue;
+  }
+
   const output = `${result.stdout || ''}${result.stderr || ''}`;
   const lines = output.split('\n');
   const inScopeErrors = lines.filter((line) => line.startsWith(scope.prefix));

--- a/app/scripts/type-check-strict.js
+++ b/app/scripts/type-check-strict.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * type-check-strict.js — run vue-tsc against strict-scoped tsconfigs and
+ * fail only when errors originate inside the scope's own files.
+ *
+ * Background: vue-tsc walks the full import graph and reports diagnostics
+ * for any referenced file. In our codebase, `src/router/routes.ts` pulls
+ * in ~40 view .vue files whose transitive dependencies violate strict
+ * mode. The root `tsconfig.json` is intentionally permissive so those
+ * violations don't block builds.
+ *
+ * For Phase E.E2, we only care that files INSIDE each strict scope are
+ * strict-clean. Out-of-scope violations remain "ignored" under the root
+ * permissive config, to be fixed as subsequent scopes get enabled.
+ *
+ * This runner:
+ *   - invokes vue-tsc -p <tsconfig> for each configured scope
+ *   - partitions diagnostic lines by file prefix
+ *   - prints in-scope errors to stderr and exits non-zero if any are found
+ *   - skips the composables-auth scope silently when no useAuth*.ts files
+ *     exist yet (E7 creates useAuth.ts in parallel)
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, globSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const appDir = resolve(__dirname, '..');
+
+/**
+ * @typedef {Object} Scope
+ * @property {string} name     - Human label for logging.
+ * @property {string} tsconfig - Path to the scope tsconfig, relative to app/.
+ * @property {string} prefix   - Path prefix (relative to app/) that marks
+ *                               "in scope" error lines.
+ * @property {string} [requireGlob] - If set, scope runs only when this glob
+ *                                    matches at least one file.
+ */
+
+/** @type {Scope[]} */
+const scopes = [
+  { name: 'router', tsconfig: 'tsconfig.router.json', prefix: 'src/router/' },
+  { name: 'api', tsconfig: 'tsconfig.api.json', prefix: 'src/api/' },
+  { name: 'types', tsconfig: 'tsconfig.types.json', prefix: 'src/types/' },
+  {
+    name: 'composables-auth',
+    tsconfig: 'tsconfig.composables-auth.json',
+    prefix: 'src/composables/useAuth',
+    requireGlob: 'src/composables/useAuth*.ts',
+  },
+];
+
+let failed = false;
+
+for (const scope of scopes) {
+  if (scope.requireGlob) {
+    const matches = globSync(scope.requireGlob, { cwd: appDir });
+    if (matches.length === 0) {
+      console.log(
+        `[type-check:strict] skipping ${scope.name}: no files match ${scope.requireGlob} yet`
+      );
+      continue;
+    }
+  }
+
+  if (!existsSync(resolve(appDir, scope.tsconfig))) {
+    console.error(`[type-check:strict] missing tsconfig: ${scope.tsconfig}`);
+    failed = true;
+    continue;
+  }
+
+  const result = spawnSync(
+    'npx',
+    ['vue-tsc', '--noEmit', '-p', scope.tsconfig],
+    { cwd: appDir, encoding: 'utf8' }
+  );
+
+  const output = `${result.stdout || ''}${result.stderr || ''}`;
+  const lines = output.split('\n');
+  const inScopeErrors = lines.filter((line) => line.startsWith(scope.prefix));
+
+  if (inScopeErrors.length > 0) {
+    console.error(`[type-check:strict] ${scope.name}: FAIL (${inScopeErrors.length} errors)`);
+    for (const line of inScopeErrors) {
+      console.error(line);
+    }
+    failed = true;
+  } else {
+    console.log(`[type-check:strict] ${scope.name}: OK`);
+  }
+}
+
+process.exit(failed ? 1 : 0);

--- a/app/scripts/type-check-strict.js
+++ b/app/scripts/type-check-strict.js
@@ -87,9 +87,38 @@ for (const scope of scopes) {
       console.error(line);
     }
     failed = true;
-  } else {
-    console.log(`[type-check:strict] ${scope.name}: OK`);
+    continue;
   }
+
+  // Catch unexpected tool failures: vue-tsc exited non-zero with no in-scope
+  // errors, but also produced no recognizable out-of-scope diagnostics.
+  //
+  // vue-tsc normally exits non-zero when ANY file in the import graph has
+  // errors — out-of-scope diagnostics are expected and intentionally ignored.
+  // They look like: `src/foo/bar.vue(12,3): error TS2322: ...`.
+  //
+  // If the exit is non-zero but NO line matches that shape, vue-tsc itself
+  // failed to run (binary missing, tsconfig-level error like TS5058 emitted
+  // without a path prefix, process crash, npm ERR!). Without this guard
+  // every scope would report "OK" with exit 0 — a silent green pass that
+  // hides real failures.
+  if (result.status !== 0) {
+    // Match any line that looks like a normal TS diagnostic:
+    // `path/to/file.ext(line,col): error TSxxxx: message`
+    const diagnosticPattern = /^\S+\.\w+\(\d+,\d+\): (?:error|warning) TS\d+:/;
+    const hasAnyDiagnostic = lines.some((line) => diagnosticPattern.test(line));
+    if (!hasAnyDiagnostic) {
+      const rawOutput = output.trim();
+      console.error(
+        `[type-check:strict] ${scope.name}: UNEXPECTED TOOL FAILURE (vue-tsc exit ${result.status})`
+      );
+      console.error(rawOutput.length > 0 ? rawOutput : '(no output)');
+      failed = true;
+      continue;
+    }
+  }
+
+  console.log(`[type-check:strict] ${scope.name}: OK`);
 }
 
 process.exit(failed ? 1 : 0);

--- a/app/scripts/type-check-strict.js
+++ b/app/scripts/type-check-strict.js
@@ -17,8 +17,10 @@
  *   - invokes vue-tsc -p <tsconfig> for each configured scope
  *   - partitions diagnostic lines by file prefix
  *   - prints in-scope errors to stderr and exits non-zero if any are found
- *   - skips the composables-auth scope silently when no useAuth*.ts files
- *     exist yet (E7 creates useAuth.ts in parallel)
+ *   - logs a skip notice and continues (exits 0) for the composables-auth
+ *     scope when no useAuth*.ts files exist yet (E7 creates useAuth.ts in
+ *     parallel); the notice is intentional so CI logs show why the scope
+ *     was deferred rather than silently missed
  */
 
 import { spawnSync } from 'node:child_process';

--- a/app/tsconfig.api.json
+++ b/app/tsconfig.api.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.strict.json",
+  "include": ["src/api/**/*.ts"]
+}

--- a/app/tsconfig.composables-auth.json
+++ b/app/tsconfig.composables-auth.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.strict.json",
+  "include": ["src/composables/useAuth*.ts"]
+}

--- a/app/tsconfig.router.json
+++ b/app/tsconfig.router.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.strict.json",
+  "include": ["src/router/**/*.ts"]
+}

--- a/app/tsconfig.strict.json
+++ b/app/tsconfig.strict.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "allowJs": true,
+    "noEmit": true
+  },
+  "include": []
+}

--- a/app/tsconfig.types.json
+++ b/app/tsconfig.types.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.strict.json",
+  "include": ["src/types/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- Adds per-directory TypeScript strict scopes: `tsconfig.strict.json` (base), `tsconfig.router.json`, `tsconfig.api.json`, `tsconfig.types.json`, `tsconfig.composables-auth.json`.
- Adds `type-check:strict` npm script that runs a small Node runner (`app/scripts/type-check-strict.js`) against each scope and reports diagnostics whose source file is inside the scope's own prefix.
- Global `tsconfig.json` remains permissive (unchanged) - 129 unmigrated JS SFCs continue to build.
- Fixed 0 implicit-any violations inline: all four scope-file sets (`src/router/*`, `src/api/*`, `src/types/*`, and a simulated `src/composables/useAuth.ts`) are already strict-clean on this branch.

Satisfies Phase E exit criterion 15 (see `.plans/v11.0/phase-e.md` §3 Phase E.E2).

## Why a runner instead of chained `vue-tsc -p <config>` calls
`vue-tsc` walks the full import graph and reports diagnostics for every transitively-referenced file. In this codebase `src/router/routes.ts` pulls in ~40 view `.vue` files whose dependencies violate strict mode (50+ errors across composables, views, and components). The permissive root `tsconfig.json` tolerates those violations today; chaining `vue-tsc -p` calls directly would fail the strict gate on those out-of-scope files.

The runner filters diagnostics by source-file prefix, so each strict scope surfaces only its own violations. Out-of-scope files remain tolerated under the root permissive config and will be strict-cleaned as subsequent scopes are added (per the v11.0 plan).

## Composables-auth tolerance
E7 creates `src/composables/useAuth.ts` in parallel. The runner checks the `src/composables/useAuth*.ts` glob and silently skips that scope until at least one matching file exists. Simulated locally by dropping a throwaway `useAuth.ts` - runner reports `composables-auth: OK`.

## Code-review fixes applied (post-opening)
- I1: runner now fails loudly on unexpected vue-tsc tool crashes / non-prefix errors (was silent-green)
- I2: `type-check:strict` wired into `.github/workflows/ci.yml` and `make ci-local` — now enforceable on master
- Copilot: surface spawnSync error/signal; reconcile "silently skipped" comment; reword exit-criterion link to avoid accidental issue reference.

## Verification
Host frontend gates:
- `cd app && npm run type-check` -> green
- `cd app && npm run type-check:strict` -> router OK, api OK, types OK, composables-auth skipped (no files yet)
- `cd app && npm run lint` -> green
- `cd app && npm run test:unit` -> 34 files, 450 passed, 6 todo

Host `make ci-local` skipped per CLAUDE.md Conda-R workaround (frontend-only change; R lint/test stack gated by A7's CI matrix).

## Test plan
- [ ] CI green on PR
- [ ] Reviewer confirms strict scopes re-enabled without touching global `tsconfig.json`
- [ ] Reviewer confirms runner script partitioning diagnostics by scope prefix is acceptable (vs. per-scope tsconfig fix-everything)

