### PR TITLE
chore(release): bump to 0.11.9 for Phase E close-out

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysndd",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysndd",
-      "version": "0.11.8",
+      "version": "0.11.9",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@unhead/vue": "^2.1.10",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Patch bump for the Phase E close-out.

Phase E of v11.0 landed via two combined PRs:
- #262 — E2 (TypeScript strict scopes), E3 (first-client migration on GeneView), E7 (useAuth consolidation)
- #266 — E4 (ManageAnnotations rewrite), E5 (ApproveReview rewrite), E6 (ApproveStatus → ApprovalTableView convergence)

Follows the Phase-D precedent (#257 bumped to 0.11.8).

## Test plan
- [x] package.json + package-lock.json match
- [ ] CI green