### PR TITLE
v11.0/closeout: F1 test-followup — pin interceptor edge cases + ESLint selector variants

### DIFF
--- a/app/src/api/client.spec.ts
+++ b/app/src/api/client.spec.ts
@@ -14,11 +14,14 @@
  * actually reaches through the axios plugin and its 401 interceptor chain.
  */
 
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect } from 'vitest';
 import { http, HttpResponse } from 'msw';
+import { AxiosHeaders } from 'axios';
 import { apiClient, isApiError, unwrapScalar } from './client';
 import { ERROR_SENTINELS } from '@/test-utils/mocks/handlers';
 import { server } from '@/test-utils/mocks/server';
+import { primeAuth } from '@/test-utils/primeAuth';
+import useAuth from '@/composables/useAuth';
 
 describe('api/client — typed wrapper smoke tests', () => {
   // ---------------------------------------------------------------------------
@@ -161,6 +164,150 @@ describe('api/client — typed wrapper smoke tests', () => {
       // Multi-element arrays are real arrays, not plumber scalar shims.
       const multi = ['a', 'b', 'c'];
       expect(unwrapScalar(multi as unknown as [string])).toEqual(multi);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Request interceptor — Bearer injection & per-call override preservation
+  // ---------------------------------------------------------------------------
+  //
+  // v11.0 closeout F1 (PR #276) moved Bearer injection from
+  // `axios.defaults.headers.common.Authorization` into a request interceptor
+  // that reads `useAuth().token.value`. A Copilot review on that PR surfaced
+  // that the naive interceptor overwrote explicit per-call `Authorization`
+  // headers — which would break the two enumerated exceptions in closeout
+  // spec §3.4 (LoginView bootstrap, PasswordResetView route-param JWT). The
+  // fixed interceptor checks `hasAuthorizationHeader(config.headers)` first
+  // and yields to explicit overrides regardless of case or header shape.
+  //
+  // These tests pin that contract against the real `apiClient` by sending
+  // requests through MSW and observing what the server sees.
+  //
+  describe('request interceptor — Bearer header', () => {
+    afterEach(() => {
+      useAuth().logout();
+    });
+
+    it('injects Bearer from useAuth().token.value when no explicit header is set', async () => {
+      const { token } = primeAuth('session-token-1');
+      let captured: string | null = null;
+      server.use(
+        http.get('*/api/ping', ({ request }) => {
+          captured = request.headers.get('authorization');
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      await apiClient.get('/api/ping');
+      expect(captured).toBe(`Bearer ${token}`);
+    });
+
+    it('omits Authorization when no session token exists', async () => {
+      let captured: string | null = 'UNSET';
+      server.use(
+        http.get('*/api/ping', ({ request }) => {
+          captured = request.headers.get('authorization');
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      await apiClient.get('/api/ping');
+      expect(captured).toBeNull();
+    });
+
+    it('preserves AxiosHeaders-shaped explicit Authorization override', async () => {
+      primeAuth('session-token-axh');
+      let captured: string | null = null;
+      server.use(
+        http.get('*/api/ping', ({ request }) => {
+          captured = request.headers.get('authorization');
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      const headers = new AxiosHeaders();
+      headers.set('Authorization', 'Bearer explicit-axh');
+      await apiClient.get('/api/ping', { headers });
+
+      expect(captured).toBe('Bearer explicit-axh');
+      expect(captured).not.toContain('session-token-axh');
+    });
+
+    it('preserves plain-object explicit Authorization override (PascalCase key)', async () => {
+      primeAuth('session-token-po-pascal');
+      let captured: string | null = null;
+      server.use(
+        http.get('*/api/ping', ({ request }) => {
+          captured = request.headers.get('authorization');
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      await apiClient.get('/api/ping', {
+        headers: { Authorization: 'Bearer explicit-pascal' },
+      });
+
+      expect(captured).toBe('Bearer explicit-pascal');
+      expect(captured).not.toContain('session-token-po-pascal');
+    });
+
+    it('preserves plain-object explicit Authorization override (lowercase key)', async () => {
+      // HTTP headers are case-insensitive; axios may receive either casing
+      // from a call site. `hasAuthorizationHeader` walks `Object.keys` and
+      // lowercases each key, so lowercase and upper/mixed case must all be
+      // treated as "already set".
+      primeAuth('session-token-po-lower');
+      let captured: string | null = null;
+      server.use(
+        http.get('*/api/ping', ({ request }) => {
+          captured = request.headers.get('authorization');
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      await apiClient.get('/api/ping', {
+        headers: { authorization: 'Bearer explicit-lower' },
+      });
+
+      expect(captured).toBe('Bearer explicit-lower');
+      expect(captured).not.toContain('session-token-po-lower');
+    });
+
+    it('preserves plain-object explicit Authorization override (UPPERCASE key)', async () => {
+      primeAuth('session-token-po-upper');
+      let captured: string | null = null;
+      server.use(
+        http.get('*/api/ping', ({ request }) => {
+          captured = request.headers.get('authorization');
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      await apiClient.get('/api/ping', {
+        headers: { AUTHORIZATION: 'Bearer explicit-upper' },
+      });
+
+      expect(captured).toBe('Bearer explicit-upper');
+      expect(captured).not.toContain('session-token-po-upper');
+    });
+
+    it('honours explicit Authorization even without a session token', async () => {
+      // Session absent, but the call site supplies its own Bearer — e.g.
+      // LoginView bootstrap uses the just-received JWT locally, before
+      // `useAuth().login()` is called. The interceptor must not strip it.
+      let captured: string | null = null;
+      server.use(
+        http.get('*/api/ping', ({ request }) => {
+          captured = request.headers.get('authorization');
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      await apiClient.get('/api/ping', {
+        headers: { Authorization: 'Bearer bootstrap-jwt' },
+      });
+
+      expect(captured).toBe('Bearer bootstrap-jwt');
     });
   });
 });

--- a/app/src/eslint-closeout-guard.spec.ts
+++ b/app/src/eslint-closeout-guard.spec.ts
@@ -32,10 +32,18 @@
 // requires the path to exist in the TS project; `lintText` reads the
 // AST from the passed-in code string regardless.
 
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, vi } from 'vitest';
 import { ESLint } from 'eslint';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+// Each `lintText` call loads the full ESLint config (typescript-eslint
+// parser + Vue plugin + project-wide rules), which can take 5–15 seconds
+// on a cold CI runner. Vitest's default 5s per-test timeout fires before
+// the first test's `lintText` completes. Bump the per-test ceiling
+// generously; a `beforeAll` warm-up below also primes the parser so every
+// subsequent test finishes within a few hundred ms.
+vi.setConfig({ testTimeout: 30000, hookTimeout: 30000 });
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -54,10 +62,17 @@ const FIXTURE_FILEPATH = path.resolve(APP_ROOT, 'src/api/client.ts');
 
 let eslint: ESLint;
 
-beforeAll(() => {
+beforeAll(async () => {
   eslint = new ESLint({
     overrideConfigFile: CONFIG_PATH,
     cwd: APP_ROOT,
+  });
+  // Warm-up lint: `new ESLint(...)` constructs lazily; the first
+  // `lintText` call triggers config loading + typescript-eslint parser
+  // init. Paying that cost in the hook keeps every individual `it`
+  // under the per-test budget on slow CI runners.
+  await eslint.lintText('export const __warmup__ = 1;', {
+    filePath: FIXTURE_FILEPATH,
   });
 });
 

--- a/app/src/eslint-closeout-guard.spec.ts
+++ b/app/src/eslint-closeout-guard.spec.ts
@@ -26,7 +26,11 @@
 // File path used for `lintText` is important: the fixture path must sit
 // under `src/` and NOT match any entry in the config's `ignores` array
 // (so not a spec file, not composables/useAuth.ts, etc.). We use
-// `src/__closeout-guard-fixture__.ts` which passes all those filters.
+// `src/api/client.ts` — an existing TypeScript source file that is in
+// tsconfig, matches the rule's `files` glob, and is NOT in its
+// `ignores` list. typescript-eslint's `parserOptions.project`
+// requires the path to exist in the TS project; `lintText` reads the
+// AST from the passed-in code string regardless.
 
 import { describe, it, expect, beforeAll } from 'vitest';
 import { ESLint } from 'eslint';
@@ -62,7 +66,7 @@ async function lintSnippet(code: string): Promise<ESLint.LintResult> {
   return result;
 }
 
-function hasClosoutViolation(result: ESLint.LintResult): boolean {
+function hasCloseoutViolation(result: ESLint.LintResult): boolean {
   return result.messages.some(
     (m) =>
       m.ruleId === 'no-restricted-syntax' &&
@@ -74,105 +78,105 @@ function hasClosoutViolation(result: ESLint.LintResult): boolean {
 describe('closeout §8.1 guardrail — MemberExpression selectors', () => {
   it('flags `localStorage.token` (direct, static)', async () => {
     const r = await lintSnippet('if (localStorage.token) { /* noop */ }');
-    expect(hasClosoutViolation(r)).toBe(true);
+    expect(hasCloseoutViolation(r)).toBe(true);
   });
 
   it('flags `localStorage.user` (direct, static)', async () => {
     const r = await lintSnippet('const u = localStorage.user;');
-    expect(hasClosoutViolation(r)).toBe(true);
+    expect(hasCloseoutViolation(r)).toBe(true);
   });
 
   it("flags `localStorage['token']` (direct, computed)", async () => {
     const r = await lintSnippet(`const t = localStorage['token'];`);
-    expect(hasClosoutViolation(r)).toBe(true);
+    expect(hasCloseoutViolation(r)).toBe(true);
   });
 
   it("flags `localStorage['user']` (direct, computed)", async () => {
     const r = await lintSnippet(`const u = localStorage['user'];`);
-    expect(hasClosoutViolation(r)).toBe(true);
+    expect(hasCloseoutViolation(r)).toBe(true);
   });
 
   it('flags `window.localStorage.token` (window-qualified, static)', async () => {
     const r = await lintSnippet('const t = window.localStorage.token;');
-    expect(hasClosoutViolation(r)).toBe(true);
+    expect(hasCloseoutViolation(r)).toBe(true);
   });
 
   it("flags `window.localStorage['token']` (window-qualified, computed)", async () => {
     const r = await lintSnippet(`const t = window.localStorage['token'];`);
-    expect(hasClosoutViolation(r)).toBe(true);
+    expect(hasCloseoutViolation(r)).toBe(true);
   });
 
   it('flags `globalThis.localStorage.user` (globalThis-qualified, static)', async () => {
     const r = await lintSnippet('const u = globalThis.localStorage.user;');
-    expect(hasClosoutViolation(r)).toBe(true);
+    expect(hasCloseoutViolation(r)).toBe(true);
   });
 
   it("flags `globalThis.localStorage['user']` (globalThis-qualified, computed)", async () => {
     const r = await lintSnippet(`const u = globalThis.localStorage['user'];`);
-    expect(hasClosoutViolation(r)).toBe(true);
+    expect(hasCloseoutViolation(r)).toBe(true);
   });
 
   it('does NOT flag non-token/user keys (e.g. `localStorage.banner_acknowledged`)', async () => {
     const r = await lintSnippet('const b = localStorage.banner_acknowledged;');
-    expect(hasClosoutViolation(r)).toBe(false);
+    expect(hasCloseoutViolation(r)).toBe(false);
   });
 
   it('does NOT flag non-localStorage receivers (e.g. `sessionStorage.token`)', async () => {
     const r = await lintSnippet('const t = sessionStorage.token;');
-    expect(hasClosoutViolation(r)).toBe(false);
+    expect(hasCloseoutViolation(r)).toBe(false);
   });
 });
 
 describe('closeout §8.1 guardrail — CallExpression selectors', () => {
   it("flags `localStorage.getItem('token')`", async () => {
     const r = await lintSnippet(`const t = localStorage.getItem('token');`);
-    expect(hasClosoutViolation(r)).toBe(true);
+    expect(hasCloseoutViolation(r)).toBe(true);
   });
 
   it("flags `localStorage.setItem('user', '…')`", async () => {
     const r = await lintSnippet(`localStorage.setItem('user', '{}');`);
-    expect(hasClosoutViolation(r)).toBe(true);
+    expect(hasCloseoutViolation(r)).toBe(true);
   });
 
   it("flags `localStorage.removeItem('token')`", async () => {
     const r = await lintSnippet(`localStorage.removeItem('token');`);
-    expect(hasClosoutViolation(r)).toBe(true);
+    expect(hasCloseoutViolation(r)).toBe(true);
   });
 
   it("flags `window.localStorage.getItem('token')`", async () => {
     const r = await lintSnippet(
       `const t = window.localStorage.getItem('token');`,
     );
-    expect(hasClosoutViolation(r)).toBe(true);
+    expect(hasCloseoutViolation(r)).toBe(true);
   });
 
   it("flags `window.localStorage.setItem('user', …)`", async () => {
     const r = await lintSnippet(`window.localStorage.setItem('user', '{}');`);
-    expect(hasClosoutViolation(r)).toBe(true);
+    expect(hasCloseoutViolation(r)).toBe(true);
   });
 
   it("flags `globalThis.localStorage.getItem('user')`", async () => {
     const r = await lintSnippet(
       `const u = globalThis.localStorage.getItem('user');`,
     );
-    expect(hasClosoutViolation(r)).toBe(true);
+    expect(hasCloseoutViolation(r)).toBe(true);
   });
 
   it("flags `globalThis.localStorage.removeItem('token')`", async () => {
     const r = await lintSnippet(`globalThis.localStorage.removeItem('token');`);
-    expect(hasClosoutViolation(r)).toBe(true);
+    expect(hasCloseoutViolation(r)).toBe(true);
   });
 
   it("does NOT flag `localStorage.getItem('banner_acknowledged')` (non-sensitive key)", async () => {
     const r = await lintSnippet(
       `const b = localStorage.getItem('banner_acknowledged');`,
     );
-    expect(hasClosoutViolation(r)).toBe(false);
+    expect(hasCloseoutViolation(r)).toBe(false);
   });
 
   it('does NOT flag `sessionStorage.getItem(\'token\')`', async () => {
     const r = await lintSnippet(`const t = sessionStorage.getItem('token');`);
-    expect(hasClosoutViolation(r)).toBe(false);
+    expect(hasCloseoutViolation(r)).toBe(false);
   });
 });
 
@@ -182,11 +186,11 @@ describe('closeout §8.1 guardrail — clean code passes', () => {
       `import useAuth from '@/composables/useAuth';
        const t = useAuth().token.value;`,
     );
-    expect(hasClosoutViolation(r)).toBe(false);
+    expect(hasCloseoutViolation(r)).toBe(false);
   });
 
   it('accepts code that does not touch localStorage at all', async () => {
     const r = await lintSnippet('const x = 42; export { x };');
-    expect(hasClosoutViolation(r)).toBe(false);
+    expect(hasCloseoutViolation(r)).toBe(false);
   });
 });

--- a/app/src/eslint-closeout-guard.spec.ts
+++ b/app/src/eslint-closeout-guard.spec.ts
@@ -1,0 +1,192 @@
+// eslint-closeout-guard.spec.ts
+// Regression tests for the v11.0 closeout §8.1 ESLint guardrail.
+//
+// The `no-restricted-syntax` rule in `app/eslint.config.js` forbids direct
+// `localStorage.(token|user)` reads outside the permitted owners
+// (useAuth.ts, plugins/axios.ts, test-utils, specs). The original F1
+// selectors only caught the `localStorage.x` form; a Copilot review on
+// PR #276 pointed out that `window.localStorage.x` and
+// `globalThis.localStorage.x` were easy bypass paths. The expanded
+// selectors now cover:
+//   - `localStorage.token`                  (direct, static)
+//   - `localStorage['token']`               (direct, computed)
+//   - `window.localStorage.token`           (window-qualified, static)
+//   - `window.localStorage['token']`        (window-qualified, computed)
+//   - `globalThis.localStorage.token`       (globalThis-qualified, static)
+//   - `globalThis.localStorage['token']`    (globalThis-qualified, computed)
+//   - `localStorage.getItem('token')` and setItem/removeItem equivalents
+//   - `window.localStorage.getItem('token')` and equivalents
+//   - `globalThis.localStorage.getItem('token')` and equivalents
+//
+// These tests pin every bypass path so a future refactor of the selector
+// cannot silently regress. Test runs the real `app/eslint.config.js` via
+// the ESLint Node API — no separate rule definition that could drift
+// from the config.
+//
+// File path used for `lintText` is important: the fixture path must sit
+// under `src/` and NOT match any entry in the config's `ignores` array
+// (so not a spec file, not composables/useAuth.ts, etc.). We use
+// `src/__closeout-guard-fixture__.ts` which passes all those filters.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { ESLint } from 'eslint';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Locate the app root (`app/`) from this spec's location (`app/src/`).
+const APP_ROOT = path.resolve(__dirname, '..');
+const CONFIG_PATH = path.resolve(APP_ROOT, 'eslint.config.js');
+
+// `lintText` uses `filePath` only for config matching (parser, rules,
+// ignores) — the AST comes from the `code` argument. typescript-eslint
+// with `parserOptions.project` still demands the path exist in the TS
+// project, so we point at an existing non-ignored source file that sits
+// under the `src/**/*.{ts,vue}` glob. `src/api/client.ts` fits: it's in
+// tsconfig, it's a `.ts` file, and it's NOT in the closeout rule's
+// `ignores` list (only test-utils, specs, and the F2-pending files are).
+const FIXTURE_FILEPATH = path.resolve(APP_ROOT, 'src/api/client.ts');
+
+let eslint: ESLint;
+
+beforeAll(() => {
+  eslint = new ESLint({
+    overrideConfigFile: CONFIG_PATH,
+    cwd: APP_ROOT,
+  });
+});
+
+async function lintSnippet(code: string): Promise<ESLint.LintResult> {
+  const [result] = await eslint.lintText(code, { filePath: FIXTURE_FILEPATH });
+  return result;
+}
+
+function hasClosoutViolation(result: ESLint.LintResult): boolean {
+  return result.messages.some(
+    (m) =>
+      m.ruleId === 'no-restricted-syntax' &&
+      (m.message.includes('localStorage.token / localStorage.user') ||
+        m.message.includes("localStorage.{get,set,remove}Item('token'|'user')")),
+  );
+}
+
+describe('closeout §8.1 guardrail — MemberExpression selectors', () => {
+  it('flags `localStorage.token` (direct, static)', async () => {
+    const r = await lintSnippet('if (localStorage.token) { /* noop */ }');
+    expect(hasClosoutViolation(r)).toBe(true);
+  });
+
+  it('flags `localStorage.user` (direct, static)', async () => {
+    const r = await lintSnippet('const u = localStorage.user;');
+    expect(hasClosoutViolation(r)).toBe(true);
+  });
+
+  it("flags `localStorage['token']` (direct, computed)", async () => {
+    const r = await lintSnippet(`const t = localStorage['token'];`);
+    expect(hasClosoutViolation(r)).toBe(true);
+  });
+
+  it("flags `localStorage['user']` (direct, computed)", async () => {
+    const r = await lintSnippet(`const u = localStorage['user'];`);
+    expect(hasClosoutViolation(r)).toBe(true);
+  });
+
+  it('flags `window.localStorage.token` (window-qualified, static)', async () => {
+    const r = await lintSnippet('const t = window.localStorage.token;');
+    expect(hasClosoutViolation(r)).toBe(true);
+  });
+
+  it("flags `window.localStorage['token']` (window-qualified, computed)", async () => {
+    const r = await lintSnippet(`const t = window.localStorage['token'];`);
+    expect(hasClosoutViolation(r)).toBe(true);
+  });
+
+  it('flags `globalThis.localStorage.user` (globalThis-qualified, static)', async () => {
+    const r = await lintSnippet('const u = globalThis.localStorage.user;');
+    expect(hasClosoutViolation(r)).toBe(true);
+  });
+
+  it("flags `globalThis.localStorage['user']` (globalThis-qualified, computed)", async () => {
+    const r = await lintSnippet(`const u = globalThis.localStorage['user'];`);
+    expect(hasClosoutViolation(r)).toBe(true);
+  });
+
+  it('does NOT flag non-token/user keys (e.g. `localStorage.banner_acknowledged`)', async () => {
+    const r = await lintSnippet('const b = localStorage.banner_acknowledged;');
+    expect(hasClosoutViolation(r)).toBe(false);
+  });
+
+  it('does NOT flag non-localStorage receivers (e.g. `sessionStorage.token`)', async () => {
+    const r = await lintSnippet('const t = sessionStorage.token;');
+    expect(hasClosoutViolation(r)).toBe(false);
+  });
+});
+
+describe('closeout §8.1 guardrail — CallExpression selectors', () => {
+  it("flags `localStorage.getItem('token')`", async () => {
+    const r = await lintSnippet(`const t = localStorage.getItem('token');`);
+    expect(hasClosoutViolation(r)).toBe(true);
+  });
+
+  it("flags `localStorage.setItem('user', '…')`", async () => {
+    const r = await lintSnippet(`localStorage.setItem('user', '{}');`);
+    expect(hasClosoutViolation(r)).toBe(true);
+  });
+
+  it("flags `localStorage.removeItem('token')`", async () => {
+    const r = await lintSnippet(`localStorage.removeItem('token');`);
+    expect(hasClosoutViolation(r)).toBe(true);
+  });
+
+  it("flags `window.localStorage.getItem('token')`", async () => {
+    const r = await lintSnippet(
+      `const t = window.localStorage.getItem('token');`,
+    );
+    expect(hasClosoutViolation(r)).toBe(true);
+  });
+
+  it("flags `window.localStorage.setItem('user', …)`", async () => {
+    const r = await lintSnippet(`window.localStorage.setItem('user', '{}');`);
+    expect(hasClosoutViolation(r)).toBe(true);
+  });
+
+  it("flags `globalThis.localStorage.getItem('user')`", async () => {
+    const r = await lintSnippet(
+      `const u = globalThis.localStorage.getItem('user');`,
+    );
+    expect(hasClosoutViolation(r)).toBe(true);
+  });
+
+  it("flags `globalThis.localStorage.removeItem('token')`", async () => {
+    const r = await lintSnippet(`globalThis.localStorage.removeItem('token');`);
+    expect(hasClosoutViolation(r)).toBe(true);
+  });
+
+  it("does NOT flag `localStorage.getItem('banner_acknowledged')` (non-sensitive key)", async () => {
+    const r = await lintSnippet(
+      `const b = localStorage.getItem('banner_acknowledged');`,
+    );
+    expect(hasClosoutViolation(r)).toBe(false);
+  });
+
+  it('does NOT flag `sessionStorage.getItem(\'token\')`', async () => {
+    const r = await lintSnippet(`const t = sessionStorage.getItem('token');`);
+    expect(hasClosoutViolation(r)).toBe(false);
+  });
+});
+
+describe('closeout §8.1 guardrail — clean code passes', () => {
+  it('accepts `useAuth().token.value` (the approved replacement)', async () => {
+    const r = await lintSnippet(
+      `import useAuth from '@/composables/useAuth';
+       const t = useAuth().token.value;`,
+    );
+    expect(hasClosoutViolation(r)).toBe(false);
+  });
+
+  it('accepts code that does not touch localStorage at all', async () => {
+    const r = await lintSnippet('const x = 42; export { x };');
+    expect(hasClosoutViolation(r)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Tests-only PR, no source code changes. Adds regression coverage for the two F1 Copilot-review fixes from PR #276:

### 1. apiClient request interceptor (7 new cases in `client.spec.ts`)
Pins the contract of the F1 interceptor + its post-Copilot-review `hasAuthorizationHeader()` helper. Tests send real requests through `apiClient` and assert on what MSW captures — behavioural, not introspective.

- Injects Bearer when no explicit header is set
- Omits `Authorization` when no session token exists
- Preserves explicit override in **AxiosHeaders** shape
- Preserves explicit override in plain-object shape — **PascalCase** key
- Preserves explicit override in plain-object shape — **lowercase** key
- Preserves explicit override in plain-object shape — **UPPERCASE** key
- Honours explicit `Authorization` even without a session token (LoginView bootstrap — local JWT used before `useAuth().login()`)

The case-variant tests pin `hasAuthorizationHeader()` — it walks `Object.keys()` lowercasing each, so every header casing must be recognised as "already set." A regression there would break the two closeout spec §3.4 exception flows.

### 2. ESLint §8.1 guardrail selectors (21 new cases in `eslint-closeout-guard.spec.ts`)
Runs the real `app/eslint.config.js` via the ESLint Node API. Every bypass path is pinned:

**MemberExpression** (10 cases):
- `localStorage.token` / `localStorage.user` (direct, static)
- `localStorage['token']` / `localStorage['user']` (direct, computed)
- `window.localStorage.token` / `window.localStorage['token']`
- `globalThis.localStorage.user` / `globalThis.localStorage['user']`
- Negative: `localStorage.banner_acknowledged`, `sessionStorage.token`

**CallExpression** (9 cases):
- `localStorage.{getItem,setItem,removeItem}('token'|'user')`
- `window.localStorage.{getItem,setItem}('token'|'user')`
- `globalThis.localStorage.{getItem,removeItem}('token'|'user')`
- Negative: `localStorage.getItem('banner_acknowledged')`, `sessionStorage.getItem('token')`

**Clean-code** (2 cases): `useAuth().token.value` and plain TS pass without firing the rule.

A future refactor of either selector string that stops flagging any of these 20 bypass paths fails the build.

## v11.0 closeout context

This PR is a follow-up to F1 (PR #276, merged as \`d79ef8e2\`). It does **not** modify source code or the ESLint config — it only characterises the behaviour introduced by F1 plus the Copilot-review fixes. Tests pass against the real \`eslint.config.js\`, so this PR stays correct as F2a–F2e land and each worktree removes its files from the \`ignores\` list.

## Mechanical gates
- \`npm run lint\` green
- \`npm run type-check && npm run type-check:strict\` green
- \`npm run test:unit\` — 37 files, 520 passed, 3 todo (+28 vs master)

## CI note
Full \`make ci-local\` deferred to GitHub Actions per \`CLAUDE.md\` Host-Env Workaround.

## Test plan
- [ ] CI green on push
- [ ] Tests remain green after each F2a–F2e merge rebases this branch (the ESLint spec reads whatever ignores list is live on disk)