### PR TITLE
v11.0/phase-e: E7 consolidate auth session (useAuth composable)

### DIFF
--- a/app/src/components/AppNavbar.vue
+++ b/app/src/components/AppNavbar.vue
@@ -75,12 +75,21 @@ import ROLES from '@/assets/js/constants/role_constants';
 import packageInfo from '../../package.json';
 import SearchCombobox from '@/components/small/SearchCombobox.vue';
 import IconPairDropdownMenu from '@/components/small/IconPairDropdownMenu.vue';
+import { useAuth } from '@/composables/useAuth';
 
 export default {
   name: 'AppNavbar',
   components: {
     SearchCombobox,
     IconPairDropdownMenu,
+  },
+  setup() {
+    // Phase E.E7: route all auth-state reads through the shared composable
+    // instead of reaching into localStorage. The Bearer header is already
+    // set by `@/plugins/axios` whenever `useAuth` mutates the token, so the
+    // navbar no longer has to read `localStorage.getItem('token')` itself.
+    const auth = useAuth();
+    return { auth };
   },
   data() {
     return {
@@ -133,21 +142,22 @@ export default {
   },
   methods: {
     isUserLoggedIn() {
-      if (localStorage.user && localStorage.token) {
+      // Phase E.E7: `isAuthenticated` covers both "token present" and
+      // "user payload parsed cleanly" — the composable already refused a
+      // corrupt localStorage blob. No direct `localStorage.token` read.
+      if (this.auth.isAuthenticated.value) {
         this.checkSigninWithJWT();
       } else {
         this.clearUserData();
       }
     },
     async checkSigninWithJWT() {
+      // The `@/plugins/axios` default Authorization header is kept in
+      // lockstep with `useAuth`, so we don't override it per-request here.
       const apiAuthenticateURL = `${URLS.API_URL}/api/auth/signin`;
 
       try {
-        const response_signin = await this.axios.get(apiAuthenticateURL, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        });
+        const response_signin = await this.axios.get(apiAuthenticateURL);
 
         this.user_from_jwt = response_signin.data;
         this.setUserFromJWT();
@@ -156,12 +166,16 @@ export default {
       }
     },
     setUserFromJWT() {
-      const localStorageUser = JSON.parse(localStorage.user);
-      if (this.user_from_jwt.user_name[0] === localStorageUser.user_name[0]) {
-        const [user] = localStorageUser.user_name;
+      const authUser = this.auth.user.value;
+      if (!authUser) {
+        this.clearUserData();
+        return;
+      }
+      if (this.user_from_jwt.user_name[0] === authUser.user_name[0]) {
+        const [user] = authUser.user_name;
         this.user = user;
 
-        const user_role = localStorageUser.user_role[0];
+        const user_role = authUser.user_role[0];
         const allowence = ROLES.ALLOWENCE_NAVIGATION[ROLES.ALLOWED_ROLES.indexOf(user_role)];
 
         this.userAllowence = {
@@ -175,8 +189,9 @@ export default {
       }
     },
     clearUserData() {
-      localStorage.removeItem('user');
-      localStorage.removeItem('token');
+      // Delegates the localStorage + axios-header cleanup to useAuth so the
+      // navbar never touches those keys directly.
+      this.auth.logout();
       this.user = null;
       this.userAllowence = {
         view: false,

--- a/app/src/components/small/LogoutCountdownBadge.vue
+++ b/app/src/components/small/LogoutCountdownBadge.vue
@@ -8,12 +8,18 @@
 
 <script>
 import useToast from '@/composables/useToast';
+import { useAuth } from '@/composables/useAuth';
 
 export default {
   name: 'LogoutCountdownBadge',
   setup() {
     const { makeToast } = useToast();
-    return { makeToast };
+    // Phase E.E7: source-of-truth for token / user / expiry is now
+    // `useAuth()`. The stale "TODO: move to a mixin" comments that were
+    // sprinkled across this file have been deleted — the mixin they asked
+    // for is, in effect, this composable.
+    const auth = useAuth();
+    return { makeToast, auth };
   },
   data() {
     return {
@@ -34,9 +40,8 @@ export default {
   },
   methods: {
     doUserLogOut() {
-      if (localStorage.user || localStorage.token) {
-        localStorage.removeItem('user');
-        localStorage.removeItem('token');
+      if (this.auth.isAuthenticated.value) {
+        this.auth.logout();
 
         // based on https://stackoverflow.com/questions/57837758/navigationduplicated-navigating-to-current-location-search-is-not-allowed
         // to avoid double navigation
@@ -50,76 +55,71 @@ export default {
         }
       }
     },
-    // TODO: move to a mixin to be used in other components (DRY)
     async refreshWithJWT() {
-      const apiAuthenticateURL = `${import.meta.env.VITE_API_URL}/api/auth/refresh`;
       try {
-        const response_refresh = await this.axios.get(apiAuthenticateURL, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        });
-        localStorage.setItem('token', response_refresh.data[0]);
+        await this.auth.refresh();
         this.signinWithJWT();
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
       }
     },
-    // TODO: move to a mixin to be used in other components (DRY)
     async signinWithJWT() {
+      // `useAuth` already maintains the axios default Authorization header,
+      // so we no longer pass it per-request. The response body is the user
+      // payload that login() expects.
       const apiAuthenticateURL = `${import.meta.env.VITE_API_URL}/api/auth/signin`;
 
       try {
-        const response_signin = await this.axios.get(apiAuthenticateURL, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        });
-
-        localStorage.setItem('user', JSON.stringify(response_signin.data));
+        const response_signin = await this.axios.get(apiAuthenticateURL);
+        if (this.auth.token.value) {
+          this.auth.login(this.auth.token.value, response_signin.data);
+        }
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
       }
     },
-    // TODO: move to a mixin to be used in other components (DRY)
     updateDiffs() {
       // TODO: remove magic numbers and put them in constants in a config file
-      const timestampMillisecondDivider = 1000;
       const secondToMinuteDivider = 60;
       const warningTimePoints = [60, 180, 300];
-      if (localStorage.token) {
-        const expires = JSON.parse(localStorage.user).exp;
-        const timestamp = Math.floor(new Date().getTime() / timestampMillisecondDivider);
+      const user = this.auth.user.value;
+      if (!this.auth.isAuthenticated.value || !user) {
+        return;
+      }
 
-        if (expires > timestamp) {
-          this.time_to_logout = ((expires - timestamp) / secondToMinuteDivider).toFixed(2);
-          if (warningTimePoints.includes(expires - timestamp)) {
-            // Use a shorter name for this.$createElement
-            const h = this.$createElement;
+      const expires = user.exp?.[0];
+      if (typeof expires !== 'number') {
+        return;
+      }
+      const timestamp = Math.floor(Date.now() / 1000);
 
-            // compose the logout message
-            const vNodesMsg = h('p', { class: ['text-center', 'mb-0'] }, [
-              'Token ',
-              h(
-                'b-badge',
-                {
-                  props: { variant: 'success', href: '#' },
-                  // TODO: make the modal close after clicking on the badge
-                  on: { click: () => this.refreshWithJWT() },
-                },
-                'refresh now'
-              ),
-            ]);
+      if (expires > timestamp) {
+        this.time_to_logout = ((expires - timestamp) / secondToMinuteDivider).toFixed(2);
+        if (warningTimePoints.includes(expires - timestamp)) {
+          // Use a shorter name for this.$createElement
+          const h = this.$createElement;
 
-            this.makeToast(
-              [vNodesMsg],
-              `Warning: Logout in ${expires - timestamp} seconds`,
-              'danger'
-            );
-          }
-        } else {
-          this.doUserLogOut();
+          // compose the logout message
+          const vNodesMsg = h('p', { class: ['text-center', 'mb-0'] }, [
+            'Token ',
+            h(
+              'b-badge',
+              {
+                props: { variant: 'success', href: '#' },
+                on: { click: () => this.refreshWithJWT() },
+              },
+              'refresh now'
+            ),
+          ]);
+
+          this.makeToast(
+            [vNodesMsg],
+            `Warning: Logout in ${expires - timestamp} seconds`,
+            'danger'
+          );
         }
+      } else {
+        this.doUserLogOut();
       }
     },
   },

--- a/app/src/composables/useAuth.spec.ts
+++ b/app/src/composables/useAuth.spec.ts
@@ -338,6 +338,30 @@ describe('useAuth', () => {
       expect(auth.isAuthenticated.value).toBe(false);
     });
 
+    it('enforces both-or-neither: a dangling user (no token) is cleared from localStorage and state', () => {
+      // Copilot Fix 2: the pre-fix syncFromStorage() only cleaned up a
+      // dangling token; a dangling user survived. Components that read
+      // `auth.user.value` directly (e.g. UserView.vue's mount hook) would
+      // then hit the API without a Bearer header. Symmetric cleanup is now
+      // enforced so every observer sees the same cleared state.
+      const user = makeFreshUser();
+      localStorage.setItem('user', JSON.stringify(user));
+      // no token key — simulates a crash between the two setItem calls,
+      // or a dev-tools manipulation.
+      axios.defaults.headers.common.Authorization = 'Bearer stale';
+
+      const auth = useAuth();
+
+      expect(auth.user.value).toBeNull();
+      expect(auth.token.value).toBeNull();
+      expect(auth.isAuthenticated.value).toBe(false);
+      // Stored user must be cleaned up too, not just the in-memory ref.
+      expect(localStorage.getItem('user')).toBeNull();
+      // And the axios default header must be cleared so the next request
+      // cannot send a stale Bearer.
+      expect(axios.defaults.headers.common.Authorization).toBeUndefined();
+    });
+
     it('rehydrates cleanly when both token and user are present', () => {
       const user = makeFreshUser();
       localStorage.setItem('token', FRESH_TOKEN);

--- a/app/src/composables/useAuth.spec.ts
+++ b/app/src/composables/useAuth.spec.ts
@@ -282,6 +282,51 @@ describe('useAuth', () => {
       expect(auth.hasRole('Administrator')).toBe(false);
     });
 
+    it('rejects a JSON array in localStorage.user (`[]` is valid JSON but not a user payload)', () => {
+      // Copilot Fix 1: `JSON.parse('[]')` yields an array, and `typeof [] ===
+      // 'object'`. Without an explicit `Array.isArray` guard, safeParseUser()
+      // would have accepted `[]`, leaving userRef truthy with neither `.exp`
+      // nor `.user_role` — callers downstream would see isAuthenticated=true
+      // while every role/expiry check silently returned undefined.
+      localStorage.setItem('token', FRESH_TOKEN);
+      localStorage.setItem('user', '[]');
+
+      const auth = useAuth();
+      auth.syncFromStorage();
+
+      expect(auth.user.value).toBeNull();
+      expect(auth.isAuthenticated.value).toBe(false);
+    });
+
+    it('rejects an object with a missing/empty `exp` array', () => {
+      // Copilot Fix 1: without a usable exp[0], isExpired can never fire, so
+      // a just-expired session would linger until the next 401. Reject at
+      // parse time instead.
+      localStorage.setItem('token', FRESH_TOKEN);
+      localStorage.setItem('user', JSON.stringify({ exp: [], user_role: ['Administrator'] }));
+
+      const auth = useAuth();
+      auth.syncFromStorage();
+
+      expect(auth.user.value).toBeNull();
+      expect(auth.isAuthenticated.value).toBe(false);
+    });
+
+    it('rejects an object with a missing/empty `user_role` array', () => {
+      // Copilot Fix 1: an empty user_role array would fail every router
+      // guard's hasRole() check anyway (roles[0] === undefined), so reject
+      // early rather than letting isAuthenticated masquerade as true.
+      const nowSec = Math.floor(Date.now() / 1000);
+      localStorage.setItem('token', FRESH_TOKEN);
+      localStorage.setItem('user', JSON.stringify({ exp: [nowSec + 3600], user_role: [] }));
+
+      const auth = useAuth();
+      auth.syncFromStorage();
+
+      expect(auth.user.value).toBeNull();
+      expect(auth.isAuthenticated.value).toBe(false);
+    });
+
     it('treats missing localStorage.user (token-only) as logged-out', () => {
       localStorage.setItem('token', FRESH_TOKEN);
       // no user key

--- a/app/src/composables/useAuth.spec.ts
+++ b/app/src/composables/useAuth.spec.ts
@@ -189,6 +189,17 @@ describe('useAuth', () => {
       expect(auth.isAuthenticated.value).toBe(true);
     });
 
+    it('flags isExpired=true at exactly exp (RFC 7519: token is invalid at or after exp)', () => {
+      // Lock in the `>=` semantics in useAuth.ts. Master's implementation used
+      // `>` which leaves a one-second window where a just-expired token still
+      // reads as valid. A future well-meaning refactor that "fixes" this back
+      // to `>` will flip this test red.
+      const auth = useAuth();
+      const nowSec = Math.floor(Date.now() / 1000);
+      auth.login(FRESH_TOKEN, makeFreshUser({ exp: [nowSec] }));
+      expect(auth.isExpired.value).toBe(true);
+    });
+
     it('refresh() calls GET /api/auth/refresh and stores the new token', async () => {
       const auth = useAuth();
       auth.login(FRESH_TOKEN, makeFreshUser());
@@ -227,6 +238,26 @@ describe('useAuth', () => {
       await expect(auth.refresh()).rejects.toThrow();
       // Token is unchanged; the axios 401 interceptor handles state cleanup.
       expect(auth.token.value).toBe(FRESH_TOKEN);
+    });
+
+    it('refresh() rejects on a malformed 200 body ([null]) and does NOT mutate token/localStorage/header', async () => {
+      // A 200 with [null] (or similar shapes where the Plumber scalar-array
+      // unwraps to undefined/null) must not poison the session with the
+      // literal string "undefined"/"null". useAuth.refresh() guards against
+      // this before persisting.
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+
+      server.use(
+        http.get('/api/auth/refresh', () => HttpResponse.json([null]))
+      );
+
+      await expect(auth.refresh()).rejects.toThrow('Refresh returned invalid token');
+
+      // Nothing must have been mutated.
+      expect(auth.token.value).toBe(FRESH_TOKEN);
+      expect(localStorage.getItem('token')).toBe(FRESH_TOKEN);
+      expect(axios.defaults.headers.common.Authorization).toBe(`Bearer ${FRESH_TOKEN}`);
     });
   });
 

--- a/app/src/composables/useAuth.spec.ts
+++ b/app/src/composables/useAuth.spec.ts
@@ -1,0 +1,330 @@
+// useAuth.spec.ts
+/**
+ * Tests for useAuth composable (Phase E.E7).
+ *
+ * Pattern: module-level reactive auth state + MSW for /api/auth/refresh
+ * --------------------------------------------------------------------
+ * `useAuth()` is the single owner of read/write/refresh/401-handling for the
+ * JWT + user payload stored in `localStorage`. It exposes reactive state
+ * (token, user, isAuthenticated, isExpired, hasRole) and actions (login,
+ * logout, refresh, handle401) so the five locked call sites (§3 Phase E.E7)
+ * no longer touch `localStorage.token` / `localStorage.user` directly.
+ *
+ * Because auth state is global (a single session per browser tab), the
+ * composable uses module-level refs — every call to `useAuth()` returns
+ * references to the same underlying state. `syncFromStorage()` re-reads
+ * `localStorage` (source of truth coordinated with the axios 401 interceptor
+ * at `@/plugins/axios`) and is called on every `useAuth()` invocation plus
+ * by `handle401()`. This keeps in-memory state consistent with what the
+ * interceptor last wrote.
+ *
+ * Coverage contract (plan §3 Phase E.E7 Required test coverage):
+ *   1. Login stores token + user.
+ *   2. Logout clears both.
+ *   3. Expired token triggers refresh or redirects (we test both branches:
+ *      `refresh()` returns a new token; `isExpired` + `handle401()` clear
+ *      state so the 401 interceptor redirect path is reachable).
+ *   4. Corrupted `localStorage.user` payload does not crash navigation.
+ *   5. 401 interceptor coordinates with useAuth state (state follows the
+ *      interceptor-cleared `localStorage` after `handle401()`).
+ *
+ * MSW-mocked endpoints: GET /api/auth/refresh (Phase B.B1 handler,
+ * `authenticateTokenOk`/`refreshTokenOk` in test-utils/mocks/data/auth.ts).
+ * We do NOT add new handlers; per-test overrides via `server.use(...)` cover
+ * the 401 branch.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import axios from 'axios';
+
+import { server } from '@/test-utils/mocks/server';
+import { refreshTokenOk } from '@/test-utils/mocks/data/auth';
+import useAuth, { type UserPayload } from './useAuth';
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * A user payload shaped the way `/api/auth/signin` returns it (R/Plumber
+ * wraps scalars in single-element arrays — see
+ * `api/config/openapi/schemas/inferred/api_auth_signin_GET.json`).
+ * `exp` is a Unix timestamp in seconds; we make it comfortably in the future
+ * so `isExpired` is false in the happy-path tests.
+ */
+function makeFreshUser(overrides: Partial<UserPayload> = {}): UserPayload {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return {
+    user_id: [42],
+    user_name: ['test_user'],
+    email: ['test_user@example.org'],
+    user_role: ['Administrator'],
+    user_created: ['2025-01-01 00:00:00'],
+    abbreviation: ['TU'],
+    orcid: {},
+    exp: [nowSec + 3600],
+    ...overrides,
+  };
+}
+
+/**
+ * A user payload whose `exp` is in the past; used to cover the refresh /
+ * handle401 branches.
+ */
+function makeExpiredUser(): UserPayload {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return makeFreshUser({ exp: [nowSec - 60] });
+}
+
+// The Phase A1 auth flow stores the raw JWT scalar (Plumber wraps it as a
+// one-element array on the wire; LoginView.vue assigns `response.data[0]`
+// straight into localStorage, which is what we mirror here).
+const FRESH_TOKEN = 'fresh.jwt.token';
+const REFRESHED_TOKEN = refreshTokenOk[0];
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('useAuth', () => {
+  beforeEach(() => {
+    // `vitest.setup.ts` clears localStorage before every test; explicitly
+    // re-sync the composable so module-level refs start null.
+    useAuth().syncFromStorage();
+    delete axios.defaults.headers.common.Authorization;
+  });
+
+  afterEach(() => {
+    // Reset module-level state so a stray assertion doesn't leak into
+    // subsequent tests. handle401() clears without redirecting because
+    // `@/router` isn't mounted in this spec.
+    const auth = useAuth();
+    auth.logout();
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 1: Login stores token + user
+  // -------------------------------------------------------------------------
+
+  describe('login', () => {
+    it('stores token + user in localStorage and in reactive state', () => {
+      const auth = useAuth();
+      const user = makeFreshUser();
+
+      auth.login(FRESH_TOKEN, user);
+
+      expect(localStorage.getItem('token')).toBe(FRESH_TOKEN);
+      expect(localStorage.getItem('user')).toBe(JSON.stringify(user));
+      expect(auth.token.value).toBe(FRESH_TOKEN);
+      expect(auth.user.value).toEqual(user);
+      expect(auth.isAuthenticated.value).toBe(true);
+    });
+
+    it('accepts the R/Plumber scalar-array token shape (response.data[0])', () => {
+      // LoginView.vue assigns `response_authenticate.data[0]`; callers already
+      // unwrap the array. login() MUST accept a plain string — it is not the
+      // unwrap point.
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+      expect(auth.token.value).toBe(FRESH_TOKEN);
+      expect(typeof auth.token.value).toBe('string');
+    });
+
+    it('sets the axios default Authorization header so subsequent calls send the Bearer token', () => {
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+
+      expect(axios.defaults.headers.common.Authorization).toBe(`Bearer ${FRESH_TOKEN}`);
+    });
+
+    it('exposes hasRole() for role-gated UI (matches the A1 scalar-array payload)', () => {
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser({ user_role: ['Curator'] }));
+
+      expect(auth.hasRole('Curator')).toBe(true);
+      expect(auth.hasRole('Administrator')).toBe(false);
+      expect(auth.hasRole('Viewer')).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 2: Logout clears both
+  // -------------------------------------------------------------------------
+
+  describe('logout', () => {
+    it('clears token, user, axios header, and reactive state', () => {
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+
+      auth.logout();
+
+      expect(localStorage.getItem('token')).toBeNull();
+      expect(localStorage.getItem('user')).toBeNull();
+      expect(auth.token.value).toBeNull();
+      expect(auth.user.value).toBeNull();
+      expect(auth.isAuthenticated.value).toBe(false);
+      expect(axios.defaults.headers.common.Authorization).toBeUndefined();
+    });
+
+    it('is idempotent when no session is active', () => {
+      const auth = useAuth();
+      expect(() => auth.logout()).not.toThrow();
+      expect(auth.isAuthenticated.value).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 3: Expired token triggers refresh or redirects
+  // -------------------------------------------------------------------------
+
+  describe('expired tokens', () => {
+    it('flags isExpired=true once user.exp has passed', () => {
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeExpiredUser());
+
+      expect(auth.isExpired.value).toBe(true);
+      // isAuthenticated still true (token + user present); expiry is a
+      // separate concern the call site decides how to handle.
+      expect(auth.isAuthenticated.value).toBe(true);
+    });
+
+    it('refresh() calls GET /api/auth/refresh and stores the new token', async () => {
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+
+      await auth.refresh();
+
+      expect(auth.token.value).toBe(REFRESHED_TOKEN);
+      expect(localStorage.getItem('token')).toBe(REFRESHED_TOKEN);
+      expect(axios.defaults.headers.common.Authorization).toBe(`Bearer ${REFRESHED_TOKEN}`);
+    });
+
+    it('refresh() forwards the current Bearer token on the request', async () => {
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+
+      let capturedAuth: string | null = null;
+      server.use(
+        http.get('/api/auth/refresh', ({ request }) => {
+          capturedAuth = request.headers.get('authorization');
+          return HttpResponse.json(refreshTokenOk);
+        })
+      );
+
+      await auth.refresh();
+      expect(capturedAuth).toBe(`Bearer ${FRESH_TOKEN}`);
+    });
+
+    it('refresh() bubbles errors; callers decide whether to logout/redirect', async () => {
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+
+      server.use(
+        http.get('/api/auth/refresh', () => HttpResponse.json({ error: 'nope' }, { status: 401 }))
+      );
+
+      await expect(auth.refresh()).rejects.toThrow();
+      // Token is unchanged; the axios 401 interceptor handles state cleanup.
+      expect(auth.token.value).toBe(FRESH_TOKEN);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 4: Corrupted localStorage.user payload does not crash navigation
+  // -------------------------------------------------------------------------
+
+  describe('corrupted payload resilience', () => {
+    it('treats corrupt JSON in localStorage.user as logged-out, not as a crash', () => {
+      localStorage.setItem('token', FRESH_TOKEN);
+      localStorage.setItem('user', '{this is not json');
+
+      // syncFromStorage must swallow JSON.parse exceptions so route guards
+      // that call useAuth() during navigation never throw.
+      const auth = useAuth();
+      expect(() => auth.syncFromStorage()).not.toThrow();
+
+      expect(auth.user.value).toBeNull();
+      expect(auth.isAuthenticated.value).toBe(false);
+      // isExpired is false when there's no user — there's nothing to expire.
+      expect(auth.isExpired.value).toBe(false);
+      expect(auth.hasRole('Administrator')).toBe(false);
+    });
+
+    it('treats missing localStorage.user (token-only) as logged-out', () => {
+      localStorage.setItem('token', FRESH_TOKEN);
+      // no user key
+
+      const auth = useAuth();
+      auth.syncFromStorage();
+
+      expect(auth.user.value).toBeNull();
+      expect(auth.isAuthenticated.value).toBe(false);
+    });
+
+    it('rehydrates cleanly when both token and user are present', () => {
+      const user = makeFreshUser();
+      localStorage.setItem('token', FRESH_TOKEN);
+      localStorage.setItem('user', JSON.stringify(user));
+
+      const auth = useAuth();
+      auth.syncFromStorage();
+
+      expect(auth.token.value).toBe(FRESH_TOKEN);
+      expect(auth.user.value).toEqual(user);
+      expect(auth.isAuthenticated.value).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 5: 401 interceptor coordinates with useAuth state
+  // -------------------------------------------------------------------------
+
+  describe('401 interceptor coordination', () => {
+    it('handle401() re-reads localStorage and mirrors the cleared state', () => {
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+      expect(auth.isAuthenticated.value).toBe(true);
+
+      // Simulate what `@/plugins/axios` does inside the 401 interceptor:
+      // it calls localStorage.removeItem('token') / .removeItem('user')
+      // directly without going through useAuth. After that, handle401()
+      // must bring the in-memory refs back in sync.
+      localStorage.removeItem('token');
+      localStorage.removeItem('user');
+
+      auth.handle401();
+
+      expect(auth.token.value).toBeNull();
+      expect(auth.user.value).toBeNull();
+      expect(auth.isAuthenticated.value).toBe(false);
+    });
+
+    it('handle401() clears the axios default header so queued requests stop sending the stale Bearer', () => {
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+      expect(axios.defaults.headers.common.Authorization).toBe(`Bearer ${FRESH_TOKEN}`);
+
+      // interceptor path: it already deletes the default header but we test
+      // that handle401() tolerates either order (idempotent cleanup).
+      localStorage.removeItem('token');
+      localStorage.removeItem('user');
+      auth.handle401();
+
+      expect(axios.defaults.headers.common.Authorization).toBeUndefined();
+    });
+
+    it('multiple useAuth() calls share the same reactive state (module-level singleton)', () => {
+      const a = useAuth();
+      const b = useAuth();
+
+      a.login(FRESH_TOKEN, makeFreshUser());
+      expect(b.token.value).toBe(FRESH_TOKEN);
+      expect(b.isAuthenticated.value).toBe(true);
+
+      b.logout();
+      expect(a.token.value).toBeNull();
+      expect(a.isAuthenticated.value).toBe(false);
+    });
+  });
+});

--- a/app/src/composables/useAuth.spec.ts
+++ b/app/src/composables/useAuth.spec.ts
@@ -241,10 +241,9 @@ describe('useAuth', () => {
     });
 
     it('refresh() rejects on a malformed 200 body ([null]) and does NOT mutate token/localStorage/header', async () => {
-      // A 200 with [null] (or similar shapes where the Plumber scalar-array
-      // unwraps to undefined/null) must not poison the session with the
-      // literal string "undefined"/"null". useAuth.refresh() guards against
-      // this before persisting.
+      // A 200 with [null] must not poison the session. Copilot Fix 3 tightens
+      // this from the earlier string-coercion check to an explicit type
+      // check: `[null]` fails `typeof raw[0] === 'string'` up front.
       const auth = useAuth();
       auth.login(FRESH_TOKEN, makeFreshUser());
 
@@ -252,12 +251,59 @@ describe('useAuth', () => {
         http.get('/api/auth/refresh', () => HttpResponse.json([null]))
       );
 
-      await expect(auth.refresh()).rejects.toThrow('Refresh returned invalid token');
+      await expect(auth.refresh()).rejects.toThrow('Refresh returned invalid token shape');
 
       // Nothing must have been mutated.
       expect(auth.token.value).toBe(FRESH_TOKEN);
       expect(localStorage.getItem('token')).toBe(FRESH_TOKEN);
       expect(axios.defaults.headers.common.Authorization).toBe(`Bearer ${FRESH_TOKEN}`);
+    });
+
+    it('refresh() rejects a plain object body (`{}`) — not a string and not an array', async () => {
+      // Copilot Fix 3: without a proper type check, `String({})` would yield
+      // "[object Object]" and pass the earlier I2 sentinel check (not
+      // "undefined" / "null" / empty), poisoning the session until a 401.
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+
+      server.use(
+        http.get('/api/auth/refresh', () => HttpResponse.json({ foo: 'bar' }))
+      );
+
+      await expect(auth.refresh()).rejects.toThrow('Refresh returned invalid token shape');
+
+      expect(auth.token.value).toBe(FRESH_TOKEN);
+      expect(localStorage.getItem('token')).toBe(FRESH_TOKEN);
+      expect(axios.defaults.headers.common.Authorization).toBe(`Bearer ${FRESH_TOKEN}`);
+    });
+
+    it('refresh() rejects an array whose first element is not a string (`[123]`)', async () => {
+      // Copilot Fix 3: even if the body is an array, element[0] must be a
+      // string. A numeric 0th element (or any non-string) is rejected.
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+
+      server.use(
+        http.get('/api/auth/refresh', () => HttpResponse.json([123]))
+      );
+
+      await expect(auth.refresh()).rejects.toThrow('Refresh returned invalid token shape');
+
+      expect(auth.token.value).toBe(FRESH_TOKEN);
+    });
+
+    it('refresh() rejects an empty array (`[]`)', async () => {
+      // Copilot Fix 3: `[]` has no `[0]` to read. Reject before persisting.
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+
+      server.use(
+        http.get('/api/auth/refresh', () => HttpResponse.json([]))
+      );
+
+      await expect(auth.refresh()).rejects.toThrow('Refresh returned invalid token shape');
+
+      expect(auth.token.value).toBe(FRESH_TOKEN);
     });
   });
 

--- a/app/src/composables/useAuth.ts
+++ b/app/src/composables/useAuth.ts
@@ -176,13 +176,26 @@ function syncFromStorage(): void {
   tokenRef.value = rawToken;
   userRef.value = safeParseUser(rawUser);
 
-  // A token without a (readable) user is treated as no session — the SPA
-  // always pairs them, and a dangling token would fail every downstream
-  // role check anyway. Clear localStorage too so the state matches on
-  // every observer.
+  // Both-or-neither invariant
+  // -------------------------
+  // A session is only coherent when BOTH localStorage keys are present and
+  // valid. Any half-state (dangling token, dangling user) is treated as
+  // logged-out and actively cleaned up, so every observer sees the same
+  // cleared state.
+  //
+  // - Dangling token (user missing/corrupt) would fail every role check
+  //   and expiry calculation downstream.
+  // - Dangling user (token missing) would trick components that only check
+  //   `auth.user.value` (for example UserView.vue's mount hook) into firing
+  //   unauthenticated API calls with no Bearer header. Pre-Copilot-Fix-2,
+  //   syncFromStorage() only cleaned up the dangling-token case; Copilot
+  //   flagged the asymmetry as a real leak path for stale user payloads.
   if (tokenRef.value && !userRef.value) {
     localStorage.removeItem(TOKEN_KEY);
     tokenRef.value = null;
+  } else if (!tokenRef.value && userRef.value) {
+    localStorage.removeItem(USER_KEY);
+    userRef.value = null;
   }
 
   // Keep the axios default header in lockstep with the current token.

--- a/app/src/composables/useAuth.ts
+++ b/app/src/composables/useAuth.ts
@@ -236,6 +236,14 @@ async function refresh(): Promise<string> {
   const raw: unknown = response.data;
   const nextToken = Array.isArray(raw) ? String(raw[0]) : String(raw);
 
+  // Guard against malformed 200 responses (null, {}, [null], non-coercible
+  // payloads). Without this check, `String(undefined)` persists the literal
+  // string "undefined" as the new token, which would masquerade as a valid
+  // session until the next request fires a 401.
+  if (!nextToken || nextToken === 'undefined' || nextToken === 'null') {
+    throw new Error('Refresh returned invalid token');
+  }
+
   tokenRef.value = nextToken;
   localStorage.setItem(TOKEN_KEY, nextToken);
   axios.defaults.headers.common.Authorization = `Bearer ${nextToken}`;

--- a/app/src/composables/useAuth.ts
+++ b/app/src/composables/useAuth.ts
@@ -1,4 +1,5 @@
 // useAuth.ts
+// SPA-only context; localStorage is always available at module load (Vite SPA, no SSR).
 /**
  * Single owner of auth / session state for the SPA (Phase E.E7).
  *
@@ -135,8 +136,8 @@ function safeParseUser(raw: string | null): UserPayload | null {
  * interceptor clears state.
  */
 function syncFromStorage(): void {
-  const rawToken = typeof localStorage !== 'undefined' ? localStorage.getItem(TOKEN_KEY) : null;
-  const rawUser = typeof localStorage !== 'undefined' ? localStorage.getItem(USER_KEY) : null;
+  const rawToken = localStorage.getItem(TOKEN_KEY);
+  const rawUser = localStorage.getItem(USER_KEY);
 
   tokenRef.value = rawToken;
   userRef.value = safeParseUser(rawUser);
@@ -145,7 +146,7 @@ function syncFromStorage(): void {
   // always pairs them, and a dangling token would fail every downstream
   // role check anyway. Clear localStorage too so the state matches on
   // every observer.
-  if (tokenRef.value && !userRef.value && typeof localStorage !== 'undefined') {
+  if (tokenRef.value && !userRef.value) {
     localStorage.removeItem(TOKEN_KEY);
     tokenRef.value = null;
   }

--- a/app/src/composables/useAuth.ts
+++ b/app/src/composables/useAuth.ts
@@ -278,17 +278,29 @@ function logout(): void {
 async function refresh(): Promise<string> {
   const apiUrl = `${import.meta.env.VITE_API_URL ?? ''}/api/auth/refresh`;
   const response = await axios.get(apiUrl);
-  // Plumber returns `["..."]`; tolerate either shape so this keeps working
-  // if the API ever un-wraps scalars.
+  // Strict shape validation (Copilot Fix 3)
+  // ---------------------------------------
+  // Plumber returns `["..."]`; master's implementation also tolerated a bare
+  // string. Accept either of those shapes explicitly and reject anything
+  // else (`{}`, `{ foo: 'bar' }`, `[]`, `[123]`, `null`, numbers, etc.)
+  // BEFORE persisting.
+  //
+  // The earlier I2 guard used `String(raw)` / `String(raw[0])` and then
+  // checked the coerced string against `"undefined"`/`"null"`. That still
+  // let an object like `{}` through as the literal string "[object Object]"
+  // — not caught by the sentinel check — and poisoned the session until a
+  // 401 fired. This type-level check supersedes the I2 guard.
   const raw: unknown = response.data;
-  const nextToken = Array.isArray(raw) ? String(raw[0]) : String(raw);
-
-  // Guard against malformed 200 responses (null, {}, [null], non-coercible
-  // payloads). Without this check, `String(undefined)` persists the literal
-  // string "undefined" as the new token, which would masquerade as a valid
-  // session until the next request fires a 401.
-  if (!nextToken || nextToken === 'undefined' || nextToken === 'null') {
-    throw new Error('Refresh returned invalid token');
+  let nextToken: string;
+  if (typeof raw === 'string') {
+    nextToken = raw;
+  } else if (Array.isArray(raw) && raw.length > 0 && typeof raw[0] === 'string') {
+    nextToken = raw[0];
+  } else {
+    throw new Error('Refresh returned invalid token shape');
+  }
+  if (!nextToken) {
+    throw new Error('Refresh returned empty token');
   }
 
   tokenRef.value = nextToken;

--- a/app/src/composables/useAuth.ts
+++ b/app/src/composables/useAuth.ts
@@ -1,0 +1,305 @@
+// useAuth.ts
+/**
+ * Single owner of auth / session state for the SPA (Phase E.E7).
+ *
+ * Before this composable landed, five call sites (`router/routes.ts`,
+ * `components/AppNavbar.vue`, `components/small/LogoutCountdownBadge.vue`,
+ * `views/LoginView.vue`, `views/UserView.vue`) each reached into
+ * `localStorage.token` / `localStorage.user` by hand, parsed the JWT payload
+ * inline, and duplicated the "Bearer ${localStorage.getItem('token')}" header
+ * pattern. `useAuth()` consolidates all of that into one typed API with
+ * reactive state, so the 401 interceptor in `@/plugins/axios` is the only
+ * other code path that mutates these keys.
+ *
+ * State model (module-level singleton)
+ * ------------------------------------
+ * Because there is exactly one authenticated session per browser tab, the
+ * reactive refs are declared at module scope. Every `useAuth()` call returns
+ * references to the same underlying state, so a `logout()` from the navbar
+ * is immediately visible to a route guard on the next `isAuthenticated`
+ * read. On first import, state is hydrated from `localStorage` and the axios
+ * default Authorization header is seeded if a token exists.
+ *
+ * Coordination with the axios 401 interceptor
+ * -------------------------------------------
+ * `@/plugins/axios` already owns the "saw a 401 → clear localStorage →
+ * redirect to /Login" flow. That interceptor writes localStorage directly
+ * (not through useAuth), so after an interceptor-triggered logout the
+ * in-memory refs can drift. `handle401()` and `syncFromStorage()` re-read
+ * localStorage so reactive state mirrors whatever the interceptor last
+ * persisted. Callers that want to react to a 401 (for example, showing a
+ * toast) can watch `isAuthenticated` or call `handle401()` from the
+ * interceptor's catch path in a future refactor.
+ *
+ * Shape of the user payload
+ * -------------------------
+ * `/api/auth/signin` returns the R/Plumber scalar-array shape
+ * (`user_role: ['Administrator']`, `exp: [1234567890]`, etc.). We preserve
+ * the raw shape so every read site — route guards, badges, profile view —
+ * sees the same structure they see today; only the reading mechanism
+ * changes. `hasRole()` indexes into `user_role[0]` to hide this detail from
+ * callers.
+ *
+ * Corrupted-payload resilience
+ * ----------------------------
+ * If a user manually corrupts `localStorage.user` (or a half-written key
+ * survives a crash), `syncFromStorage()` catches `JSON.parse` failures and
+ * treats the session as logged-out. Route guards therefore never throw
+ * during navigation, which was the failure mode the P1 "auth state is
+ * duplicated" review finding called out.
+ */
+
+import type { ComputedRef, Ref } from 'vue';
+import { computed, ref } from 'vue';
+import axios from 'axios';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape of the user payload stored in `localStorage.user` (post Phase A1).
+ * Mirrors `GET /api/auth/signin` as documented in
+ * `api/config/openapi/schemas/inferred/api_auth_signin_GET.json` — R/Plumber
+ * wraps every scalar in a one-element array.
+ *
+ * The fields listed here are the ones the SPA actually reads; additional
+ * fields returned by the API are tolerated (the composable does not strip
+ * them).
+ */
+export interface UserPayload {
+  user_id: number[];
+  user_name: string[];
+  email: string[];
+  user_role: string[];
+  user_created: string[];
+  abbreviation: string[];
+  orcid: Record<string, unknown> | string[];
+  exp: number[];
+  [key: string]: unknown;
+}
+
+/**
+ * Return type of `useAuth()`. Keeping this exported makes it easy for
+ * Options-API components to annotate their `setup()` return value.
+ */
+export interface UseAuthReturn {
+  // State (reactive)
+  token: Ref<string | null>;
+  user: Ref<UserPayload | null>;
+
+  // Derived (computed)
+  isAuthenticated: ComputedRef<boolean>;
+  isExpired: ComputedRef<boolean>;
+
+  // Actions
+  login: (token: string, user: UserPayload) => void;
+  logout: () => void;
+  refresh: () => Promise<string>;
+  handle401: () => void;
+  syncFromStorage: () => void;
+  hasRole: (role: string) => boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level singleton state
+// ---------------------------------------------------------------------------
+
+const TOKEN_KEY = 'token';
+const USER_KEY = 'user';
+
+const tokenRef = ref<string | null>(null);
+const userRef = ref<UserPayload | null>(null);
+
+/**
+ * Parse a JSON string and return `null` on any failure. Shared by
+ * `syncFromStorage()` and used to keep the parse site in one place.
+ */
+function safeParseUser(raw: string | null): UserPayload | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as UserPayload;
+    // Defence-in-depth: parsed non-objects (numbers, strings, null) are
+    // treated as corrupt so later `.exp` / `.user_role` reads don't NPE.
+    if (!parsed || typeof parsed !== 'object') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Re-read both keys from `localStorage` and mirror them into the module
+ * refs. Called once at module load, on every `useAuth()` invocation (cheap —
+ * just two `getItem` calls), and by `handle401()` after the axios
+ * interceptor clears state.
+ */
+function syncFromStorage(): void {
+  const rawToken = typeof localStorage !== 'undefined' ? localStorage.getItem(TOKEN_KEY) : null;
+  const rawUser = typeof localStorage !== 'undefined' ? localStorage.getItem(USER_KEY) : null;
+
+  tokenRef.value = rawToken;
+  userRef.value = safeParseUser(rawUser);
+
+  // A token without a (readable) user is treated as no session — the SPA
+  // always pairs them, and a dangling token would fail every downstream
+  // role check anyway. Clear localStorage too so the state matches on
+  // every observer.
+  if (tokenRef.value && !userRef.value && typeof localStorage !== 'undefined') {
+    localStorage.removeItem(TOKEN_KEY);
+    tokenRef.value = null;
+  }
+
+  // Keep the axios default header in lockstep with the current token.
+  if (tokenRef.value) {
+    axios.defaults.headers.common.Authorization = `Bearer ${tokenRef.value}`;
+  } else {
+    delete axios.defaults.headers.common.Authorization;
+  }
+}
+
+// Hydrate once at import time so the Bearer header is set before the first
+// request fires. `@/plugins/axios` does the same seeding; running this here
+// is redundant but harmless, and protects callers who import this module
+// before `@/plugins/axios`.
+syncFromStorage();
+
+// ---------------------------------------------------------------------------
+// Computed derivations
+// ---------------------------------------------------------------------------
+
+const isAuthenticated = computed<boolean>(
+  () => tokenRef.value !== null && userRef.value !== null
+);
+
+const isExpired = computed<boolean>(() => {
+  const exp = userRef.value?.exp?.[0];
+  if (typeof exp !== 'number') return false;
+  const nowSec = Math.floor(Date.now() / 1000);
+  return nowSec >= exp;
+});
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+/**
+ * Persist a fresh login: token + user payload → localStorage + reactive
+ * state + axios default Authorization header.
+ *
+ * @param token - The raw JWT string. `LoginView.vue` reads the Plumber
+ *                scalar-array at `response.data[0]`; callers are expected
+ *                to unwrap before passing in. We do NOT re-unwrap here so
+ *                the type contract stays a simple `string`.
+ * @param user  - The parsed `/api/auth/signin` response body.
+ */
+function login(token: string, user: UserPayload): void {
+  tokenRef.value = token;
+  userRef.value = user;
+  localStorage.setItem(TOKEN_KEY, token);
+  localStorage.setItem(USER_KEY, JSON.stringify(user));
+  axios.defaults.headers.common.Authorization = `Bearer ${token}`;
+}
+
+/**
+ * Clear the session: both localStorage keys, both refs, and the axios
+ * default header. Does NOT navigate — call sites that want a redirect
+ * handle `$router.push(...)` themselves so this composable stays router-
+ * agnostic and testable without mounting a router.
+ */
+function logout(): void {
+  tokenRef.value = null;
+  userRef.value = null;
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(USER_KEY);
+  delete axios.defaults.headers.common.Authorization;
+}
+
+/**
+ * Call `GET /api/auth/refresh` with the current Bearer token and store the
+ * returned JWT. The API returns a R/Plumber scalar-array, matching the
+ * authenticate endpoint shape.
+ *
+ * Errors bubble so callers can decide whether to toast, logout, or retry.
+ * The axios 401 interceptor already handles unauthorized refresh responses
+ * by clearing localStorage and redirecting — we do not duplicate that
+ * behaviour here.
+ *
+ * @returns The new token string.
+ */
+async function refresh(): Promise<string> {
+  const apiUrl = `${import.meta.env.VITE_API_URL ?? ''}/api/auth/refresh`;
+  const response = await axios.get(apiUrl);
+  // Plumber returns `["..."]`; tolerate either shape so this keeps working
+  // if the API ever un-wraps scalars.
+  const raw: unknown = response.data;
+  const nextToken = Array.isArray(raw) ? String(raw[0]) : String(raw);
+
+  tokenRef.value = nextToken;
+  localStorage.setItem(TOKEN_KEY, nextToken);
+  axios.defaults.headers.common.Authorization = `Bearer ${nextToken}`;
+  return nextToken;
+}
+
+/**
+ * Called (explicitly or implicitly) when a 401 is observed — re-reads
+ * `localStorage` to mirror whatever the axios interceptor wrote, then
+ * clears the axios default header so in-flight or queued requests stop
+ * sending the stale Bearer. Safe to call multiple times; if the
+ * interceptor hasn't cleared localStorage yet, we still fall through to
+ * the "cleared" state via `logout()` semantics on re-sync.
+ */
+function handle401(): void {
+  // The interceptor removes the keys directly; re-reading puts refs back
+  // in sync. If for some reason localStorage still has values (e.g. this
+  // is called defensively without an interceptor trigger), treat it as a
+  // hard logout to be safe.
+  const rawToken = localStorage.getItem(TOKEN_KEY);
+  const rawUser = localStorage.getItem(USER_KEY);
+  if (rawToken === null && rawUser === null) {
+    // Interceptor-cleared path: just sync.
+    tokenRef.value = null;
+    userRef.value = null;
+    delete axios.defaults.headers.common.Authorization;
+    return;
+  }
+  // Defensive path: caller invoked handle401() without the interceptor
+  // having run. Force a full logout.
+  logout();
+}
+
+// ---------------------------------------------------------------------------
+// Public composable
+// ---------------------------------------------------------------------------
+
+/**
+ * Single entry point. Returns the shared reactive auth state plus typed
+ * actions. The refs are stable across calls (module-level singleton); use
+ * `useAuth()` freely inside components, guards, or other composables
+ * without worrying about duplicate subscriptions.
+ */
+export function useAuth(): UseAuthReturn {
+  // Re-sync on every call so module state can't drift from localStorage
+  // after the axios interceptor path. Cheap: two `getItem` + optional
+  // `JSON.parse`.
+  syncFromStorage();
+
+  return {
+    token: tokenRef,
+    user: userRef,
+    isAuthenticated,
+    isExpired,
+    login,
+    logout,
+    refresh,
+    handle401,
+    syncFromStorage,
+    hasRole: (role: string): boolean => {
+      const roles = userRef.value?.user_role;
+      if (!Array.isArray(roles)) return false;
+      return roles[0] === role;
+    },
+  };
+}
+
+export default useAuth;

--- a/app/src/composables/useAuth.ts
+++ b/app/src/composables/useAuth.ts
@@ -115,18 +115,52 @@ const userRef = ref<UserPayload | null>(null);
 /**
  * Parse a JSON string and return `null` on any failure. Shared by
  * `syncFromStorage()` and used to keep the parse site in one place.
+ *
+ * Shape validation
+ * ----------------
+ * A successful `JSON.parse` is necessary but not sufficient: the SPA reads
+ * `user.exp[0]` (expiry check) and `user.user_role[0]` (role gating) on
+ * every navigation. If `localStorage.user` is set to a valid-but-wrong JSON
+ * value (for example `'[]'` from a dev-tools typo, or `'null'`, or an object
+ * missing `exp`/`user_role`), those reads would silently return `undefined`
+ * and the session would appear authenticated to `isAuthenticated` while
+ * failing every role check and exp calculation. We defensively require the
+ * minimal shape the call sites rely on:
+ *   - non-null, non-array object
+ *   - `exp` is a non-empty `number[]` (expiry computations)
+ *   - `user_role` is a non-empty `string[]` (router guards, badges)
+ * Any failure is treated the same as corrupt JSON: `null`, handled upstream
+ * as a logged-out state.
  */
 function safeParseUser(raw: string | null): UserPayload | null {
   if (!raw) return null;
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(raw) as UserPayload;
-    // Defence-in-depth: parsed non-objects (numbers, strings, null) are
-    // treated as corrupt so later `.exp` / `.user_role` reads don't NPE.
-    if (!parsed || typeof parsed !== 'object') return null;
-    return parsed;
+    parsed = JSON.parse(raw);
   } catch {
     return null;
   }
+  // Reject null, primitives, and arrays (`typeof [] === 'object'`, so the
+  // array guard is not redundant).
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null;
+  }
+  const candidate = parsed as Record<string, unknown>;
+  // `exp` must be a non-empty numeric array — `[0]` is what `isExpired`
+  // reads. A missing or empty exp would make `isExpired` always false and
+  // silently keep an expired session alive.
+  const exp = candidate.exp;
+  if (!Array.isArray(exp) || exp.length === 0 || typeof exp[0] !== 'number') {
+    return null;
+  }
+  // `user_role` must be a non-empty string array — router guards resolve
+  // `roles[0]`; an empty array would fail every guard anyway, so rejecting
+  // here keeps `isAuthenticated` honest.
+  const roles = candidate.user_role;
+  if (!Array.isArray(roles) || roles.length === 0 || typeof roles[0] !== 'string') {
+    return null;
+  }
+  return parsed as UserPayload;
 }
 
 /**

--- a/app/src/router/routes.ts
+++ b/app/src/router/routes.ts
@@ -1,8 +1,42 @@
 // src/router/routes.ts
 
 import type { RouteRecordRaw, RouteLocationNormalized, NavigationGuardNext } from 'vue-router';
+import { useAuth } from '@/composables/useAuth';
 
-// TODO: remove redundance in localStorage setting/reading
+/**
+ * Role-based route-guard factory (Phase E.E7).
+ *
+ * Replaces an 18x-duplicated pattern that hand-parsed `localStorage.token`
+ * and `localStorage.user` inside every `beforeEnter` hook. The new flow
+ * delegates every auth decision to the `useAuth()` composable:
+ *
+ *   - `isAuthenticated` covers the "have both token and user" check that
+ *     the old guards wrote as `!localStorage.user`.
+ *   - `isExpired` replaces the inline `timestamp > expires` comparison
+ *     (and picks up the corrupt-payload handling in `useAuth` for free —
+ *     a bad JSON blob now fails closed to logged-out instead of throwing
+ *     inside navigation).
+ *   - `hasRole(role)` unwraps the R/Plumber scalar-array (`user_role[0]`)
+ *     that the old guards did inline.
+ *
+ * Each call site still supplies its own `allowed_roles` list; behaviour is
+ * otherwise identical to the pre-refactor guards.
+ */
+function createAuthGuard(allowed_roles: readonly string[]) {
+  return (
+    _to: RouteLocationNormalized,
+    _from: RouteLocationNormalized,
+    next: NavigationGuardNext
+  ) => {
+    const { isAuthenticated, isExpired, hasRole } = useAuth();
+    const isAllowed = allowed_roles.some((role) => hasRole(role));
+    if (!isAuthenticated.value || isExpired.value || !isAllowed) {
+      next({ name: 'Login' });
+    } else {
+      next();
+    }
+  };
+}
 
 export const routes: RouteRecordRaw[] = [
   {
@@ -335,26 +369,7 @@ export const routes: RouteRecordRaw[] = [
     name: 'User',
     component: () => import('@/views/UserView.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator', 'Curator', 'Reviewer'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator', 'Curator', 'Reviewer']),
   },
   {
     path: '/PasswordReset/:request_jwt?',
@@ -367,312 +382,84 @@ export const routes: RouteRecordRaw[] = [
     name: 'Review',
     component: () => import('@/views/review/Review.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator', 'Curator', 'Reviewer'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator', 'Curator', 'Reviewer']),
   },
   {
     path: '/ReviewInstructions',
     name: 'ReviewInstructions',
     component: () => import('@/views/review/ReviewInstructions.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator', 'Curator', 'Reviewer'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator', 'Curator', 'Reviewer']),
   },
   {
     path: '/CreateEntity',
     name: 'CreateEntity',
     component: () => import('@/views/curate/CreateEntity.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator', 'Curator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator', 'Curator']),
   },
   {
     path: '/ModifyEntity',
     name: 'ModifyEntity',
     component: () => import('@/views/curate/ModifyEntity.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator', 'Curator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator', 'Curator']),
   },
   {
     path: '/ApproveReview',
     name: 'ApproveReview',
     component: () => import('@/views/curate/ApproveReview.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator', 'Curator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator', 'Curator']),
   },
   {
     path: '/ApproveStatus',
     name: 'ApproveStatus',
     component: () => import('@/views/curate/ApproveStatus.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator', 'Curator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator', 'Curator']),
   },
   {
     path: '/ApproveUser',
     name: 'ApproveUser',
     component: () => import('@/views/curate/ApproveUser.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator', 'Curator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator', 'Curator']),
   },
   {
     path: '/ManageReReview',
     name: 'ManageReReview',
     component: () => import('@/views/curate/ManageReReview.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator', 'Curator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator', 'Curator']),
   },
   {
     path: '/ManageUser',
     name: 'ManageUser',
     component: () => import('@/views/admin/ManageUser.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator']),
   },
   {
     path: '/ManageAnnotations',
     name: 'ManageAnnotations',
     component: () => import('@/views/admin/ManageAnnotations.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator']),
   },
   {
     path: '/ManageOntology',
     name: 'ManageOntology',
     component: () => import('@/views/admin/ManageOntology.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator']),
   },
   {
     path: '/ManageAbout',
     name: 'ManageAbout',
     component: () => import('@/views/admin/ManageAbout.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator']),
   },
   {
     path: '/ViewLogs',
@@ -687,140 +474,35 @@ export const routes: RouteRecordRaw[] = [
       fspec: route.query.fspec || undefined,
     }),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else {
-        next();
-      }
-    },
+    beforeEnter: createAuthGuard(['Administrator']),
   },
   {
     path: '/AdminStatistics',
     name: 'AdminStatistics',
     component: () => import('@/views/admin/AdminStatistics.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else {
-        next();
-      }
-    },
+    beforeEnter: createAuthGuard(['Administrator']),
   },
   {
     path: '/ManageBackups',
     name: 'ManageBackups',
     component: () => import('@/views/admin/ManageBackups.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else {
-        next();
-      }
-    },
+    beforeEnter: createAuthGuard(['Administrator']),
   },
   {
     path: '/ManagePubtator',
     name: 'ManagePubtator',
     component: () => import('@/views/admin/ManagePubtator.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else {
-        next();
-      }
-    },
+    beforeEnter: createAuthGuard(['Administrator']),
   },
   {
     path: '/ManageLLM',
     name: 'ManageLLM',
     component: () => import('@/views/admin/ManageLLM.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else {
-        next();
-      }
-    },
+    beforeEnter: createAuthGuard(['Administrator']),
   },
   {
     path: '/Entities/:entity_id',

--- a/app/src/views/LoginView.vue
+++ b/app/src/views/LoginView.vue
@@ -70,6 +70,7 @@ import { useHead } from '@unhead/vue';
 import { useForm, useField, defineRule } from 'vee-validate';
 import { required, min, max } from '@vee-validate/rules';
 import useToast from '@/composables/useToast';
+import { useAuth } from '@/composables/useAuth';
 
 // Define validation rules globally
 defineRule('required', required);
@@ -80,6 +81,8 @@ export default {
   name: 'LoginView',
   setup() {
     const { makeToast } = useToast();
+    // Phase E.E7: delegate all auth state reads/writes to `useAuth()`.
+    const auth = useAuth();
     useHead({
       title: 'Login',
       meta: [
@@ -121,10 +124,13 @@ export default {
       handleSubmit,
       resetVeeForm,
       makeToast,
+      auth,
     };
   },
   mounted() {
-    if (localStorage.user) {
+    // If the Login view is reached while still authenticated, clear the
+    // session before showing the form (matches the pre-refactor behaviour).
+    if (this.auth.isAuthenticated.value) {
       this.doUserLogOut();
     }
     this.loading = false;
@@ -145,27 +151,34 @@ export default {
           user_name: this.user_name,
           password: this.password,
         });
-        localStorage.setItem('token', response_authenticate.data[0]);
+        // R/Plumber wraps the scalar token in a single-element array — unwrap
+        // before handing it to useAuth / the /signin call.
+        const token = response_authenticate.data[0];
         this.makeToast(
           `You have logged in (status ${response_authenticate.status} - ${response_authenticate.statusText}).`,
           'Success',
           'success'
         );
-        this.signinWithJWT();
+        this.signinWithJWT(token);
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
       }
     },
-    async signinWithJWT() {
+    async signinWithJWT(token) {
+      // Two-step login: (1) POST /authenticate returned the JWT above;
+      // (2) GET /signin exchanges it for the full user payload. We set the
+      // Authorization header manually for this single call because
+      // `auth.login()` only fires after we have both pieces — splitting
+      // login into "set token" + "set user" would expose an intermediate
+      // half-logged-in state other tabs/components could observe.
       const apiAuthenticateURL = `${import.meta.env.VITE_API_URL}/api/auth/signin`;
       try {
         const response_signin = await this.axios.get(apiAuthenticateURL, {
           headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
+            Authorization: `Bearer ${token}`,
           },
         });
-        this.user = response_signin.data;
-        localStorage.setItem('user', JSON.stringify(response_signin.data));
+        this.auth.login(token, response_signin.data);
         this.$router.push('/');
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
@@ -177,10 +190,8 @@ export default {
       this.resetVeeForm();
     },
     doUserLogOut() {
-      if (localStorage.user || localStorage.token) {
-        localStorage.removeItem('user');
-        localStorage.removeItem('token');
-        this.user = null;
+      if (this.auth.isAuthenticated.value) {
+        this.auth.logout();
         this.$router.push('/');
       }
     },

--- a/app/src/views/LoginView.vue
+++ b/app/src/views/LoginView.vue
@@ -151,9 +151,35 @@ export default {
           user_name: this.user_name,
           password: this.password,
         });
-        // R/Plumber wraps the scalar token in a single-element array — unwrap
-        // before handing it to useAuth / the /signin call.
-        const token = response_authenticate.data[0];
+        // R/Plumber wraps the scalar token in a single-element array, but
+        // master also tolerated a bare string body. Validate the shape before
+        // calling signinWithJWT — without this guard (Copilot Fix 4), a
+        // malformed 200 response would hand `undefined` to signinWithJWT,
+        // which would then send "Bearer undefined" to /signin and call
+        // `auth.login(undefined, ...)` after it (eventually) succeeded or
+        // failed with a confusing 401.
+        const raw = response_authenticate.data;
+        let token;
+        if (typeof raw === 'string') {
+          token = raw;
+        } else if (Array.isArray(raw) && raw.length > 0 && typeof raw[0] === 'string') {
+          token = raw[0];
+        } else {
+          this.makeToast(
+            'Authentication failed: invalid token shape from server',
+            'Error',
+            'danger'
+          );
+          return;
+        }
+        if (!token) {
+          this.makeToast(
+            'Authentication failed: empty token from server',
+            'Error',
+            'danger'
+          );
+          return;
+        }
         this.makeToast(
           `You have logged in (status ${response_authenticate.status} - ${response_authenticate.statusText}).`,
           'Success',

--- a/app/src/views/UserView.vue
+++ b/app/src/views/UserView.vue
@@ -404,6 +404,7 @@
 import { useForm, useField, defineRule } from 'vee-validate';
 import { required, min, max, confirmed } from '@vee-validate/rules';
 import { useToast, useColorAndSymbols } from '@/composables';
+import { useAuth } from '@/composables/useAuth';
 
 // Define validation rules globally
 defineRule('required', required);
@@ -426,6 +427,9 @@ export default {
   setup() {
     const { makeToast } = useToast();
     const colorAndSymbols = useColorAndSymbols();
+    // Phase E.E7: shared auth state — replaces every direct localStorage
+    // read in this view (user payload, expiry, Bearer header).
+    const auth = useAuth();
 
     // Setup form validation with vee-validate 4
     const { handleSubmit, resetForm } = useForm();
@@ -463,6 +467,7 @@ export default {
       newPasswordRepeat,
       confirmPasswordError,
       confirmPasswordMeta,
+      auth,
     };
   },
   data() {
@@ -547,8 +552,13 @@ export default {
     },
   },
   mounted() {
-    if (localStorage.user) {
-      this.user = JSON.parse(localStorage.user);
+    // Hydrate the view from the shared auth state (already parsed + guarded
+    // against corrupt localStorage.user by `useAuth`). If the composable
+    // reports no user (e.g. a route-guard race or cleared state), skip the
+    // subsequent calls rather than hitting the API with a stale token.
+    const authUser = this.auth.user.value;
+    if (authUser) {
+      this.user = { ...authUser };
 
       this.interval = setInterval(() => {
         this.updateDiffs();
@@ -581,21 +591,24 @@ export default {
       this.resetPasswordForm();
     },
     updateDiffs() {
-      if (localStorage.token) {
-        const expires = JSON.parse(localStorage.user).exp;
-        const timestamp = Math.floor(new Date().getTime() / 1000);
-        this.time_to_logout = ((expires - timestamp) / 60).toFixed(2);
+      const authUser = this.auth.user.value;
+      if (!this.auth.isAuthenticated.value || !authUser) {
+        return;
       }
+      const expires = authUser.exp?.[0];
+      if (typeof expires !== 'number') {
+        return;
+      }
+      const timestamp = Math.floor(Date.now() / 1000);
+      this.time_to_logout = ((expires - timestamp) / 60).toFixed(2);
     },
     async getUserContributions() {
+      // `useAuth` already seeded the axios default Authorization header, so
+      // per-request Bearer overrides are no longer needed here.
       const apiContributionsURL = `${import.meta.env.VITE_API_URL}/api/user/${this.user.user_id[0]}/contributions`;
 
       try {
-        const response_contributions = await this.axios.get(apiContributionsURL, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        });
+        const response_contributions = await this.axios.get(apiContributionsURL);
         [this.user.active_reviews] = response_contributions.data.active_reviews;
         [this.user.active_status] = response_contributions.data.active_status;
       } catch (e) {
@@ -603,17 +616,11 @@ export default {
       }
     },
     async refreshWithJWT() {
-      const apiAuthenticateURL = `${import.meta.env.VITE_API_URL}/api/auth/refresh`;
-
       try {
-        const response_refresh = await this.axios.get(apiAuthenticateURL, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        });
-
-        localStorage.setItem('token', response_refresh.data[0]);
-        this.signinWithJWT();
+        // `auth.refresh()` owns the /api/auth/refresh call, stores the new
+        // token, and re-seeds the axios default Authorization header.
+        await this.auth.refresh();
+        await this.signinWithJWT();
         this.makeToast('Session refreshed successfully', 'Success', 'success');
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
@@ -623,14 +630,15 @@ export default {
       const apiAuthenticateURL = `${import.meta.env.VITE_API_URL}/api/auth/signin`;
 
       try {
-        const response_signin = await this.axios.get(apiAuthenticateURL, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        });
-
-        localStorage.setItem('user', JSON.stringify(response_signin.data));
-        this.user = response_signin.data;
+        const response_signin = await this.axios.get(apiAuthenticateURL);
+        // Persist the refreshed user payload via the composable so every
+        // subscriber (navbar, countdown badge, route guards) sees the new
+        // `exp` immediately.
+        const token = this.auth.token.value;
+        if (token) {
+          this.auth.login(token, response_signin.data);
+        }
+        this.user = { ...response_signin.data };
         this.updateDiffs();
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
@@ -644,20 +652,14 @@ export default {
       // hotfix rollout; the JSON body variant is the only one we send.
       const apiChangePasswordURL = `${import.meta.env.VITE_API_URL}/api/user/password/update`;
       try {
-        const response_password_change = await this.axios.put(
-          apiChangePasswordURL,
-          {
-            user_id_pass_change: this.user.user_id[0],
-            old_pass: this.currentPassword,
-            new_pass_1: this.newPasswordEntry,
-            new_pass_2: this.newPasswordRepeat,
-          },
-          {
-            headers: {
-              Authorization: `Bearer ${localStorage.getItem('token')}`,
-            },
-          }
-        );
+        // `useAuth` keeps the axios default Authorization header current;
+        // no per-request override needed.
+        const response_password_change = await this.axios.put(apiChangePasswordURL, {
+          user_id_pass_change: this.user.user_id[0],
+          old_pass: this.currentPassword,
+          new_pass_1: this.newPasswordEntry,
+          new_pass_2: this.newPasswordRepeat,
+        });
         this.makeToast(
           `${response_password_change.data.message} (status ${response_password_change.status})`,
           'Success',
@@ -740,7 +742,6 @@ export default {
 
         const response = await this.axios.put(apiProfileURL, payload, {
           headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
             'Content-Type': 'application/json',
           },
         });
@@ -753,8 +754,12 @@ export default {
           this.user.orcid = [orcidTrimmed];
         }
 
-        // Update localStorage
-        localStorage.setItem('user', JSON.stringify(this.user));
+        // Persist the updated profile through `useAuth` so the navbar and
+        // other observers see the new email/ORCID without a page refresh.
+        const token = this.auth.token.value;
+        if (token) {
+          this.auth.login(token, this.user);
+        }
 
         this.makeToast(
           `Profile updated successfully. ${response.data.updated_fields?.join(', ') || ''}`,


### PR DESCRIPTION
## Summary
- New `app/src/composables/useAuth.ts` — single owner of auth state (token, user, expiry, refresh, 401 coordination) with a module-level singleton so every `useAuth()` caller sees the same reactive state.
- New `app/src/composables/useAuth.spec.ts` — 25 tests covering the 5 required cases from plan §3 Phase E.E7: login stores token+user, logout clears both, expired tokens refresh (+ RFC 7519 boundary lock + malformed-body coverage), corrupt `localStorage.user` does not crash navigation, and 401-interceptor coordination.
- Migrates the 5 locked call sites off direct `localStorage.token` / `localStorage.user` reads:
  - `app/src/router/routes.ts` — replaces an 18x-duplicated `beforeEnter` body with a single `createAuthGuard(allowed_roles)` factory driven by `useAuth`.
  - `app/src/components/AppNavbar.vue` — `isUserLoggedIn`, `checkSigninWithJWT`, `setUserFromJWT`, `clearUserData` all read/write via `useAuth`.
  - `app/src/components/small/LogoutCountdownBadge.vue` — `doUserLogOut`, `refreshWithJWT`, `signinWithJWT`, `updateDiffs` use `useAuth`; the three stale "TODO: move to a mixin" comments are deleted.
  - `app/src/views/LoginView.vue` — two-step login flow now finalises through `auth.login(token, user)`.
  - `app/src/views/UserView.vue` — mount/refresh/profile/password flows all route through `useAuth`.
- Closes the P1 "Frontend auth/session state is duplicated" review finding (spec Appendix C) and Phase E.E7 exit criterion (`.plans/v11.0/phase-e.md` §3 Phase E.E7).

## Code-review fixes applied (post-opening)
- **I1**: removed dead SSR guards in `syncFromStorage` — SysNDD is a Vite SPA, not SSR'd. The `typeof localStorage !== 'undefined'` checks contradicted every other function (login/logout/refresh/handle401) that accesses localStorage unconditionally. Added a one-line comment at the top of the file documenting the SPA-only assumption. JSON parse-safety in `safeParseUser()` is unchanged.
- **I2**: validate `refresh()` response body before persisting. A 200 with a malformed body (`null`, `[null]`, non-coercible) would have passed `String()` coercion and persisted the literal string `"undefined"` or `"null"` as the new token, masquerading as a valid session until the next request fires a 401. *Superseded by Copilot Fix 3 below, which replaces the string-coercion sentinel check with a stricter type check.*
- **I3**: two new tests (16 → 18):
  - `isExpired` boundary lock: asserts `isExpired=true` when `nowSec === exp`. `useAuth.ts` uses `>=` (stricter than master's `>` by one second, intentional RFC 7519 hardening — "token is invalid at or after exp"). A future refactor that flips it back to `>` will turn this test red.
  - Malformed-body coverage for I2: MSW-overrides `/api/auth/refresh` to return `[null]`; confirms `refresh()` rejects AND does not mutate `tokenRef` / `localStorage` / the axios default `Authorization` header.

## Copilot review fixes (second round, post-I1–I3)
- **Copilot Fix 1** — `safeParseUser()` now rejects arrays and requires the minimal shape the SPA actually reads. Pre-fix, `localStorage.user = '[]'` would pass the `typeof === 'object'` check (arrays are objects), leaving `userRef` truthy with neither `.exp` nor `.user_role` — `isAuthenticated` would read `true` while every role/expiry calculation silently returned `undefined`. New validation: non-null, non-array object; `exp` is a non-empty `number[]`; `user_role` is a non-empty `string[]`. Tests: `[]`, missing `exp`, missing `user_role` (+3 tests).
- **Copilot Fix 2** — `syncFromStorage()` enforces a both-or-neither invariant. Pre-fix cleaned up a dangling token when the user was missing/corrupt but did nothing for a dangling user when the token was missing, which would trick components that only check `auth.user.value` (e.g. UserView.vue's mount hook) into firing unauthenticated API calls. Symmetric cleanup is now enforced. This also resolves Copilot's low-confidence **I4** concern (UserView hydrate path) because `auth.user.value` can no longer be non-null without a token. Tests: dangling user → user cleared, axios header cleared (+1 test).
- **Copilot Fix 3** — `refresh()` strict-types the raw response instead of the earlier `String(raw)` / `String(raw[0])` coercion. Pre-fix, a plain object body like `{}` would coerce to `"[object Object]"`, which passed the I2 sentinel check (not `"undefined"`/`"null"`/empty) and poisoned the session. Now accepts only `string` or `[string, ...]`; anything else throws `Refresh returned invalid token shape` before any state / localStorage / axios-header mutation. This supersedes the I2 sentinel guard. Tests: `[null]` (updated message), `{ foo: 'bar' }`, `[123]`, `[]` (+3 tests; I2 existing test updated).
- **Copilot Fix 4** — `LoginView.loadJWT()` validates the `/authenticate` response shape with the same contract as `refresh()`. Pre-fix, a malformed 200 body would hand `undefined` to `signinWithJWT()`, which would send "Bearer undefined" to `/signin` and then call `auth.login(undefined, ...)` after the inevitable confusing 401. Now toasts and early-returns on invalid shape / empty string. No new unit tests (the existing LoginView integration coverage is unchanged; this is a defensive guard matching the existing error-toast pattern).

## Tracked for follow-up (not in E7 locked scope)
- **M1–M7**: minor nits, deferred.

## Scope clarification
The plan's acceptance `grep -rn "localStorage\.token\|localStorage\.user" app/src/` would still return ~80 hits across ~15 other files (ApproveReview, ApproveStatus, ModifyEntity, Review, RegisterView, CreateEntity, ManageReReview, composables/useStatusForm, composables/useReviewForm, etc.) — **these are outside the locked E7 scope and deferred to v11.1**. Within the 5 locked files + the new `useAuth.ts`, the grep is clean (remaining matches are documentation comments only). The task directive explicitly relaxed the acceptance grep to this locked-file scope; flagging the interpretation here so the reviewer can confirm.

Also scoped up inside `router/routes.ts`: the plan listed 5 guards (lines 348/380/406/432/458) but the file actually had 18 copies of the identical `beforeEnter` body. All 18 were migrated to the new `createAuthGuard` factory because migrating only 5 and leaving 13 behind would have been inconsistent within a locked file. Behaviour is unchanged per guard.

## Verification
- `cd app && npm run type-check` — clean
- `cd app && npm run lint` — clean (0 issues)
- `cd app && npm run test:unit` — 475 passed (35 files, incl. 25 in useAuth.spec.ts), 6 todo, 0 failures
- Host `make ci-local` skipped per CLAUDE.md Conda-R workaround (frontend-only change).

## Atomic commits
- `useAuth.ts` + spec (6 cases, 16 tests)
- `router/routes.ts` guards → factory
- `AppNavbar.vue` → useAuth
- `LogoutCountdownBadge.vue` → useAuth (+ stale TODOs deleted)
- `LoginView.vue` → useAuth
- `UserView.vue` → useAuth
- Code-review fixes: I1 (SSR guards removed), I2 (refresh-body guard), I3 (boundary + malformed-body tests)
- Copilot fixes: Fix 1 (safeParseUser array + shape), Fix 2 (both-or-neither invariant), Fix 3 (refresh strict-type, supersedes I2), Fix 4 (LoginView token-shape guard)

## Test plan
- [ ] CI green
- [ ] Login flow smoke test (login → see user/token populated; navbar shows role dropdowns)
- [ ] Logout flow smoke test (logout → state cleared; navbar reverts to Login link)
- [ ] Token refresh smoke test (wait for countdown warning → "refresh now" badge; /auth/refresh succeeds and the countdown resets)
- [ ] Corrupted-localStorage smoke test (manually set `localStorage.user = 'bad json'` in DevTools → navigate to /User; should redirect to /Login without throwing)
- [ ] Array-shaped-localStorage smoke test (manually set `localStorage.user = '[]'` in DevTools → `useAuth` should treat as logged-out, Copilot Fix 1)
- [ ] Dangling-user smoke test (manually set `localStorage.user = '{...}'` with NO `localStorage.token` → hard reload → user is cleared, axios header cleared, Copilot Fix 2)