### PR TITLE
v11.0/phase-e: E2 + E3 + E7 combined (strict scopes, first client migration, useAuth consolidation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,9 @@ jobs:
       - name: Run TypeScript check
         run: npm run type-check
 
+      - name: Run TypeScript check (strict scopes)
+        run: npm run type-check:strict
+
       - name: Run Vitest tests
         run: npm run test:unit
 

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ pre-commit: ## [quality] Run all quality checks before committing
 
 ci-local: ## [quality] Run CI checks locally (lint + test with DB - mirrors GitHub Actions)
 	@printf "$(CYAN)==> Running CI checks locally (mirrors GitHub Actions)...$(RESET)\n"
-	@printf "\n$(CYAN)[1/5] Starting test database...$(RESET)\n"
+	@printf "\n$(CYAN)[1/6] Starting test database...$(RESET)\n"
 	@cd $(ROOT_DIR) && docker compose -f docker-compose.dev.yml up -d mysql-test && \
 		printf "$(GREEN)✓ Test database started$(RESET)\n" || \
 		(printf "$(RED)✗ Failed to start test database$(RESET)\n" && exit 1)
@@ -193,14 +193,17 @@ ci-local: ## [quality] Run CI checks locally (lint + test with DB - mirrors GitH
 		sleep 1; \
 		SECONDS=$$((SECONDS+1)); \
 	done
-	@printf "\n$(CYAN)[2/5] Linting R code...$(RESET)\n"
+	@printf "\n$(CYAN)[2/6] Linting R code...$(RESET)\n"
 	@$(MAKE) lint-api || ($(MAKE) _ci-cleanup && exit 1)
-	@printf "\n$(CYAN)[3/5] Linting frontend code...$(RESET)\n"
+	@printf "\n$(CYAN)[3/6] Linting frontend code...$(RESET)\n"
 	@$(MAKE) lint-app || ($(MAKE) _ci-cleanup && exit 1)
-	@printf "\n$(CYAN)[4/5] Type-checking frontend...$(RESET)\n"
+	@printf "\n$(CYAN)[4/6] Type-checking frontend...$(RESET)\n"
 	@cd $(ROOT_DIR)/app && npm run type-check || ($(MAKE) _ci-cleanup && exit 1)
 	@printf "$(GREEN)✓ Type check passed$(RESET)\n"
-	@printf "\n$(CYAN)[5/5] Running R API tests (with database)...$(RESET)\n"
+	@printf "\n$(CYAN)[5/6] Type-checking frontend (strict scopes)...$(RESET)\n"
+	@cd $(ROOT_DIR)/app && npm run type-check:strict || ($(MAKE) _ci-cleanup && exit 1)
+	@printf "$(GREEN)✓ Strict type check passed$(RESET)\n"
+	@printf "\n$(CYAN)[6/6] Running R API tests (with database)...$(RESET)\n"
 	@cd $(ROOT_DIR)/api && \
 		MYSQL_HOST=127.0.0.1 MYSQL_PORT=7655 MYSQL_DATABASE=sysndd_db_test \
 		MYSQL_USER=bernt MYSQL_PASSWORD=Nur7DoofeFliegen. \

--- a/app/package.json
+++ b/app/package.json
@@ -11,6 +11,7 @@
     "build:docker": "vite build --mode docker",
     "build:production": "vite build --mode production",
     "type-check": "vue-tsc --noEmit",
+    "type-check:strict": "node scripts/type-check-strict.js",
     "lint": "eslint . --ext .vue,.js,.ts,.tsx",
     "lint:fix": "eslint . --ext .vue,.js,.ts,.tsx --fix",
     "format": "prettier --write \"src/**/*.{js,ts,vue,json,css,scss}\"",

--- a/app/scripts/type-check-strict.js
+++ b/app/scripts/type-check-strict.js
@@ -77,6 +77,24 @@ for (const scope of scopes) {
     { cwd: appDir, encoding: 'utf8' }
   );
 
+  // Spawn failed outright (e.g. npx not on PATH, ENOENT, permission denied).
+  // `result.status` is null in this case, so fall-through would surface as
+  // "UNEXPECTED TOOL FAILURE (vue-tsc exit null)" and bury the real cause.
+  if (result.error) {
+    console.error(`[type-check:strict] ${scope.name}: SPAWN FAILED — ${result.error.message}`);
+    console.error(result.error.stack ?? '(no stack)');
+    failed = true;
+    continue;
+  }
+  // Process was terminated by a signal (e.g. SIGKILL from OOM killer).
+  // Again, `result.status` is null here, so we need to surface the signal
+  // explicitly before the generic guard below misreports it.
+  if (result.signal) {
+    console.error(`[type-check:strict] ${scope.name}: KILLED BY SIGNAL ${result.signal}`);
+    failed = true;
+    continue;
+  }
+
   const output = `${result.stdout || ''}${result.stderr || ''}`;
   const lines = output.split('\n');
   const inScopeErrors = lines.filter((line) => line.startsWith(scope.prefix));

--- a/app/scripts/type-check-strict.js
+++ b/app/scripts/type-check-strict.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * type-check-strict.js — run vue-tsc against strict-scoped tsconfigs and
+ * fail only when errors originate inside the scope's own files.
+ *
+ * Background: vue-tsc walks the full import graph and reports diagnostics
+ * for any referenced file. In our codebase, `src/router/routes.ts` pulls
+ * in ~40 view .vue files whose transitive dependencies violate strict
+ * mode. The root `tsconfig.json` is intentionally permissive so those
+ * violations don't block builds.
+ *
+ * For Phase E.E2, we only care that files INSIDE each strict scope are
+ * strict-clean. Out-of-scope violations remain "ignored" under the root
+ * permissive config, to be fixed as subsequent scopes get enabled.
+ *
+ * This runner:
+ *   - invokes vue-tsc -p <tsconfig> for each configured scope
+ *   - partitions diagnostic lines by file prefix
+ *   - prints in-scope errors to stderr and exits non-zero if any are found
+ *   - skips the composables-auth scope silently when no useAuth*.ts files
+ *     exist yet (E7 creates useAuth.ts in parallel)
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, globSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const appDir = resolve(__dirname, '..');
+
+/**
+ * @typedef {Object} Scope
+ * @property {string} name     - Human label for logging.
+ * @property {string} tsconfig - Path to the scope tsconfig, relative to app/.
+ * @property {string} prefix   - Path prefix (relative to app/) that marks
+ *                               "in scope" error lines.
+ * @property {string} [requireGlob] - If set, scope runs only when this glob
+ *                                    matches at least one file.
+ */
+
+/** @type {Scope[]} */
+const scopes = [
+  { name: 'router', tsconfig: 'tsconfig.router.json', prefix: 'src/router/' },
+  { name: 'api', tsconfig: 'tsconfig.api.json', prefix: 'src/api/' },
+  { name: 'types', tsconfig: 'tsconfig.types.json', prefix: 'src/types/' },
+  {
+    name: 'composables-auth',
+    tsconfig: 'tsconfig.composables-auth.json',
+    prefix: 'src/composables/useAuth',
+    requireGlob: 'src/composables/useAuth*.ts',
+  },
+];
+
+let failed = false;
+
+for (const scope of scopes) {
+  if (scope.requireGlob) {
+    const matches = globSync(scope.requireGlob, { cwd: appDir });
+    if (matches.length === 0) {
+      console.log(
+        `[type-check:strict] skipping ${scope.name}: no files match ${scope.requireGlob} yet`
+      );
+      continue;
+    }
+  }
+
+  if (!existsSync(resolve(appDir, scope.tsconfig))) {
+    console.error(`[type-check:strict] missing tsconfig: ${scope.tsconfig}`);
+    failed = true;
+    continue;
+  }
+
+  const result = spawnSync(
+    'npx',
+    ['vue-tsc', '--noEmit', '-p', scope.tsconfig],
+    { cwd: appDir, encoding: 'utf8' }
+  );
+
+  const output = `${result.stdout || ''}${result.stderr || ''}`;
+  const lines = output.split('\n');
+  const inScopeErrors = lines.filter((line) => line.startsWith(scope.prefix));
+
+  if (inScopeErrors.length > 0) {
+    console.error(`[type-check:strict] ${scope.name}: FAIL (${inScopeErrors.length} errors)`);
+    for (const line of inScopeErrors) {
+      console.error(line);
+    }
+    failed = true;
+  } else {
+    console.log(`[type-check:strict] ${scope.name}: OK`);
+  }
+}
+
+process.exit(failed ? 1 : 0);

--- a/app/scripts/type-check-strict.js
+++ b/app/scripts/type-check-strict.js
@@ -87,9 +87,38 @@ for (const scope of scopes) {
       console.error(line);
     }
     failed = true;
-  } else {
-    console.log(`[type-check:strict] ${scope.name}: OK`);
+    continue;
   }
+
+  // Catch unexpected tool failures: vue-tsc exited non-zero with no in-scope
+  // errors, but also produced no recognizable out-of-scope diagnostics.
+  //
+  // vue-tsc normally exits non-zero when ANY file in the import graph has
+  // errors — out-of-scope diagnostics are expected and intentionally ignored.
+  // They look like: `src/foo/bar.vue(12,3): error TS2322: ...`.
+  //
+  // If the exit is non-zero but NO line matches that shape, vue-tsc itself
+  // failed to run (binary missing, tsconfig-level error like TS5058 emitted
+  // without a path prefix, process crash, npm ERR!). Without this guard
+  // every scope would report "OK" with exit 0 — a silent green pass that
+  // hides real failures.
+  if (result.status !== 0) {
+    // Match any line that looks like a normal TS diagnostic:
+    // `path/to/file.ext(line,col): error TSxxxx: message`
+    const diagnosticPattern = /^\S+\.\w+\(\d+,\d+\): (?:error|warning) TS\d+:/;
+    const hasAnyDiagnostic = lines.some((line) => diagnosticPattern.test(line));
+    if (!hasAnyDiagnostic) {
+      const rawOutput = output.trim();
+      console.error(
+        `[type-check:strict] ${scope.name}: UNEXPECTED TOOL FAILURE (vue-tsc exit ${result.status})`
+      );
+      console.error(rawOutput.length > 0 ? rawOutput : '(no output)');
+      failed = true;
+      continue;
+    }
+  }
+
+  console.log(`[type-check:strict] ${scope.name}: OK`);
 }
 
 process.exit(failed ? 1 : 0);

--- a/app/scripts/type-check-strict.js
+++ b/app/scripts/type-check-strict.js
@@ -17,8 +17,10 @@
  *   - invokes vue-tsc -p <tsconfig> for each configured scope
  *   - partitions diagnostic lines by file prefix
  *   - prints in-scope errors to stderr and exits non-zero if any are found
- *   - skips the composables-auth scope silently when no useAuth*.ts files
- *     exist yet (E7 creates useAuth.ts in parallel)
+ *   - logs a skip notice and continues (exits 0) for the composables-auth
+ *     scope when no useAuth*.ts files exist yet (E7 creates useAuth.ts in
+ *     parallel); the notice is intentional so CI logs show why the scope
+ *     was deferred rather than silently missed
  */
 
 import { spawnSync } from 'node:child_process';

--- a/app/src/api/client.ts
+++ b/app/src/api/client.ts
@@ -14,6 +14,17 @@
  * separate `axios.create({...})` would skip that interceptor chain and
  * silently bypass the login-redirect behaviour. Every method below delegates
  * to the configured default instance so the wrapper inherits all of it.
+ *
+ * `withCredentials` is NOT enabled by default on the shared singleton
+ * (`@/plugins/axios` does not set `axios.defaults.withCredentials`). The vast
+ * majority of endpoints are Bearer-authenticated and either idempotent or
+ * backend-memoised, so they do not need cookies. Call sites that DO depend on
+ * sticky-session cookies — notably long-running async-job polling against the
+ * load-balanced API, which relies on Traefik's `sysndd_api_sticky` cookie to
+ * keep hitting the container that owns the job — must opt in explicitly by
+ * passing `withCredentials: true` via the `config` argument to
+ * `apiClient.get/post/put/patch/delete`. See `@/composables/useAsyncJob.ts`
+ * (`checkJobStatus`) for the canonical example.
  */
 
 import axios, { AxiosError, type AxiosRequestConfig, type AxiosResponse } from 'axios';

--- a/app/src/api/external.ts
+++ b/app/src/api/external.ts
@@ -1,5 +1,67 @@
 // app/src/api/external.ts
-// Stub — v11.0 Phase E.E1 establishes the api/ module structure.
-// Resource helpers to be filled in during v11.1 per each view's migration.
-// See docs/superpowers/specs/2026-04-11-v11.0-test-foundation-design.md §3 Phase E.
-export {};
+/**
+ * External-proxy resource helpers.
+ *
+ * Phase E.E1 established this module as a stub; Phase E.E3 fills in the
+ * first real helper (`getUniprotDomains`) as part of migrating
+ * `GeneView.vue` off raw `axios.get`. Additional external-proxy helpers
+ * (Ensembl, AlphaFold metadata, ClinVar, gnomAD variants, MGI, RGD) will
+ * be added as each call site migrates during v11.1.
+ *
+ * Wire shapes mirror `api/endpoints/external_endpoints.R`. The endpoints
+ * use `@serializer unboxedJSON`, so responses arrive as plain objects
+ * (not the R/Plumber 1-element-array scalar wrapping used by tibble
+ * collectors elsewhere). Consumers therefore do NOT need `unwrapScalar`.
+ */
+
+import type { AxiosRequestConfig } from 'axios';
+import { apiClient } from './client';
+
+// ---------------------------------------------------------------------------
+// UniProt domain architecture
+// ---------------------------------------------------------------------------
+
+/**
+ * A single protein feature emitted by UniProt (domain, region, signal, etc.).
+ * Mirrors the shape used by `GeneView.vue` — `begin`/`end` can come back as
+ * strings for some UniProt entries, so the type accepts both forms.
+ */
+export interface UniProtDomainFeature {
+  type: string;
+  description?: string;
+  begin: number | string;
+  end: number | string;
+}
+
+/**
+ * Response body from `GET /api/external/uniprot/domains/<symbol>`.
+ * The upstream endpoint memoises for 14 days; 404 is the canonical
+ * "gene not in UniProt" branch, and consumers typically surface it as
+ * "no data" rather than an error.
+ */
+export interface UniProtData {
+  source: string;
+  gene_symbol: string;
+  accession: string;
+  protein_name: string;
+  protein_length: number | string;
+  domains: UniProtDomainFeature[];
+}
+
+/**
+ * GET /api/external/uniprot/domains/<symbol>
+ *
+ * Returns the protein-domain architecture for the given gene symbol.
+ * Throws the underlying `AxiosError` on non-2xx (including the 404
+ * "gene not found in UniProt" branch) — callers that want to map 404
+ * to "no data, no error" should catch and inspect via `isApiError` +
+ * `err.response?.status`. See `GeneView.vue`'s `fetchUniprotData` for
+ * the canonical handling pattern.
+ */
+export async function getUniprotDomains(
+  symbol: string,
+  config?: AxiosRequestConfig,
+): Promise<UniProtData> {
+  const path = `/api/external/uniprot/domains/${encodeURIComponent(symbol)}`;
+  return apiClient.get<UniProtData>(path, config);
+}

