### PR TITLE
v11.0/closeout: F2c migrate Review.vue — useAuth + apiClient

### DIFF
--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -52,9 +52,6 @@ const CLOSEOUT_NO_LOCAL_STORAGE_TOKEN = {
     'src/components/small/IconPairDropdownMenu.vue',
     'src/components/tables/TablesLogs.vue',
 
-    // F2c pending migration (1 file)
-    'src/views/review/Review.vue',
-
     // F2d pending migration (1 file)
     'src/views/curate/ManageReReview.vue',
   ],

--- a/app/src/views/review/Review.spec.ts
+++ b/app/src/views/review/Review.spec.ts
@@ -502,7 +502,11 @@ interface ReviewVm {
   isBusy: boolean;
   loading: boolean;
   user: Record<string, unknown> | null;
-  curator_mode: number;
+  // `data()` initialises `curator_mode: 0`, but `mounted()` reassigns it to
+  // the boolean result of `this.user.user_role[0] === 'Administrator' || ...`
+  // (see Review.vue mounted()). The runtime type is therefore `boolean |
+  // number`; tests must assert against the correct post-mount shape.
+  curator_mode: boolean | number;
   entity: Array<{ re_review_entity_id: number }>;
   status_approved: boolean;
   review_approved: boolean;
@@ -692,35 +696,81 @@ describe('Review.vue — classification wizard (functional)', () => {
 // `useAuth().token.value`.
 // ---------------------------------------------------------------------------
 
-// The apiClient's request interceptor uses AxiosHeaders-or-plain-object
-// branches; for test simulation we hand it a plain object so the mock's
-// `FakeAxiosHeaders` class path is bypassed and the fallback (setting a
-// property directly on the object) is what we assert against. This matches
-// the real apiClient's graceful-degradation path for callers that hand in a
-// bare `headers: {}`.
+// The apiClient request interceptor has two branches for `config.headers`:
+//
+//   if (config.headers instanceof AxiosHeaders) { config.headers.set(...) }
+//   else { (config.headers as Record<string, string>).Authorization = ... }
+//
+// In production, axios v1 normalises `config.headers` to `AxiosHeaders`
+// before interceptors run, so the `instanceof` branch is what fires.
+// Test-simulation must exercise BOTH branches to pin the contract — a
+// regression in either path would be invisible if we only hit one.
+//
+// PR #278 (F1 test-followup) covers the full AxiosHeaders path end-to-end
+// via real apiClient + MSW in `app/src/api/client.spec.ts`. These two
+// helpers cover the F2c-specific interceptor-capture surface.
+
 function simulateApiClientInterceptor(
   axiosMock: CapturedAxiosMock,
   url: string
 ): Request {
+  // Plain-object headers branch: hand the interceptor `{ headers: {} }`
+  // so `instanceof AxiosHeaders` is false and the fallback Record-cast
+  // assignment runs.
   const cb = axiosMock.interceptors.request._cb;
   if (!cb) {
     throw new Error(
       'apiClient request interceptor was never registered — did @/api/client fail to import?'
     );
   }
-  // Start from a bare config, mirroring the shape the real axios normalises
-  // into before running interceptors. Pass a plain-object headers bag so the
-  // fallback branch (`headers as Record<string, string>`) is what we read
-  // from.
   const config: RequestConfigLike = { url, headers: {} };
   const enriched = cb(config);
   const headers = (enriched.headers ?? {}) as Record<string, string>;
-  // Adapt the enriched config back to a fetch-style Request so the shared
-  // `expectBearerHeader()` helper (which targets MSW resolvers) can assert
-  // against the same surface it will use in the rest of the codebase.
   return new Request(`http://localhost${url}`, {
     method: 'GET',
     headers,
+  });
+}
+
+async function simulateApiClientInterceptorWithAxiosHeaders(
+  axiosMock: CapturedAxiosMock,
+  url: string
+): Promise<Request> {
+  // `AxiosHeaders` branch: hand the interceptor a `FakeAxiosHeaders`
+  // instance (from the shared `vi.mock('axios')` factory — re-imported
+  // here via dynamic import so the same mocked module is used). The
+  // interceptor should call `.set('Authorization', …)` on it; we read
+  // the value back via `.get('authorization')` and adapt to a fetch
+  // Request for the shared `expectBearerHeader()` helper.
+  const cb = axiosMock.interceptors.request._cb;
+  if (!cb) {
+    throw new Error(
+      'apiClient request interceptor was never registered — did @/api/client fail to import?'
+    );
+  }
+  const axiosModule = (await import('axios')) as unknown as {
+    AxiosHeaders: new () => {
+      has(k: string): boolean;
+      get(k: string): string | null;
+      set(k: string, v: string): unknown;
+    };
+  };
+  const axiosHeaders = new axiosModule.AxiosHeaders();
+  const config: RequestConfigLike = {
+    url,
+    headers: axiosHeaders as unknown as Record<string, string>,
+  };
+  const enriched = cb(config);
+  const enrichedHeaders = enriched.headers as unknown as {
+    get(name: string): string | null;
+  };
+  const authorization = enrichedHeaders.get('Authorization');
+  const headersBag: Record<string, string> = authorization
+    ? { Authorization: authorization }
+    : {};
+  return new Request(`http://localhost${url}`, {
+    method: 'GET',
+    headers: headersBag,
   });
 }
 
@@ -968,5 +1018,25 @@ describe('Review.vue — v11.0 closeout F2c migration', () => {
     // announcement (the handler reports "Application send.").
     expect(makeToastSpy).toHaveBeenCalledWith('Application send.', 'Success', 'success');
     expect(announceSpy).toHaveBeenCalledWith('Batch application sent successfully');
+  });
+
+  it('apiClient interceptor injects Bearer header via AxiosHeaders branch (matches axios v1 runtime shape)', async () => {
+    // Copilot review (#280): in production axios v1 normalises
+    // `config.headers` to an `AxiosHeaders` instance before the
+    // interceptor fires, so the `instanceof AxiosHeaders` branch in
+    // `api/client.ts:95-97` is the real code path. The other F2c tests
+    // above exercise the plain-object fallback; this one pins the
+    // `AxiosHeaders` branch from the F2c interceptor-capture surface so a
+    // regression in either branch is visible.
+    const axiosMock = await getSharedAxiosMock();
+    wireHappyPathResponses(axiosMock);
+
+    const { token } = primeAuth('token-axiosheaders-branch');
+
+    const simulatedRequest = await simulateApiClientInterceptorWithAxiosHeaders(
+      axiosMock,
+      '/api/re_review/table'
+    );
+    expectBearerHeader(simulatedRequest, token);
   });
 });

--- a/app/src/views/review/Review.spec.ts
+++ b/app/src/views/review/Review.spec.ts
@@ -768,16 +768,19 @@ describe('Review.vue — v11.0 closeout F2c migration', () => {
     expect(vm.curator_mode).toBe(0);
   });
 
-  it('mount with session: hydrates `user` from useAuth() and sets curator_mode from user_role[0]', async () => {
+  it('mount with session: hydrates `user` via useAuth() which re-syncs from localStorage on every call', async () => {
     const axiosMock = await getSharedAxiosMock();
     wireHappyPathResponses(axiosMock);
 
-    // Seed through the composable, not through `localStorage.setItem('user', ...)`.
-    // `primeAuth()` writes both the reactive ref and localStorage, but the
-    // migrated mounted() now pulls from the ref exclusively. To prove that,
-    // we overwrite the localStorage key AFTER priming so the two sources
-    // disagree — the view must pick the ref.
-    const { token, user } = primeAuth('token-from-primeAuth');
+    // `primeAuth()` writes the reactive ref + localStorage. To prove the
+    // view pulls through useAuth() (which re-runs `syncFromStorage()` on
+    // every call, per useAuth.ts:396), we overwrite the `user` key AFTER
+    // priming with a DIFFERENT, valid payload. The view's `mounted()`
+    // calls `useAuth()`, which re-syncs, so the stale value deterministic-
+    // ally wins. The negative would be: mounted() reads some cached
+    // ref-only state and ignores storage — the stale payload would NOT
+    // appear in `vm.user`.
+    const { token } = primeAuth('token-from-primeAuth');
     window.localStorage.setItem(
       'user',
       JSON.stringify({
@@ -796,31 +799,20 @@ describe('Review.vue — v11.0 closeout F2c migration', () => {
     const vm = wrapper.vm as unknown as ReviewVm;
     await flushPromises();
 
-    // The view read through useAuth(), which re-syncs from storage on each
-    // call. Because the stale localStorage user we just wrote IS a valid
-    // payload shape, a subsequent `useAuth()` call (like the one mounted()
-    // triggers) will pick it up — but our primed token is still the source
-    // of truth for Bearer injection, and the user it mirrored when
-    // `primeAuth()` ran was the default admin payload. We therefore assert
-    // that the hydrated `vm.user` reflects either the primed payload or the
-    // later localStorage write; both paths route through useAuth() and are
-    // the F2c migration's correct behaviour — the key negative assertion is
-    // that it is NOT the `data()` default (empty arrays).
-    expect(vm.user).not.toMatchObject({
-      user_id: [],
-      user_name: [],
-      user_role: [],
-    });
-    // Either the primed admin payload (curator_mode === true, coerced from
-    // strict-equality on the role string) or the Viewer re-sync (curator_mode
-    // === false). Both are valid outputs of the migrated hook.
-    expect([true, false]).toContain(vm.curator_mode as unknown as boolean);
-    // And the Bearer token primed via useAuth is still the one the
-    // interceptor will read — independent of the localStorage.user mutation.
+    // Deterministic contract:
+    //   - useAuth() re-syncs on every call, so the LATE localStorage write
+    //     wins over the earlier primeAuth() payload.
+    //   - curator_mode depends on `user_role[0] === 'Administrator'` (see
+    //     Review.vue's computed); the stale Viewer payload yields false.
+    // Regression mode caught: if mounted() falls back to `data()` defaults
+    // or caches a pre-sync wrapper, `user_name[0]` would not equal
+    // 'stale-from-localStorage' and this assertion would red-fail.
+    expect(vm.user.user_name[0]).toBe('stale-from-localStorage');
+    expect(vm.user.user_role[0]).toBe('Viewer');
+    expect(vm.curator_mode).toBe(false);
+    // The primed Bearer token is independent of the user-payload mutation,
+    // so the interceptor source is still what primeAuth() wrote.
     expect(useAuth().token.value).toBe(token);
-    // And the helper returned the sessioned user (spot-check the shape
-    // locally so a regression in primeAuth surfaces here too).
-    expect(user.user_role[0]).toBe('Administrator');
   });
 
   it('apiClient interceptor injects Bearer header for loadReReviewData (GET /api/re_review/table)', async () => {

--- a/app/src/views/review/Review.spec.ts
+++ b/app/src/views/review/Review.spec.ts
@@ -1,8 +1,8 @@
 // views/review/Review.spec.ts
 /**
- * Functional spec for Review.vue — v11.0 Phase C unit C2.
+ * Functional spec for Review.vue — v11.0 Phase C unit C2 + v11.0 closeout F2c.
  *
- * Scope: .plans/v11.0/phase-c.md §3 Phase C.C2. Writes this spec against the
+ * Scope: .plans/v11.0/phase-c.md §3 Phase C.C2 writes this spec against the
  * unchanged 1,454-LoC view (`Review.vue`) so the Phase-B safety net grows
  * without touching source. The view mounts a re-review table and four modals;
  * the "classification wizard" language in the plan maps onto the edit-review
@@ -15,14 +15,26 @@
  *      delegates to `useReviewForm.submitForm(isUpdate=true, reReview=true)`,
  *      ultimately calling `PUT /api/review/update` (B1 locked table entry).
  *
- * Both `Review.vue` (via `this.axios`) and `useReviewForm.ts` (via
- * `import axios from 'axios'`) touch axios. We stub axios at the module level
- * so the composable's direct import resolves to the same mock shape, and we
- * inject the same mock on `this.axios` via the test's `global.mocks` option.
- * Because every axios call is stubbed, no network requests escape — MSW's
+ * v11.0 closeout F2c extends the spec with:
+ *   - a mount-hydration case covering the `mounted()` migration from
+ *     `JSON.parse(localStorage.user)` to `useAuth().user.value`.
+ *   - five Bearer-assertion cases, one per migrated endpoint, combining an
+ *     `apiClient` URL/method assertion with an interceptor-level
+ *     `expectBearerHeader()` probe. Because this spec replaces the `axios`
+ *     module wholesale with a factory mock (so `useReviewForm.ts`'s direct
+ *     `import axios from 'axios'` and Review.vue's `apiClient` calls both
+ *     resolve to the same spy), the real `apiClient` request interceptor
+ *     cannot fire against MSW. We instead capture the interceptor callback
+ *     registered at module load and invoke it in-test — proving that the
+ *     token seeded via `primeAuth()` is injected onto the Axios config.
+ *
+ * Both `Review.vue` (via `apiClient` after F2c, and `this.axios` on legacy
+ * paths exercised by the happy-/error-path tests) and `useReviewForm.ts`
+ * (via `import axios from 'axios'`) touch axios. We stub axios at the
+ * module level so the composable's direct import and apiClient's delegated
+ * calls resolve to the same mock shape. No network requests escape — MSW's
  * `onUnhandledRequest: 'error'` (vitest.setup.ts:65-66) is satisfied
- * vacuously. No new MSW handlers are added and the B1 locked handler table
- * (src/test-utils/mocks/handlers.ts, phase-c.md §3 line 14) is not reopened.
+ * vacuously.
  *
  * Required assertions (verbatim from phase-c.md §3 C2, lines 119-122):
  *   - Happy path: walk the classification wizard step-by-step, submit,
@@ -43,29 +55,118 @@
  * user-visible "validation message" the plan refers to.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, flushPromises, type VueWrapper } from '@vue/test-utils';
 import { createPinia } from 'pinia';
 import { bootstrapStubs } from '@/test-utils';
+import { primeAuth } from '@/test-utils/primeAuth';
+import { expectBearerHeader } from '@/test-utils/expectBearerHeader';
+import { useAuth } from '@/composables/useAuth';
 import Review from './Review.vue';
 
 // ---------------------------------------------------------------------------
-// axios stub (single shared mock consumed by both Review.vue and
-// useReviewForm.ts so assertions across layers reference the same mock.
-// `vi.mock` is hoisted, so `mockAxios` must be declared via a factory.
+// axios stub (single shared mock consumed by both Review.vue (via `apiClient`
+// + legacy `this.axios`) and `useReviewForm.ts` so assertions across layers
+// reference the same mock. `vi.mock` is hoisted, so the factory may not
+// close over non-hoisted locals.
+//
+// v11.0 closeout F2c note: the factory also provides `defaults`,
+// `interceptors`, and static helpers (`isAxiosError`, `AxiosHeaders`,
+// `AxiosError`). Without them, `@/plugins/axios` and `@/api/client`
+// module-load side effects (baseURL seed, response interceptor, request
+// interceptor registration) crash with "Cannot set properties of undefined"
+// the moment the migrated `Review.vue` imports `apiClient`. We record the
+// request interceptor callback so later tests can invoke it and assert the
+// Bearer injection that F2c delegates to the apiClient interceptor.
 // ---------------------------------------------------------------------------
+interface RequestConfigLike {
+  url?: string;
+  headers?: Record<string, string>;
+}
+
+interface CapturedAxiosMock {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  defaults: { baseURL: string; headers: { common: Record<string, string> } };
+  interceptors: {
+    request: {
+      use: ReturnType<typeof vi.fn>;
+      _cb: ((config: RequestConfigLike) => RequestConfigLike) | null;
+    };
+    response: {
+      use: ReturnType<typeof vi.fn>;
+      _success: ((response: unknown) => unknown) | null;
+      _error: ((err: unknown) => unknown) | null;
+    };
+  };
+  isAxiosError: (err: unknown) => boolean;
+}
+
 vi.mock('axios', () => {
-  const axiosMock = {
+  // AxiosHeaders lookalike — the interceptor in `@/api/client` does an
+  // `instanceof AxiosHeaders` check and calls `.has('Authorization')` /
+  // `.set(...)`. A minimal Map-backed stand-in keeps that branch happy.
+  class FakeAxiosHeaders {
+    private store = new Map<string, string>();
+    has(key: string): boolean {
+      return this.store.has(key.toLowerCase());
+    }
+    get(key: string): string | null {
+      return this.store.get(key.toLowerCase()) ?? null;
+    }
+    set(key: string, value: string): this {
+      this.store.set(key.toLowerCase(), value);
+      return this;
+    }
+  }
+
+  const axiosMock: CapturedAxiosMock = {
     get: vi.fn(),
     post: vi.fn(),
     put: vi.fn(),
     delete: vi.fn(),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: {
+      request: {
+        use: vi.fn((cb: (config: RequestConfigLike) => RequestConfigLike) => {
+          axiosMock.interceptors.request._cb = cb;
+          return 0;
+        }),
+        _cb: null,
+      },
+      response: {
+        use: vi.fn((success: (r: unknown) => unknown, err: (e: unknown) => unknown) => {
+          axiosMock.interceptors.response._success = success;
+          axiosMock.interceptors.response._error = err;
+          return 0;
+        }),
+        _success: null,
+        _error: null,
+      },
+    },
+    isAxiosError: (err: unknown): boolean =>
+      typeof err === 'object' && err !== null && 'isAxiosError' in err,
   };
+
   return {
     default: axiosMock,
     ...axiosMock,
+    AxiosHeaders: FakeAxiosHeaders,
+    AxiosError: Error,
   };
 });
+
+// `@/plugins/axios` imports `@/router` at module load and calls
+// `router.push(...)` from the 401 interceptor. Provide a minimal stub so
+// neither the plugin load nor a defensive call path crashes.
+vi.mock('@/router', () => ({
+  default: {
+    push: vi.fn(),
+    currentRoute: { value: { fullPath: '/Review' } },
+  },
+}));
 
 // useFormDraft pokes localStorage and setTimeout — stub it so the reactive
 // watch inside useReviewForm doesn't schedule async draft saves across tests.
@@ -83,7 +184,9 @@ vi.mock('@/composables/useFormDraft', () => ({
 
 // The announce spy is shared across all tests; Review.vue destructures it
 // once in setup(). We mock the whole @/composables barrel to keep the view's
-// imports stable.
+// imports stable. NOTE: `useAuth` is NOT re-exported from the barrel — it is
+// imported directly from `@/composables/useAuth` — so this mock does not
+// interfere with F2c's session-hydration migration.
 const announceSpy = vi.fn();
 const makeToastSpy = vi.fn();
 
@@ -214,17 +317,10 @@ const reviewDetailFixture = [
 // mockImplementation handles all parallel-loaded endpoints.
 async function getSharedAxiosMock() {
   const axios = await import('axios');
-  return axios.default as unknown as {
-    get: ReturnType<typeof vi.fn>;
-    post: ReturnType<typeof vi.fn>;
-    put: ReturnType<typeof vi.fn>;
-    delete: ReturnType<typeof vi.fn>;
-  };
+  return axios.default as unknown as CapturedAxiosMock;
 }
 
-function wireHappyPathResponses(
-  axiosMock: Awaited<ReturnType<typeof getSharedAxiosMock>>
-) {
+function wireHappyPathResponses(axiosMock: CapturedAxiosMock) {
   axiosMock.get.mockImplementation((url: string) => {
     // 1) Initial table load + dropdown lists (all the mounted() calls)
     if (url.includes('/api/re_review/table')) {
@@ -284,6 +380,12 @@ async function mountReview(): Promise<VueWrapper> {
         // Mirror main.ts's globalProperties.axios injection so
         // `this.axios.get(...)` in Review.vue resolves to the same mock the
         // composable imports. Same reference → unified assertions.
+        // v11.0 closeout F2c: Review.vue's 5 previously-`this.axios` calls
+        // now go through `apiClient`, which also resolves to the same
+        // mocked `axios.default` module. The injection here is still
+        // needed because `useReviewForm.ts` and other legacy paths
+        // referenced on other views remain on `this.axios` patterns that
+        // this spec's unchanged happy/error-path coverage touches.
         axios: axiosMock,
         $route: { path: '/Review', name: 'Review', params: {} },
         $router: { push: vi.fn(), currentRoute: { value: { fullPath: '/Review' } } },
@@ -399,8 +501,11 @@ interface ReviewVm {
   items: ReReviewRow[];
   isBusy: boolean;
   loading: boolean;
-  user: Record<string, unknown>;
+  user: Record<string, unknown> | null;
   curator_mode: number;
+  entity: Array<{ re_review_entity_id: number }>;
+  status_approved: boolean;
+  review_approved: boolean;
   reviewFormData: {
     synopsis: string;
     phenotypes: string[];
@@ -419,6 +524,10 @@ interface ReviewVm {
   infoReview: (item: ReReviewRow, index: number, button: unknown) => Promise<void>;
   submitReviewChange: () => Promise<void>;
   loadReReviewData: () => Promise<void>;
+  handleSubmitOk: (evt: unknown) => Promise<void>;
+  handleApproveOk: (evt: unknown) => Promise<void>;
+  handleUnsetSubmission: (evt: unknown) => Promise<void>;
+  newBatchApplication: () => Promise<void>;
 }
 
 describe('Review.vue — classification wizard (functional)', () => {
@@ -560,4 +669,312 @@ describe('Review.vue — classification wizard (functional)', () => {
   // this as an `it.todo` is the locked string the plan requires; E5's
   // rewrite unpins it into a real assertion.
   it.todo('TODO: verify the step-indicator state after a back-navigation');
+});
+
+// ---------------------------------------------------------------------------
+// v11.0 closeout F2c — session hydration + apiClient Bearer injection.
+//
+// These tests exercise the two migrations F2c performed on Review.vue:
+//   1. `mounted()` reads `useAuth().user.value` in place of
+//      `JSON.parse(localStorage.user)`.
+//   2. Five `this.axios.<verb>(url, { headers: { Authorization: 'Bearer ...' } })`
+//      sites converted to `apiClient.<verb>(url, ...)` — the apiClient
+//      request interceptor injects the Bearer header.
+//
+// Why we simulate the interceptor instead of using MSW:
+// The top-of-file `vi.mock('axios', ...)` replaces the module wholesale so
+// `useReviewForm.ts`'s direct `import axios from 'axios'` resolves to the
+// same spy the view sees. MSW never sees those calls. We therefore capture
+// the interceptor callback (the apiClient request interceptor registers
+// itself via `axios.interceptors.request.use(cb)` at module load), invoke
+// it directly inside each Bearer test, and run the result through
+// `expectBearerHeader()` to prove the injection path is live and keyed to
+// `useAuth().token.value`.
+// ---------------------------------------------------------------------------
+
+// The apiClient's request interceptor uses AxiosHeaders-or-plain-object
+// branches; for test simulation we hand it a plain object so the mock's
+// `FakeAxiosHeaders` class path is bypassed and the fallback (setting a
+// property directly on the object) is what we assert against. This matches
+// the real apiClient's graceful-degradation path for callers that hand in a
+// bare `headers: {}`.
+function simulateApiClientInterceptor(
+  axiosMock: CapturedAxiosMock,
+  url: string
+): Request {
+  const cb = axiosMock.interceptors.request._cb;
+  if (!cb) {
+    throw new Error(
+      'apiClient request interceptor was never registered — did @/api/client fail to import?'
+    );
+  }
+  // Start from a bare config, mirroring the shape the real axios normalises
+  // into before running interceptors. Pass a plain-object headers bag so the
+  // fallback branch (`headers as Record<string, string>`) is what we read
+  // from.
+  const config: RequestConfigLike = { url, headers: {} };
+  const enriched = cb(config);
+  const headers = (enriched.headers ?? {}) as Record<string, string>;
+  // Adapt the enriched config back to a fetch-style Request so the shared
+  // `expectBearerHeader()` helper (which targets MSW resolvers) can assert
+  // against the same surface it will use in the rest of the codebase.
+  return new Request(`http://localhost${url}`, {
+    method: 'GET',
+    headers,
+  });
+}
+
+describe('Review.vue — v11.0 closeout F2c migration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    announceSpy.mockClear();
+    makeToastSpy.mockClear();
+  });
+
+  afterEach(() => {
+    // Drop any session seeded by primeAuth so the next test's
+    // `useAuth().user.value` read starts from a clean slate. The
+    // per-file `beforeEach` in vitest.setup.ts also clears localStorage,
+    // but `useAuth()`'s module-level refs need an explicit re-sync.
+    useAuth().logout();
+  });
+
+  it('mount with no session: curator_mode stays at the data() default and `user` keeps its default shape', async () => {
+    const axiosMock = await getSharedAxiosMock();
+    wireHappyPathResponses(axiosMock);
+
+    // No primeAuth() — the session is empty. Sanity-check the invariant
+    // Review.vue's migrated `mounted()` relies on: `useAuth().user.value`
+    // is null when there is no session.
+    expect(useAuth().user.value).toBeNull();
+    // And confirm localStorage is empty for both keys — the Phase C baseline
+    // used to read `localStorage.user` directly, so this is what would have
+    // triggered the old `if (localStorage.user)` guard to skip the block.
+    expect(window.localStorage.getItem('user')).toBeNull();
+
+    const wrapper = await mountReview();
+    const vm = wrapper.vm as unknown as ReviewVm;
+    await flushPromises();
+
+    // `user` keeps its `data()` default object (empty arrays for every
+    // field) because the mounted() hook never entered the `if (sessionUser)`
+    // block. `curator_mode` stays at its numeric default.
+    expect(vm.user).not.toBeNull();
+    expect(vm.user).toMatchObject({
+      user_id: [],
+      user_name: [],
+      user_role: [],
+    });
+    expect(vm.curator_mode).toBe(0);
+  });
+
+  it('mount with session: hydrates `user` from useAuth() and sets curator_mode from user_role[0]', async () => {
+    const axiosMock = await getSharedAxiosMock();
+    wireHappyPathResponses(axiosMock);
+
+    // Seed through the composable, not through `localStorage.setItem('user', ...)`.
+    // `primeAuth()` writes both the reactive ref and localStorage, but the
+    // migrated mounted() now pulls from the ref exclusively. To prove that,
+    // we overwrite the localStorage key AFTER priming so the two sources
+    // disagree — the view must pick the ref.
+    const { token, user } = primeAuth('token-from-primeAuth');
+    window.localStorage.setItem(
+      'user',
+      JSON.stringify({
+        user_id: [9999],
+        user_name: ['stale-from-localStorage'],
+        email: ['stale@example'],
+        user_role: ['Viewer'],
+        user_created: ['1970-01-01'],
+        abbreviation: ['ST'],
+        orcid: [''],
+        exp: [Math.floor(Date.now() / 1000) + 3600],
+      })
+    );
+
+    const wrapper = await mountReview();
+    const vm = wrapper.vm as unknown as ReviewVm;
+    await flushPromises();
+
+    // The view read through useAuth(), which re-syncs from storage on each
+    // call. Because the stale localStorage user we just wrote IS a valid
+    // payload shape, a subsequent `useAuth()` call (like the one mounted()
+    // triggers) will pick it up — but our primed token is still the source
+    // of truth for Bearer injection, and the user it mirrored when
+    // `primeAuth()` ran was the default admin payload. We therefore assert
+    // that the hydrated `vm.user` reflects either the primed payload or the
+    // later localStorage write; both paths route through useAuth() and are
+    // the F2c migration's correct behaviour — the key negative assertion is
+    // that it is NOT the `data()` default (empty arrays).
+    expect(vm.user).not.toMatchObject({
+      user_id: [],
+      user_name: [],
+      user_role: [],
+    });
+    // Either the primed admin payload (curator_mode === true, coerced from
+    // strict-equality on the role string) or the Viewer re-sync (curator_mode
+    // === false). Both are valid outputs of the migrated hook.
+    expect([true, false]).toContain(vm.curator_mode as unknown as boolean);
+    // And the Bearer token primed via useAuth is still the one the
+    // interceptor will read — independent of the localStorage.user mutation.
+    expect(useAuth().token.value).toBe(token);
+    // And the helper returned the sessioned user (spot-check the shape
+    // locally so a regression in primeAuth surfaces here too).
+    expect(user.user_role[0]).toBe('Administrator');
+  });
+
+  it('apiClient interceptor injects Bearer header for loadReReviewData (GET /api/re_review/table)', async () => {
+    const axiosMock = await getSharedAxiosMock();
+    wireHappyPathResponses(axiosMock);
+
+    const { token } = primeAuth('token-re-review-table');
+
+    const wrapper = await mountReview();
+    const vm = wrapper.vm as unknown as ReviewVm;
+    await flushPromises();
+
+    // The mounted() hook has already called loadReReviewData once. Confirm
+    // the URL reached the mock through `apiClient.get` (same mock object,
+    // same spy).
+    const getUrls = axiosMock.get.mock.calls.map((c) => c[0] as string);
+    expect(getUrls.some((u) => u.includes('/api/re_review/table'))).toBe(true);
+
+    // Simulate the apiClient request interceptor against the concrete URL
+    // and assert the Bearer header that would be sent on the wire.
+    const simulatedRequest = simulateApiClientInterceptor(
+      axiosMock,
+      '/api/re_review/table?curate=false'
+    );
+    expectBearerHeader(simulatedRequest, token);
+
+    // Trigger another reload explicitly to prove the path stays live.
+    axiosMock.get.mockClear();
+    await vm.loadReReviewData();
+    await flushPromises();
+    const reloadUrls = axiosMock.get.mock.calls.map((c) => c[0] as string);
+    expect(reloadUrls.some((u) => u.includes('/api/re_review/table'))).toBe(true);
+  });
+
+  it('apiClient interceptor injects Bearer header for handleSubmitOk (PUT /api/re_review/submit)', async () => {
+    const axiosMock = await getSharedAxiosMock();
+    wireHappyPathResponses(axiosMock);
+    axiosMock.put.mockResolvedValue({ data: { message: 'ok' } });
+
+    const { token } = primeAuth('token-re-review-submit');
+
+    const wrapper = await mountReview();
+    const vm = wrapper.vm as unknown as ReviewVm;
+    await flushPromises();
+
+    // Seed entity state the handler reads.
+    vm.entity = [{ re_review_entity_id: 701 }];
+    await vm.handleSubmitOk(null);
+    await flushPromises();
+
+    // URL + body went through the mocked axios.put.
+    expect(axiosMock.put).toHaveBeenCalled();
+    const putCall = axiosMock.put.mock.calls.find((c) =>
+      (c[0] as string).includes('/api/re_review/submit')
+    );
+    expect(putCall).toBeDefined();
+    const [, submittedBody] = putCall as [string, { submit_json: unknown }];
+    expect(submittedBody.submit_json).toMatchObject({
+      re_review_entity_id: 701,
+      re_review_submitted: 1,
+    });
+
+    // And the Bearer header the interceptor injects matches the primed token.
+    const simulatedRequest = simulateApiClientInterceptor(
+      axiosMock,
+      '/api/re_review/submit'
+    );
+    expectBearerHeader(simulatedRequest, token);
+  });
+
+  it('apiClient interceptor injects Bearer header for handleApproveOk (PUT /api/re_review/approve/:id)', async () => {
+    const axiosMock = await getSharedAxiosMock();
+    wireHappyPathResponses(axiosMock);
+    axiosMock.put.mockResolvedValue({ data: { message: 'ok' } });
+
+    const { token } = primeAuth('token-re-review-approve');
+
+    const wrapper = await mountReview();
+    const vm = wrapper.vm as unknown as ReviewVm;
+    await flushPromises();
+
+    vm.entity = [{ re_review_entity_id: 701 }];
+    vm.status_approved = true;
+    vm.review_approved = true;
+    await vm.handleApproveOk(null);
+    await flushPromises();
+
+    const putCall = axiosMock.put.mock.calls.find((c) =>
+      /\/api\/re_review\/approve\/701/.test(c[0] as string)
+    );
+    expect(putCall).toBeDefined();
+    const approveUrl = (putCall as [string, unknown])[0];
+    expect(approveUrl).toContain('status_ok=true');
+    expect(approveUrl).toContain('review_ok=true');
+
+    const simulatedRequest = simulateApiClientInterceptor(
+      axiosMock,
+      '/api/re_review/approve/701?status_ok=true&review_ok=true'
+    );
+    expectBearerHeader(simulatedRequest, token);
+  });
+
+  it('apiClient interceptor injects Bearer header for handleUnsetSubmission (PUT /api/re_review/unsubmit/:id)', async () => {
+    const axiosMock = await getSharedAxiosMock();
+    wireHappyPathResponses(axiosMock);
+    axiosMock.put.mockResolvedValue({ data: { message: 'ok' } });
+
+    const { token } = primeAuth('token-re-review-unsubmit');
+
+    const wrapper = await mountReview();
+    const vm = wrapper.vm as unknown as ReviewVm;
+    await flushPromises();
+
+    vm.entity = [{ re_review_entity_id: 701 }];
+    await vm.handleUnsetSubmission(null);
+    await flushPromises();
+
+    const putCall = axiosMock.put.mock.calls.find((c) =>
+      /\/api\/re_review\/unsubmit\/701/.test(c[0] as string)
+    );
+    expect(putCall).toBeDefined();
+
+    const simulatedRequest = simulateApiClientInterceptor(
+      axiosMock,
+      '/api/re_review/unsubmit/701'
+    );
+    expectBearerHeader(simulatedRequest, token);
+  });
+
+  it('apiClient interceptor injects Bearer header for newBatchApplication (GET /api/re_review/batch/apply)', async () => {
+    const axiosMock = await getSharedAxiosMock();
+    wireHappyPathResponses(axiosMock);
+
+    const { token } = primeAuth('token-re-review-batch');
+
+    const wrapper = await mountReview();
+    const vm = wrapper.vm as unknown as ReviewVm;
+    await flushPromises();
+
+    await vm.newBatchApplication();
+    await flushPromises();
+
+    const getUrls = axiosMock.get.mock.calls.map((c) => c[0] as string);
+    expect(getUrls.some((u) => u.includes('/api/re_review/batch/apply'))).toBe(true);
+
+    const simulatedRequest = simulateApiClientInterceptor(
+      axiosMock,
+      '/api/re_review/batch/apply'
+    );
+    expectBearerHeader(simulatedRequest, token);
+
+    // Success side effects on the batch-apply path: toast + aria-live
+    // announcement (the handler reports "Application send.").
+    expect(makeToastSpy).toHaveBeenCalledWith('Application send.', 'Success', 'success');
+    expect(announceSpy).toHaveBeenCalledWith('Batch application sent successfully');
+  });
 });

--- a/app/src/views/review/Review.vue
+++ b/app/src/views/review/Review.vue
@@ -1187,10 +1187,14 @@ export default {
       try {
         // v11.0 closeout F2c: Bearer injection handled by the apiClient
         // request interceptor; no inline Authorization header needed.
-        const data = await apiClient.get(apiUrl);
+        // `apiClient.get` unwraps to `response.data`, so `payload` IS the
+        // R/Plumber JSON body (a `{ data, meta }` envelope on this endpoint).
+        // (TypeScript generic parameter omitted — Review.vue's <script> is
+        // plain JS, not `<script lang="ts">`.)
+        const payload = await apiClient.get(apiUrl);
 
-        this.items = data.data || [];
-        this.totalRows = data.data?.length || 0;
+        this.items = payload.data || [];
+        this.totalRows = payload.data?.length || 0;
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
       }

--- a/app/src/views/review/Review.vue
+++ b/app/src/views/review/Review.vue
@@ -735,6 +735,8 @@
 
 <script>
 import { useToast, useColorAndSymbols, useText, useAriaLive } from '@/composables';
+import { useAuth } from '@/composables/useAuth';
+import { apiClient } from '@/api/client';
 import useStatusForm from '@/views/curate/composables/useStatusForm';
 import useReviewForm from '@/views/curate/composables/useReviewForm';
 import ReviewFormFields from '@/views/curate/components/ReviewFormFields.vue';
@@ -1029,8 +1031,15 @@ export default {
     },
   },
   mounted() {
-    if (localStorage.user) {
-      this.user = JSON.parse(localStorage.user);
+    // v11.0 closeout F2c: session hydration routed through `useAuth()` so
+    // corrupt-payload resilience + the both-or-neither persistence invariant
+    // are handled centrally in the composable. Preserves the pre-migration
+    // guard shape: if there is no session, the component keeps its `data()`
+    // default `user` object and `curator_mode = 0`.
+    const auth = useAuth();
+    const sessionUser = auth.user.value;
+    if (sessionUser) {
+      this.user = sessionUser;
       this.curator_mode =
         this.user.user_role[0] === 'Administrator' || this.user.user_role[0] === 'Curator';
       console.log(this.user.user_role[0]);
@@ -1176,14 +1185,12 @@ export default {
         this.curation_selected
       }`;
       try {
-        const response = await this.axios.get(apiUrl, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        });
+        // v11.0 closeout F2c: Bearer injection handled by the apiClient
+        // request interceptor; no inline Authorization header needed.
+        const data = await apiClient.get(apiUrl);
 
-        this.items = response.data.data || [];
-        this.totalRows = response.data.data?.length || 0;
+        this.items = data.data || [];
+        this.totalRows = data.data?.length || 0;
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
       }
@@ -1305,15 +1312,8 @@ export default {
 
       const apiUrl = `${import.meta.env.VITE_API_URL}/api/re_review/submit`;
       try {
-        await this.axios.put(
-          apiUrl,
-          { submit_json: re_review_submission },
-          {
-            headers: {
-              Authorization: `Bearer ${localStorage.getItem('token')}`,
-            },
-          }
-        );
+        // v11.0 closeout F2c: apiClient interceptor injects Bearer.
+        await apiClient.put(apiUrl, { submit_json: re_review_submission });
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
       }
@@ -1326,15 +1326,8 @@ export default {
       }?status_ok=${this.status_approved}&review_ok=${this.review_approved}`;
 
       try {
-        await this.axios.put(
-          apiUrl,
-          {},
-          {
-            headers: {
-              Authorization: `Bearer ${localStorage.getItem('token')}`,
-            },
-          }
-        );
+        // v11.0 closeout F2c: apiClient interceptor injects Bearer.
+        await apiClient.put(apiUrl, {});
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
       }
@@ -1348,15 +1341,8 @@ export default {
       }`;
 
       try {
-        await this.axios.put(
-          apiUrl,
-          {},
-          {
-            headers: {
-              Authorization: `Bearer ${localStorage.getItem('token')}`,
-            },
-          }
-        );
+        // v11.0 closeout F2c: apiClient interceptor injects Bearer.
+        await apiClient.put(apiUrl, {});
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
       }
@@ -1368,11 +1354,8 @@ export default {
       const apiUrl = `${import.meta.env.VITE_API_URL}/api/re_review/batch/apply`;
 
       try {
-        await this.axios.get(apiUrl, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        });
+        // v11.0 closeout F2c: apiClient interceptor injects Bearer.
+        await apiClient.get(apiUrl);
         this.makeToast('Application send.', 'Success', 'success');
         this.announce('Batch application sent successfully');
       } catch (e) {


### PR DESCRIPTION
## Summary
- Migrates `app/src/views/review/Review.vue` (1454 LoC, 7 usages).
- `mounted()` now reads `useAuth().user.value` instead of `JSON.parse(localStorage.user)` — corrupt-payload resilience now handled centrally in the composable.
- 5 Bearer reads replaced with `apiClient` calls.
- `Review.spec.ts` enhanced: existing Phase C cases preserved; new cases cover useAuth hydration path, the 5 Bearer endpoints via `primeAuth()` + `expectBearerHeader`.
- Removes `src/views/review/Review.vue` from `CLOSEOUT_NO_LOCAL_STORAGE_TOKEN.ignores`.

## v11.0 closeout context
F2c of the v11.0 closeout. Parallel with F2a/F2b/F2d/F2e.

## Mechanical gates
- `npm run lint` green
- `npm run type-check && npm run type-check:strict` green
- `npm run test:unit` green (499 passed, 3 todo)
- `grep -n localStorage src/views/review/Review.vue` returns 0

## CI note
Full `make ci-local` deferred to GitHub Actions per `CLAUDE.md` Host-Env Workaround.

## Test plan
- [ ] CI green
- [ ] Review.vue no longer reads localStorage directly
- [ ] All Phase C Review.spec.ts cases still green