### PR TITLE
chore(release): bump to 0.11.10 for dependency consolidation

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysndd",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysndd",
-      "version": "0.11.9",
+      "version": "0.11.10",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@unhead/vue": "^3.0.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Patch bump after #274 (dependency consolidation) landed on master.

Bumps in #274:
- gsap 3.14.2 → 3.15.0
- @unhead/vue 2.1.10 → 3.0.3
- jsdom 28.1.0 → 29.0.2
- typescript 5.9.3 → 6.0.2
- dev-deps group (8 packages, minor/patch)

Vite 8 deferred until \`vite-plugin-pwa\` ships a Vite-8 compatible release.

## Test plan
- [x] package.json + package-lock.json match
- [ ] CI green