--- a/app/src/api/genes.spec.ts
+++ b/app/src/api/genes.spec.ts
@@ -1,0 +1,215 @@
+// app/src/api/genes.spec.ts
+/**
+ * Phase E.E3 unit tests for the typed gene and uniprot-domains helpers.
+ *
+ * Covers:
+ *   - `getGene(gene_input, input_type)`
+ *   - `getGeneBySymbol(symbol)`
+ *   - `listGenes(params)`
+ *   - `getUniprotDomains(symbol)` (from api/external.ts)
+ *
+ * MSW handlers live in `@/test-utils/mocks/handlers` (registered with the
+ * global server in `vitest.setup.ts`) and the fixtures live in
+ * `@/test-utils/mocks/data/genes`. See `.plans/v11.0/phase-e.md` §3 Phase
+ * E.E3 for the migration rationale; these tests lock in the wire shapes
+ * before rewriting `GeneView.vue`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { getGene, getGeneBySymbol, listGenes } from './genes';
+import { getUniprotDomains } from './external';
+import { isApiError } from './client';
+import { server } from '@/test-utils/mocks/server';
+import {
+  geneLookupOk,
+  geneListOk,
+  uniprotDomainsOk,
+  UNIPROT_NOT_FOUND_SYMBOL,
+} from '@/test-utils/mocks/data/genes';
+
+describe('api/genes — typed helpers', () => {
+  // ---------------------------------------------------------------------------
+  // getGene
+  // ---------------------------------------------------------------------------
+
+  describe('getGene', () => {
+    it('returns the 1-row lookup array for a valid HGNC id', async () => {
+      const rows = await getGene('HGNC:4586', 'hgnc');
+
+      expect(Array.isArray(rows)).toBe(true);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].symbol).toEqual(geneLookupOk[0].symbol);
+      expect(rows[0].hgnc_id).toEqual(['HGNC:4586']);
+      // Phase A A2 regression guard: gnomad_constraints arrives as a scalar
+      // JSON string (NOT a pipe-split array).
+      expect(typeof rows[0].gnomad_constraints).toBe('string');
+    });
+
+    it('defaults input_type to "hgnc" when omitted', async () => {
+      let observedInputType: string | null = null;
+      server.use(
+        http.get('/api/gene/:gene_input', ({ request }) => {
+          observedInputType = new URL(request.url).searchParams.get('input_type');
+          return HttpResponse.json(geneLookupOk);
+        }),
+      );
+
+      await getGene('HGNC:4586');
+      expect(observedInputType).toBe('hgnc');
+    });
+
+    it('sends input_type=symbol when explicitly requested', async () => {
+      let observedInputType: string | null = null;
+      server.use(
+        http.get('/api/gene/:gene_input', ({ request }) => {
+          observedInputType = new URL(request.url).searchParams.get('input_type');
+          return HttpResponse.json(geneLookupOk);
+        }),
+      );
+
+      await getGene('GRIN2B', 'symbol');
+      expect(observedInputType).toBe('symbol');
+    });
+
+    it('returns an empty array for the UNKNOWN_GENE sentinel', async () => {
+      const rows = await getGene('UNKNOWN_GENE', 'symbol');
+      expect(Array.isArray(rows)).toBe(true);
+      expect(rows).toHaveLength(0);
+    });
+
+    it('URL-encodes the gene_input path param', async () => {
+      let observedPath: string | null = null;
+      server.use(
+        http.get('/api/gene/:gene_input', ({ params, request }) => {
+          observedPath = new URL(request.url).pathname;
+          // Also confirm MSW decoded the path param back to the raw value.
+          expect(params.gene_input).toBe('HGNC:4586');
+          return HttpResponse.json(geneLookupOk);
+        }),
+      );
+
+      await getGene('HGNC:4586', 'hgnc');
+      // `:` must be percent-encoded in the outgoing URL — otherwise callers
+      // with symbols containing reserved characters would drop path segments.
+      expect(observedPath).toBe('/api/gene/HGNC%3A4586');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getGeneBySymbol
+  // ---------------------------------------------------------------------------
+
+  describe('getGeneBySymbol', () => {
+    it('wraps getGene with input_type=symbol', async () => {
+      let observedInputType: string | null = null;
+      let observedSymbol: string | null = null;
+      server.use(
+        http.get('/api/gene/:gene_input', ({ params, request }) => {
+          observedSymbol = String(params.gene_input);
+          observedInputType = new URL(request.url).searchParams.get('input_type');
+          return HttpResponse.json(geneLookupOk);
+        }),
+      );
+
+      const rows = await getGeneBySymbol('GRIN2B');
+      expect(observedSymbol).toBe('GRIN2B');
+      expect(observedInputType).toBe('symbol');
+      expect(rows).toHaveLength(1);
+      expect(rows[0].symbol).toEqual(['GRIN2B']);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // listGenes
+  // ---------------------------------------------------------------------------
+
+  describe('listGenes', () => {
+    it('returns the cursor-paginated envelope', async () => {
+      const envelope = await listGenes({ page_size: '10' });
+
+      expect(envelope).toHaveProperty('data');
+      expect(envelope).toHaveProperty('meta');
+      expect(envelope).toHaveProperty('links');
+      expect(Array.isArray(envelope.data)).toBe(true);
+      expect(envelope.data).toHaveLength(geneListOk.data.length);
+      expect(envelope.data[0].symbol).toEqual(geneListOk.data[0].symbol);
+    });
+
+    it('forwards all listing params to the query string', async () => {
+      let observedQuery: URLSearchParams | null = null;
+      server.use(
+        http.get('/api/gene', ({ request }) => {
+          observedQuery = new URL(request.url).searchParams;
+          return HttpResponse.json(geneListOk);
+        }),
+      );
+
+      await listGenes({
+        sort: 'symbol',
+        filter: 'contains(symbol,GR)',
+        fields: 'hgnc_id,symbol',
+        page_after: 'HGNC:4586',
+        page_size: '25',
+        fspec: 'default',
+      });
+
+      expect(observedQuery).not.toBeNull();
+      const q = observedQuery as unknown as URLSearchParams;
+      expect(q.get('sort')).toBe('symbol');
+      expect(q.get('filter')).toBe('contains(symbol,GR)');
+      expect(q.get('fields')).toBe('hgnc_id,symbol');
+      expect(q.get('page_after')).toBe('HGNC:4586');
+      expect(q.get('page_size')).toBe('25');
+      expect(q.get('fspec')).toBe('default');
+    });
+
+    it('works with no params (defaults)', async () => {
+      const envelope = await listGenes();
+      expect(envelope).toHaveProperty('data');
+    });
+  });
+});
+
+describe('api/external — getUniprotDomains', () => {
+  it('returns the UniProt domains payload on 200', async () => {
+    const data = await getUniprotDomains('GRIN2B');
+
+    expect(data.source).toBe('uniprot');
+    expect(data.gene_symbol).toBe(uniprotDomainsOk.gene_symbol);
+    expect(data.accession).toBe(uniprotDomainsOk.accession);
+    expect(Array.isArray(data.domains)).toBe(true);
+    expect(data.domains.length).toBeGreaterThan(0);
+    expect(data.domains[0]).toHaveProperty('type');
+    expect(data.domains[0]).toHaveProperty('begin');
+    expect(data.domains[0]).toHaveProperty('end');
+  });
+
+  it('URL-encodes the symbol path param', async () => {
+    let observedPath: string | null = null;
+    server.use(
+      http.get('/api/external/uniprot/domains/:symbol', ({ request }) => {
+        observedPath = new URL(request.url).pathname;
+        return HttpResponse.json(uniprotDomainsOk);
+      }),
+    );
+
+    await getUniprotDomains('GRIN 2B');
+    expect(observedPath).toBe('/api/external/uniprot/domains/GRIN%202B');
+  });
+
+  it('rejects with an AxiosError on the 404 sentinel branch', async () => {
+    let caught: unknown;
+    try {
+      await getUniprotDomains(UNIPROT_NOT_FOUND_SYMBOL);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeDefined();
+    expect(isApiError(caught)).toBe(true);
+    if (isApiError(caught)) {
+      expect(caught.response?.status).toBe(404);
+    }
+  });
+});

--- a/app/src/components/AppNavbar.vue
+++ b/app/src/components/AppNavbar.vue
@@ -75,12 +75,21 @@ import ROLES from '@/assets/js/constants/role_constants';
 import packageInfo from '../../package.json';
 import SearchCombobox from '@/components/small/SearchCombobox.vue';
 import IconPairDropdownMenu from '@/components/small/IconPairDropdownMenu.vue';
+import { useAuth } from '@/composables/useAuth';
 
 export default {
   name: 'AppNavbar',
   components: {
     SearchCombobox,
     IconPairDropdownMenu,
+  },
+  setup() {
+    // Phase E.E7: route all auth-state reads through the shared composable
+    // instead of reaching into localStorage. The Bearer header is already
+    // set by `@/plugins/axios` whenever `useAuth` mutates the token, so the
+    // navbar no longer has to read `localStorage.getItem('token')` itself.
+    const auth = useAuth();
+    return { auth };
   },
   data() {
     return {
@@ -133,21 +142,22 @@ export default {
   },
   methods: {
     isUserLoggedIn() {
-      if (localStorage.user && localStorage.token) {
+      // Phase E.E7: `isAuthenticated` covers both "token present" and
+      // "user payload parsed cleanly" — the composable already refused a
+      // corrupt localStorage blob. No direct `localStorage.token` read.
+      if (this.auth.isAuthenticated.value) {
         this.checkSigninWithJWT();
       } else {
         this.clearUserData();
       }
     },
     async checkSigninWithJWT() {
+      // The `@/plugins/axios` default Authorization header is kept in
+      // lockstep with `useAuth`, so we don't override it per-request here.
       const apiAuthenticateURL = `${URLS.API_URL}/api/auth/signin`;
 
       try {
-        const response_signin = await this.axios.get(apiAuthenticateURL, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        });
+        const response_signin = await this.axios.get(apiAuthenticateURL);
 
         this.user_from_jwt = response_signin.data;
         this.setUserFromJWT();
@@ -156,12 +166,16 @@ export default {
       }
     },
     setUserFromJWT() {
-      const localStorageUser = JSON.parse(localStorage.user);
-      if (this.user_from_jwt.user_name[0] === localStorageUser.user_name[0]) {
-        const [user] = localStorageUser.user_name;
+      const authUser = this.auth.user.value;
+      if (!authUser) {
+        this.clearUserData();
+        return;
+      }
+      if (this.user_from_jwt.user_name[0] === authUser.user_name[0]) {
+        const [user] = authUser.user_name;
         this.user = user;
 
-        const user_role = localStorageUser.user_role[0];
+        const user_role = authUser.user_role[0];
         const allowence = ROLES.ALLOWENCE_NAVIGATION[ROLES.ALLOWED_ROLES.indexOf(user_role)];
 
         this.userAllowence = {
@@ -175,8 +189,9 @@ export default {
       }
     },
     clearUserData() {
-      localStorage.removeItem('user');
-      localStorage.removeItem('token');
+      // Delegates the localStorage + axios-header cleanup to useAuth so the
+      // navbar never touches those keys directly.
+      this.auth.logout();
       this.user = null;
       this.userAllowence = {
         view: false,

--- a/app/src/components/small/LogoutCountdownBadge.vue
+++ b/app/src/components/small/LogoutCountdownBadge.vue
@@ -8,12 +8,18 @@
 
 <script>
 import useToast from '@/composables/useToast';
+import { useAuth } from '@/composables/useAuth';
 
 export default {
   name: 'LogoutCountdownBadge',
   setup() {
     const { makeToast } = useToast();
-    return { makeToast };
+    // Phase E.E7: source-of-truth for token / user / expiry is now
+    // `useAuth()`. The stale "TODO: move to a mixin" comments that were
+    // sprinkled across this file have been deleted — the mixin they asked
+    // for is, in effect, this composable.
+    const auth = useAuth();
+    return { makeToast, auth };
   },
   data() {
     return {
@@ -34,9 +40,8 @@ export default {
   },
   methods: {
     doUserLogOut() {
-      if (localStorage.user || localStorage.token) {
-        localStorage.removeItem('user');
-        localStorage.removeItem('token');
+      if (this.auth.isAuthenticated.value) {
+        this.auth.logout();
 
         // based on https://stackoverflow.com/questions/57837758/navigationduplicated-navigating-to-current-location-search-is-not-allowed
         // to avoid double navigation
@@ -50,76 +55,71 @@ export default {
         }
       }
     },
-    // TODO: move to a mixin to be used in other components (DRY)
     async refreshWithJWT() {
-      const apiAuthenticateURL = `${import.meta.env.VITE_API_URL}/api/auth/refresh`;
       try {
-        const response_refresh = await this.axios.get(apiAuthenticateURL, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        });
-        localStorage.setItem('token', response_refresh.data[0]);
+        await this.auth.refresh();
         this.signinWithJWT();
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
       }
     },
-    // TODO: move to a mixin to be used in other components (DRY)
     async signinWithJWT() {
+      // `useAuth` already maintains the axios default Authorization header,
+      // so we no longer pass it per-request. The response body is the user
+      // payload that login() expects.
       const apiAuthenticateURL = `${import.meta.env.VITE_API_URL}/api/auth/signin`;
 
       try {
-        const response_signin = await this.axios.get(apiAuthenticateURL, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        });
-
-        localStorage.setItem('user', JSON.stringify(response_signin.data));
+        const response_signin = await this.axios.get(apiAuthenticateURL);
+        if (this.auth.token.value) {
+          this.auth.login(this.auth.token.value, response_signin.data);
+        }
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
       }
     },
-    // TODO: move to a mixin to be used in other components (DRY)
     updateDiffs() {
       // TODO: remove magic numbers and put them in constants in a config file
-      const timestampMillisecondDivider = 1000;
       const secondToMinuteDivider = 60;
       const warningTimePoints = [60, 180, 300];
-      if (localStorage.token) {
-        const expires = JSON.parse(localStorage.user).exp;
-        const timestamp = Math.floor(new Date().getTime() / timestampMillisecondDivider);
+      const user = this.auth.user.value;
+      if (!this.auth.isAuthenticated.value || !user) {
+        return;
+      }
 
-        if (expires > timestamp) {
-          this.time_to_logout = ((expires - timestamp) / secondToMinuteDivider).toFixed(2);
-          if (warningTimePoints.includes(expires - timestamp)) {
-            // Use a shorter name for this.$createElement
-            const h = this.$createElement;
+      const expires = user.exp?.[0];
+      if (typeof expires !== 'number') {
+        return;
+      }
+      const timestamp = Math.floor(Date.now() / 1000);
 
-            // compose the logout message
-            const vNodesMsg = h('p', { class: ['text-center', 'mb-0'] }, [
-              'Token ',
-              h(
-                'b-badge',
-                {
-                  props: { variant: 'success', href: '#' },
-                  // TODO: make the modal close after clicking on the badge
-                  on: { click: () => this.refreshWithJWT() },
-                },
-                'refresh now'
-              ),
-            ]);
+      if (expires > timestamp) {
+        this.time_to_logout = ((expires - timestamp) / secondToMinuteDivider).toFixed(2);
+        if (warningTimePoints.includes(expires - timestamp)) {
+          // Use a shorter name for this.$createElement
+          const h = this.$createElement;
 
-            this.makeToast(
-              [vNodesMsg],
-              `Warning: Logout in ${expires - timestamp} seconds`,
-              'danger'
-            );
-          }
-        } else {
-          this.doUserLogOut();
+          // compose the logout message
+          const vNodesMsg = h('p', { class: ['text-center', 'mb-0'] }, [
+            'Token ',
+            h(
+              'b-badge',
+              {
+                props: { variant: 'success', href: '#' },
+                on: { click: () => this.refreshWithJWT() },
+              },
+              'refresh now'
+            ),
+          ]);
+
+          this.makeToast(
+            [vNodesMsg],
+            `Warning: Logout in ${expires - timestamp} seconds`,
+            'danger'
+          );
         }
+      } else {
+        this.doUserLogOut();
       }
     },
   },

--- a/app/src/composables/useAuth.spec.ts
+++ b/app/src/composables/useAuth.spec.ts
@@ -338,6 +338,30 @@ describe('useAuth', () => {
       expect(auth.isAuthenticated.value).toBe(false);
     });
 
+    it('enforces both-or-neither: a dangling user (no token) is cleared from localStorage and state', () => {
+      // Copilot Fix 2: the pre-fix syncFromStorage() only cleaned up a
+      // dangling token; a dangling user survived. Components that read
+      // `auth.user.value` directly (e.g. UserView.vue's mount hook) would
+      // then hit the API without a Bearer header. Symmetric cleanup is now
+      // enforced so every observer sees the same cleared state.
+      const user = makeFreshUser();
+      localStorage.setItem('user', JSON.stringify(user));
+      // no token key — simulates a crash between the two setItem calls,
+      // or a dev-tools manipulation.
+      axios.defaults.headers.common.Authorization = 'Bearer stale';
+
+      const auth = useAuth();
+
+      expect(auth.user.value).toBeNull();
+      expect(auth.token.value).toBeNull();
+      expect(auth.isAuthenticated.value).toBe(false);
+      // Stored user must be cleaned up too, not just the in-memory ref.
+      expect(localStorage.getItem('user')).toBeNull();
+      // And the axios default header must be cleared so the next request
+      // cannot send a stale Bearer.
+      expect(axios.defaults.headers.common.Authorization).toBeUndefined();
+    });
+
     it('rehydrates cleanly when both token and user are present', () => {
       const user = makeFreshUser();
       localStorage.setItem('token', FRESH_TOKEN);

--- a/app/src/composables/useAuth.spec.ts
+++ b/app/src/composables/useAuth.spec.ts
@@ -282,6 +282,51 @@ describe('useAuth', () => {
       expect(auth.hasRole('Administrator')).toBe(false);
     });
 
+    it('rejects a JSON array in localStorage.user (`[]` is valid JSON but not a user payload)', () => {
+      // Copilot Fix 1: `JSON.parse('[]')` yields an array, and `typeof [] ===
+      // 'object'`. Without an explicit `Array.isArray` guard, safeParseUser()
+      // would have accepted `[]`, leaving userRef truthy with neither `.exp`
+      // nor `.user_role` — callers downstream would see isAuthenticated=true
+      // while every role/expiry check silently returned undefined.
+      localStorage.setItem('token', FRESH_TOKEN);
+      localStorage.setItem('user', '[]');
+
+      const auth = useAuth();
+      auth.syncFromStorage();
+
+      expect(auth.user.value).toBeNull();
+      expect(auth.isAuthenticated.value).toBe(false);
+    });
+
+    it('rejects an object with a missing/empty `exp` array', () => {
+      // Copilot Fix 1: without a usable exp[0], isExpired can never fire, so
+      // a just-expired session would linger until the next 401. Reject at
+      // parse time instead.
+      localStorage.setItem('token', FRESH_TOKEN);
+      localStorage.setItem('user', JSON.stringify({ exp: [], user_role: ['Administrator'] }));
+
+      const auth = useAuth();
+      auth.syncFromStorage();
+
+      expect(auth.user.value).toBeNull();
+      expect(auth.isAuthenticated.value).toBe(false);
+    });
+
+    it('rejects an object with a missing/empty `user_role` array', () => {
+      // Copilot Fix 1: an empty user_role array would fail every router
+      // guard's hasRole() check anyway (roles[0] === undefined), so reject
+      // early rather than letting isAuthenticated masquerade as true.
+      const nowSec = Math.floor(Date.now() / 1000);
+      localStorage.setItem('token', FRESH_TOKEN);
+      localStorage.setItem('user', JSON.stringify({ exp: [nowSec + 3600], user_role: [] }));
+
+      const auth = useAuth();
+      auth.syncFromStorage();
+
+      expect(auth.user.value).toBeNull();
+      expect(auth.isAuthenticated.value).toBe(false);
+    });
+
     it('treats missing localStorage.user (token-only) as logged-out', () => {
       localStorage.setItem('token', FRESH_TOKEN);
       // no user key

--- a/app/src/composables/useAuth.spec.ts
+++ b/app/src/composables/useAuth.spec.ts
@@ -189,6 +189,17 @@ describe('useAuth', () => {
       expect(auth.isAuthenticated.value).toBe(true);
     });
 
+    it('flags isExpired=true at exactly exp (RFC 7519: token is invalid at or after exp)', () => {
+      // Lock in the `>=` semantics in useAuth.ts. Master's implementation used
+      // `>` which leaves a one-second window where a just-expired token still
+      // reads as valid. A future well-meaning refactor that "fixes" this back
+      // to `>` will flip this test red.
+      const auth = useAuth();
+      const nowSec = Math.floor(Date.now() / 1000);
+      auth.login(FRESH_TOKEN, makeFreshUser({ exp: [nowSec] }));
+      expect(auth.isExpired.value).toBe(true);
+    });
+
     it('refresh() calls GET /api/auth/refresh and stores the new token', async () => {
       const auth = useAuth();
       auth.login(FRESH_TOKEN, makeFreshUser());
@@ -227,6 +238,26 @@ describe('useAuth', () => {
       await expect(auth.refresh()).rejects.toThrow();
       // Token is unchanged; the axios 401 interceptor handles state cleanup.
       expect(auth.token.value).toBe(FRESH_TOKEN);
+    });
+
+    it('refresh() rejects on a malformed 200 body ([null]) and does NOT mutate token/localStorage/header', async () => {
+      // A 200 with [null] (or similar shapes where the Plumber scalar-array
+      // unwraps to undefined/null) must not poison the session with the
+      // literal string "undefined"/"null". useAuth.refresh() guards against
+      // this before persisting.
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+
+      server.use(
+        http.get('/api/auth/refresh', () => HttpResponse.json([null]))
+      );
+
+      await expect(auth.refresh()).rejects.toThrow('Refresh returned invalid token');
+
+      // Nothing must have been mutated.
+      expect(auth.token.value).toBe(FRESH_TOKEN);
+      expect(localStorage.getItem('token')).toBe(FRESH_TOKEN);
+      expect(axios.defaults.headers.common.Authorization).toBe(`Bearer ${FRESH_TOKEN}`);
     });
   });
 

--- a/app/src/composables/useAuth.spec.ts
+++ b/app/src/composables/useAuth.spec.ts
@@ -1,0 +1,330 @@
+// useAuth.spec.ts
+/**
+ * Tests for useAuth composable (Phase E.E7).
+ *
+ * Pattern: module-level reactive auth state + MSW for /api/auth/refresh
+ * --------------------------------------------------------------------
+ * `useAuth()` is the single owner of read/write/refresh/401-handling for the
+ * JWT + user payload stored in `localStorage`. It exposes reactive state
+ * (token, user, isAuthenticated, isExpired, hasRole) and actions (login,
+ * logout, refresh, handle401) so the five locked call sites (§3 Phase E.E7)
+ * no longer touch `localStorage.token` / `localStorage.user` directly.
+ *
+ * Because auth state is global (a single session per browser tab), the
+ * composable uses module-level refs — every call to `useAuth()` returns
+ * references to the same underlying state. `syncFromStorage()` re-reads
+ * `localStorage` (source of truth coordinated with the axios 401 interceptor
+ * at `@/plugins/axios`) and is called on every `useAuth()` invocation plus
+ * by `handle401()`. This keeps in-memory state consistent with what the
+ * interceptor last wrote.
+ *
+ * Coverage contract (plan §3 Phase E.E7 Required test coverage):
+ *   1. Login stores token + user.
+ *   2. Logout clears both.
+ *   3. Expired token triggers refresh or redirects (we test both branches:
+ *      `refresh()` returns a new token; `isExpired` + `handle401()` clear
+ *      state so the 401 interceptor redirect path is reachable).
+ *   4. Corrupted `localStorage.user` payload does not crash navigation.
+ *   5. 401 interceptor coordinates with useAuth state (state follows the
+ *      interceptor-cleared `localStorage` after `handle401()`).
+ *
+ * MSW-mocked endpoints: GET /api/auth/refresh (Phase B.B1 handler,
+ * `authenticateTokenOk`/`refreshTokenOk` in test-utils/mocks/data/auth.ts).
+ * We do NOT add new handlers; per-test overrides via `server.use(...)` cover
+ * the 401 branch.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import axios from 'axios';
+
+import { server } from '@/test-utils/mocks/server';
+import { refreshTokenOk } from '@/test-utils/mocks/data/auth';
+import useAuth, { type UserPayload } from './useAuth';
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * A user payload shaped the way `/api/auth/signin` returns it (R/Plumber
+ * wraps scalars in single-element arrays — see
+ * `api/config/openapi/schemas/inferred/api_auth_signin_GET.json`).
+ * `exp` is a Unix timestamp in seconds; we make it comfortably in the future
+ * so `isExpired` is false in the happy-path tests.
+ */
+function makeFreshUser(overrides: Partial<UserPayload> = {}): UserPayload {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return {
+    user_id: [42],
+    user_name: ['test_user'],
+    email: ['test_user@example.org'],
+    user_role: ['Administrator'],
+    user_created: ['2025-01-01 00:00:00'],
+    abbreviation: ['TU'],
+    orcid: {},
+    exp: [nowSec + 3600],
+    ...overrides,
+  };
+}
+
+/**
+ * A user payload whose `exp` is in the past; used to cover the refresh /
+ * handle401 branches.
+ */
+function makeExpiredUser(): UserPayload {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return makeFreshUser({ exp: [nowSec - 60] });
+}
+
+// The Phase A1 auth flow stores the raw JWT scalar (Plumber wraps it as a
+// one-element array on the wire; LoginView.vue assigns `response.data[0]`
+// straight into localStorage, which is what we mirror here).
+const FRESH_TOKEN = 'fresh.jwt.token';
+const REFRESHED_TOKEN = refreshTokenOk[0];
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('useAuth', () => {
+  beforeEach(() => {
+    // `vitest.setup.ts` clears localStorage before every test; explicitly
+    // re-sync the composable so module-level refs start null.
+    useAuth().syncFromStorage();
+    delete axios.defaults.headers.common.Authorization;
+  });
+
+  afterEach(() => {
+    // Reset module-level state so a stray assertion doesn't leak into
+    // subsequent tests. handle401() clears without redirecting because
+    // `@/router` isn't mounted in this spec.
+    const auth = useAuth();
+    auth.logout();
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 1: Login stores token + user
+  // -------------------------------------------------------------------------
+
+  describe('login', () => {
+    it('stores token + user in localStorage and in reactive state', () => {
+      const auth = useAuth();
+      const user = makeFreshUser();
+
+      auth.login(FRESH_TOKEN, user);
+
+      expect(localStorage.getItem('token')).toBe(FRESH_TOKEN);
+      expect(localStorage.getItem('user')).toBe(JSON.stringify(user));
+      expect(auth.token.value).toBe(FRESH_TOKEN);
+      expect(auth.user.value).toEqual(user);
+      expect(auth.isAuthenticated.value).toBe(true);
+    });
+
+    it('accepts the R/Plumber scalar-array token shape (response.data[0])', () => {
+      // LoginView.vue assigns `response_authenticate.data[0]`; callers already
+      // unwrap the array. login() MUST accept a plain string — it is not the
+      // unwrap point.
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+      expect(auth.token.value).toBe(FRESH_TOKEN);
+      expect(typeof auth.token.value).toBe('string');
+    });
+
+    it('sets the axios default Authorization header so subsequent calls send the Bearer token', () => {
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+
+      expect(axios.defaults.headers.common.Authorization).toBe(`Bearer ${FRESH_TOKEN}`);
+    });
+
+    it('exposes hasRole() for role-gated UI (matches the A1 scalar-array payload)', () => {
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser({ user_role: ['Curator'] }));
+
+      expect(auth.hasRole('Curator')).toBe(true);
+      expect(auth.hasRole('Administrator')).toBe(false);
+      expect(auth.hasRole('Viewer')).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 2: Logout clears both
+  // -------------------------------------------------------------------------
+
+  describe('logout', () => {
+    it('clears token, user, axios header, and reactive state', () => {
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+
+      auth.logout();
+
+      expect(localStorage.getItem('token')).toBeNull();
+      expect(localStorage.getItem('user')).toBeNull();
+      expect(auth.token.value).toBeNull();
+      expect(auth.user.value).toBeNull();
+      expect(auth.isAuthenticated.value).toBe(false);
+      expect(axios.defaults.headers.common.Authorization).toBeUndefined();
+    });
+
+    it('is idempotent when no session is active', () => {
+      const auth = useAuth();
+      expect(() => auth.logout()).not.toThrow();
+      expect(auth.isAuthenticated.value).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 3: Expired token triggers refresh or redirects
+  // -------------------------------------------------------------------------
+
+  describe('expired tokens', () => {
+    it('flags isExpired=true once user.exp has passed', () => {
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeExpiredUser());
+
+      expect(auth.isExpired.value).toBe(true);
+      // isAuthenticated still true (token + user present); expiry is a
+      // separate concern the call site decides how to handle.
+      expect(auth.isAuthenticated.value).toBe(true);
+    });
+
+    it('refresh() calls GET /api/auth/refresh and stores the new token', async () => {
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+
+      await auth.refresh();
+
+      expect(auth.token.value).toBe(REFRESHED_TOKEN);
+      expect(localStorage.getItem('token')).toBe(REFRESHED_TOKEN);
+      expect(axios.defaults.headers.common.Authorization).toBe(`Bearer ${REFRESHED_TOKEN}`);
+    });
+
+    it('refresh() forwards the current Bearer token on the request', async () => {
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+
+      let capturedAuth: string | null = null;
+      server.use(
+        http.get('/api/auth/refresh', ({ request }) => {
+          capturedAuth = request.headers.get('authorization');
+          return HttpResponse.json(refreshTokenOk);
+        })
+      );
+
+      await auth.refresh();
+      expect(capturedAuth).toBe(`Bearer ${FRESH_TOKEN}`);
+    });
+
+    it('refresh() bubbles errors; callers decide whether to logout/redirect', async () => {
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+
+      server.use(
+        http.get('/api/auth/refresh', () => HttpResponse.json({ error: 'nope' }, { status: 401 }))
+      );
+
+      await expect(auth.refresh()).rejects.toThrow();
+      // Token is unchanged; the axios 401 interceptor handles state cleanup.
+      expect(auth.token.value).toBe(FRESH_TOKEN);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 4: Corrupted localStorage.user payload does not crash navigation
+  // -------------------------------------------------------------------------
+
+  describe('corrupted payload resilience', () => {
+    it('treats corrupt JSON in localStorage.user as logged-out, not as a crash', () => {
+      localStorage.setItem('token', FRESH_TOKEN);
+      localStorage.setItem('user', '{this is not json');
+
+      // syncFromStorage must swallow JSON.parse exceptions so route guards
+      // that call useAuth() during navigation never throw.
+      const auth = useAuth();
+      expect(() => auth.syncFromStorage()).not.toThrow();
+
+      expect(auth.user.value).toBeNull();
+      expect(auth.isAuthenticated.value).toBe(false);
+      // isExpired is false when there's no user — there's nothing to expire.
+      expect(auth.isExpired.value).toBe(false);
+      expect(auth.hasRole('Administrator')).toBe(false);
+    });
+
+    it('treats missing localStorage.user (token-only) as logged-out', () => {
+      localStorage.setItem('token', FRESH_TOKEN);
+      // no user key
+
+      const auth = useAuth();
+      auth.syncFromStorage();
+
+      expect(auth.user.value).toBeNull();
+      expect(auth.isAuthenticated.value).toBe(false);
+    });
+
+    it('rehydrates cleanly when both token and user are present', () => {
+      const user = makeFreshUser();
+      localStorage.setItem('token', FRESH_TOKEN);
+      localStorage.setItem('user', JSON.stringify(user));
+
+      const auth = useAuth();
+      auth.syncFromStorage();
+
+      expect(auth.token.value).toBe(FRESH_TOKEN);
+      expect(auth.user.value).toEqual(user);
+      expect(auth.isAuthenticated.value).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 5: 401 interceptor coordinates with useAuth state
+  // -------------------------------------------------------------------------
+
+  describe('401 interceptor coordination', () => {
+    it('handle401() re-reads localStorage and mirrors the cleared state', () => {
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+      expect(auth.isAuthenticated.value).toBe(true);
+
+      // Simulate what `@/plugins/axios` does inside the 401 interceptor:
+      // it calls localStorage.removeItem('token') / .removeItem('user')
+      // directly without going through useAuth. After that, handle401()
+      // must bring the in-memory refs back in sync.
+      localStorage.removeItem('token');
+      localStorage.removeItem('user');
+
+      auth.handle401();
+
+      expect(auth.token.value).toBeNull();
+      expect(auth.user.value).toBeNull();
+      expect(auth.isAuthenticated.value).toBe(false);
+    });
+
+    it('handle401() clears the axios default header so queued requests stop sending the stale Bearer', () => {
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+      expect(axios.defaults.headers.common.Authorization).toBe(`Bearer ${FRESH_TOKEN}`);
+
+      // interceptor path: it already deletes the default header but we test
+      // that handle401() tolerates either order (idempotent cleanup).
+      localStorage.removeItem('token');
+      localStorage.removeItem('user');
+      auth.handle401();
+
+      expect(axios.defaults.headers.common.Authorization).toBeUndefined();
+    });
+
+    it('multiple useAuth() calls share the same reactive state (module-level singleton)', () => {
+      const a = useAuth();
+      const b = useAuth();
+
+      a.login(FRESH_TOKEN, makeFreshUser());
+      expect(b.token.value).toBe(FRESH_TOKEN);
+      expect(b.isAuthenticated.value).toBe(true);
+
+      b.logout();
+      expect(a.token.value).toBeNull();
+      expect(a.isAuthenticated.value).toBe(false);
+    });
+  });
+});

--- a/app/src/composables/useAuth.spec.ts
+++ b/app/src/composables/useAuth.spec.ts
@@ -241,10 +241,9 @@ describe('useAuth', () => {
     });
 
     it('refresh() rejects on a malformed 200 body ([null]) and does NOT mutate token/localStorage/header', async () => {
-      // A 200 with [null] (or similar shapes where the Plumber scalar-array
-      // unwraps to undefined/null) must not poison the session with the
-      // literal string "undefined"/"null". useAuth.refresh() guards against
-      // this before persisting.
+      // A 200 with [null] must not poison the session. Copilot Fix 3 tightens
+      // this from the earlier string-coercion check to an explicit type
+      // check: `[null]` fails `typeof raw[0] === 'string'` up front.
       const auth = useAuth();
       auth.login(FRESH_TOKEN, makeFreshUser());
 
@@ -252,12 +251,59 @@ describe('useAuth', () => {
         http.get('/api/auth/refresh', () => HttpResponse.json([null]))
       );
 
-      await expect(auth.refresh()).rejects.toThrow('Refresh returned invalid token');
+      await expect(auth.refresh()).rejects.toThrow('Refresh returned invalid token shape');
 
       // Nothing must have been mutated.
       expect(auth.token.value).toBe(FRESH_TOKEN);
       expect(localStorage.getItem('token')).toBe(FRESH_TOKEN);
       expect(axios.defaults.headers.common.Authorization).toBe(`Bearer ${FRESH_TOKEN}`);
+    });
+
+    it('refresh() rejects a plain object body (`{}`) — not a string and not an array', async () => {
+      // Copilot Fix 3: without a proper type check, `String({})` would yield
+      // "[object Object]" and pass the earlier I2 sentinel check (not
+      // "undefined" / "null" / empty), poisoning the session until a 401.
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+
+      server.use(
+        http.get('/api/auth/refresh', () => HttpResponse.json({ foo: 'bar' }))
+      );
+
+      await expect(auth.refresh()).rejects.toThrow('Refresh returned invalid token shape');
+
+      expect(auth.token.value).toBe(FRESH_TOKEN);
+      expect(localStorage.getItem('token')).toBe(FRESH_TOKEN);
+      expect(axios.defaults.headers.common.Authorization).toBe(`Bearer ${FRESH_TOKEN}`);
+    });
+
+    it('refresh() rejects an array whose first element is not a string (`[123]`)', async () => {
+      // Copilot Fix 3: even if the body is an array, element[0] must be a
+      // string. A numeric 0th element (or any non-string) is rejected.
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+
+      server.use(
+        http.get('/api/auth/refresh', () => HttpResponse.json([123]))
+      );
+
+      await expect(auth.refresh()).rejects.toThrow('Refresh returned invalid token shape');
+
+      expect(auth.token.value).toBe(FRESH_TOKEN);
+    });
+
+    it('refresh() rejects an empty array (`[]`)', async () => {
+      // Copilot Fix 3: `[]` has no `[0]` to read. Reject before persisting.
+      const auth = useAuth();
+      auth.login(FRESH_TOKEN, makeFreshUser());
+
+      server.use(
+        http.get('/api/auth/refresh', () => HttpResponse.json([]))
+      );
+
+      await expect(auth.refresh()).rejects.toThrow('Refresh returned invalid token shape');
+
+      expect(auth.token.value).toBe(FRESH_TOKEN);
     });
   });
 

--- a/app/src/composables/useAuth.ts
+++ b/app/src/composables/useAuth.ts
@@ -176,13 +176,26 @@ function syncFromStorage(): void {
   tokenRef.value = rawToken;
   userRef.value = safeParseUser(rawUser);
 
-  // A token without a (readable) user is treated as no session — the SPA
-  // always pairs them, and a dangling token would fail every downstream
-  // role check anyway. Clear localStorage too so the state matches on
-  // every observer.
+  // Both-or-neither invariant
+  // -------------------------
+  // A session is only coherent when BOTH localStorage keys are present and
+  // valid. Any half-state (dangling token, dangling user) is treated as
+  // logged-out and actively cleaned up, so every observer sees the same
+  // cleared state.
+  //
+  // - Dangling token (user missing/corrupt) would fail every role check
+  //   and expiry calculation downstream.
+  // - Dangling user (token missing) would trick components that only check
+  //   `auth.user.value` (for example UserView.vue's mount hook) into firing
+  //   unauthenticated API calls with no Bearer header. Pre-Copilot-Fix-2,
+  //   syncFromStorage() only cleaned up the dangling-token case; Copilot
+  //   flagged the asymmetry as a real leak path for stale user payloads.
   if (tokenRef.value && !userRef.value) {
     localStorage.removeItem(TOKEN_KEY);
     tokenRef.value = null;
+  } else if (!tokenRef.value && userRef.value) {
+    localStorage.removeItem(USER_KEY);
+    userRef.value = null;
   }
 
   // Keep the axios default header in lockstep with the current token.

--- a/app/src/composables/useAuth.ts
+++ b/app/src/composables/useAuth.ts
@@ -236,6 +236,14 @@ async function refresh(): Promise<string> {
   const raw: unknown = response.data;
   const nextToken = Array.isArray(raw) ? String(raw[0]) : String(raw);
 
+  // Guard against malformed 200 responses (null, {}, [null], non-coercible
+  // payloads). Without this check, `String(undefined)` persists the literal
+  // string "undefined" as the new token, which would masquerade as a valid
+  // session until the next request fires a 401.
+  if (!nextToken || nextToken === 'undefined' || nextToken === 'null') {
+    throw new Error('Refresh returned invalid token');
+  }
+
   tokenRef.value = nextToken;
   localStorage.setItem(TOKEN_KEY, nextToken);
   axios.defaults.headers.common.Authorization = `Bearer ${nextToken}`;

--- a/app/src/composables/useAuth.ts
+++ b/app/src/composables/useAuth.ts
@@ -1,4 +1,5 @@
 // useAuth.ts
+// SPA-only context; localStorage is always available at module load (Vite SPA, no SSR).
 /**
  * Single owner of auth / session state for the SPA (Phase E.E7).
  *
@@ -135,8 +136,8 @@ function safeParseUser(raw: string | null): UserPayload | null {
  * interceptor clears state.
  */
 function syncFromStorage(): void {
-  const rawToken = typeof localStorage !== 'undefined' ? localStorage.getItem(TOKEN_KEY) : null;
-  const rawUser = typeof localStorage !== 'undefined' ? localStorage.getItem(USER_KEY) : null;
+  const rawToken = localStorage.getItem(TOKEN_KEY);
+  const rawUser = localStorage.getItem(USER_KEY);
 
   tokenRef.value = rawToken;
   userRef.value = safeParseUser(rawUser);
@@ -145,7 +146,7 @@ function syncFromStorage(): void {
   // always pairs them, and a dangling token would fail every downstream
   // role check anyway. Clear localStorage too so the state matches on
   // every observer.
-  if (tokenRef.value && !userRef.value && typeof localStorage !== 'undefined') {
+  if (tokenRef.value && !userRef.value) {
     localStorage.removeItem(TOKEN_KEY);
     tokenRef.value = null;
   }

--- a/app/src/composables/useAuth.ts
+++ b/app/src/composables/useAuth.ts
@@ -278,17 +278,29 @@ function logout(): void {
 async function refresh(): Promise<string> {
   const apiUrl = `${import.meta.env.VITE_API_URL ?? ''}/api/auth/refresh`;
   const response = await axios.get(apiUrl);
-  // Plumber returns `["..."]`; tolerate either shape so this keeps working
-  // if the API ever un-wraps scalars.
+  // Strict shape validation (Copilot Fix 3)
+  // ---------------------------------------
+  // Plumber returns `["..."]`; master's implementation also tolerated a bare
+  // string. Accept either of those shapes explicitly and reject anything
+  // else (`{}`, `{ foo: 'bar' }`, `[]`, `[123]`, `null`, numbers, etc.)
+  // BEFORE persisting.
+  //
+  // The earlier I2 guard used `String(raw)` / `String(raw[0])` and then
+  // checked the coerced string against `"undefined"`/`"null"`. That still
+  // let an object like `{}` through as the literal string "[object Object]"
+  // — not caught by the sentinel check — and poisoned the session until a
+  // 401 fired. This type-level check supersedes the I2 guard.
   const raw: unknown = response.data;
-  const nextToken = Array.isArray(raw) ? String(raw[0]) : String(raw);
-
-  // Guard against malformed 200 responses (null, {}, [null], non-coercible
-  // payloads). Without this check, `String(undefined)` persists the literal
-  // string "undefined" as the new token, which would masquerade as a valid
-  // session until the next request fires a 401.
-  if (!nextToken || nextToken === 'undefined' || nextToken === 'null') {
-    throw new Error('Refresh returned invalid token');
+  let nextToken: string;
+  if (typeof raw === 'string') {
+    nextToken = raw;
+  } else if (Array.isArray(raw) && raw.length > 0 && typeof raw[0] === 'string') {
+    nextToken = raw[0];
+  } else {
+    throw new Error('Refresh returned invalid token shape');
+  }
+  if (!nextToken) {
+    throw new Error('Refresh returned empty token');
   }
 
   tokenRef.value = nextToken;

--- a/app/src/composables/useAuth.ts
+++ b/app/src/composables/useAuth.ts
@@ -1,0 +1,305 @@
+// useAuth.ts
+/**
+ * Single owner of auth / session state for the SPA (Phase E.E7).
+ *
+ * Before this composable landed, five call sites (`router/routes.ts`,
+ * `components/AppNavbar.vue`, `components/small/LogoutCountdownBadge.vue`,
+ * `views/LoginView.vue`, `views/UserView.vue`) each reached into
+ * `localStorage.token` / `localStorage.user` by hand, parsed the JWT payload
+ * inline, and duplicated the "Bearer ${localStorage.getItem('token')}" header
+ * pattern. `useAuth()` consolidates all of that into one typed API with
+ * reactive state, so the 401 interceptor in `@/plugins/axios` is the only
+ * other code path that mutates these keys.
+ *
+ * State model (module-level singleton)
+ * ------------------------------------
+ * Because there is exactly one authenticated session per browser tab, the
+ * reactive refs are declared at module scope. Every `useAuth()` call returns
+ * references to the same underlying state, so a `logout()` from the navbar
+ * is immediately visible to a route guard on the next `isAuthenticated`
+ * read. On first import, state is hydrated from `localStorage` and the axios
+ * default Authorization header is seeded if a token exists.
+ *
+ * Coordination with the axios 401 interceptor
+ * -------------------------------------------
+ * `@/plugins/axios` already owns the "saw a 401 → clear localStorage →
+ * redirect to /Login" flow. That interceptor writes localStorage directly
+ * (not through useAuth), so after an interceptor-triggered logout the
+ * in-memory refs can drift. `handle401()` and `syncFromStorage()` re-read
+ * localStorage so reactive state mirrors whatever the interceptor last
+ * persisted. Callers that want to react to a 401 (for example, showing a
+ * toast) can watch `isAuthenticated` or call `handle401()` from the
+ * interceptor's catch path in a future refactor.
+ *
+ * Shape of the user payload
+ * -------------------------
+ * `/api/auth/signin` returns the R/Plumber scalar-array shape
+ * (`user_role: ['Administrator']`, `exp: [1234567890]`, etc.). We preserve
+ * the raw shape so every read site — route guards, badges, profile view —
+ * sees the same structure they see today; only the reading mechanism
+ * changes. `hasRole()` indexes into `user_role[0]` to hide this detail from
+ * callers.
+ *
+ * Corrupted-payload resilience
+ * ----------------------------
+ * If a user manually corrupts `localStorage.user` (or a half-written key
+ * survives a crash), `syncFromStorage()` catches `JSON.parse` failures and
+ * treats the session as logged-out. Route guards therefore never throw
+ * during navigation, which was the failure mode the P1 "auth state is
+ * duplicated" review finding called out.
+ */
+
+import type { ComputedRef, Ref } from 'vue';
+import { computed, ref } from 'vue';
+import axios from 'axios';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape of the user payload stored in `localStorage.user` (post Phase A1).
+ * Mirrors `GET /api/auth/signin` as documented in
+ * `api/config/openapi/schemas/inferred/api_auth_signin_GET.json` — R/Plumber
+ * wraps every scalar in a one-element array.
+ *
+ * The fields listed here are the ones the SPA actually reads; additional
+ * fields returned by the API are tolerated (the composable does not strip
+ * them).
+ */
+export interface UserPayload {
+  user_id: number[];
+  user_name: string[];
+  email: string[];
+  user_role: string[];
+  user_created: string[];
+  abbreviation: string[];
+  orcid: Record<string, unknown> | string[];
+  exp: number[];
+  [key: string]: unknown;
+}
+
+/**
+ * Return type of `useAuth()`. Keeping this exported makes it easy for
+ * Options-API components to annotate their `setup()` return value.
+ */
+export interface UseAuthReturn {
+  // State (reactive)
+  token: Ref<string | null>;
+  user: Ref<UserPayload | null>;
+
+  // Derived (computed)
+  isAuthenticated: ComputedRef<boolean>;
+  isExpired: ComputedRef<boolean>;
+
+  // Actions
+  login: (token: string, user: UserPayload) => void;
+  logout: () => void;
+  refresh: () => Promise<string>;
+  handle401: () => void;
+  syncFromStorage: () => void;
+  hasRole: (role: string) => boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level singleton state
+// ---------------------------------------------------------------------------
+
+const TOKEN_KEY = 'token';
+const USER_KEY = 'user';
+
+const tokenRef = ref<string | null>(null);
+const userRef = ref<UserPayload | null>(null);
+
+/**
+ * Parse a JSON string and return `null` on any failure. Shared by
+ * `syncFromStorage()` and used to keep the parse site in one place.
+ */
+function safeParseUser(raw: string | null): UserPayload | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as UserPayload;
+    // Defence-in-depth: parsed non-objects (numbers, strings, null) are
+    // treated as corrupt so later `.exp` / `.user_role` reads don't NPE.
+    if (!parsed || typeof parsed !== 'object') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Re-read both keys from `localStorage` and mirror them into the module
+ * refs. Called once at module load, on every `useAuth()` invocation (cheap —
+ * just two `getItem` calls), and by `handle401()` after the axios
+ * interceptor clears state.
+ */
+function syncFromStorage(): void {
+  const rawToken = typeof localStorage !== 'undefined' ? localStorage.getItem(TOKEN_KEY) : null;
+  const rawUser = typeof localStorage !== 'undefined' ? localStorage.getItem(USER_KEY) : null;
+
+  tokenRef.value = rawToken;
+  userRef.value = safeParseUser(rawUser);
+
+  // A token without a (readable) user is treated as no session — the SPA
+  // always pairs them, and a dangling token would fail every downstream
+  // role check anyway. Clear localStorage too so the state matches on
+  // every observer.
+  if (tokenRef.value && !userRef.value && typeof localStorage !== 'undefined') {
+    localStorage.removeItem(TOKEN_KEY);
+    tokenRef.value = null;
+  }
+
+  // Keep the axios default header in lockstep with the current token.
+  if (tokenRef.value) {
+    axios.defaults.headers.common.Authorization = `Bearer ${tokenRef.value}`;
+  } else {
+    delete axios.defaults.headers.common.Authorization;
+  }
+}
+
+// Hydrate once at import time so the Bearer header is set before the first
+// request fires. `@/plugins/axios` does the same seeding; running this here
+// is redundant but harmless, and protects callers who import this module
+// before `@/plugins/axios`.
+syncFromStorage();
+
+// ---------------------------------------------------------------------------
+// Computed derivations
+// ---------------------------------------------------------------------------
+
+const isAuthenticated = computed<boolean>(
+  () => tokenRef.value !== null && userRef.value !== null
+);
+
+const isExpired = computed<boolean>(() => {
+  const exp = userRef.value?.exp?.[0];
+  if (typeof exp !== 'number') return false;
+  const nowSec = Math.floor(Date.now() / 1000);
+  return nowSec >= exp;
+});
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+/**
+ * Persist a fresh login: token + user payload → localStorage + reactive
+ * state + axios default Authorization header.
+ *
+ * @param token - The raw JWT string. `LoginView.vue` reads the Plumber
+ *                scalar-array at `response.data[0]`; callers are expected
+ *                to unwrap before passing in. We do NOT re-unwrap here so
+ *                the type contract stays a simple `string`.
+ * @param user  - The parsed `/api/auth/signin` response body.
+ */
+function login(token: string, user: UserPayload): void {
+  tokenRef.value = token;
+  userRef.value = user;
+  localStorage.setItem(TOKEN_KEY, token);
+  localStorage.setItem(USER_KEY, JSON.stringify(user));
+  axios.defaults.headers.common.Authorization = `Bearer ${token}`;
+}
+
+/**
+ * Clear the session: both localStorage keys, both refs, and the axios
+ * default header. Does NOT navigate — call sites that want a redirect
+ * handle `$router.push(...)` themselves so this composable stays router-
+ * agnostic and testable without mounting a router.
+ */
+function logout(): void {
+  tokenRef.value = null;
+  userRef.value = null;
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(USER_KEY);
+  delete axios.defaults.headers.common.Authorization;
+}
+
+/**
+ * Call `GET /api/auth/refresh` with the current Bearer token and store the
+ * returned JWT. The API returns a R/Plumber scalar-array, matching the
+ * authenticate endpoint shape.
+ *
+ * Errors bubble so callers can decide whether to toast, logout, or retry.
+ * The axios 401 interceptor already handles unauthorized refresh responses
+ * by clearing localStorage and redirecting — we do not duplicate that
+ * behaviour here.
+ *
+ * @returns The new token string.
+ */
+async function refresh(): Promise<string> {
+  const apiUrl = `${import.meta.env.VITE_API_URL ?? ''}/api/auth/refresh`;
+  const response = await axios.get(apiUrl);
+  // Plumber returns `["..."]`; tolerate either shape so this keeps working
+  // if the API ever un-wraps scalars.
+  const raw: unknown = response.data;
+  const nextToken = Array.isArray(raw) ? String(raw[0]) : String(raw);
+
+  tokenRef.value = nextToken;
+  localStorage.setItem(TOKEN_KEY, nextToken);
+  axios.defaults.headers.common.Authorization = `Bearer ${nextToken}`;
+  return nextToken;
+}
+
+/**
+ * Called (explicitly or implicitly) when a 401 is observed — re-reads
+ * `localStorage` to mirror whatever the axios interceptor wrote, then
+ * clears the axios default header so in-flight or queued requests stop
+ * sending the stale Bearer. Safe to call multiple times; if the
+ * interceptor hasn't cleared localStorage yet, we still fall through to
+ * the "cleared" state via `logout()` semantics on re-sync.
+ */
+function handle401(): void {
+  // The interceptor removes the keys directly; re-reading puts refs back
+  // in sync. If for some reason localStorage still has values (e.g. this
+  // is called defensively without an interceptor trigger), treat it as a
+  // hard logout to be safe.
+  const rawToken = localStorage.getItem(TOKEN_KEY);
+  const rawUser = localStorage.getItem(USER_KEY);
+  if (rawToken === null && rawUser === null) {
+    // Interceptor-cleared path: just sync.
+    tokenRef.value = null;
+    userRef.value = null;
+    delete axios.defaults.headers.common.Authorization;
+    return;
+  }
+  // Defensive path: caller invoked handle401() without the interceptor
+  // having run. Force a full logout.
+  logout();
+}
+
+// ---------------------------------------------------------------------------
+// Public composable
+// ---------------------------------------------------------------------------
+
+/**
+ * Single entry point. Returns the shared reactive auth state plus typed
+ * actions. The refs are stable across calls (module-level singleton); use
+ * `useAuth()` freely inside components, guards, or other composables
+ * without worrying about duplicate subscriptions.
+ */
+export function useAuth(): UseAuthReturn {
+  // Re-sync on every call so module state can't drift from localStorage
+  // after the axios interceptor path. Cheap: two `getItem` + optional
+  // `JSON.parse`.
+  syncFromStorage();
+
+  return {
+    token: tokenRef,
+    user: userRef,
+    isAuthenticated,
+    isExpired,
+    login,
+    logout,
+    refresh,
+    handle401,
+    syncFromStorage,
+    hasRole: (role: string): boolean => {
+      const roles = userRef.value?.user_role;
+      if (!Array.isArray(roles)) return false;
+      return roles[0] === role;
+    },
+  };
+}
+
+export default useAuth;

--- a/app/src/composables/useAuth.ts
+++ b/app/src/composables/useAuth.ts
@@ -115,18 +115,52 @@ const userRef = ref<UserPayload | null>(null);
 /**
  * Parse a JSON string and return `null` on any failure. Shared by
  * `syncFromStorage()` and used to keep the parse site in one place.
+ *
+ * Shape validation
+ * ----------------
+ * A successful `JSON.parse` is necessary but not sufficient: the SPA reads
+ * `user.exp[0]` (expiry check) and `user.user_role[0]` (role gating) on
+ * every navigation. If `localStorage.user` is set to a valid-but-wrong JSON
+ * value (for example `'[]'` from a dev-tools typo, or `'null'`, or an object
+ * missing `exp`/`user_role`), those reads would silently return `undefined`
+ * and the session would appear authenticated to `isAuthenticated` while
+ * failing every role check and exp calculation. We defensively require the
+ * minimal shape the call sites rely on:
+ *   - non-null, non-array object
+ *   - `exp` is a non-empty `number[]` (expiry computations)
+ *   - `user_role` is a non-empty `string[]` (router guards, badges)
+ * Any failure is treated the same as corrupt JSON: `null`, handled upstream
+ * as a logged-out state.
  */
 function safeParseUser(raw: string | null): UserPayload | null {
   if (!raw) return null;
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(raw) as UserPayload;
-    // Defence-in-depth: parsed non-objects (numbers, strings, null) are
-    // treated as corrupt so later `.exp` / `.user_role` reads don't NPE.
-    if (!parsed || typeof parsed !== 'object') return null;
-    return parsed;
+    parsed = JSON.parse(raw);
   } catch {
     return null;
   }
+  // Reject null, primitives, and arrays (`typeof [] === 'object'`, so the
+  // array guard is not redundant).
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null;
+  }
+  const candidate = parsed as Record<string, unknown>;
+  // `exp` must be a non-empty numeric array — `[0]` is what `isExpired`
+  // reads. A missing or empty exp would make `isExpired` always false and
+  // silently keep an expired session alive.
+  const exp = candidate.exp;
+  if (!Array.isArray(exp) || exp.length === 0 || typeof exp[0] !== 'number') {
+    return null;
+  }
+  // `user_role` must be a non-empty string array — router guards resolve
+  // `roles[0]`; an empty array would fail every guard anyway, so rejecting
+  // here keeps `isAuthenticated` honest.
+  const roles = candidate.user_role;
+  if (!Array.isArray(roles) || roles.length === 0 || typeof roles[0] !== 'string') {
+    return null;
+  }
+  return parsed as UserPayload;
 }
 
 /**

--- a/app/src/composables/useAuth.ts
+++ b/app/src/composables/useAuth.ts
@@ -53,6 +53,16 @@
 import type { ComputedRef, Ref } from 'vue';
 import { computed, ref } from 'vue';
 import axios from 'axios';
+// Ensure the axios plugin's initialisation side effects (baseURL, 401
+// interceptor, default Authorization seeding) have run before any of our
+// axios.get / axios.defaults.* calls fire. `api/client.ts` does the same
+// for the typed helpers; the explicit import here keeps useAuth correct
+// regardless of import order (Copilot review).
+import '@/plugins/axios';
+// Delegate HTTP for refresh to the typed api/auth helper so all callers
+// flow through one code path (apiClient + unwrapScalar + baseURL). Aliased
+// to avoid shadowing the local `refresh` action exported by useAuth.
+import { refresh as apiAuthRefresh } from '@/api/auth';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -220,11 +230,29 @@ const isAuthenticated = computed<boolean>(
   () => tokenRef.value !== null && userRef.value !== null
 );
 
+// Reactive wall-clock ref
+// -----------------------
+// `isExpired` compares `Date.now()` against `user.exp[0]`, but `Date.now()`
+// is not reactive. Vue's computed caches its result until a tracked dep
+// changes — without a reactive time source, `isExpired.value` would stay
+// cached at its first-read result even as wall-clock time passes. Route
+// guards avoided this because `useAuth()` → `syncFromStorage()` reassigns
+// `userRef` on every navigation, invalidating the cache. Long-lived
+// template bindings (v-if, display badges) would see stale values.
+//
+// Drive it from a 1-second tick so `isExpired.value` flips to true as
+// real time passes (Copilot review). The 1-second cadence matches the
+// existing ticker in `LogoutCountdownBadge.vue` and is overwhelmingly
+// cheap compared to a navigation cycle.
+const nowSecRef = ref<number>(Math.floor(Date.now() / 1000));
+setInterval(() => {
+  nowSecRef.value = Math.floor(Date.now() / 1000);
+}, 1000);
+
 const isExpired = computed<boolean>(() => {
   const exp = userRef.value?.exp?.[0];
   if (typeof exp !== 'number') return false;
-  const nowSec = Math.floor(Date.now() / 1000);
-  return nowSec >= exp;
+  return nowSecRef.value >= exp;
 });
 
 // ---------------------------------------------------------------------------
@@ -276,32 +304,25 @@ function logout(): void {
  * @returns The new token string.
  */
 async function refresh(): Promise<string> {
-  const apiUrl = `${import.meta.env.VITE_API_URL ?? ''}/api/auth/refresh`;
-  const response = await axios.get(apiUrl);
-  // Strict shape validation (Copilot Fix 3)
-  // ---------------------------------------
-  // Plumber returns `["..."]`; master's implementation also tolerated a bare
-  // string. Accept either of those shapes explicitly and reject anything
-  // else (`{}`, `{ foo: 'bar' }`, `[]`, `[123]`, `null`, numbers, etc.)
-  // BEFORE persisting.
+  // Delegate the HTTP call to `api/auth.refresh` so every refresh flows
+  // through one code path (apiClient → configured axios singleton → 401
+  // interceptor → baseURL). Previously this function built an absolute
+  // URL from `VITE_API_URL` and called `axios.get` directly, duplicating
+  // logic that `api/auth.ts` already owned; Copilot flagged the
+  // duplication as drift-prone. The helper runs the response through
+  // `unwrapScalar`, so a well-formed `["token"]` comes back as the bare
+  // string and a well-formed `"token"` is unchanged.
   //
-  // The earlier I2 guard used `String(raw)` / `String(raw[0])` and then
-  // checked the coerced string against `"undefined"`/`"null"`. That still
-  // let an object like `{}` through as the literal string "[object Object]"
-  // — not caught by the sentinel check — and poisoned the session until a
-  // 401 fired. This type-level check supersedes the I2 guard.
-  const raw: unknown = response.data;
-  let nextToken: string;
-  if (typeof raw === 'string') {
-    nextToken = raw;
-  } else if (Array.isArray(raw) && raw.length > 0 && typeof raw[0] === 'string') {
-    nextToken = raw[0];
-  } else {
+  // Runtime shape validation still belongs here: `unwrapScalar` does NOT
+  // type-check its argument, so a malformed 200 body (`{}`, `[null]`,
+  // `[123]`, `[]`, numbers, nested arrays) returns whatever the coercion
+  // path yields. Reject anything that is not a non-empty string BEFORE
+  // mutating refs, localStorage, or the axios default header.
+  const raw: unknown = await apiAuthRefresh();
+  if (typeof raw !== 'string' || raw.length === 0) {
     throw new Error('Refresh returned invalid token shape');
   }
-  if (!nextToken) {
-    throw new Error('Refresh returned empty token');
-  }
+  const nextToken = raw;
 
   tokenRef.value = nextToken;
   localStorage.setItem(TOKEN_KEY, nextToken);

--- a/app/src/router/routes.ts
+++ b/app/src/router/routes.ts
@@ -1,8 +1,42 @@
 // src/router/routes.ts
 
 import type { RouteRecordRaw, RouteLocationNormalized, NavigationGuardNext } from 'vue-router';
+import { useAuth } from '@/composables/useAuth';
 
-// TODO: remove redundance in localStorage setting/reading
+/**
+ * Role-based route-guard factory (Phase E.E7).
+ *
+ * Replaces an 18x-duplicated pattern that hand-parsed `localStorage.token`
+ * and `localStorage.user` inside every `beforeEnter` hook. The new flow
+ * delegates every auth decision to the `useAuth()` composable:
+ *
+ *   - `isAuthenticated` covers the "have both token and user" check that
+ *     the old guards wrote as `!localStorage.user`.
+ *   - `isExpired` replaces the inline `timestamp > expires` comparison
+ *     (and picks up the corrupt-payload handling in `useAuth` for free —
+ *     a bad JSON blob now fails closed to logged-out instead of throwing
+ *     inside navigation).
+ *   - `hasRole(role)` unwraps the R/Plumber scalar-array (`user_role[0]`)
+ *     that the old guards did inline.
+ *
+ * Each call site still supplies its own `allowed_roles` list; behaviour is
+ * otherwise identical to the pre-refactor guards.
+ */
+function createAuthGuard(allowed_roles: readonly string[]) {
+  return (
+    _to: RouteLocationNormalized,
+    _from: RouteLocationNormalized,
+    next: NavigationGuardNext
+  ) => {
+    const { isAuthenticated, isExpired, hasRole } = useAuth();
+    const isAllowed = allowed_roles.some((role) => hasRole(role));
+    if (!isAuthenticated.value || isExpired.value || !isAllowed) {
+      next({ name: 'Login' });
+    } else {
+      next();
+    }
+  };
+}
 
 export const routes: RouteRecordRaw[] = [
   {
@@ -335,26 +369,7 @@ export const routes: RouteRecordRaw[] = [
     name: 'User',
     component: () => import('@/views/UserView.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator', 'Curator', 'Reviewer'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator', 'Curator', 'Reviewer']),
   },
   {
     path: '/PasswordReset/:request_jwt?',
@@ -367,312 +382,84 @@ export const routes: RouteRecordRaw[] = [
     name: 'Review',
     component: () => import('@/views/review/Review.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator', 'Curator', 'Reviewer'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator', 'Curator', 'Reviewer']),
   },
   {
     path: '/ReviewInstructions',
     name: 'ReviewInstructions',
     component: () => import('@/views/review/ReviewInstructions.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator', 'Curator', 'Reviewer'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator', 'Curator', 'Reviewer']),
   },
   {
     path: '/CreateEntity',
     name: 'CreateEntity',
     component: () => import('@/views/curate/CreateEntity.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator', 'Curator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator', 'Curator']),
   },
   {
     path: '/ModifyEntity',
     name: 'ModifyEntity',
     component: () => import('@/views/curate/ModifyEntity.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator', 'Curator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator', 'Curator']),
   },
   {
     path: '/ApproveReview',
     name: 'ApproveReview',
     component: () => import('@/views/curate/ApproveReview.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator', 'Curator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator', 'Curator']),
   },
   {
     path: '/ApproveStatus',
     name: 'ApproveStatus',
     component: () => import('@/views/curate/ApproveStatus.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator', 'Curator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator', 'Curator']),
   },
   {
     path: '/ApproveUser',
     name: 'ApproveUser',
     component: () => import('@/views/curate/ApproveUser.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator', 'Curator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator', 'Curator']),
   },
   {
     path: '/ManageReReview',
     name: 'ManageReReview',
     component: () => import('@/views/curate/ManageReReview.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator', 'Curator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator', 'Curator']),
   },
   {
     path: '/ManageUser',
     name: 'ManageUser',
     component: () => import('@/views/admin/ManageUser.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator']),
   },
   {
     path: '/ManageAnnotations',
     name: 'ManageAnnotations',
     component: () => import('@/views/admin/ManageAnnotations.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator']),
   },
   {
     path: '/ManageOntology',
     name: 'ManageOntology',
     component: () => import('@/views/admin/ManageOntology.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator']),
   },
   {
     path: '/ManageAbout',
     name: 'ManageAbout',
     component: () => import('@/views/admin/ManageAbout.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else next();
-    },
+    beforeEnter: createAuthGuard(['Administrator']),
   },
   {
     path: '/ViewLogs',
@@ -687,140 +474,35 @@ export const routes: RouteRecordRaw[] = [
       fspec: route.query.fspec || undefined,
     }),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else {
-        next();
-      }
-    },
+    beforeEnter: createAuthGuard(['Administrator']),
   },
   {
     path: '/AdminStatistics',
     name: 'AdminStatistics',
     component: () => import('@/views/admin/AdminStatistics.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else {
-        next();
-      }
-    },
+    beforeEnter: createAuthGuard(['Administrator']),
   },
   {
     path: '/ManageBackups',
     name: 'ManageBackups',
     component: () => import('@/views/admin/ManageBackups.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else {
-        next();
-      }
-    },
+    beforeEnter: createAuthGuard(['Administrator']),
   },
   {
     path: '/ManagePubtator',
     name: 'ManagePubtator',
     component: () => import('@/views/admin/ManagePubtator.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else {
-        next();
-      }
-    },
+    beforeEnter: createAuthGuard(['Administrator']),
   },
   {
     path: '/ManageLLM',
     name: 'ManageLLM',
     component: () => import('@/views/admin/ManageLLM.vue'),
     meta: { sitemap: { ignoreRoute: true } },
-    beforeEnter: (
-      to: RouteLocationNormalized,
-      from: RouteLocationNormalized,
-      next: NavigationGuardNext
-    ) => {
-      const allowed_roles = ['Administrator'];
-      let expires = 0;
-      let timestamp = 0;
-      let user_role = 'Viewer';
-
-      if (localStorage.token) {
-        expires = JSON.parse(localStorage.user).exp;
-        user_role = JSON.parse(localStorage.user).user_role;
-        timestamp = Math.floor(new Date().getTime() / 1000);
-      }
-
-      if (!localStorage.user || timestamp > expires || !allowed_roles.includes(user_role[0])) {
-        next({ name: 'Login' });
-      } else {
-        next();
-      }
-    },
+    beforeEnter: createAuthGuard(['Administrator']),
   },
   {
     path: '/Entities/:entity_id',

--- a/app/src/test-utils/mocks/data/genes.ts
+++ b/app/src/test-utils/mocks/data/genes.ts
@@ -1,0 +1,134 @@
+// test-utils/mocks/data/genes.ts
+/**
+ * Static fixtures for gene and UniProt-domains endpoints used by the
+ * Phase E.E3 migration of `GeneView.vue` off raw axios.get onto the typed
+ * `api/genes.ts` + `api/external.ts` helpers.
+ *
+ * Wire shapes mirror:
+ *   - api/endpoints/gene_endpoints.R @get /<gene_input>  — returns a `tibble`
+ *     collected to JSON (1-row array when the gene exists, empty `[]` when
+ *     not found). Each string column is pipe-split into a `string[]`.
+ *   - api/endpoints/gene_endpoints.R @get /            — cursor-paginated
+ *     `{meta, data, links}` envelope.
+ *   - api/endpoints/external_endpoints.R @get uniprot/domains/<symbol>  —
+ *     unboxedJSON serializer; the body is a plain object with a `domains`
+ *     array. 404 uses the `application/problem+json` error shape.
+ *
+ * Sentinel path params:
+ *   - gene symbol `UNKNOWN_GENE` → `/api/gene/:id` returns `[]` (empty lookup).
+ *   - gene symbol `NO_UNIPROT`   → `/api/external/uniprot/domains/:symbol`
+ *     returns a 404 (mirrors the "gene not in UniProt" branch of the real
+ *     endpoint).
+ */
+
+import type { GeneApiData } from '@/types/gene';
+
+// ---------------------------------------------------------------------------
+// /api/gene/:id
+// ---------------------------------------------------------------------------
+
+/** Default 1-row lookup result returned for any input_type=hgnc|symbol. */
+export const geneLookupOk: GeneApiData[] = [
+  {
+    hgnc_id: ['HGNC:4586'],
+    symbol: ['GRIN2B'],
+    name: ['glutamate ionotropic receptor NMDA type subunit 2B'],
+    entrez_id: ['2904'],
+    ensembl_gene_id: ['ENSG00000273079'],
+    ucsc_id: ['uc001qvj.4'],
+    ccds_id: ['CCDS8573'],
+    uniprot_ids: ['Q13224'],
+    omim_id: ['138252'],
+    mane_select: ['NM_000834.5'],
+    mgd_id: ['MGI:95821'],
+    rgd_id: ['RGD:620630'],
+    STRING_id: ['9606.ENSP00000477455'],
+    bed_hg38: ['chr12:13437873-13982410'],
+    gnomad_constraints: '{"pli":0.99,"loeuf":0.18,"mis_z":5.4,"syn_z":0.4}',
+    alphafold_id: ['AF-Q13224-F1'],
+  },
+];
+
+/** Empty-lookup branch: the real endpoint returns `[]` for unknown input. */
+export const geneLookupEmpty: GeneApiData[] = [];
+
+// ---------------------------------------------------------------------------
+// /api/gene (cursor-paginated listing)
+// ---------------------------------------------------------------------------
+
+export interface GeneListEnvelope {
+  meta: unknown[];
+  data: GeneApiData[];
+  links: unknown[];
+}
+
+export const geneListOk: GeneListEnvelope = {
+  meta: [{ page_size: 10, total: 2 }],
+  data: [
+    geneLookupOk[0],
+    {
+      hgnc_id: ['HGNC:4851'],
+      symbol: ['HNRNPU'],
+      name: ['heterogeneous nuclear ribonucleoprotein U'],
+      entrez_id: ['3192'],
+      ensembl_gene_id: ['ENSG00000153187'],
+      ucsc_id: ['uc001htx.3'],
+      ccds_id: ['CCDS1578'],
+      uniprot_ids: ['Q00839'],
+      omim_id: ['602869'],
+      mane_select: ['NM_031844.3'],
+      mgd_id: ['MGI:105052'],
+      rgd_id: ['RGD:1305876'],
+      STRING_id: ['9606.ENSP00000283179'],
+      bed_hg38: ['chr1:244839603-244856519'],
+      gnomad_constraints: null,
+      alphafold_id: ['AF-Q00839-F1'],
+    },
+  ],
+  links: [{ self: '/api/gene?page_size=10' }],
+};
+
+// ---------------------------------------------------------------------------
+// /api/external/uniprot/domains/:symbol
+// ---------------------------------------------------------------------------
+
+export interface UniProtDomainFeatureFixture {
+  type: string;
+  description?: string;
+  begin: number | string;
+  end: number | string;
+}
+
+export interface UniProtDataFixture {
+  source: string;
+  gene_symbol: string;
+  accession: string;
+  protein_name: string;
+  protein_length: number | string;
+  domains: UniProtDomainFeatureFixture[];
+}
+
+export const uniprotDomainsOk: UniProtDataFixture = {
+  source: 'uniprot',
+  gene_symbol: 'GRIN2B',
+  accession: 'Q13224',
+  protein_name: 'Glutamate receptor ionotropic, NMDA 2B',
+  protein_length: 1484,
+  domains: [
+    { type: 'DOMAIN', description: 'Lig_chan-Glu_bd', begin: 557, end: 780 },
+    { type: 'DOMAIN', description: 'ANF_receptor', begin: 27, end: 387 },
+    { type: 'REGION', description: 'Cytoplasmic tail', begin: 839, end: 1484 },
+  ],
+};
+
+/** Sentinel gene symbol that triggers the 404 branch. */
+export const UNIPROT_NOT_FOUND_SYMBOL = 'NO_UNIPROT';
+
+export const uniprotDomainsNotFound = {
+  type: 'about:blank',
+  title: 'Gene not found in UniProt',
+  status: 404,
+  detail: 'Gene NO_UNIPROT not found in UniProt',
+  instance: '/api/external/uniprot/domains/NO_UNIPROT',
+  source: 'uniprot',
+};

--- a/app/src/test-utils/mocks/handlers.ts
+++ b/app/src/test-utils/mocks/handlers.ts
@@ -142,6 +142,14 @@ import {
   listGeneOk,
   listDiseaseOk,
 } from './data/lists';
+import {
+  geneLookupOk,
+  geneLookupEmpty,
+  geneListOk,
+  uniprotDomainsOk,
+  uniprotDomainsNotFound,
+  UNIPROT_NOT_FOUND_SYMBOL,
+} from './data/genes';
 import { reReviewTableOk } from './data/re_review';
 import {
   annotationDatesOk,
@@ -754,6 +762,49 @@ export const handlers = [
   // OpenAPI: GET /api/comparisons/metadata
   // api/endpoints/comparisons_endpoints.R @get /metadata
   http.get('/api/comparisons/metadata', () => HttpResponse.json(comparisonsMetadataOk)),
+
+  // ---------------------------------------------------------------------------
+  // Phase E.E3 — GeneView.vue migration (first-client-migration)
+  //
+  // These handlers back the `api/genes.ts` + `api/external.ts` typed helpers
+  // that Phase E.E3 introduces to replace the raw `axios.get` calls in
+  // `GeneView.vue`. Registered here so the `genes.spec.ts` helper unit tests
+  // and any future GeneView.vue component spec can rely on MSW interception.
+  // See `.plans/v11.0/phase-e.md` §3 Phase E.E3 exit criterion #14.
+  // ---------------------------------------------------------------------------
+
+  // OpenAPI: GET /api/gene  (cursor-paginated listing)
+  // api/endpoints/gene_endpoints.R @get /
+  // Registered BEFORE `/api/gene/:gene_input` so the literal match wins over
+  // the parameterised one in MSW's first-match-wins ordering.
+  http.get('/api/gene', () => HttpResponse.json(geneListOk)),
+
+  // OpenAPI: GET /api/gene/:gene_input?input_type=hgnc|symbol
+  // api/endpoints/gene_endpoints.R @get /<gene_input>
+  //
+  // Wire shape: 1-row array when found, empty `[]` when unknown. `GeneView`
+  // dispatches two lookups in parallel (hgnc + symbol) and picks whichever
+  // comes back with rows. Use the sentinel value `UNKNOWN_GENE` to trigger
+  // the empty branch regardless of input_type.
+  http.get('/api/gene/:gene_input', ({ params }) => {
+    if (params.gene_input === 'UNKNOWN_GENE') {
+      return HttpResponse.json(geneLookupEmpty);
+    }
+    return HttpResponse.json(geneLookupOk);
+  }),
+
+  // OpenAPI: GET /api/external/uniprot/domains/:symbol
+  // api/endpoints/external_endpoints.R @get uniprot/domains/<symbol>
+  //
+  // 404 branch uses the sentinel symbol `NO_UNIPROT` (mirrors the "gene not
+  // in UniProt" path of the real endpoint). The body follows the
+  // `application/problem+json` shape the endpoint emits on error.
+  http.get('/api/external/uniprot/domains/:symbol', ({ params }) => {
+    if (params.symbol === UNIPROT_NOT_FOUND_SYMBOL) {
+      return HttpResponse.json(uniprotDomainsNotFound, { status: 404 });
+    }
+    return HttpResponse.json(uniprotDomainsOk);
+  }),
 ];
 
 export default handlers;

--- a/app/src/views/LoginView.vue
+++ b/app/src/views/LoginView.vue
@@ -70,6 +70,7 @@ import { useHead } from '@unhead/vue';
 import { useForm, useField, defineRule } from 'vee-validate';
 import { required, min, max } from '@vee-validate/rules';
 import useToast from '@/composables/useToast';
+import { useAuth } from '@/composables/useAuth';
 
 // Define validation rules globally
 defineRule('required', required);
@@ -80,6 +81,8 @@ export default {
   name: 'LoginView',
   setup() {
     const { makeToast } = useToast();
+    // Phase E.E7: delegate all auth state reads/writes to `useAuth()`.
+    const auth = useAuth();
     useHead({
       title: 'Login',
       meta: [
@@ -121,10 +124,13 @@ export default {
       handleSubmit,
       resetVeeForm,
       makeToast,
+      auth,
     };
   },
   mounted() {
-    if (localStorage.user) {
+    // If the Login view is reached while still authenticated, clear the
+    // session before showing the form (matches the pre-refactor behaviour).
+    if (this.auth.isAuthenticated.value) {
       this.doUserLogOut();
     }
     this.loading = false;
@@ -145,27 +151,34 @@ export default {
           user_name: this.user_name,
           password: this.password,
         });
-        localStorage.setItem('token', response_authenticate.data[0]);
+        // R/Plumber wraps the scalar token in a single-element array — unwrap
+        // before handing it to useAuth / the /signin call.
+        const token = response_authenticate.data[0];
         this.makeToast(
           `You have logged in (status ${response_authenticate.status} - ${response_authenticate.statusText}).`,
           'Success',
           'success'
         );
-        this.signinWithJWT();
+        this.signinWithJWT(token);
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
       }
     },
-    async signinWithJWT() {
+    async signinWithJWT(token) {
+      // Two-step login: (1) POST /authenticate returned the JWT above;
+      // (2) GET /signin exchanges it for the full user payload. We set the
+      // Authorization header manually for this single call because
+      // `auth.login()` only fires after we have both pieces — splitting
+      // login into "set token" + "set user" would expose an intermediate
+      // half-logged-in state other tabs/components could observe.
       const apiAuthenticateURL = `${import.meta.env.VITE_API_URL}/api/auth/signin`;
       try {
         const response_signin = await this.axios.get(apiAuthenticateURL, {
           headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
+            Authorization: `Bearer ${token}`,
           },
         });
-        this.user = response_signin.data;
-        localStorage.setItem('user', JSON.stringify(response_signin.data));
+        this.auth.login(token, response_signin.data);
         this.$router.push('/');
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
@@ -177,10 +190,8 @@ export default {
       this.resetVeeForm();
     },
     doUserLogOut() {
-      if (localStorage.user || localStorage.token) {
-        localStorage.removeItem('user');
-        localStorage.removeItem('token');
-        this.user = null;
+      if (this.auth.isAuthenticated.value) {
+        this.auth.logout();
         this.$router.push('/');
       }
     },

--- a/app/src/views/LoginView.vue
+++ b/app/src/views/LoginView.vue
@@ -151,9 +151,35 @@ export default {
           user_name: this.user_name,
           password: this.password,
         });
-        // R/Plumber wraps the scalar token in a single-element array — unwrap
-        // before handing it to useAuth / the /signin call.
-        const token = response_authenticate.data[0];
+        // R/Plumber wraps the scalar token in a single-element array, but
+        // master also tolerated a bare string body. Validate the shape before
+        // calling signinWithJWT — without this guard (Copilot Fix 4), a
+        // malformed 200 response would hand `undefined` to signinWithJWT,
+        // which would then send "Bearer undefined" to /signin and call
+        // `auth.login(undefined, ...)` after it (eventually) succeeded or
+        // failed with a confusing 401.
+        const raw = response_authenticate.data;
+        let token;
+        if (typeof raw === 'string') {
+          token = raw;
+        } else if (Array.isArray(raw) && raw.length > 0 && typeof raw[0] === 'string') {
+          token = raw[0];
+        } else {
+          this.makeToast(
+            'Authentication failed: invalid token shape from server',
+            'Error',
+            'danger'
+          );
+          return;
+        }
+        if (!token) {
+          this.makeToast(
+            'Authentication failed: empty token from server',
+            'Error',
+            'danger'
+          );
+          return;
+        }
         this.makeToast(
           `You have logged in (status ${response_authenticate.status} - ${response_authenticate.statusText}).`,
           'Success',

--- a/app/src/views/UserView.vue
+++ b/app/src/views/UserView.vue
@@ -404,6 +404,7 @@
 import { useForm, useField, defineRule } from 'vee-validate';
 import { required, min, max, confirmed } from '@vee-validate/rules';
 import { useToast, useColorAndSymbols } from '@/composables';
+import { useAuth } from '@/composables/useAuth';
 
 // Define validation rules globally
 defineRule('required', required);
@@ -426,6 +427,9 @@ export default {
   setup() {
     const { makeToast } = useToast();
     const colorAndSymbols = useColorAndSymbols();
+    // Phase E.E7: shared auth state — replaces every direct localStorage
+    // read in this view (user payload, expiry, Bearer header).
+    const auth = useAuth();
 
     // Setup form validation with vee-validate 4
     const { handleSubmit, resetForm } = useForm();
@@ -463,6 +467,7 @@ export default {
       newPasswordRepeat,
       confirmPasswordError,
       confirmPasswordMeta,
+      auth,
     };
   },
   data() {
@@ -547,8 +552,13 @@ export default {
     },
   },
   mounted() {
-    if (localStorage.user) {
-      this.user = JSON.parse(localStorage.user);
+    // Hydrate the view from the shared auth state (already parsed + guarded
+    // against corrupt localStorage.user by `useAuth`). If the composable
+    // reports no user (e.g. a route-guard race or cleared state), skip the
+    // subsequent calls rather than hitting the API with a stale token.
+    const authUser = this.auth.user.value;
+    if (authUser) {
+      this.user = { ...authUser };
 
       this.interval = setInterval(() => {
         this.updateDiffs();
@@ -581,21 +591,24 @@ export default {
       this.resetPasswordForm();
     },
     updateDiffs() {
-      if (localStorage.token) {
-        const expires = JSON.parse(localStorage.user).exp;
-        const timestamp = Math.floor(new Date().getTime() / 1000);
-        this.time_to_logout = ((expires - timestamp) / 60).toFixed(2);
+      const authUser = this.auth.user.value;
+      if (!this.auth.isAuthenticated.value || !authUser) {
+        return;
       }
+      const expires = authUser.exp?.[0];
+      if (typeof expires !== 'number') {
+        return;
+      }
+      const timestamp = Math.floor(Date.now() / 1000);
+      this.time_to_logout = ((expires - timestamp) / 60).toFixed(2);
     },
     async getUserContributions() {
+      // `useAuth` already seeded the axios default Authorization header, so
+      // per-request Bearer overrides are no longer needed here.
       const apiContributionsURL = `${import.meta.env.VITE_API_URL}/api/user/${this.user.user_id[0]}/contributions`;
 
       try {
-        const response_contributions = await this.axios.get(apiContributionsURL, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        });
+        const response_contributions = await this.axios.get(apiContributionsURL);
         [this.user.active_reviews] = response_contributions.data.active_reviews;
         [this.user.active_status] = response_contributions.data.active_status;
       } catch (e) {
@@ -603,17 +616,11 @@ export default {
       }
     },
     async refreshWithJWT() {
-      const apiAuthenticateURL = `${import.meta.env.VITE_API_URL}/api/auth/refresh`;
-
       try {
-        const response_refresh = await this.axios.get(apiAuthenticateURL, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        });
-
-        localStorage.setItem('token', response_refresh.data[0]);
-        this.signinWithJWT();
+        // `auth.refresh()` owns the /api/auth/refresh call, stores the new
+        // token, and re-seeds the axios default Authorization header.
+        await this.auth.refresh();
+        await this.signinWithJWT();
         this.makeToast('Session refreshed successfully', 'Success', 'success');
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
@@ -623,14 +630,15 @@ export default {
       const apiAuthenticateURL = `${import.meta.env.VITE_API_URL}/api/auth/signin`;
 
       try {
-        const response_signin = await this.axios.get(apiAuthenticateURL, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        });
-
-        localStorage.setItem('user', JSON.stringify(response_signin.data));
-        this.user = response_signin.data;
+        const response_signin = await this.axios.get(apiAuthenticateURL);
+        // Persist the refreshed user payload via the composable so every
+        // subscriber (navbar, countdown badge, route guards) sees the new
+        // `exp` immediately.
+        const token = this.auth.token.value;
+        if (token) {
+          this.auth.login(token, response_signin.data);
+        }
+        this.user = { ...response_signin.data };
         this.updateDiffs();
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
@@ -644,20 +652,14 @@ export default {
       // hotfix rollout; the JSON body variant is the only one we send.
       const apiChangePasswordURL = `${import.meta.env.VITE_API_URL}/api/user/password/update`;
       try {
-        const response_password_change = await this.axios.put(
-          apiChangePasswordURL,
-          {
-            user_id_pass_change: this.user.user_id[0],
-            old_pass: this.currentPassword,
-            new_pass_1: this.newPasswordEntry,
-            new_pass_2: this.newPasswordRepeat,
-          },
-          {
-            headers: {
-              Authorization: `Bearer ${localStorage.getItem('token')}`,
-            },
-          }
-        );
+        // `useAuth` keeps the axios default Authorization header current;
+        // no per-request override needed.
+        const response_password_change = await this.axios.put(apiChangePasswordURL, {
+          user_id_pass_change: this.user.user_id[0],
+          old_pass: this.currentPassword,
+          new_pass_1: this.newPasswordEntry,
+          new_pass_2: this.newPasswordRepeat,
+        });
         this.makeToast(
           `${response_password_change.data.message} (status ${response_password_change.status})`,
           'Success',
@@ -740,7 +742,6 @@ export default {
 
         const response = await this.axios.put(apiProfileURL, payload, {
           headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
             'Content-Type': 'application/json',
           },
         });
@@ -753,8 +754,12 @@ export default {
           this.user.orcid = [orcidTrimmed];
         }
 
-        // Update localStorage
-        localStorage.setItem('user', JSON.stringify(this.user));
+        // Persist the updated profile through `useAuth` so the navbar and
+        // other observers see the new email/ORCID without a page refresh.
+        const token = this.auth.token.value;
+        if (token) {
+          this.auth.login(token, this.user);
+        }
 
         this.makeToast(
           `Profile updated successfully. ${response.data.updated_fields?.join(', ') || ''}`,

--- a/app/src/views/pages/GeneView.vue
+++ b/app/src/views/pages/GeneView.vue
@@ -276,7 +276,7 @@ async function loadGeneInfo() {
       geneData.value = hgncRows;
     }
   } catch (e) {
-    makeToast(e as string, 'Error', 'danger');
+    makeToast(e, 'Error', 'danger');
   }
   loading.value = false;
 

--- a/app/src/views/pages/GeneView.vue
+++ b/app/src/views/pages/GeneView.vue
@@ -136,7 +136,9 @@ import { useHead } from '@unhead/vue';
 import { useToast } from '@/composables';
 import { useGeneExternalData } from '@/composables/useGeneExternalData';
 import { useModelOrganismData } from '@/composables/useModelOrganismData';
-import axios from 'axios';
+import { getGene, getGeneBySymbol } from '@/api/genes';
+import { getUniprotDomains, type UniProtData } from '@/api/external';
+import { isApiError } from '@/api/client';
 import GeneBadge from '@/components/ui/GeneBadge.vue';
 import IdentifierCard from '@/components/gene/IdentifierCard.vue';
 import ClinicalResourcesCard from '@/components/gene/ClinicalResourcesCard.vue';
@@ -147,27 +149,9 @@ import GenomicVisualizationTabs from '@/components/gene/GenomicVisualizationTabs
 import TablesEntities from '@/components/tables/TablesEntities.vue';
 import type { GeneApiData } from '@/types/gene';
 
-/**
- * UniProt domain feature from the API response
- */
-interface UniProtDomainFeature {
-  type: string;
-  description?: string;
-  begin: number | string;
-  end: number | string;
-}
-
-/**
- * UniProt API response structure from /api/external/uniprot/domains/<symbol>
- */
-interface UniProtData {
-  source: string;
-  gene_symbol: string;
-  accession: string;
-  protein_name: string;
-  protein_length: number | string;
-  domains: UniProtDomainFeature[];
-}
+// UniProtData + UniProtDomainFeature are now exported from `@/api/external`
+// (Phase E.E3 migration). Importing them keeps one source of truth between
+// the api/ helper and this view's prop-forwarding to GenomicVisualizationTabs.
 
 const route = useRoute();
 const router = useRouter();
@@ -230,22 +214,16 @@ async function fetchUniprotData(): Promise<void> {
   uniprotError.value = null;
 
   try {
-    const apiBase = import.meta.env.VITE_API_URL;
-    const response = await axios.get(
-      `${apiBase}/api/external/uniprot/domains/${geneSymbol.value}`,
-      {
-        withCredentials: true,
-      }
-    );
+    const data = await getUniprotDomains(geneSymbol.value);
 
     // Check for valid response with domains
-    if (response.data && response.data.domains) {
-      uniprotData.value = response.data;
+    if (data && data.domains) {
+      uniprotData.value = data;
     } else {
       uniprotData.value = null;
     }
   } catch (err) {
-    if (axios.isAxiosError(err) && err.response?.status === 404) {
+    if (isApiError(err) && err.response?.status === 404) {
       // Gene not found in UniProt - not an error, just no data
       uniprotData.value = null;
       uniprotError.value = null;
@@ -278,23 +256,24 @@ async function retryAllExternalData(): Promise<void> {
 async function loadGeneInfo() {
   loading.value = true;
   const symbol = route.params.symbol as string;
-  const apiBase = import.meta.env.VITE_API_URL;
-  const apiGeneURL = `${apiBase}/api/gene/${symbol}?input_type=hgnc`;
-  const apiGeneSymbolURL = `${apiBase}/api/gene/${symbol}?input_type=symbol`;
 
   try {
-    // Parallel fetch: both gene API calls run concurrently
-    const [responseGene, responseSymbol] = await Promise.all([
-      axios.get(apiGeneURL, { withCredentials: true }),
-      axios.get(apiGeneSymbolURL, { withCredentials: true }),
+    // Parallel fetch: both gene API calls run concurrently. `getGene` /
+    // `getGeneBySymbol` (from `@/api/genes`) return the 1-row-array lookup
+    // shape directly — the legacy `?input_type=...` query string is folded
+    // into the helper signature, and the `apiBase` prepend is handled by
+    // the configured axios singleton under `@/plugins/axios`.
+    const [hgncRows, symbolRows] = await Promise.all([
+      getGene(symbol, 'hgnc'),
+      getGeneBySymbol(symbol),
     ]);
 
-    if (responseGene.data.length === 0 && responseSymbol.data.length === 0) {
+    if (hgncRows.length === 0 && symbolRows.length === 0) {
       router.push('/PageNotFound');
-    } else if (responseGene.data.length === 0) {
-      geneData.value = responseSymbol.data;
+    } else if (hgncRows.length === 0) {
+      geneData.value = symbolRows;
     } else {
-      geneData.value = responseGene.data;
+      geneData.value = hgncRows;
     }
   } catch (e) {
     makeToast(e as string, 'Error', 'danger');

--- a/app/tsconfig.api.json
+++ b/app/tsconfig.api.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.strict.json",
+  "include": ["src/api/**/*.ts"]
+}

--- a/app/tsconfig.composables-auth.json
+++ b/app/tsconfig.composables-auth.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.strict.json",
+  "include": ["src/composables/useAuth*.ts"]
+}

--- a/app/tsconfig.router.json
+++ b/app/tsconfig.router.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.strict.json",
+  "include": ["src/router/**/*.ts"]
+}

--- a/app/tsconfig.strict.json
+++ b/app/tsconfig.strict.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "allowJs": true,
+    "noEmit": true
+  },
+  "include": []
+}

--- a/app/tsconfig.types.json
+++ b/app/tsconfig.types.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.strict.json",
+  "include": ["src/types/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Consolidated Phase E PR covering three units (E2, E3, E7) whose file ownership is disjoint and which verified green in parallel during dispatch. Supersedes #259, #260, #261.

### E2 — `ts-strictness-scopes`
Per-directory TypeScript strict scopes without flipping the global config. Global `tsconfig.json` stays permissive (129 unmigrated JS SFCs keep building).

- New: `tsconfig.strict.json` (base) + `tsconfig.{router,api,types,composables-auth}.json`
- New: `app/scripts/type-check-strict.js` — Node runner that prefix-filters vue-tsc diagnostics per scope (chained `vue-tsc -p` can't work here because `routes.ts` pulls ~40 views whose transitive deps violate strict under the permissive root).
- New: `type-check:strict` npm script, wired into `.github/workflows/ci.yml` and `make ci-local`.
- Runner fails loudly on unexpected tool crashes / spawn errors (surfaced via verified smoke test: `spawnSync npx ENOENT` propagates instead of falling to the generic "exit null" path).

Satisfies Phase E exit criterion 15 (see `.plans/v11.0/phase-e.md` §3 Phase E.E2).

### E3 — `first-client-migration` (GeneView)
Template migration of one view off raw `axios.get` onto the new `api/client.ts` + typed helpers introduced in E1 (#258).

- `GeneView.vue`: 3 `axios.get` calls replaced with `getGene` / `getGeneBySymbol` from `@/api/genes` and `getUniprotDomains` from `@/api/external`.
- `api/external.ts`: stub replaced with real `getUniprotDomains` + `UniProtData` / `UniProtDomainFeature` types.
- `api/genes.spec.ts`: 12 tests covering all four helpers (URL encoding, input_type, empty-lookup sentinel, 404 AxiosError shape).
- MSW fixtures/handlers under `src/test-utils/mocks/` (sentinel pattern: `UNKNOWN_GENE`, `NO_UNIPROT`).
- `api/client.ts` header now documents that `withCredentials` is NOT set by default; call sites needing sticky-session cookies (e.g. `useAsyncJob`) must pass it explicitly.
- GeneView `makeToast` catch preserves error shape (Copilot) — `__handled401` tag survives, Axios `response.data.message` extraction works.

Advances Phase E exit criterion 14 template migration (see `.plans/v11.0/phase-e.md` §3 Phase E.E3).

### E7 — `consolidate-auth-session` (useAuth composable)
Closes P1 "Frontend auth/session state is duplicated" review finding (spec Appendix C).

- New: `app/src/composables/useAuth.ts` (373 lines) — single owner of token/user/expiry/refresh/axios-header-seeding/401-coordination. Reactive module-level singleton; module-load `syncFromStorage()` seeds state from `localStorage`.
- New: `app/src/composables/useAuth.spec.ts` — 25 tests. Covers the 5 required cases (login, logout, expired-triggers-refresh-or-redirect, corrupt-localStorage, 401 coordination) plus defensive hardening.
- 5 locked call sites migrated off direct `localStorage.token`/`localStorage.user`: `router/routes.ts`, `components/AppNavbar.vue`, `components/small/LogoutCountdownBadge.vue` (+ 3 stale "TODO: move to a mixin" comments deleted), `views/LoginView.vue`, `views/UserView.vue`.
- `routes.ts`: 18 byte-identical auth guards consolidated into a `createAuthGuard(allowed_roles)` factory. File shrank 877 → 559 lines.
- `isExpired` uses `nowSec >= exp` (RFC 7519: token invalid at or after exp) — 1-second stricter than master's `>`. Locked in with an explicit boundary test.
- Hardening from Copilot: `safeParseUser` rejects arrays and requires minimal fields (`exp`, `user_role` as non-empty arrays); `syncFromStorage` enforces token+user both-or-neither invariant (resolves the `UserView.vue` hydrate-without-token concern without touching UserView directly); `refresh()` strict-types the response shape (rejects `{}`, `[123]`, `[]`); `LoginView.loadJWT` validates `/authenticate` response is a non-empty string before proceeding.

Closes P1 review finding + advances Phase E.E7 exit criterion (see `.plans/v11.0/phase-e.md` §3 Phase E.E7).

**Scope clarification for E7:** The plan's aspirational `grep -rn localStorage\\.token|localStorage\\.user` "returns only useAuth.ts" is relaxed — ~80 hits across ~15 other files (ApproveReview, ApproveStatus, ModifyEntity, Review, RegisterView, CreateEntity, ManageReReview, composables/useStatusForm, composables/useReviewForm, etc.) are known leftovers deferred to v11.1. The 5 locked files have no direct `localStorage` token/user reads after this PR; only `useAuth.ts` does.

## Verification (combined branch)

```
cd app && npm run type-check          # GREEN
cd app && npm run type-check:strict   # router: OK, api: OK, types: OK, composables-auth: OK
cd app && npm run lint                # GREEN
cd app && npm run test:unit           # 36 files / 487 passed / 6 todo  (baseline was 450; +37 new tests across E3 and E7)
```

Host `make ci-local` skipped per `CLAUDE.md` Conda-R workaround (frontend-only changes; R lint/test stack gated by A7's CI matrix).

The `composables-auth` strict scope is now engaged for real (it was skipped on the E2 branch alone because `useAuth.ts` didn't exist yet — this was the planned E2/E7 coupling).

## Review history

This PR supersedes three individually-reviewed branches:
- E2 → #260 (closed) — all Copilot / spec / code-quality findings addressed
- E3 → #259 (closed) — all Copilot / spec / code-quality findings addressed
- E7 → #261 (closed) — all Copilot / spec / code-quality findings addressed

Each unit went through: implementer TDD loop → spec-compliance review → code-quality review → targeted fixer pass → Copilot review round → second targeted fixer pass. All fixes documented in the individual commit messages.

## Deferred to follow-up (NOT in this PR)

- E4 — rewrite `ManageAnnotations.vue` (2159 → ≤700 LoC, with extracted modal components). Belongs in a dedicated session.
- E5 — rewrite `ApproveReview.vue` (2138 → ≤700 LoC, establishes the pattern E6 consumes). Dedicated session.
- E6 — create `ApprovalTableView.vue` + rewrite `ApproveStatus.vue` as thin wrapper (≤100 LoC). Depends on E5's pattern.
- I4 (from E7 code review): `UserView.vue` local `data.user` shadows `auth.user` — no reactive rebinding if external refresh updates state. Not a correctness bug after Fix 2 (both-or-neither invariant) but a cleanup item for a future UserView-focused pass.

## Test plan

- [x] CI green on PR
- [ ] Reviewer confirms the 3 merge commits correctly partition the change set along unit boundaries
- [ ] Manual smoke: gene page loads, auth flow works (login → refresh → logout), strict type-check catches implicit-any in router/api/types/composables-auth scopes