### PR TITLE
v11.0/closeout: F2e document 2 enumerated Bearer-header exceptions + specs

### DIFF
--- a/app/src/views/LoginView.spec.ts
+++ b/app/src/views/LoginView.spec.ts
@@ -71,17 +71,12 @@ import useAuth from '@/composables/useAuth';
 // mounting `@/router` would drag in the full route table, auth guards, and a
 // real history stack. Replace it with a minimal stub so the axios 401
 // interceptor can call `router.push(...)` without blowing up.
-vi.mock('@/router', () => {
-  const push = vi.fn();
-  (globalThis as unknown as { __loginRouterPushMock: ReturnType<typeof vi.fn> }).__loginRouterPushMock =
-    push;
-  return {
-    default: {
-      push,
-      currentRoute: { value: { fullPath: '/Login' } },
-    },
-  };
-});
+vi.mock('@/router', () => ({
+  default: {
+    push: vi.fn(),
+    currentRoute: { value: { fullPath: '/Login' } },
+  },
+}));
 
 // `@unhead/vue`'s `useHead()` requires a `createHead()` plugin to be
 // registered on the app. Replace it with a no-op so the LoginView `setup()`

--- a/app/src/views/LoginView.spec.ts
+++ b/app/src/views/LoginView.spec.ts
@@ -1,0 +1,367 @@
+// LoginView.spec.ts
+/**
+ * v11.0 closeout F2e — Exception E1 characterisation.
+ *
+ * The closeout spec §3.4 enumerates two flows that LEGITIMATELY construct
+ * their own `Authorization: Bearer` header instead of going through the
+ * apiClient interceptor. This file pins down the **LoginView bootstrap
+ * handshake (E1)** in executable form.
+ *
+ * Why E1 is a sanctioned exception
+ * --------------------------------
+ * Logging in is a two-step dance:
+ *   1. POST /api/auth/authenticate returns the new JWT (Plumber scalar-array).
+ *   2. GET  /api/auth/signin exchanges that JWT for the full user payload.
+ *
+ * `useAuth().login(token, user)` is an atomic operation — it must receive
+ * BOTH the token AND the user at the same call so the module-level refs,
+ * `localStorage.token`, and `localStorage.user` flip from "logged out" to
+ * "logged in" in one transition. If LoginView called `login(token, null)`
+ * first, then `login(token, user)` after step 2, any component reading the
+ * refs in the gap would observe a half-logged-in session (token present,
+ * user missing) — exactly the drift the F1 interceptor contract is designed
+ * to prevent.
+ *
+ * So LoginView.vue attaches `Authorization: Bearer ${token}` to the single
+ * /signin call via an explicit per-request header. The apiClient
+ * interceptor (post-Copilot-review) yields to any explicit per-call
+ * `Authorization`, so this works at runtime without ever touching the
+ * session state.
+ *
+ * Why this spec exists
+ * --------------------
+ * The E1 contract is subtle. A well-meaning future refactor that "cleans
+ * up" the bootstrap — for example by storing the token with
+ * `localStorage.setItem('token', ...)` before calling /signin, or by
+ * calling `useAuth().login(token, ...)` twice — would silently break it.
+ * The three cases below turn that contract into a failing red test:
+ *
+ *   1. The Bearer on /signin is the LOCAL variable, not a storage read.
+ *      Proven by a server-side handler that asserts
+ *      `localStorage.getItem('token') === null` at the moment the signin
+ *      request lands — if the bootstrap ever persisted the token to
+ *      storage before calling /signin, this resolver would throw.
+ *
+ *   2. `useAuth().login()` is called exactly once, and it receives both
+ *      the token AND the user payload atomically. Any implementation that
+ *      splits login into "set token" + "set user" fails this.
+ *
+ *   3. No localStorage writes happen before the atomic login() call.
+ *      Snapshots `localStorage.length` before, during, and after the
+ *      signin handshake; only `login()` may mutate storage.
+ *
+ * See `docs/superpowers/specs/2026-04-14-v11.0-closeout-design.md` §3.4
+ * for the full exception policy; `.plans/v11.0/closeout.md` §3 F2e for the
+ * task-level brief.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { http, HttpResponse } from 'msw';
+
+import { server } from '@/test-utils/mocks/server';
+import { signinOk, type AuthSigninResponse } from '@/test-utils/mocks/data/auth';
+import useAuth from '@/composables/useAuth';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+// `src/plugins/axios.ts` does `import router from '@/router'` at module load;
+// mounting `@/router` would drag in the full route table, auth guards, and a
+// real history stack. Replace it with a minimal stub so the axios 401
+// interceptor can call `router.push(...)` without blowing up.
+vi.mock('@/router', () => {
+  const push = vi.fn();
+  (globalThis as unknown as { __loginRouterPushMock: ReturnType<typeof vi.fn> }).__loginRouterPushMock =
+    push;
+  return {
+    default: {
+      push,
+      currentRoute: { value: { fullPath: '/Login' } },
+    },
+  };
+});
+
+// `@unhead/vue`'s `useHead()` requires a `createHead()` plugin to be
+// registered on the app. Replace it with a no-op so the LoginView `setup()`
+// hook doesn't throw when mounted standalone.
+vi.mock('@unhead/vue', () => ({
+  useHead: vi.fn(),
+}));
+
+// The view imports `useToast` and calls `makeToast` on error paths. The real
+// `useToast` pulls in bootstrap-vue-next's BApp provider; swap it for a
+// minimal stub so mount doesn't require the provider.
+vi.mock('@/composables/useToast', () => ({
+  default: () => ({ makeToast: vi.fn() }),
+}));
+
+// Import AFTER the `@/router` mock is registered so the axios plugin
+// (transitively imported via `useAuth` / `LoginView`) picks up the stub.
+import axios from '@/plugins/axios';
+import LoginView from '@/views/LoginView.vue';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const BOOTSTRAP_TOKEN = 'BOOTSTRAP_TOKEN';
+
+/**
+ * Plumber wraps the authenticate-endpoint token in a one-element array.
+ * LoginView unwraps this at `response_authenticate.data[0]`.
+ */
+const bootstrapTokenEnvelope: [string] = [BOOTSTRAP_TOKEN];
+
+/**
+ * `/api/auth/signin` returns the scalar-array user payload shape that
+ * `useAuth().login()` expects as its second argument.
+ */
+const bootstrapUser: AuthSigninResponse = {
+  ...signinOk,
+  user_role: ['Administrator'],
+};
+
+// The view reads `import.meta.env.VITE_API_URL` at call time and concatenates
+// `${VITE_API_URL}/api/auth/authenticate`. Vitest leaves this unset by
+// default, which collapses to `undefined/api/auth/authenticate` — a URL MSW
+// cannot match against the `/api/auth/*` handler patterns. Normalise to an
+// empty string so the path-only handlers match.
+const envBag = import.meta.env as unknown as Record<string, string>;
+const originalViteApiUrl = envBag.VITE_API_URL;
+
+// ---------------------------------------------------------------------------
+// Mount helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Mount LoginView with enough stubs to exercise the bootstrap methods. We
+ * drive the flow by calling `wrapper.vm.loadJWT()` / `signinWithJWT(...)`
+ * directly, skipping the vee-validate form-submit wrapper — that keeps the
+ * test focused on the E1 contract (auth handshake shape) rather than on
+ * form validation plumbing.
+ */
+const mountLoginView = (): VueWrapper => {
+  return mount(LoginView, {
+    global: {
+      mocks: {
+        // `main.ts` wires the configured axios instance onto
+        // `app.config.globalProperties.axios`. Provide the same instance —
+        // with its real 401 interceptor — so outbound calls flow through
+        // the interceptor we import above.
+        axios,
+        $router: { push: vi.fn() },
+      },
+      stubs: {
+        BContainer: { template: '<div><slot /></div>' },
+        BRow: { template: '<div><slot /></div>' },
+        BCol: { template: '<div><slot /></div>' },
+        BCard: {
+          template: '<div><slot name="header" /><slot /></div>',
+        },
+        BCardText: { template: '<div><slot /></div>' },
+        BFormGroup: { template: '<div><slot /></div>' },
+        BFormInput: {
+          props: ['modelValue', 'placeholder', 'type', 'state'],
+          template: '<input />',
+        },
+        BFormInvalidFeedback: { template: '<div><slot /></div>' },
+        BButton: { template: '<button><slot /></button>' },
+        BLink: { template: '<a><slot /></a>' },
+        BSpinner: { template: '<div role="status" />' },
+      },
+    },
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+/**
+ * Narrow view-model shape so we can call methods directly via `wrapper.vm`.
+ * LoginView uses Options API; vue-tsc can't infer the method types through
+ * `wrapper.vm`.
+ */
+interface LoginViewVm {
+  user_name: string;
+  password: string;
+  loadJWT: () => Promise<void>;
+  signinWithJWT: (token: string) => Promise<void>;
+}
+
+const vm = (wrapper: VueWrapper): LoginViewVm =>
+  wrapper.vm as unknown as LoginViewVm;
+
+describe('LoginView — closeout exception E1 (bootstrap Bearer)', () => {
+  beforeEach(() => {
+    envBag.VITE_API_URL = '';
+    // Ensure no session state leaks in from a previous test. `useAuth()` is
+    // a module-level singleton — a stale login would let the apiClient
+    // interceptor inject a Bearer we'd mistake for the bootstrap one.
+    useAuth().logout();
+  });
+
+  afterEach(() => {
+    if (originalViteApiUrl === undefined) {
+      delete envBag.VITE_API_URL;
+    } else {
+      envBag.VITE_API_URL = originalViteApiUrl;
+    }
+    useAuth().logout();
+    localStorage.clear();
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 1: /signin carries Bearer of the LOCAL variable, not a storage read.
+  // -------------------------------------------------------------------------
+
+  it('E1 bootstrap: GET /api/auth/signin carries Bearer of the local token (not localStorage)', async () => {
+    // Pre-condition: no session, no storage-backed token.
+    expect(localStorage.getItem('token')).toBeNull();
+
+    let signinAuth: string | null = null;
+    server.use(
+      http.post('/api/auth/authenticate', () =>
+        HttpResponse.json(bootstrapTokenEnvelope),
+      ),
+      http.get('/api/auth/signin', ({ request }) => {
+        // Capture the Authorization header off the wire.
+        signinAuth = request.headers.get('authorization');
+        // E1 contract: the Bearer value MUST come from the local `token`
+        // variable in `signinWithJWT(token)`, NOT from `localStorage`.
+        // Proving it directly: localStorage.token is still null at the
+        // moment the signin request lands, so the header cannot possibly
+        // have been read from storage.
+        expect(localStorage.getItem('token')).toBeNull();
+        expect(localStorage.getItem('user')).toBeNull();
+        return HttpResponse.json(bootstrapUser);
+      }),
+    );
+
+    const wrapper = mountLoginView();
+    const view = vm(wrapper);
+    view.user_name = 'testuser';
+    view.password = 'testpass';
+
+    // Drive the bootstrap directly — form submit would add vee-validate
+    // timing noise that is not part of the E1 contract.
+    await view.loadJWT();
+    await flushPromises();
+
+    // The /signin call saw the exact local-variable Bearer we expect.
+    expect(signinAuth).toBe(`Bearer ${BOOTSTRAP_TOKEN}`);
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 2: useAuth().login() called exactly once, with both token and user.
+  // -------------------------------------------------------------------------
+
+  it('E1 bootstrap: useAuth().login() called exactly once, with both token and user', async () => {
+    server.use(
+      http.post('/api/auth/authenticate', () =>
+        HttpResponse.json(bootstrapTokenEnvelope),
+      ),
+      http.get('/api/auth/signin', () => HttpResponse.json(bootstrapUser)),
+    );
+
+    const wrapper = mountLoginView();
+    const view = vm(wrapper);
+    view.user_name = 'testuser';
+    view.password = 'testpass';
+
+    // `useAuth()` returns a fresh wrapper object on each call (the module
+    // exports a function that returns a new plain object literal each
+    // invocation; only the underlying refs are singletons). LoginView calls
+    // `useAuth()` at setup and stores the wrapper on `this.auth`; spy on
+    // THAT wrapper so we intercept the exact call site.
+    const viewAuth = (wrapper.vm as unknown as { auth: ReturnType<typeof useAuth> }).auth;
+    const loginSpy = vi.spyOn(viewAuth, 'login');
+
+    await view.loadJWT();
+    await flushPromises();
+
+    // E1 contract: exactly one atomic login() call.
+    expect(loginSpy).toHaveBeenCalledTimes(1);
+
+    // First arg: the unwrapped scalar token (NOT the `[token]` envelope —
+    // LoginView.vue unwraps `response.data[0]` before calling login()).
+    const call = loginSpy.mock.calls[0];
+    expect(call[0]).toBe(BOOTSTRAP_TOKEN);
+    expect(typeof call[0]).toBe('string');
+
+    // Second arg: the full user payload from /signin. The assertion is on
+    // the SHAPE (the scalar-array convention) — if a refactor ever unwrapped
+    // the arrays or sliced the payload, router guards downstream would fail
+    // role/expiry checks. `toMatchObject` proves the critical fields survive.
+    expect(call[1]).toMatchObject({
+      user_role: ['Administrator'],
+      exp: expect.arrayContaining([expect.any(Number)]),
+    });
+
+    loginSpy.mockRestore();
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 3: No localStorage writes happen before the atomic login() call.
+  // -------------------------------------------------------------------------
+
+  it('E1 bootstrap: no localStorage writes happen before the atomic useAuth().login() call', async () => {
+    // Track ALL setItem calls across the whole flow so we can assert the
+    // timing of writes. The vitest.setup.ts localStorage mock doesn't
+    // expose `.length` or key enumeration, but `setItem` is a vi.fn() —
+    // we consult its `.mock.calls` to reconstruct write history.
+    const setItemSpy = vi.spyOn(window.localStorage, 'setItem');
+
+    // Sanity: no session keys before the flow.
+    expect(localStorage.getItem('token')).toBeNull();
+    expect(localStorage.getItem('user')).toBeNull();
+
+    let setItemCallsAtAuthenticate: number | null = null;
+    let setItemCallsAtSignin: number | null = null;
+    server.use(
+      http.post('/api/auth/authenticate', () => {
+        // Post-authenticate, pre-signin: if the bootstrap persisted the
+        // token to storage here (a plausible "simplification" a refactor
+        // might introduce), we would see a setItem call recorded.
+        setItemCallsAtAuthenticate = setItemSpy.mock.calls.length;
+        return HttpResponse.json(bootstrapTokenEnvelope);
+      }),
+      http.get('/api/auth/signin', () => {
+        // Snapshot write count at the signin boundary. `login()` has NOT
+        // yet been called (it only fires after /signin resolves), so no
+        // token/user setItem may have happened.
+        setItemCallsAtSignin = setItemSpy.mock.calls.length;
+        return HttpResponse.json(bootstrapUser);
+      }),
+    );
+
+    const wrapper = mountLoginView();
+    const view = vm(wrapper);
+    view.user_name = 'testuser';
+    view.password = 'testpass';
+
+    await view.loadJWT();
+    await flushPromises();
+
+    // Between authenticate and signin: no setItem may have happened.
+    // These are the in-resolver snapshots — they fire while the flow is
+    // mid-handshake, so they are the load-bearing timing assertion.
+    expect(setItemCallsAtAuthenticate).toBe(0);
+    expect(setItemCallsAtSignin).toBe(0);
+
+    // After the full flow: the atomic login() has now persisted BOTH keys
+    // at once (the E1 contract — the whole reason for the exception).
+    expect(localStorage.getItem('token')).toBe(BOOTSTRAP_TOKEN);
+    expect(localStorage.getItem('user')).not.toBeNull();
+    // Verify BOTH keys got written (login() calls setItem twice atomically).
+    const finalWrites = setItemSpy.mock.calls
+      .map(([key]) => key as string)
+      .filter((k) => k === 'token' || k === 'user')
+      .sort();
+    expect(finalWrites).toEqual(['token', 'user']);
+
+    setItemSpy.mockRestore();
+  });
+});

--- a/app/src/views/LoginView.vue
+++ b/app/src/views/LoginView.vue
@@ -201,7 +201,7 @@ export default {
       try {
         const response_signin = await this.axios.get(apiAuthenticateURL, {
           headers: {
-            Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${token}`, // closeout-exception-E1: bootstrap two-step handshake; useAuth.login() requires both token+user atomically (§3.4)
           },
         });
         this.auth.login(token, response_signin.data);

--- a/app/src/views/PasswordResetView.spec.ts
+++ b/app/src/views/PasswordResetView.spec.ts
@@ -33,17 +33,26 @@
  *
  *   1. The Bearer on the password-change POST is `$route.params.request_jwt`
  *      — a route-param read, never a storage read. A refactor that "caches"
- *      the JWT in localStorage.token would silently break this.
+ *      the JWT in localStorage.token would silently break this. (Case 1)
  *
  *   2. `localStorage.token` and `localStorage.user` are null throughout the
  *      flow. Password reset must NOT create a session. Any future code path
  *      that calls `useAuth().login(...)` from this view would fail this
- *      assertion.
+ *      assertion — `login()` writes both keys, so non-null after the flow
+ *      means a session was created. Case 2 is the authoritative guard
+ *      against session creation. (Case 2)
  *
- *   3. `useAuth()` itself is NEVER invoked. The composable is the session
- *      layer; a one-shot credential flow has no business touching it. Spying
- *      on `login` and asserting `not.toHaveBeenCalled()` makes this
- *      machine-checkable.
+ *   3. No `useAuth()` wrapper obtained inside this spec has its `login`
+ *      called. PasswordResetView.vue today does not import `useAuth` at
+ *      all, so Case 3 holds vacuously and is a regression guard against
+ *      anyone later wiring `useAuth` into this view. Note: because
+ *      `useAuth()` returns a fresh object literal per call (while the
+ *      underlying refs are singletons), a future view that imports and
+ *      calls `useAuth()` on its own wrapper would NOT route through this
+ *      spec's spy — Case 2's localStorage invariant is the load-bearing
+ *      check for session creation. Case 3 exists as a cheap, narrow guard
+ *      that catches "the view now holds a wrapper whose login this spec
+ *      can see" regressions, and as a readable contract assertion.
  *
  * See `docs/superpowers/specs/2026-04-14-v11.0-closeout-design.md` §3.4
  * for the full exception policy; `.plans/v11.0/closeout.md` §3 F2e for the
@@ -254,11 +263,16 @@ describe('PasswordResetView — closeout exception E2 (route-param Bearer)', () 
   // Case 3: useAuth() is never invoked from this view.
   // -------------------------------------------------------------------------
 
-  it('E2 route-param: useAuth().login is never called during the reset flow', async () => {
-    // Spy on the module-level singleton BEFORE mounting the view. If the
-    // view ever reached into `useAuth().login(...)` (the only supported
-    // way to create a session), the spy would fire. The E2 contract says
-    // this flow must NOT create a session — it's a one-shot credential.
+  it('E2 route-param: no direct login() runs against this spec\'s useAuth() wrapper', async () => {
+    // `useAuth()` returns a fresh object literal each call with `.login`
+    // pointing at the module-level function. Spying on `authInstance.login`
+    // only intercepts calls routed through this exact wrapper. Today
+    // PasswordResetView.vue does not import `useAuth` at all, so the spy
+    // holds vacuously — this test is a narrow regression guard against
+    // "the view now stashes a wrapper visible to this spec and calls
+    // login() on it." The authoritative session-creation guard is Case 2
+    // (login() writes localStorage.token + user, both of which must stay
+    // null through the flow).
     const authInstance = useAuth();
     const loginSpy = vi.spyOn(authInstance, 'login');
 

--- a/app/src/views/PasswordResetView.spec.ts
+++ b/app/src/views/PasswordResetView.spec.ts
@@ -1,0 +1,284 @@
+// PasswordResetView.spec.ts
+/**
+ * v11.0 closeout F2e — Exception E2 characterisation.
+ *
+ * The closeout spec §3.4 enumerates two flows that LEGITIMATELY construct
+ * their own `Authorization: Bearer` header instead of going through the
+ * apiClient interceptor. This file pins down the **PasswordResetView
+ * route-param JWT (E2)** in executable form.
+ *
+ * Why E2 is a sanctioned exception
+ * --------------------------------
+ * The password-reset flow is initiated by an email link of the form:
+ *
+ *     https://sysndd.example.org/PasswordReset/<reset-jwt>
+ *
+ * The `<reset-jwt>` lands in `$route.params.request_jwt`. It is a one-shot
+ * credential (not a session token) issued by the backend to authorise ONE
+ * password change and nothing else. Storing it in `localStorage.token`
+ * would be an error — it would masquerade as a session and fail every
+ * role/expiry check downstream, and it would survive after the password
+ * change, creating a ghost-session attack surface.
+ *
+ * So PasswordResetView.vue attaches `Authorization: Bearer
+ * ${this.$route.params.request_jwt}` to the single POST
+ * /api/user/password/reset/change call via an explicit per-request header.
+ * The apiClient interceptor (post-Copilot-review) yields to any explicit
+ * per-call `Authorization`, so this works at runtime without ever
+ * creating a session.
+ *
+ * Why this spec exists
+ * --------------------
+ * The E2 contract has three critical invariants:
+ *
+ *   1. The Bearer on the password-change POST is `$route.params.request_jwt`
+ *      — a route-param read, never a storage read. A refactor that "caches"
+ *      the JWT in localStorage.token would silently break this.
+ *
+ *   2. `localStorage.token` and `localStorage.user` are null throughout the
+ *      flow. Password reset must NOT create a session. Any future code path
+ *      that calls `useAuth().login(...)` from this view would fail this
+ *      assertion.
+ *
+ *   3. `useAuth()` itself is NEVER invoked. The composable is the session
+ *      layer; a one-shot credential flow has no business touching it. Spying
+ *      on `login` and asserting `not.toHaveBeenCalled()` makes this
+ *      machine-checkable.
+ *
+ * See `docs/superpowers/specs/2026-04-14-v11.0-closeout-design.md` §3.4
+ * for the full exception policy; `.plans/v11.0/closeout.md` §3 F2e for the
+ * task-level brief.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises, mount, type VueWrapper } from '@vue/test-utils';
+import { http, HttpResponse } from 'msw';
+
+import { server } from '@/test-utils/mocks/server';
+import useAuth from '@/composables/useAuth';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+// Axios plugin imports `@/router`; replace with a stub so the 401
+// interceptor's `router.push(...)` doesn't blow up if the backend returns
+// 401 on an expired reset JWT.
+vi.mock('@/router', () => {
+  const push = vi.fn();
+  (globalThis as unknown as { __resetRouterPushMock: ReturnType<typeof vi.fn> }).__resetRouterPushMock =
+    push;
+  return {
+    default: {
+      push,
+      currentRoute: { value: { fullPath: '/PasswordReset' } },
+    },
+  };
+});
+
+vi.mock('@unhead/vue', () => ({
+  useHead: vi.fn(),
+}));
+
+vi.mock('@/composables/useToast', () => ({
+  default: () => ({ makeToast: vi.fn() }),
+}));
+
+// Import AFTER the `@/router` mock so the axios plugin picks it up.
+import axios from '@/plugins/axios';
+import PasswordResetView from '@/views/PasswordResetView.vue';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ROUTE_JWT = 'ROUTE_JWT';
+
+const envBag = import.meta.env as unknown as Record<string, string>;
+const originalViteApiUrl = envBag.VITE_API_URL;
+
+// ---------------------------------------------------------------------------
+// Mount helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Mount PasswordResetView with a mocked `$route` carrying a reset JWT.
+ * We stub `$router` too so the post-change redirect doesn't navigate to
+ * a route that isn't registered in the test environment.
+ */
+const mountResetView = (routeJwt: string = ROUTE_JWT): VueWrapper => {
+  return mount(PasswordResetView, {
+    global: {
+      mocks: {
+        axios,
+        $route: {
+          params: { request_jwt: routeJwt },
+        },
+        $router: { push: vi.fn() },
+      },
+      stubs: {
+        BContainer: { template: '<div><slot /></div>' },
+        BRow: { template: '<div><slot /></div>' },
+        BCol: { template: '<div><slot /></div>' },
+        BCard: {
+          template: '<div><slot name="header" /><slot /></div>',
+        },
+        BCardText: { template: '<div><slot /></div>' },
+        BForm: { template: '<form><slot /></form>' },
+        BFormGroup: { template: '<div><slot /></div>' },
+        BFormInput: {
+          props: ['modelValue', 'placeholder', 'type', 'state'],
+          template: '<input />',
+        },
+        BFormInvalidFeedback: { template: '<div><slot /></div>' },
+        BButton: { template: '<button><slot /></button>' },
+        BSpinner: { template: '<div role="status" />' },
+      },
+    },
+  });
+};
+
+/**
+ * Narrow view-model shape so TypeScript lets us poke the Options API methods
+ * directly via `wrapper.vm`. PasswordResetView uses data-bound `v-model`
+ * fields; setting them through `wrapper.vm.newPasswordEntry = '...'` drives
+ * the reactive state without synthesising keyboard events on stubbed inputs.
+ */
+interface PasswordResetViewVm {
+  newPasswordEntry: string;
+  newPasswordRepeat: string;
+  emailEntry: string;
+  doPasswordChange: () => Promise<void>;
+  requestPasswordReset: () => Promise<void>;
+}
+
+const vm = (wrapper: VueWrapper): PasswordResetViewVm =>
+  wrapper.vm as unknown as PasswordResetViewVm;
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('PasswordResetView — closeout exception E2 (route-param Bearer)', () => {
+  beforeEach(() => {
+    envBag.VITE_API_URL = '';
+    // Ensure no prior session leaks in — the E2 contract is that
+    // localStorage is null throughout; a stale login would falsify that.
+    useAuth().logout();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    if (originalViteApiUrl === undefined) {
+      delete envBag.VITE_API_URL;
+    } else {
+      envBag.VITE_API_URL = originalViteApiUrl;
+    }
+    useAuth().logout();
+    localStorage.clear();
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 1: outbound POST carries Bearer of `$route.params.request_jwt`.
+  // -------------------------------------------------------------------------
+
+  it('E2 route-param: outbound POST carries Bearer of $route.params.request_jwt', async () => {
+    let capturedAuth: string | null = null;
+    server.use(
+      http.post('/api/user/password/reset/change', ({ request }) => {
+        capturedAuth = request.headers.get('authorization');
+        return HttpResponse.json({ status: 'ok' });
+      }),
+    );
+
+    const wrapper = mountResetView();
+    const view = vm(wrapper);
+    view.newPasswordEntry = 'newpassword123';
+    view.newPasswordRepeat = 'newpassword123';
+
+    // Drive the reset directly; form submit would pull in vee-validate
+    // timing that is not part of the E2 contract.
+    await view.doPasswordChange();
+    await flushPromises();
+
+    // E2 contract: the Bearer comes from the route param, full-stop.
+    expect(capturedAuth).toBe(`Bearer ${ROUTE_JWT}`);
+    // Doubly nail the "not session" part: the session token, if one
+    // existed, would be a completely different string; this rules out any
+    // future code path that ever sneaks a session Bearer onto this call.
+    expect(capturedAuth).not.toBe('Bearer undefined');
+    expect(capturedAuth).not.toBe('Bearer null');
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 2: localStorage.token is null throughout the flow.
+  // -------------------------------------------------------------------------
+
+  it('E2 route-param: localStorage.getItem("token") is null throughout the reset flow', async () => {
+    // Before: clean storage (beforeEach guaranteed it).
+    expect(localStorage.getItem('token')).toBeNull();
+    expect(localStorage.getItem('user')).toBeNull();
+
+    let storageDuringRequest: { token: string | null; user: string | null } | null = null;
+    server.use(
+      http.post('/api/user/password/reset/change', () => {
+        // During: neither key may materialise mid-flow. If a future code
+        // path ever called `localStorage.setItem('token', routeJwt)` to
+        // "make apiClient work", this resolver would catch it.
+        storageDuringRequest = {
+          token: localStorage.getItem('token'),
+          user: localStorage.getItem('user'),
+        };
+        return HttpResponse.json({ status: 'ok' });
+      }),
+    );
+
+    const wrapper = mountResetView();
+    const view = vm(wrapper);
+    view.newPasswordEntry = 'newpassword123';
+    view.newPasswordRepeat = 'newpassword123';
+
+    await view.doPasswordChange();
+    await flushPromises();
+
+    expect(storageDuringRequest).toEqual({ token: null, user: null });
+
+    // After: still nothing persisted. A successful password reset does
+    // NOT log the user in; they must go to /Login and authenticate
+    // normally with the new password.
+    expect(localStorage.getItem('token')).toBeNull();
+    expect(localStorage.getItem('user')).toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Case 3: useAuth() is never invoked from this view.
+  // -------------------------------------------------------------------------
+
+  it('E2 route-param: useAuth().login is never called during the reset flow', async () => {
+    // Spy on the module-level singleton BEFORE mounting the view. If the
+    // view ever reached into `useAuth().login(...)` (the only supported
+    // way to create a session), the spy would fire. The E2 contract says
+    // this flow must NOT create a session — it's a one-shot credential.
+    const authInstance = useAuth();
+    const loginSpy = vi.spyOn(authInstance, 'login');
+
+    server.use(
+      http.post('/api/user/password/reset/change', () =>
+        HttpResponse.json({ status: 'ok' }),
+      ),
+    );
+
+    const wrapper = mountResetView();
+    const view = vm(wrapper);
+    view.newPasswordEntry = 'newpassword123';
+    view.newPasswordRepeat = 'newpassword123';
+
+    await view.doPasswordChange();
+    await flushPromises();
+
+    // E2 contract: no session creation, ever.
+    expect(loginSpy).not.toHaveBeenCalled();
+
+    loginSpy.mockRestore();
+  });
+});

--- a/app/src/views/PasswordResetView.spec.ts
+++ b/app/src/views/PasswordResetView.spec.ts
@@ -73,17 +73,12 @@ import useAuth from '@/composables/useAuth';
 // Axios plugin imports `@/router`; replace with a stub so the 401
 // interceptor's `router.push(...)` doesn't blow up if the backend returns
 // 401 on an expired reset JWT.
-vi.mock('@/router', () => {
-  const push = vi.fn();
-  (globalThis as unknown as { __resetRouterPushMock: ReturnType<typeof vi.fn> }).__resetRouterPushMock =
-    push;
-  return {
-    default: {
-      push,
-      currentRoute: { value: { fullPath: '/PasswordReset' } },
-    },
-  };
-});
+vi.mock('@/router', () => ({
+  default: {
+    push: vi.fn(),
+    currentRoute: { value: { fullPath: '/PasswordReset' } },
+  },
+}));
 
 vi.mock('@unhead/vue', () => ({
   useHead: vi.fn(),

--- a/app/src/views/PasswordResetView.vue
+++ b/app/src/views/PasswordResetView.vue
@@ -229,7 +229,7 @@ export default {
           },
           {
             headers: {
-              Authorization: `Bearer ${this.$route.params.request_jwt}`,
+              Authorization: `Bearer ${this.$route.params.request_jwt}`, // closeout-exception-E2: route-param one-shot JWT from email link; not a session token (§3.4)
             },
           }
         );


### PR DESCRIPTION
## Summary
- Documents the two enumerated Bearer-header exceptions from closeout spec §3.4:
  - **E1**: LoginView bootstrap handshake (`LoginView.vue:204`) — two-step flow where `useAuth().login()` needs both token and user atomically.
  - **E2**: PasswordResetView route-param JWT (`PasswordResetView.vue:232`) — one-shot email-link credential; not a session token.
- Adds marker comments anchoring both sites to §3.4 so a future reader understands why these are legitimate exceptions to the apiClient-only rule.
- Authors `LoginView.spec.ts` (3 cases) and `PasswordResetView.spec.ts` (3 cases) PROVING neither flow reads `localStorage.token`/`localStorage.user`:
  - E1: `useAuth().login()` is called exactly once, with both token and user atomically; the signin handshake carries the local-variable Bearer, not a storage-backed one; no setItem happens before the atomic login() call.
  - E2: `useAuth().login` is NEVER invoked; localStorage.token/user are null throughout the flow.
- F1's interceptor (post-Copilot-review) yields to explicit per-call `Authorization` headers, so both exceptions work correctly at runtime without touching `localStorage` in the view.

## v11.0 closeout context
F2e of the v11.0 closeout. Parallel with F2a/F2b/F2c/F2d.

## Mechanical gates
- `npm run lint` green (including new ESLint rule applied to these files — neither view is in the ignore list)
- `npm run type-check && npm run type-check:strict` green
- `npm run test:unit` green (38 test files, 501 tests; +6 new cases from F2e)
- Marker comments present (1× each file)

## CI note
Full `make ci-local` deferred to GitHub Actions per `CLAUDE.md` Host-Env Workaround (conda R on Ubuntu Questing blocks the R side of ci-local).

## Test plan
- [ ] CI green
- [ ] Both new specs pass
- [ ] Marker comments visible in diff