### PR TITLE
v11.0/closeout: F2b tier-2 migration (9 files, 34 usages)

### DIFF
--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -41,8 +41,8 @@ const CLOSEOUT_NO_LOCAL_STORAGE_TOKEN = {
     'src/components/llm/LlmLogViewer.vue',
     'src/composables/useLlmAdmin.ts',
 
-    // F2b migrations landed in PR #277 — the 9 files now route through
-    // `useAuth()` / `apiClient` and no longer need the ignore entries.
+    // F2b migrations landed — the 9 files now route through `useAuth()`
+    // / `apiClient` and no longer need the ignore entries.
 
     // F2c pending migration (1 file)
     'src/views/review/Review.vue',

--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -41,16 +41,8 @@ const CLOSEOUT_NO_LOCAL_STORAGE_TOKEN = {
     'src/components/llm/LlmLogViewer.vue',
     'src/composables/useLlmAdmin.ts',
 
-    // F2b pending migrations (9 files)
-    'src/views/RegisterView.vue',
-    'src/views/admin/ManageOntology.vue',
-    'src/views/admin/ManageUser.vue',
-    'src/views/admin/ManageBackups.vue',
-    'src/views/curate/ApproveUser.vue',
-    'src/views/curate/ModifyEntity.vue',
-    'src/composables/useBatchForm.ts',
-    'src/components/small/IconPairDropdownMenu.vue',
-    'src/components/tables/TablesLogs.vue',
+    // F2b migrations landed in PR #277 — the 9 files now route through
+    // `useAuth()` / `apiClient` and no longer need the ignore entries.
 
     // F2c pending migration (1 file)
     'src/views/review/Review.vue',

--- a/app/src/components/small/IconPairDropdownMenu.spec.ts
+++ b/app/src/components/small/IconPairDropdownMenu.spec.ts
@@ -1,0 +1,178 @@
+// IconPairDropdownMenu.spec.ts
+/**
+ * v11.0 closeout F2b — spec covering the three migrated auth branches on
+ * `IconPairDropdownMenu.vue`:
+ *
+ *   1. `doUserLogOut` routes through `useAuth().logout()` and does NOT
+ *      touch `localStorage.removeItem('token' | 'user')` directly.
+ *   2. `refreshWithJWT` issues `GET /api/auth/refresh` with the current
+ *      session Bearer and persists the returned token through `useAuth`.
+ *   3. `signinWithJWT` issues `GET /api/auth/signin` with the Bearer
+ *      header (injected by the apiClient request interceptor) and
+ *      updates `useAuth().user` via `login(currentToken, user)`.
+ *
+ * The pre-F2b implementation read/wrote `localStorage.token` /
+ * `localStorage.user` by hand in every one of those branches — the
+ * closeout grep gate fails any regression, and this spec pins the
+ * migrated path so future edits cannot drift without notice.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { http, HttpResponse } from 'msw';
+
+import { server } from '@/test-utils/mocks/server';
+import { primeAuth } from '@/test-utils/primeAuth';
+import { expectBearerHeader } from '@/test-utils/expectBearerHeader';
+import { useAuth } from '@/composables/useAuth';
+
+// Importing the plugin attaches the baseURL + 401 response interceptor to
+// the shared axios default instance so the apiClient request interceptor
+// fires with the same config the production app sees.
+import '@/plugins/axios';
+import IconPairDropdownMenu from './IconPairDropdownMenu.vue';
+
+const makeToastSpy = vi.fn();
+vi.mock('@/composables/useToast', () => ({
+  default: () => ({ makeToast: makeToastSpy }),
+}));
+
+interface DropdownVm {
+  doUserLogOut: () => void;
+  refreshWithJWT: () => Promise<void>;
+  signinWithJWT: () => Promise<void>;
+}
+
+const routerPush = vi.fn();
+const routerGo = vi.fn();
+
+function mountMenu() {
+  return mount(IconPairDropdownMenu, {
+    props: {
+      title: 'User',
+      required: [],
+      align: 'right',
+      items: [],
+    },
+    global: {
+      mocks: {
+        $route: { path: '/SomeOther' },
+        $router: { push: routerPush, go: routerGo },
+      },
+      stubs: {
+        BNavItemDropdown: { template: '<div><slot /></div>' },
+        BDropdownItem: { template: '<a><slot /></a>' },
+      },
+    },
+  });
+}
+
+beforeEach(() => {
+  makeToastSpy.mockClear();
+  routerPush.mockClear();
+  routerGo.mockClear();
+});
+
+afterEach(() => {
+  useAuth().logout();
+});
+
+describe('IconPairDropdownMenu — v11.0 closeout F2b auth migration', () => {
+  it('doUserLogOut routes through useAuth().logout() — no direct localStorage removal', async () => {
+    primeAuth();
+    const auth = useAuth();
+    expect(auth.isAuthenticated.value).toBe(true);
+
+    // Spy on `window.localStorage.removeItem` — the pre-F2b implementation
+    // called `localStorage.removeItem('user')` + `localStorage.removeItem('token')`
+    // directly. `useAuth().logout()` still uses `removeItem`, but only from
+    // inside the composable module. We assert the observable outcome: after
+    // invoking `doUserLogOut`, both keys are gone AND the reactive refs are
+    // cleared (proving the call went through the composable, not a local
+    // dot-access shortcut that would miss the refs).
+    const wrapper = mountMenu();
+
+    (wrapper.vm as unknown as DropdownVm).doUserLogOut();
+    await flushPromises();
+
+    // Both keys must be gone — `useAuth().logout()` owns the cleanup.
+    expect(window.localStorage.getItem('token')).toBeNull();
+    expect(window.localStorage.getItem('user')).toBeNull();
+    // The composable cleared its reactive refs (evidence the logout flowed
+    // through `useAuth()` — a direct localStorage nuke would leave these
+    // stale until the next `syncFromStorage`).
+    expect(auth.token.value).toBeNull();
+    expect(auth.user.value).toBeNull();
+    expect(auth.isAuthenticated.value).toBe(false);
+    // The component triggers a home redirect through the router after
+    // logout; the route path is not '/', so `push({ name: 'Home' })` fires.
+    expect(routerPush).toHaveBeenCalledWith({ name: 'Home' });
+  });
+
+  it('refreshWithJWT calls /api/auth/refresh with Bearer and persists the new token via useAuth', async () => {
+    primeAuth('test-token-old');
+    const auth = useAuth();
+
+    server.use(
+      http.get('/api/auth/refresh', ({ request }) => {
+        expectBearerHeader(request, 'test-token-old');
+        // R/Plumber scalar-array shape is unwrapped by `useAuth().refresh`.
+        return HttpResponse.json(['fresh-token-123']);
+      }),
+      http.get('/api/auth/signin', ({ request }) => {
+        // The subsequent signinWithJWT must pick up the new token.
+        expectBearerHeader(request, 'fresh-token-123');
+        return HttpResponse.json({
+          user_id: [1],
+          user_name: ['test-admin'],
+          email: ['test@sysndd.local'],
+          user_role: ['Administrator'],
+          user_created: ['2024-01-01'],
+          abbreviation: ['TA'],
+          orcid: [''],
+          exp: [Math.floor(Date.now() / 1000) + 3600],
+        });
+      })
+    );
+
+    const wrapper = mountMenu();
+    await (wrapper.vm as unknown as DropdownVm).refreshWithJWT();
+    await flushPromises();
+
+    expect(auth.token.value).toBe('fresh-token-123');
+    // signinWithJWT completed successfully → no danger toast raised.
+    expect(makeToastSpy).not.toHaveBeenCalled();
+  });
+
+  it('signinWithJWT sends the Bearer header and stores the returned user via useAuth', async () => {
+    primeAuth('test-token-sign');
+    const auth = useAuth();
+
+    const payload = {
+      user_id: [42],
+      user_name: ['curator-42'],
+      email: ['curator@sysndd.local'],
+      user_role: ['Curator'],
+      user_created: ['2025-01-01'],
+      abbreviation: ['C42'],
+      orcid: [''],
+      exp: [Math.floor(Date.now() / 1000) + 7200],
+    };
+
+    server.use(
+      http.get('/api/auth/signin', ({ request }) => {
+        expectBearerHeader(request, 'test-token-sign');
+        return HttpResponse.json(payload);
+      })
+    );
+
+    const wrapper = mountMenu();
+    await (wrapper.vm as unknown as DropdownVm).signinWithJWT();
+    await flushPromises();
+
+    expect(auth.user.value?.user_name?.[0]).toBe('curator-42');
+    expect(auth.user.value?.user_role?.[0]).toBe('Curator');
+    // Token is unchanged because signin doesn't rotate it.
+    expect(auth.token.value).toBe('test-token-sign');
+  });
+});

--- a/app/src/components/small/IconPairDropdownMenu.vue
+++ b/app/src/components/small/IconPairDropdownMenu.vue
@@ -20,7 +20,8 @@
 </template>
 
 <script>
-import URLS from '@/assets/js/constants/url_constants';
+import { apiClient } from '@/api/client';
+import { useAuth } from '@/composables/useAuth';
 import useToast from '@/composables/useToast';
 
 export default {
@@ -45,7 +46,12 @@ export default {
   },
   setup() {
     const { makeToast } = useToast();
-    return { makeToast };
+    // v11.0 closeout F2b: auth state and token lifecycle flow through the
+    // `useAuth()` composable. Previously this component read/wrote the
+    // `token`/`user` localStorage keys directly and duplicated the logout
+    // branch that `useAuth().logout()` now owns.
+    const auth = useAuth();
+    return { makeToast, auth };
   },
   methods: {
     handleItemClick(item) {
@@ -54,9 +60,12 @@ export default {
       }
     },
     doUserLogOut() {
-      if (localStorage.user || localStorage.token) {
-        localStorage.removeItem('user');
-        localStorage.removeItem('token');
+      // v11.0 closeout F2b: route through `useAuth().logout()` — the
+      // composable owns both localStorage keys and the reactive refs, so
+      // sibling components (navbar badges, route guards) see the logout
+      // immediately on the next tick.
+      if (this.auth.isAuthenticated.value) {
+        this.auth.logout();
         this.reloadHomePage();
       }
     },
@@ -69,28 +78,28 @@ export default {
       }
     },
     async refreshWithJWT() {
-      const apiAuthenticateURL = `${URLS.API_URL}/api/auth/refresh`;
       try {
-        const response = await this.axios.get(apiAuthenticateURL, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        });
-        localStorage.setItem('token', response.data[0]);
-        this.signinWithJWT();
+        // `useAuth().refresh()` delegates to `api/auth.refresh`, updates
+        // the reactive token + localStorage, and returns the bare JWT. The
+        // `apiClient` request interceptor picks up the new token on the
+        // next outbound call (the subsequent `signinWithJWT`).
+        await this.auth.refresh();
+        await this.signinWithJWT();
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
       }
     },
     async signinWithJWT() {
-      const apiAuthenticateURL = `${URLS.API_URL}/api/auth/signin`;
       try {
-        const response = await this.axios.get(apiAuthenticateURL, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        });
-        localStorage.setItem('user', JSON.stringify(response.data));
+        // `apiClient.get` auto-injects the Bearer header from the reactive
+        // `useAuth().token`. `login(token, user)` persists the user
+        // payload alongside the current token so route guards and badges
+        // see the updated profile without a page reload.
+        const user = await apiClient.get('/api/auth/signin');
+        const currentToken = this.auth.token.value;
+        if (currentToken) {
+          this.auth.login(currentToken, user);
+        }
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
       }

--- a/app/src/components/tables/TablesLogs.spec.ts
+++ b/app/src/components/tables/TablesLogs.spec.ts
@@ -1,0 +1,243 @@
+// TablesLogs.spec.ts
+/**
+ * v11.0 closeout F2b — spec for `components/tables/TablesLogs.vue`.
+ *
+ * Four authed endpoints now route through `apiClient.raw.*`:
+ *
+ *   - GET    /api/user/list   (`loadUserList`)
+ *   - GET    /api/logs/       (`doLoadData` — main table)
+ *   - GET    /api/logs/       (`requestExcel` — blob response)
+ *   - DELETE /api/logs/       (`deleteLogs`)
+ *
+ * Each previously stamped its own
+ * `Authorization: Bearer ${localStorage.getItem('token')}` header. This
+ * spec pins the apiClient interceptor injection with
+ * `primeAuth() + expectBearerHeader()`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { createRouter, createMemoryHistory } from 'vue-router';
+import { http, HttpResponse } from 'msw';
+
+import '@/plugins/axios';
+import axios from '@/plugins/axios';
+import { server } from '@/test-utils/mocks/server';
+import { primeAuth } from '@/test-utils/primeAuth';
+import { expectBearerHeader } from '@/test-utils/expectBearerHeader';
+import { useAuth } from '@/composables/useAuth';
+import TablesLogs from './TablesLogs.vue';
+
+const makeToastSpy = vi.fn();
+
+vi.mock('@/composables', async () => {
+  const { ref, computed } = await import('vue');
+  return {
+    useToast: () => ({ makeToast: makeToastSpy }),
+    useUrlParsing: () => ({
+      filterObjToStr: () => '',
+      filterStrToObj: (_s: string, o: unknown) => o,
+      sortStringToVariables: () => ({ sortBy: [] }),
+    }),
+    useColorAndSymbols: () => ({}),
+    useText: () => ({ truncate: (s: string) => s }),
+    useTableData: () => ({
+      items: ref([]),
+      loading: ref(false),
+      downloading: ref(false),
+      currentPage: ref(1),
+      perPage: ref(10),
+      totalRows: ref(0),
+      sort: ref('-id'),
+      sortBy: ref([]),
+      filter_string: ref(''),
+      currentItemID: ref(0),
+      prevItemID: ref(0),
+      nextItemID: ref(0),
+      lastItemID: ref(0),
+      executionTime: ref(0),
+      pageOptions: ref([10]),
+      isBusy: ref(false),
+      totalPages: computed(() => 0),
+    }),
+    useTableMethods: () => ({}),
+  };
+});
+
+interface LogsVm {
+  loadUserList: () => Promise<void>;
+  doLoadData: () => Promise<void>;
+  requestExcel: () => Promise<void>;
+  deleteLogs: () => Promise<void>;
+  deleteMode: string;
+  totalRows: number;
+  user_options: unknown[];
+}
+
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/', name: 'Home', component: { template: '<div />' } }],
+  });
+}
+
+async function mountTable() {
+  setActivePinia(createPinia());
+  const router = makeRouter();
+  await router.push('/');
+  await router.isReady();
+
+  const wrapper = mount(TablesLogs, {
+    global: {
+      plugins: [router],
+      mocks: { axios },
+      provide: { axios },
+      directives: { 'b-tooltip': {}, 'b-toggle': {} },
+      stubs: {
+        TableHeaderLabel: { template: '<div />' },
+        TableSearchInput: { template: '<div />' },
+        TablePaginationControls: { template: '<div />' },
+        TableDownloadLinkCopyButtons: { template: '<div />' },
+        GenericTable: { template: '<div />' },
+        LogDetailDrawer: { template: '<div />' },
+        BContainer: { template: '<div><slot /></div>' },
+        BRow: { template: '<div><slot /></div>' },
+        BCol: { template: '<div><slot /></div>' },
+        BCard: { template: '<div><slot name="header" /><slot /></div>' },
+        BBadge: { template: '<span><slot /></span>' },
+        BButton: { template: '<button><slot /></button>' },
+        BSpinner: { template: '<div />' },
+        BFormInput: { template: '<input />' },
+        BFormSelect: { template: '<select />' },
+        BInputGroup: { template: '<div><slot /></div>' },
+        BInputGroupText: { template: '<span><slot /></span>' },
+        BModal: { template: '<div><slot /></div>' },
+        BFormGroup: { template: '<div><slot /></div>' },
+      },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+beforeEach(() => {
+  makeToastSpy.mockClear();
+  vi.stubEnv('VITE_API_URL', '');
+});
+
+afterEach(() => {
+  useAuth().logout();
+  vi.unstubAllEnvs();
+});
+
+describe('TablesLogs — v11.0 closeout F2b apiClient migration', () => {
+  it('loadUserList issues GET /api/user/list with the Bearer header', async () => {
+    primeAuth('logs-users-token');
+
+    server.use(
+      http.get('/api/user/list', ({ request }) => {
+        expectBearerHeader(request, 'logs-users-token');
+        return HttpResponse.json([{ user_name: 'alice', user_role: 'Administrator' }]);
+      }),
+      http.get('/api/logs/', () =>
+        HttpResponse.json({ data: [], meta: [{ totalItems: 0, currentPage: 1, totalPages: 1 }] })
+      )
+    );
+
+    const wrapper = await mountTable();
+    const vm = wrapper.vm as unknown as LogsVm;
+    await vm.loadUserList();
+    await flushPromises();
+    expect(vm.user_options).toEqual([{ value: 'alice', text: 'alice (Administrator)' }]);
+  });
+
+  it('doLoadData issues GET /api/logs/ with the Bearer header', async () => {
+    primeAuth('logs-data-token');
+
+    server.use(
+      http.get('/api/user/list', () => HttpResponse.json([])),
+      http.get('/api/logs/', ({ request }) => {
+        expectBearerHeader(request, 'logs-data-token');
+        return HttpResponse.json({
+          data: [],
+          meta: [
+            {
+              totalItems: 0,
+              currentPage: 1,
+              totalPages: 1,
+              prevItemID: 0,
+              currentItemID: 0,
+              nextItemID: 0,
+              lastItemID: 0,
+              executionTime: 5,
+            },
+          ],
+        });
+      })
+    );
+
+    const wrapper = await mountTable();
+    await (wrapper.vm as unknown as LogsVm).doLoadData();
+    await flushPromises();
+  });
+
+  it('requestExcel issues GET /api/logs/?format=xlsx with the Bearer header', async () => {
+    primeAuth('logs-excel-token');
+
+    let sawBearer = false;
+    server.use(
+      http.get('/api/user/list', () => HttpResponse.json([])),
+      http.get('/api/logs/', ({ request }) => {
+        const url = new URL(request.url);
+        // The excel path passes `format=xlsx`; the data path does not.
+        if (url.searchParams.get('format') === 'xlsx') {
+          expectBearerHeader(request, 'logs-excel-token');
+          sawBearer = true;
+          return new HttpResponse(new Blob(['xlsx bytes']));
+        }
+        return HttpResponse.json({ data: [], meta: [{ totalItems: 0 }] });
+      })
+    );
+
+    // Stub URL.createObjectURL — jsdom does not implement it.
+    const createSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock');
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    const wrapper = await mountTable();
+    const vm = wrapper.vm as unknown as LogsVm;
+    vm.totalRows = 100;
+    await vm.requestExcel();
+    await flushPromises();
+
+    createSpy.mockRestore();
+    revokeSpy.mockRestore();
+
+    expect(sawBearer).toBe(true);
+  });
+
+  it('deleteLogs issues DELETE /api/logs/ with the Bearer header', async () => {
+    primeAuth('logs-delete-token');
+
+    let sawBearer = false;
+    server.use(
+      http.get('/api/user/list', () => HttpResponse.json([])),
+      http.delete('/api/logs/', ({ request }) => {
+        expectBearerHeader(request, 'logs-delete-token');
+        sawBearer = true;
+        return HttpResponse.json({ deleted_count: 3 });
+      }),
+      http.get('/api/logs/', () =>
+        HttpResponse.json({ data: [], meta: [{ totalItems: 0, currentPage: 1, totalPages: 1 }] })
+      )
+    );
+
+    const wrapper = await mountTable();
+    const vm = wrapper.vm as unknown as LogsVm;
+    vm.deleteMode = 'all';
+    await vm.deleteLogs();
+    await flushPromises();
+
+    expect(sawBearer).toBe(true);
+  });
+});

--- a/app/src/components/tables/TablesLogs.vue
+++ b/app/src/components/tables/TablesLogs.vue
@@ -392,6 +392,11 @@ import LogDetailDrawer from '@/components/small/LogDetailDrawer.vue';
 
 import Utils from '@/assets/js/utils';
 import { useUiStore } from '@/stores/ui';
+// v11.0 closeout F2b: apiClient is the single outbound surface — the
+// request interceptor injects `Authorization: Bearer <token>` from
+// `useAuth().token.value`, so this component stops building the header
+// by hand.
+import { apiClient } from '@/api/client';
 
 // Module-level variables to track API calls across component remounts
 // This survives when Vue Router remounts the component on URL changes
@@ -715,9 +720,7 @@ export default {
     // Load user list for filter dropdown
     async loadUserList() {
       try {
-        const response = await this.axios.get(`${import.meta.env.VITE_API_URL}/api/user/list`, {
-          headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
-        });
+        const response = await apiClient.raw.get(`${import.meta.env.VITE_API_URL}/api/user/list`);
         this.user_options = response.data.map((item) => ({
           value: item.user_name,
           text: `${item.user_name} (${item.user_role})`,
@@ -763,15 +766,12 @@ export default {
       this.isBusy = true;
 
       try {
-        const response = await this.axios.get(`${import.meta.env.VITE_API_URL}/api/logs/`, {
+        const response = await apiClient.raw.get(`${import.meta.env.VITE_API_URL}/api/logs/`, {
           params: {
             sort: this.sort,
             filter: this.filter_string,
             page_after: this.currentItemID,
             page_size: this.perPage,
-          },
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
           },
         });
 
@@ -926,16 +926,13 @@ export default {
       }
 
       try {
-        const response = await this.axios.get(`${import.meta.env.VITE_API_URL}/api/logs/`, {
+        const response = await apiClient.raw.get(`${import.meta.env.VITE_API_URL}/api/logs/`, {
           params: {
             page_after: 0,
             page_size: 'all',
             format: 'xlsx',
             filter: this.filter_string, // Apply current filters
             sort: this.sort,
-          },
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
           },
           responseType: 'blob', // Important for binary download
         });
@@ -1058,12 +1055,9 @@ export default {
       this.isDeleting = true;
       try {
         const olderThanDays = this.deleteMode === 'all' ? 0 : parseInt(this.deleteMode, 10);
-        const response = await this.axios.delete(`${import.meta.env.VITE_API_URL}/api/logs/`, {
+        const response = await apiClient.raw.delete(`${import.meta.env.VITE_API_URL}/api/logs/`, {
           params: {
             older_than_days: olderThanDays,
-          },
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
           },
         });
 

--- a/app/src/composables/useBatchForm.spec.ts
+++ b/app/src/composables/useBatchForm.spec.ts
@@ -1,0 +1,164 @@
+// useBatchForm.spec.ts
+/**
+ * v11.0 closeout F2b — spec for `composables/useBatchForm.ts`.
+ *
+ * Pre-F2b, every authed call in this composable built its own
+ * `Authorization: Bearer ${localStorage.getItem('token')}` header (8 raw
+ * reads). The migration routes each request through `apiClient.raw.*`;
+ * the shared request interceptor injects the Bearer from
+ * `useAuth().token.value`. This spec pins:
+ *
+ *   - `searchEntities()`   GET /api/entity/
+ *   - `loadOptions()`      GET /api/user/list + /api/list/status + /api/gene/
+ *   - `handlePreview()`    POST /api/re_review/batch/preview
+ *   - `handleSubmit()`     POST /api/re_review/batch/create
+ *
+ * All requests must carry `Authorization: Bearer <token>` when a session
+ * is present.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+
+import '@/plugins/axios';
+import { server } from '@/test-utils/mocks/server';
+import { primeAuth } from '@/test-utils/primeAuth';
+import { expectBearerHeader } from '@/test-utils/expectBearerHeader';
+import { useAuth } from '@/composables/useAuth';
+import useBatchForm from './useBatchForm';
+
+const makeToastSpy = vi.fn();
+vi.mock('./useToast', () => ({
+  default: () => ({ makeToast: makeToastSpy }),
+}));
+
+beforeEach(() => {
+  makeToastSpy.mockClear();
+  vi.stubEnv('VITE_API_URL', '');
+});
+
+afterEach(() => {
+  useAuth().logout();
+  vi.unstubAllEnvs();
+});
+
+describe('useBatchForm — v11.0 closeout F2b apiClient migration', () => {
+  it('searchEntities issues GET /api/entity/ with the Bearer header', async () => {
+    primeAuth('search-token');
+
+    server.use(
+      http.get('/api/entity/', ({ request }) => {
+        expectBearerHeader(request, 'search-token');
+        return HttpResponse.json({ data: [] });
+      })
+    );
+
+    const form = useBatchForm();
+    await form.searchEntities('BRCA');
+    expect(form.entitySearchResults.value).toEqual([]);
+  });
+
+  it('loadOptions issues GET /api/user/list, /api/list/status, /api/gene/ all with the Bearer header', async () => {
+    primeAuth('options-token');
+
+    let userListAuth = false;
+    let statusAuth = false;
+    let genesAuth = false;
+
+    server.use(
+      http.get('/api/user/list', ({ request }) => {
+        expectBearerHeader(request, 'options-token');
+        userListAuth = true;
+        return HttpResponse.json([
+          { user_id: 1, user_name: 'alice' },
+          { user_id: 2, user_name: 'bob' },
+        ]);
+      }),
+      http.get('/api/list/status', ({ request }) => {
+        expectBearerHeader(request, 'options-token');
+        statusAuth = true;
+        return HttpResponse.json({
+          data: [
+            { category_id: 1, category: 'Definitive' },
+            { category_id: 2, category: 'Moderate' },
+          ],
+        });
+      }),
+      http.get('/api/gene/', ({ request }) => {
+        expectBearerHeader(request, 'options-token');
+        genesAuth = true;
+        return HttpResponse.json({
+          data: [
+            { hgnc_id: 1100, symbol: 'BRCA1' },
+            { hgnc_id: 1101, symbol: 'BRCA2' },
+          ],
+        });
+      })
+    );
+
+    const form = useBatchForm();
+    await form.loadOptions();
+
+    expect(userListAuth).toBe(true);
+    expect(statusAuth).toBe(true);
+    expect(genesAuth).toBe(true);
+    expect(form.userOptions.value).toHaveLength(2);
+    expect(form.statusOptions.value).toHaveLength(2);
+    expect(form.geneOptions.value).toHaveLength(2);
+  });
+
+  it('handlePreview issues POST /api/re_review/batch/preview with the Bearer header', async () => {
+    primeAuth('preview-token');
+
+    let sawBearer = false;
+    server.use(
+      http.post('/api/re_review/batch/preview', ({ request }) => {
+        expectBearerHeader(request, 'preview-token');
+        sawBearer = true;
+        return HttpResponse.json({
+          data: [
+            {
+              entity_id: 1,
+              hgnc_id: 1100,
+              gene_symbol: 'BRCA1',
+              disease_ontology_name: 'BRCA',
+              review_date: '2025-01-01',
+            },
+          ],
+        });
+      })
+    );
+
+    const form = useBatchForm();
+    // A preview call requires at least one criterion; seed gene_list so
+    // `isFormValid` passes without touching the UI-only entity selector.
+    form.formData.gene_list = [1100];
+
+    await form.handlePreview();
+    expect(sawBearer).toBe(true);
+    expect(form.previewEntities.value).toHaveLength(1);
+  });
+
+  it('handleSubmit issues POST /api/re_review/batch/create with the Bearer header', async () => {
+    primeAuth('submit-token');
+
+    let sawBearer = false;
+    server.use(
+      http.post('/api/re_review/batch/create', ({ request }) => {
+        expectBearerHeader(request, 'submit-token');
+        sawBearer = true;
+        return HttpResponse.json({
+          entry: { entity_count: 5 },
+        });
+      })
+    );
+
+    const form = useBatchForm();
+    form.formData.gene_list = [1100];
+    form.formData.batch_name = 'My Batch';
+
+    const ok = await form.handleSubmit();
+    expect(ok).toBe(true);
+    expect(sawBearer).toBe(true);
+  });
+});

--- a/app/src/composables/useBatchForm.ts
+++ b/app/src/composables/useBatchForm.ts
@@ -5,7 +5,12 @@
  * Follows single-form interface pattern from CONTEXT.md decisions.
  */
 import { ref, reactive, computed } from 'vue';
-import axios from 'axios';
+// v11.0 closeout F2b: route authed calls through the apiClient — the
+// request interceptor injects the Bearer from `useAuth().token.value`,
+// so this composable no longer reads the session token from storage.
+// `isApiError` is re-exported from `@/api/client` for the error branches
+// that previously relied on `axios.isAxiosError`.
+import { apiClient, isApiError } from '@/api/client';
 import useToast from './useToast';
 
 // Types for batch criteria
@@ -115,7 +120,6 @@ export function useBatchForm() {
 
     isEntitySearching.value = true;
     const apiUrl = import.meta.env.VITE_API_URL;
-    const token = localStorage.getItem('token');
 
     try {
       // Build filter: search by entity_id (if numeric), symbol, or disease name
@@ -124,17 +128,27 @@ export function useBatchForm() {
         ? `equals(entity_id,${query})`
         : `or(contains(symbol,${query}),contains(disease_ontology_name,${query}))`;
 
-      // Search entities using the API filter syntax
-      const response = await axios.get(`${apiUrl}/api/entity/`, {
-        params: {
-          filter,
-          page_size: 15,
-        },
-        headers: token ? { Authorization: `Bearer ${token}` } : {},
-        withCredentials: true,
-      });
-      const data = response.data?.data || response.data || [];
-      entitySearchResults.value = Array.isArray(data) ? data : [];
+      // Search entities using the API filter syntax. The apiClient request
+      // interceptor injects the Bearer header when a session is present;
+      // calls without a token simply fire no Authorization, matching the
+      // pre-F2b behaviour (the ternary used to skip the header).
+      const response = await apiClient.raw.get<{ data?: unknown } | unknown[]>(
+        `${apiUrl}/api/entity/`,
+        {
+          params: {
+            filter,
+            page_size: 15,
+          },
+          withCredentials: true,
+        }
+      );
+      const payload = response.data as { data?: unknown[] } | unknown[] | null;
+      const data = Array.isArray(payload)
+        ? payload
+        : (payload?.data ?? []);
+      entitySearchResults.value = Array.isArray(data)
+        ? (data as EntitySearchResult[])
+        : [];
     } catch (error) {
       console.error('Entity search failed:', error);
       entitySearchResults.value = [];
@@ -202,48 +216,52 @@ export function useBatchForm() {
   // Load dropdown options
   const loadOptions = async () => {
     const apiUrl = import.meta.env.VITE_API_URL;
-    const token = localStorage.getItem('token');
-    const headers = { Authorization: `Bearer ${token}` };
 
     try {
-      // Load users (Curators and Reviewers)
-      const usersResponse = await axios.get(`${apiUrl}/api/user/list?roles=Curator,Reviewer`, {
-        headers,
-        withCredentials: true,
-      });
+      // Load users (Curators and Reviewers). The apiClient request
+      // interceptor attaches the Bearer header from `useAuth().token.value`
+      // — no manual header construction below.
+      const usersResponse = await apiClient.raw.get<unknown>(
+        `${apiUrl}/api/user/list?roles=Curator,Reviewer`,
+        { withCredentials: true }
+      );
       const usersData = usersResponse.data;
       userOptions.value = Array.isArray(usersData)
-        ? usersData.map((u: { user_id: number; user_name: string }) => ({
+        ? (usersData as { user_id: number; user_name: string }[]).map((u) => ({
             value: u.user_id,
             text: u.user_name,
           }))
         : [];
 
       // Load status categories from /api/list/status
-      const statusResponse = await axios.get(`${apiUrl}/api/list/status`, {
-        headers,
-        withCredentials: true,
-      });
-      const statusData = statusResponse.data;
+      const statusResponse = await apiClient.raw.get<unknown>(
+        `${apiUrl}/api/list/status`,
+        { withCredentials: true }
+      );
+      const statusData = statusResponse.data as { data?: unknown } | unknown[] | null;
       // Handle paginated response format
-      const statusArray = statusData?.data || statusData;
+      const statusArray = Array.isArray(statusData)
+        ? statusData
+        : (statusData?.data ?? statusData);
       statusOptions.value = Array.isArray(statusArray)
-        ? statusArray.map((s: { category_id: number; category: string }) => ({
+        ? (statusArray as { category_id: number; category: string }[]).map((s) => ({
             value: s.category_id,
             text: s.category,
           }))
         : [];
 
       // Load genes from /api/gene/ (get all genes for selection)
-      const genesResponse = await axios.get(
+      const genesResponse = await apiClient.raw.get<unknown>(
         `${apiUrl}/api/gene/?page_size=all&fields=symbol,hgnc_id`,
-        { headers, withCredentials: true }
+        { withCredentials: true }
       );
-      const genesData = genesResponse.data;
+      const genesData = genesResponse.data as { data?: unknown } | unknown[] | null;
       // Handle paginated response format
-      const genesArray = genesData?.data || genesData;
+      const genesArray = Array.isArray(genesData)
+        ? genesData
+        : (genesData?.data ?? genesData);
       geneOptions.value = Array.isArray(genesArray)
-        ? genesArray.map((g: { hgnc_id: number; symbol: string }) => ({
+        ? (genesArray as { hgnc_id: number; symbol: string }[]).map((g) => ({
             value: g.hgnc_id,
             text: g.symbol,
           }))
@@ -263,18 +281,18 @@ export function useBatchForm() {
 
     isPreviewLoading.value = true;
     const apiUrl = import.meta.env.VITE_API_URL;
-    const token = localStorage.getItem('token');
 
     try {
-      const response = await axios.post(`${apiUrl}/api/re_review/batch/preview`, buildCriteria(), {
-        headers: { Authorization: `Bearer ${token}` },
-        withCredentials: true,
-      });
+      const response = await apiClient.raw.post<{ data?: PreviewEntity[] }>(
+        `${apiUrl}/api/re_review/batch/preview`,
+        buildCriteria(),
+        { withCredentials: true }
+      );
 
       previewEntities.value = response.data.data || [];
       showPreviewModal.value = true;
     } catch (error: unknown) {
-      const message = axios.isAxiosError(error)
+      const message = isApiError<{ message?: string }>(error)
         ? error.response?.data?.message || error.message
         : 'Preview failed';
       makeToast(message, 'Error', 'danger');
@@ -292,7 +310,6 @@ export function useBatchForm() {
 
     isLoading.value = true;
     const apiUrl = import.meta.env.VITE_API_URL;
-    const token = localStorage.getItem('token');
 
     try {
       const payload = {
@@ -301,10 +318,11 @@ export function useBatchForm() {
         assigned_user_id: formData.assigned_user_id,
       };
 
-      const response = await axios.post(`${apiUrl}/api/re_review/batch/create`, payload, {
-        headers: { Authorization: `Bearer ${token}` },
-        withCredentials: true,
-      });
+      const response = await apiClient.raw.post<{ entry: { entity_count: number } }>(
+        `${apiUrl}/api/re_review/batch/create`,
+        payload,
+        { withCredentials: true }
+      );
 
       const result = response.data.entry;
       makeToast(`Batch created with ${result.entity_count} entities`, 'Success', 'success');
@@ -313,7 +331,7 @@ export function useBatchForm() {
       resetForm();
       return true;
     } catch (error: unknown) {
-      const message = axios.isAxiosError(error)
+      const message = isApiError<{ message?: string }>(error)
         ? error.response?.data?.message || error.message
         : 'Batch creation failed';
       makeToast(message, 'Error', 'danger');

--- a/app/src/views/RegisterView.spec.ts
+++ b/app/src/views/RegisterView.spec.ts
@@ -1,0 +1,189 @@
+// RegisterView.spec.ts
+/**
+ * v11.0 closeout F2b — spec covering the auth migration on
+ * `views/RegisterView.vue`:
+ *
+ *   1. `mounted()` reads `useAuth().isAuthenticated.value` (not
+ *      `localStorage.user`) as the guard for clearing a stale session
+ *      before the register form loads.
+ *   2. `doUserLogOut()` delegates to `useAuth().logout()` — not to
+ *      `localStorage.removeItem('token' | 'user')` — when a stale
+ *      session is present.
+ *   3. `sendRegistration()` issues `GET /api/auth/signup?signup_data=...`
+ *      WITHOUT an `Authorization` header. Registration is inherently
+ *      unauthenticated; the apiClient request interceptor only injects
+ *      the Bearer when `useAuth().token.value` is non-null (not the
+ *      case before a user signs up).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { http, HttpResponse } from 'msw';
+
+import '@/plugins/axios';
+import { server } from '@/test-utils/mocks/server';
+import { primeAuth } from '@/test-utils/primeAuth';
+import { useAuth } from '@/composables/useAuth';
+import RegisterView from './RegisterView.vue';
+
+import axios from '@/plugins/axios';
+
+const makeToastSpy = vi.fn();
+vi.mock('@/composables/useToast', () => ({
+  default: () => ({ makeToast: makeToastSpy }),
+}));
+
+// The RegisterView setup() calls `useHead()` for route-level meta
+// titles; outside of `main.ts` / `createHead()` this throws "no
+// provide context". The meta tags are not under test here — stubbing
+// the composable keeps the setup callable.
+vi.mock('@unhead/vue', () => ({
+  useHead: () => {},
+}));
+
+// vee-validate brings runtime form state we do not exercise here —
+// `useField`/`useForm` still render, but we drive the view via the exported
+// Options-API methods so vee-validate's validation remains untouched.
+
+const routerPush = vi.fn();
+
+interface RegisterVm {
+  doUserLogOut: () => void;
+  sendRegistration: () => Promise<void>;
+  user_name: string;
+  email: string;
+  orcid: string;
+  first_name: string;
+  family_name: string;
+  comment: string;
+  terms_agreed: string;
+  auth: ReturnType<typeof useAuth>;
+}
+
+function mountRegister() {
+  return mount(RegisterView, {
+    global: {
+      mocks: {
+        axios,
+        $route: { path: '/Register' },
+        $router: { push: routerPush },
+      },
+      stubs: {
+        BContainer: { template: '<div><slot /></div>' },
+        BRow: { template: '<div><slot /></div>' },
+        BCol: { template: '<div><slot /></div>' },
+        BCard: { template: '<div><slot /></div>' },
+        BOverlay: { template: '<div><slot /></div>' },
+        BCardText: { template: '<div><slot /></div>' },
+        BForm: { template: '<form><slot /></form>' },
+        BFormGroup: { template: '<div><slot /></div>' },
+        BFormInput: { template: '<input />' },
+        BFormInvalidFeedback: { template: '<div><slot /></div>' },
+        BFormCheckbox: { template: '<input type="checkbox" />' },
+        BButton: { template: '<button><slot /></button>' },
+        BSpinner: { template: '<div />' },
+      },
+    },
+  });
+}
+
+beforeEach(() => {
+  makeToastSpy.mockClear();
+  routerPush.mockClear();
+  vi.stubEnv('VITE_API_URL', '');
+});
+
+afterEach(() => {
+  useAuth().logout();
+  vi.unstubAllEnvs();
+});
+
+describe('RegisterView — v11.0 closeout F2b auth migration', () => {
+  it('mounted() uses useAuth().isAuthenticated.value, not localStorage.user, to detect a stale session', async () => {
+    // Stale session present — the guard must fire and clear it via
+    // `useAuth().logout()`.
+    primeAuth();
+    const auth = useAuth();
+    expect(auth.isAuthenticated.value).toBe(true);
+
+    mountRegister();
+    await flushPromises();
+
+    // Post-mount: the stale session was torn down through the composable
+    // (both keys cleared, reactive refs cleared). A pre-F2b implementation
+    // that guarded on `localStorage.user` would have done the same to
+    // localStorage but left `auth.token.value` stale.
+    expect(window.localStorage.getItem('token')).toBeNull();
+    expect(window.localStorage.getItem('user')).toBeNull();
+    expect(auth.token.value).toBeNull();
+    expect(auth.user.value).toBeNull();
+    expect(auth.isAuthenticated.value).toBe(false);
+    // doUserLogOut pushes to '/' on its way out.
+    expect(routerPush).toHaveBeenCalledWith('/');
+  });
+
+  it('mounted() does NOT touch auth state when no session is present', async () => {
+    const auth = useAuth();
+    expect(auth.isAuthenticated.value).toBe(false);
+
+    mountRegister();
+    await flushPromises();
+
+    // No stale session → no push, no toast, auth still empty.
+    expect(routerPush).not.toHaveBeenCalled();
+    expect(auth.token.value).toBeNull();
+  });
+
+  it('doUserLogOut routes through useAuth().logout() when called directly', async () => {
+    primeAuth();
+    const auth = useAuth();
+
+    const wrapper = mountRegister();
+    // After mount, the guard has already cleared the session — re-seed
+    // so we can observe the direct-call path too.
+    primeAuth('direct-token');
+    expect(auth.isAuthenticated.value).toBe(true);
+
+    (wrapper.vm as unknown as RegisterVm).doUserLogOut();
+    await flushPromises();
+
+    expect(window.localStorage.getItem('token')).toBeNull();
+    expect(window.localStorage.getItem('user')).toBeNull();
+    expect(auth.token.value).toBeNull();
+    expect(auth.user.value).toBeNull();
+    // Called twice now: once from mounted(), once from the direct call.
+    expect(routerPush).toHaveBeenCalledWith('/');
+  });
+
+  it('sendRegistration carries no Bearer header — registration is unauthenticated', async () => {
+    // No primeAuth(): this is a fresh visitor submitting the register form.
+    const wrapper = mountRegister();
+    await flushPromises();
+
+    let capturedAuthHeader: string | null | undefined;
+    server.use(
+      http.get('/api/auth/signup', ({ request }) => {
+        capturedAuthHeader = request.headers.get('authorization');
+        return HttpResponse.json({ ok: true });
+      })
+    );
+
+    const vm = wrapper.vm as unknown as RegisterVm;
+    // Fill the form fields directly so vee-validate's state stays out of
+    // scope; sendRegistration reads `this.user_name` etc.
+    vm.user_name = 'new_user';
+    vm.email = 'new@sysndd.local';
+    vm.orcid = '0000-0000-0000-0000';
+    vm.first_name = 'New';
+    vm.family_name = 'User';
+    vm.comment = 'Motivation';
+    vm.terms_agreed = 'accepted';
+
+    await vm.sendRegistration();
+    await flushPromises();
+
+    // The interceptor must NOT inject a Bearer header when the session is
+    // empty — registration is pre-auth by definition.
+    expect(capturedAuthHeader).toBeFalsy();
+  });
+});

--- a/app/src/views/RegisterView.vue
+++ b/app/src/views/RegisterView.vue
@@ -130,6 +130,10 @@ import { useHead } from '@unhead/vue';
 import { useForm, useField, defineRule } from 'vee-validate';
 import { required, min, max, email, regex } from '@vee-validate/rules';
 import useToast from '@/composables/useToast';
+// v11.0 closeout F2b: `useAuth()` is the single owner of auth state. This
+// view only needs the `isAuthenticated` guard (to clear a stale session
+// on the register route) and `logout()` (to perform that clear).
+import { useAuth } from '@/composables/useAuth';
 
 // Define validation rules
 defineRule('required', required);
@@ -143,6 +147,7 @@ export default {
   name: 'RegisterView',
   setup() {
     const { makeToast } = useToast();
+    const auth = useAuth();
     useHead({
       title: 'Register',
       meta: [
@@ -241,10 +246,16 @@ export default {
       handleSubmit,
       resetVeeForm,
       makeToast,
+      auth,
     };
   },
   mounted() {
-    if (localStorage.user) {
+    // v11.0 closeout F2b: the register route must never run while a stale
+    // session is present — clear through `useAuth().logout()` so the
+    // composable's single source of truth owns the cleanup. Reading
+    // `auth.isAuthenticated.value` replaces the previous dot-access read
+    // that the ESLint guardrail now forbids.
+    if (this.auth.isAuthenticated.value) {
       this.doUserLogOut();
     }
     this.loading = false;
@@ -306,9 +317,12 @@ export default {
       }, 1000);
     },
     doUserLogOut() {
-      if (localStorage.user || localStorage.token) {
-        localStorage.removeItem('user');
-        localStorage.removeItem('token');
+      // v11.0 closeout F2b: delegate to `useAuth().logout()` instead of
+      // poking localStorage directly. The composable clears both keys and
+      // drops the reactive refs, so the apiClient request interceptor
+      // stops injecting the stale Bearer on the very next outbound call.
+      if (this.auth.isAuthenticated.value) {
+        this.auth.logout();
         this.user = null;
         this.$router.push('/');
       }

--- a/app/src/views/admin/ManageBackups.spec.ts
+++ b/app/src/views/admin/ManageBackups.spec.ts
@@ -1,0 +1,213 @@
+// ManageBackups.spec.ts
+/**
+ * v11.0 closeout F2b — spec for `views/admin/ManageBackups.vue`.
+ *
+ * Five authed endpoints were previously stamped with a hand-built
+ * `Authorization: Bearer ${localStorage.getItem('token')}` header. They
+ * now route through `apiClient.raw.*`, which inherits the Bearer from the
+ * shared request interceptor. This spec pins all five call sites:
+ *
+ *   - GET   /api/backup/list
+ *   - GET   /api/backup/download/:filename
+ *   - POST  /api/backup/restore
+ *   - DELETE /api/backup/delete/:filename
+ *   - POST  /api/backup/create
+ *
+ * Each test uses `primeAuth() + expectBearerHeader()` — a 401 would have
+ * made the original `fetchBackupList()` catch branch toast silently, so
+ * asserting the header shape is the only way to prove the migration is
+ * correct.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { http, HttpResponse } from 'msw';
+
+import '@/plugins/axios';
+import { server } from '@/test-utils/mocks/server';
+import { primeAuth } from '@/test-utils/primeAuth';
+import { expectBearerHeader } from '@/test-utils/expectBearerHeader';
+import { useAuth } from '@/composables/useAuth';
+import ManageBackups from './ManageBackups.vue';
+
+const makeToastSpy = vi.fn();
+vi.mock('@/composables/useToast', () => ({
+  default: () => ({ makeToast: makeToastSpy }),
+}));
+
+// The view composes `useAsyncJob` for backup/restore status polling; stub
+// it to a minimal surface so the spec focuses on the Bearer-header
+// contract rather than the polling state machine (that has dedicated
+// coverage in `useAsyncJob.spec.ts`). The template reads several reactive
+// refs (`status.value`, `isLoading.value`, `progress.value`, `message.value`
+// and `error.value`); stub them all with `.value === idle/false` defaults.
+vi.mock('@/composables/useAsyncJob', () => ({
+  useAsyncJob: () => ({
+    status: { value: 'idle' },
+    isLoading: { value: false },
+    progress: { value: 0 },
+    message: { value: '' },
+    error: { value: null },
+    jobId: { value: null },
+    reset: vi.fn(),
+    startJob: vi.fn(),
+  }),
+}));
+
+interface BackupsVm {
+  fetchBackupList: () => Promise<void>;
+  downloadBackup: (filename: string) => Promise<void>;
+  confirmRestore: () => Promise<void>;
+  confirmDelete: () => Promise<void>;
+  triggerBackup: () => Promise<void>;
+  selectedBackup: { filename: string } | null;
+  restoreConfirmText: string;
+  deleteConfirmText: string;
+  backups: unknown[];
+}
+
+function mountView() {
+  return mount(ManageBackups, {
+    global: {
+      directives: { 'b-tooltip': {}, 'b-toggle': {} },
+      stubs: {
+        BContainer: { template: '<div><slot /></div>' },
+        BRow: { template: '<div><slot /></div>' },
+        BCol: { template: '<div><slot /></div>' },
+        BCard: { template: '<div><slot name="header" /><slot /></div>' },
+        BBadge: { template: '<span><slot /></span>' },
+        BButton: { template: '<button><slot /></button>' },
+        BSpinner: { template: '<div />' },
+        BFormInput: { template: '<input />' },
+        BFormSelect: { template: '<select />' },
+        BInputGroup: { template: '<div><slot name="prepend" /><slot /></div>' },
+        BInputGroupText: { template: '<span><slot /></span>' },
+        BModal: { template: '<div><slot /></div>' },
+        BTable: { template: '<table />' },
+        BPagination: { template: '<nav />' },
+        BProgress: { template: '<div />' },
+      },
+    },
+  });
+}
+
+beforeEach(() => {
+  makeToastSpy.mockClear();
+  vi.stubEnv('VITE_API_URL', '');
+});
+
+afterEach(() => {
+  useAuth().logout();
+  vi.unstubAllEnvs();
+});
+
+describe('ManageBackups — v11.0 closeout F2b apiClient migration', () => {
+  it('fetchBackupList() issues GET /api/backup/list with the Bearer header', async () => {
+    primeAuth('backup-token');
+
+    server.use(
+      http.get('/api/backup/list', ({ request }) => {
+        expectBearerHeader(request, 'backup-token');
+        return HttpResponse.json({ data: [], meta: { total_count: 0, total_size_bytes: 0 } });
+      })
+    );
+
+    const wrapper = mountView();
+    await (wrapper.vm as unknown as BackupsVm).fetchBackupList();
+    await flushPromises();
+    expect((wrapper.vm as unknown as BackupsVm).backups).toEqual([]);
+  });
+
+  it('downloadBackup() issues GET /api/backup/download/:filename with the Bearer header', async () => {
+    primeAuth('download-token');
+
+    let sawBearerOnDownload = false;
+    server.use(
+      http.get('/api/backup/download/:filename', ({ request }) => {
+        expectBearerHeader(request, 'download-token');
+        sawBearerOnDownload = true;
+        return new HttpResponse(new Blob(['ok']));
+      })
+    );
+
+    // jsdom doesn't fully implement `URL.createObjectURL` / <a>.click() —
+    // stub both so the download branch completes without throwing.
+    const createSpy = vi
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue('blob:mock');
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    const wrapper = mountView();
+    await (wrapper.vm as unknown as BackupsVm).downloadBackup('manual_2025-10-01.sql.gz');
+    await flushPromises();
+
+    createSpy.mockRestore();
+    revokeSpy.mockRestore();
+
+    // The handler fired AND the Bearer assertion inside it did not throw.
+    // The download-click DOM dance may still fail in jsdom — that is
+    // out of scope for the migration contract.
+    expect(sawBearerOnDownload).toBe(true);
+  });
+
+  it('confirmRestore() issues POST /api/backup/restore with the Bearer header', async () => {
+    primeAuth('restore-token');
+
+    server.use(
+      http.post('/api/backup/restore', async ({ request }) => {
+        expectBearerHeader(request, 'restore-token');
+        const body = (await request.json()) as { filename: string };
+        expect(body.filename).toBe('manual_2025-10-01.sql.gz');
+        return HttpResponse.json({ job_id: 'restore-1' });
+      })
+    );
+
+    const wrapper = mountView();
+    const vm = wrapper.vm as unknown as BackupsVm;
+    vm.selectedBackup = { filename: 'manual_2025-10-01.sql.gz' };
+    vm.restoreConfirmText = 'RESTORE';
+
+    await vm.confirmRestore();
+    await flushPromises();
+  });
+
+  it('confirmDelete() issues DELETE /api/backup/delete/:filename with the Bearer header', async () => {
+    primeAuth('delete-token');
+
+    server.use(
+      http.delete('/api/backup/delete/:filename', async ({ request, params }) => {
+        expectBearerHeader(request, 'delete-token');
+        expect(params.filename).toBe('manual_2025-10-01.sql.gz');
+        return HttpResponse.json({ message: 'Deleted' });
+      }),
+      // Post-delete refresh hits /api/backup/list — keep it green so the
+      // test doesn't fail on the refetch leg.
+      http.get('/api/backup/list', () =>
+        HttpResponse.json({ data: [], meta: { total_count: 0, total_size_bytes: 0 } })
+      )
+    );
+
+    const wrapper = mountView();
+    const vm = wrapper.vm as unknown as BackupsVm;
+    vm.selectedBackup = { filename: 'manual_2025-10-01.sql.gz' };
+    vm.deleteConfirmText = 'DELETE';
+
+    await vm.confirmDelete();
+    await flushPromises();
+  });
+
+  it('triggerBackup() issues POST /api/backup/create with the Bearer header', async () => {
+    primeAuth('create-token');
+
+    server.use(
+      http.post('/api/backup/create', ({ request }) => {
+        expectBearerHeader(request, 'create-token');
+        return HttpResponse.json({ job_id: 'backup-1' });
+      })
+    );
+
+    const wrapper = mountView();
+    await (wrapper.vm as unknown as BackupsVm).triggerBackup();
+    await flushPromises();
+  });
+});

--- a/app/src/views/admin/ManageBackups.vue
+++ b/app/src/views/admin/ManageBackups.vue
@@ -387,9 +387,12 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue';
-import axios from 'axios';
 import useToast from '@/composables/useToast';
 import { useAsyncJob } from '@/composables/useAsyncJob';
+// v11.0 closeout F2b: every authed call now flows through the shared
+// apiClient so the request interceptor injects the Bearer from
+// `useAuth().token.value` — no direct localStorage reads.
+import { apiClient } from '@/api/client';
 
 // Types
 interface BackupItem {
@@ -600,10 +603,10 @@ function onSortChanged(ctx: { sortBy: string; sortDesc: boolean }) {
 async function fetchBackupList() {
   loading.value = true;
   try {
-    const response = await axios.get(`${import.meta.env.VITE_API_URL}/api/backup/list`, {
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('token')}`,
-      },
+    const response = await apiClient.raw.get<{
+      data?: Record<string, unknown>[];
+      meta?: Record<string, unknown>;
+    }>(`${import.meta.env.VITE_API_URL}/api/backup/list`, {
       withCredentials: true,
     });
 
@@ -638,15 +641,13 @@ async function fetchBackupList() {
 // Download backup file
 async function downloadBackup(filename: string) {
   try {
-    const response = await axios({
-      url: `${import.meta.env.VITE_API_URL}/api/backup/download/${filename}`,
-      method: 'GET',
-      responseType: 'blob',
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('token')}`,
-      },
-      withCredentials: true,
-    });
+    const response = await apiClient.raw.get<Blob>(
+      `${import.meta.env.VITE_API_URL}/api/backup/download/${filename}`,
+      {
+        responseType: 'blob',
+        withCredentials: true,
+      }
+    );
 
     const url = window.URL.createObjectURL(new Blob([response.data]));
     const link = document.createElement('a');
@@ -684,12 +685,15 @@ async function confirmRestore() {
   showRestoreModal.value = false;
 
   try {
-    const response = await axios.post(
+    const response = await apiClient.raw.post<{
+      error?: unknown;
+      message?: string;
+      job_id: string;
+    }>(
       `${import.meta.env.VITE_API_URL}/api/backup/restore`,
       { filename: selectedBackup.value.filename },
       {
         headers: {
-          Authorization: `Bearer ${localStorage.getItem('token')}`,
           'Content-Type': 'application/json',
         },
         withCredentials: true,
@@ -716,11 +720,13 @@ async function confirmDelete() {
   const filename = selectedBackup.value.filename;
 
   try {
-    const response = await axios.delete(
+    const response = await apiClient.raw.delete<{
+      error?: unknown;
+      message?: string;
+    }>(
       `${import.meta.env.VITE_API_URL}/api/backup/delete/${filename}`,
       {
         headers: {
-          Authorization: `Bearer ${localStorage.getItem('token')}`,
           'Content-Type': 'application/json',
         },
         data: { confirm: 'DELETE' },
@@ -746,13 +752,14 @@ async function triggerBackup() {
   backupJob.reset();
 
   try {
-    const response = await axios.post(
+    const response = await apiClient.raw.post<{
+      error?: unknown;
+      message?: string;
+      job_id: string;
+    }>(
       `${import.meta.env.VITE_API_URL}/api/backup/create`,
       {},
       {
-        headers: {
-          Authorization: `Bearer ${localStorage.getItem('token')}`,
-        },
         withCredentials: true,
       }
     );

--- a/app/src/views/admin/ManageOntology.spec.ts
+++ b/app/src/views/admin/ManageOntology.spec.ts
@@ -1,0 +1,189 @@
+// ManageOntology.spec.ts
+/**
+ * v11.0 closeout F2b — spec covering the apiClient migration of
+ * `views/admin/ManageOntology.vue`.
+ *
+ *   1. `doLoadData()` fetches `GET /api/ontology/variant/table` with the
+ *      `Authorization: Bearer <token>` header injected by the apiClient
+ *      request interceptor.
+ *   2. `updateOntologyData()` writes via `PUT /api/ontology/variant/update`
+ *      and also carries the Bearer header.
+ *
+ * The pre-F2b implementation hard-coded
+ * `Authorization: Bearer ${localStorage.getItem('token')}` on each call;
+ * this spec pins the migrated path so any regression trips the lint
+ * guardrail AND fails an observable test.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { http, HttpResponse } from 'msw';
+
+import '@/plugins/axios';
+import axios from '@/plugins/axios';
+import { server } from '@/test-utils/mocks/server';
+import { primeAuth } from '@/test-utils/primeAuth';
+import { expectBearerHeader } from '@/test-utils/expectBearerHeader';
+import { useAuth } from '@/composables/useAuth';
+import ManageOntology from './ManageOntology.vue';
+
+const makeToastSpy = vi.fn();
+vi.mock('@/composables/useToast', () => ({
+  default: () => ({ makeToast: makeToastSpy }),
+}));
+
+// The view composes `useTableData`, `useUrlParsing`, and `useExcelExport`
+// from the barrel. Stub them to minimal shapes so the spec focuses on
+// the two migrated HTTP call sites.
+vi.mock('@/composables', () => ({
+  useTableData: () => ({
+    currentPage: 1,
+    perPage: 25,
+    totalRows: 0,
+    sort: '+vario_id',
+    sortBy: [],
+    filter_string: '',
+    currentItemID: 0,
+    prevItemID: 0,
+    nextItemID: 0,
+    lastItemID: 0,
+    executionTime: 0,
+    pageOptions: [25],
+    isBusy: false,
+  }),
+  useUrlParsing: () => ({
+    filterObjToStr: () => '',
+    filterStrToObj: (_s: string, o: unknown) => o,
+    sortStringToVariables: () => ({ sortBy: [] }),
+  }),
+  useExcelExport: () => ({
+    isExporting: false,
+    exportToExcel: vi.fn(),
+  }),
+}));
+
+interface OntologyVm {
+  doLoadData: () => Promise<void>;
+  updateOntologyData: () => Promise<void>;
+  ontologyToEdit: Record<string, unknown>;
+  ontologies: unknown[];
+  filter: Record<string, unknown>;
+}
+
+const tableOk = {
+  data: [
+    {
+      vario_id: 'VariO:0001',
+      vario_name: 'Example',
+      definition: 'Example def',
+      obsolete: 0,
+      is_active: 1,
+      sort: 1,
+      update_date: '2025-01-01',
+    },
+  ],
+  meta: [
+    {
+      totalItems: 1,
+      currentPage: 1,
+      totalPages: 1,
+      prevItemID: 0,
+      currentItemID: 0,
+      nextItemID: 0,
+      lastItemID: 0,
+      executionTime: 10,
+    },
+  ],
+};
+
+async function mountView() {
+  setActivePinia(createPinia());
+  const wrapper = mount(ManageOntology, {
+    global: {
+      mocks: { axios },
+      provide: { axios },
+      directives: { 'b-tooltip': {}, 'b-toggle': {} },
+      stubs: {
+        GenericTable: { template: '<div />' },
+        TablePaginationControls: { template: '<div />' },
+        BContainer: { template: '<div><slot /></div>' },
+        BRow: { template: '<div><slot /></div>' },
+        BCol: { template: '<div><slot /></div>' },
+        BCard: { template: '<div><slot name="header" /><slot /></div>' },
+        BBadge: { template: '<span><slot /></span>' },
+        BButton: { template: '<button><slot /></button>' },
+        BSpinner: { template: '<div />' },
+        BFormInput: { template: '<input />' },
+        BInputGroup: { template: '<div><slot name="prepend" /><slot /></div>' },
+        BInputGroupText: { template: '<span><slot /></span>' },
+        BFormSelect: { template: '<select />' },
+        BModal: { template: '<div><slot /></div>' },
+      },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+beforeEach(() => {
+  makeToastSpy.mockClear();
+  vi.stubEnv('VITE_API_URL', '');
+});
+
+afterEach(() => {
+  useAuth().logout();
+  vi.unstubAllEnvs();
+});
+
+describe('ManageOntology — v11.0 closeout F2b apiClient migration', () => {
+  it('doLoadData() fetches the ontology table with the Bearer header injected by apiClient', async () => {
+    primeAuth('ontology-token');
+
+    server.use(
+      http.get('/api/ontology/variant/table', ({ request }) => {
+        expectBearerHeader(request, 'ontology-token');
+        return HttpResponse.json(tableOk);
+      })
+    );
+
+    const wrapper = await mountView();
+    await (wrapper.vm as unknown as OntologyVm).doLoadData();
+    await flushPromises();
+
+    // Sanity: the migration did not break the table's consumption of
+    // `response.data` — ontologies populated from the fixture.
+    const vm = wrapper.vm as unknown as OntologyVm;
+    expect(Array.isArray(vm.ontologies)).toBe(true);
+    expect(vm.ontologies).toHaveLength(1);
+  });
+
+  it('updateOntologyData() writes via PUT with the Bearer header', async () => {
+    primeAuth('ontology-write-token');
+
+    server.use(
+      http.put('/api/ontology/variant/update', ({ request }) => {
+        expectBearerHeader(request, 'ontology-write-token');
+        return HttpResponse.json({ message: 'Updated' });
+      })
+    );
+
+    const wrapper = await mountView();
+    const vm = wrapper.vm as unknown as OntologyVm;
+    vm.ontologyToEdit = {
+      vario_id: 'VariO:0001',
+      vario_name: 'Renamed',
+      definition: 'New def',
+    };
+    // `ontologies` must exist so the post-update splice has something
+    // to find (even if no match, the code path still validates the
+    // Bearer-header contract).
+    vm.ontologies = [];
+
+    await vm.updateOntologyData();
+    await flushPromises();
+
+    // Success toast fired because the PUT resolved 2xx.
+    expect(makeToastSpy).toHaveBeenCalled();
+  });
+});

--- a/app/src/views/admin/ManageOntology.vue
+++ b/app/src/views/admin/ManageOntology.vue
@@ -312,6 +312,10 @@ import GenericTable from '@/components/small/GenericTable.vue';
 import TablePaginationControls from '@/components/small/TablePaginationControls.vue';
 import useToast from '@/composables/useToast';
 import { useUrlParsing, useTableData, useExcelExport } from '@/composables';
+// v11.0 closeout F2b: reach for `apiClient` instead of the raw axios
+// instance so the request interceptor injects the Bearer header from
+// `useAuth().token.value` (single source of truth for session auth).
+import { apiClient } from '@/api/client';
 
 // Import the Pinia store
 import { useUiStore } from '@/stores/ui';
@@ -663,11 +667,10 @@ export default {
       const apiUrl = `${import.meta.env.VITE_API_URL}/api/ontology/variant/table?${urlParam}`;
 
       try {
-        const response = await this.axios.get(apiUrl, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        });
+        // v11.0 closeout F2b: `apiClient.raw` returns the full AxiosResponse
+        // so the existing `response.data` unpacking stays intact; the
+        // request interceptor adds the Bearer header automatically.
+        const response = await apiClient.raw.get(apiUrl);
         moduleApiCallInProgress = false;
         moduleLastApiResponse = response.data;
         this.applyApiResponse(response.data);
@@ -744,15 +747,11 @@ export default {
     async updateOntologyData() {
       const apiUrl = `${import.meta.env.VITE_API_URL}/api/ontology/variant/update`;
       try {
-        const response = await this.axios.put(
-          apiUrl,
-          { ontology_details: this.ontologyToEdit },
-          {
-            headers: {
-              Authorization: `Bearer ${localStorage.getItem('token')}`,
-            },
-          }
-        );
+        // v11.0 closeout F2b: Bearer header flows through the apiClient
+        // request interceptor from `useAuth().token.value`.
+        const response = await apiClient.raw.put(apiUrl, {
+          ontology_details: this.ontologyToEdit,
+        });
         this.makeToast(response.data.message, 'Success', 'success');
         // Update the ontology in the local state
         const index = this.ontologies.findIndex((o) => o.vario_id === this.ontologyToEdit.vario_id);

--- a/app/src/views/admin/ManageUser.spec.ts
+++ b/app/src/views/admin/ManageUser.spec.ts
@@ -46,6 +46,14 @@ import {
   userUpdateForbidden,
   type UserTableRow,
 } from '@/test-utils/mocks/data/users';
+// v11.0 closeout F2b — apiClient helpers for the 9 new Bearer-header
+// tests below. The Phase C tests above stay on `localStorage.setItem`
+// seeding to keep their assertions stable; the new block uses the
+// composable abstraction (`primeAuth()`) so regressions in F1 plumbing
+// (useAuth / apiClient interceptor) surface here too.
+import { primeAuth } from '@/test-utils/primeAuth';
+import { expectBearerHeader } from '@/test-utils/expectBearerHeader';
+import { useAuth } from '@/composables/useAuth';
 
 // -----------------------------------------------------------------------------
 // Toast spy — the view surfaces its error "banner" as a danger-variant toast.
@@ -170,14 +178,18 @@ describe('ManageUser view — functional (Phase C.C6)', () => {
     // the MSW-intercepted relative path (`/api/...`).  `vi.stubEnv` is the
     // Vitest-sanctioned way to mutate `import.meta.env` inside a test.
     vi.stubEnv('VITE_API_URL', '');
-    // Seed a token so the axios calls include the Authorization header the
-    // /role_list and /list handlers require (B1 handler table rejects with
-    // 401 when the header is missing).
-    window.localStorage.setItem('token', 'test-token');
+    // Seed a session so the B1 handler table accepts requests. Pre-F2b
+    // this used `localStorage.setItem('token', 'test-token')` directly;
+    // post-F2b the view reads its Bearer from `useAuth().token.value`
+    // through the apiClient interceptor, so we prime the composable
+    // instead. Behaviour is identical — a 'test-token' Bearer on every
+    // outbound call — but the abstraction seam is the correct one.
+    primeAuth('test-token');
     makeToastSpy.mockClear();
   });
 
   afterEach(() => {
+    useAuth().logout();
     vi.unstubAllEnvs();
   });
 
@@ -314,4 +326,253 @@ describe('ManageUser view — functional (Phase C.C6)', () => {
   it.todo(
     'TODO: verify the search-and-filter state persists across role edits and user_role bulk assignments via POST /api/user/bulk_assign_role'
   );
+});
+
+// ===========================================================================
+// v11.0 closeout F2b — apiClient Bearer header contract (9 new tests)
+// ===========================================================================
+// Nine authed call sites in ManageUser.vue were migrated from hand-built
+// `Authorization: Bearer ${localStorage.getItem('token')}` headers onto
+// `apiClient.raw.*`. Each test below pins one migrated call site with
+// `primeAuth() + expectBearerHeader()` so any regression in either this
+// view or the F1 plumbing (useAuth / apiClient interceptor) surfaces as
+// an observable test failure — not just an ESLint warning.
+describe('ManageUser view — v11.0 closeout F2b apiClient Bearer contract', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_API_URL', '');
+    makeToastSpy.mockClear();
+  });
+
+  afterEach(() => {
+    useAuth().logout();
+    vi.unstubAllEnvs();
+  });
+
+  async function mountWithToken(token: string) {
+    primeAuth(token);
+    // Keep the initial mount loads quiet and valid.
+    server.use(
+      http.get('/api/user/table', () => HttpResponse.json(userTableOk)),
+      http.get('/api/user/role_list', () =>
+        HttpResponse.json([
+          { role: 'Administrator' },
+          { role: 'Curator' },
+          { role: 'Viewer' },
+        ])
+      ),
+      http.get('/api/user/list', () => HttpResponse.json([]))
+    );
+    return mountComponent();
+  }
+
+
+  it('1. confirmBulkApprove → POST /api/user/bulk_approve carries the Bearer header', async () => {
+    let sawBearer = false;
+    server.use(
+      http.post('/api/user/bulk_approve', ({ request }) => {
+        expectBearerHeader(request, 'bulk-approve-token');
+        sawBearer = true;
+        return HttpResponse.json({ processed: 2 });
+      })
+    );
+
+    const wrapper = await mountWithToken('bulk-approve-token');
+    // Feed the selection the view reads via `getSelectedArray()`.
+    (
+      wrapper.vm as unknown as {
+        getSelectedArray?: () => number[];
+        selected?: Record<number, boolean>;
+      }
+    ).selected = { 1: true, 2: true };
+    (
+      wrapper.vm as unknown as {
+        getSelectedArray: () => number[];
+      }
+    ).getSelectedArray = () => [1, 2];
+
+    await (wrapper.vm as unknown as { confirmBulkApprove: () => Promise<void> }).confirmBulkApprove();
+    await flushPromises();
+    expect(sawBearer).toBe(true);
+  });
+
+  it('2. confirmBulkRoleAssignment → POST /api/user/bulk_assign_role carries the Bearer header', async () => {
+    let sawBearer = false;
+    server.use(
+      http.post('/api/user/bulk_assign_role', ({ request }) => {
+        expectBearerHeader(request, 'bulk-role-token');
+        sawBearer = true;
+        return HttpResponse.json({ processed: 1 });
+      })
+    );
+
+    const wrapper = await mountWithToken('bulk-role-token');
+    (
+      wrapper.vm as unknown as {
+        getSelectedArray: () => number[];
+        bulkRoleSelection: string;
+      }
+    ).getSelectedArray = () => [2];
+    (wrapper.vm as unknown as { bulkRoleSelection: string }).bulkRoleSelection = 'Curator';
+
+    await (
+      wrapper.vm as unknown as { confirmBulkRoleAssignment: () => Promise<void> }
+    ).confirmBulkRoleAssignment();
+    await flushPromises();
+    expect(sawBearer).toBe(true);
+  });
+
+  it('3. confirmBulkDelete → POST /api/user/bulk_delete carries the Bearer header', async () => {
+    let sawBearer = false;
+    server.use(
+      http.post('/api/user/bulk_delete', ({ request }) => {
+        expectBearerHeader(request, 'bulk-delete-token');
+        sawBearer = true;
+        return HttpResponse.json({ processed: 1 });
+      })
+    );
+
+    const wrapper = await mountWithToken('bulk-delete-token');
+    (
+      wrapper.vm as unknown as { getSelectedArray: () => number[] }
+    ).getSelectedArray = () => [2];
+
+    await (
+      wrapper.vm as unknown as { confirmBulkDelete: () => Promise<void> }
+    ).confirmBulkDelete();
+    await flushPromises();
+    expect(sawBearer).toBe(true);
+  });
+
+  it('4. doLoadData → GET /api/user/table carries the Bearer header', async () => {
+    // Install the Bearer-checking handler BEFORE mountWithToken so the
+    // initial mount fetch gets intercepted. The view has a 500ms
+    // module-level "same-params skip" guard on doLoadData; wait it out
+    // so the initial mount actually fires a fresh network request
+    // instead of re-using a cached response from an earlier test in
+    // this describe block.
+    await new Promise((resolve) => setTimeout(resolve, 520));
+    primeAuth('user-table-token');
+    let sawBearer = false;
+    server.use(
+      http.get('/api/user/table', ({ request }) => {
+        expectBearerHeader(request, 'user-table-token');
+        sawBearer = true;
+        return HttpResponse.json(userTableOk);
+      }),
+      http.get('/api/user/role_list', () => HttpResponse.json([])),
+      http.get('/api/user/list', () => HttpResponse.json([]))
+    );
+    await mountComponent();
+    expect(sawBearer).toBe(true);
+  });
+
+  it('5. loadRoleList → GET /api/user/role_list carries the Bearer header', async () => {
+    primeAuth('role-list-token');
+    let sawBearer = false;
+    server.use(
+      http.get('/api/user/table', () => HttpResponse.json(userTableOk)),
+      http.get('/api/user/role_list', ({ request }) => {
+        expectBearerHeader(request, 'role-list-token');
+        sawBearer = true;
+        return HttpResponse.json([{ role: 'Administrator' }]);
+      }),
+      http.get('/api/user/list', () => HttpResponse.json([]))
+    );
+    await mountComponent();
+    expect(sawBearer).toBe(true);
+  });
+
+  it('6. loadUserList → GET /api/user/list carries the Bearer header', async () => {
+    primeAuth('user-list-token');
+    let sawBearer = false;
+    server.use(
+      http.get('/api/user/table', () => HttpResponse.json(userTableOk)),
+      http.get('/api/user/role_list', () => HttpResponse.json([])),
+      http.get('/api/user/list', ({ request }) => {
+        expectBearerHeader(request, 'user-list-token');
+        sawBearer = true;
+        return HttpResponse.json([]);
+      })
+    );
+    await mountComponent();
+    expect(sawBearer).toBe(true);
+  });
+
+  it('7. confirmDeleteUser → DELETE /api/user/delete carries the Bearer header', async () => {
+    let sawBearer = false;
+    server.use(
+      http.delete('/api/user/delete', ({ request }) => {
+        expectBearerHeader(request, 'delete-user-token');
+        sawBearer = true;
+        return HttpResponse.json({ message: 'Deleted' });
+      })
+    );
+
+    const wrapper = await mountWithToken('delete-user-token');
+    (wrapper.vm as unknown as { userToDelete: { user_id: number } }).userToDelete = {
+      user_id: 2,
+    };
+
+    await (
+      wrapper.vm as unknown as { confirmDeleteUser: () => Promise<void> }
+    ).confirmDeleteUser();
+    await flushPromises();
+    expect(sawBearer).toBe(true);
+  });
+
+  it('8. updateUserData → PUT /api/user/update carries the Bearer header', async () => {
+    let sawBearer = false;
+    server.use(
+      http.put('/api/user/update', ({ request }) => {
+        expectBearerHeader(request, 'update-user-token');
+        sawBearer = true;
+        return HttpResponse.json({ message: 'Updated' });
+      })
+    );
+
+    const wrapper = await mountWithToken('update-user-token');
+    const bob = (userTableOk.data as UserTableRow[]).find((u) => u.user_id === 2)!;
+    (wrapper.vm as unknown as { userToUpdate: UserTableRow }).userToUpdate = { ...bob };
+
+    await (wrapper.vm as unknown as { updateUserData: () => Promise<void> }).updateUserData();
+    await flushPromises();
+    expect(sawBearer).toBe(true);
+  });
+
+  it('9. changeUserPassword → PUT /api/user/password/update carries the Bearer header', async () => {
+    let sawBearer = false;
+    server.use(
+      http.put('/api/user/password/update', ({ request }) => {
+        expectBearerHeader(request, 'pass-update-token');
+        sawBearer = true;
+        return HttpResponse.json({ message: 'Password updated' });
+      })
+    );
+
+    const wrapper = await mountWithToken('pass-update-token');
+    (wrapper.vm as unknown as { userToUpdate: UserTableRow }).userToUpdate = {
+      ...(userTableOk.data as UserTableRow[])[0],
+    };
+    const vm = wrapper.vm as unknown as {
+      passwordChange: {
+        newPassword: string;
+        confirmPassword: string;
+        showPassword: boolean;
+        isChanging: boolean;
+      };
+      passwordValidation: { isValid: boolean };
+      changeUserPassword: () => Promise<void>;
+    };
+    vm.passwordChange.newPassword = 'NewPass1!abcdefgh';
+    vm.passwordChange.confirmPassword = 'NewPass1!abcdefgh';
+    // Force the validation guard true so the code path proceeds to the PUT.
+    Object.defineProperty(vm, 'passwordValidation', {
+      value: { isValid: true },
+      configurable: true,
+    });
+
+    await vm.changeUserPassword();
+    await flushPromises();
+    expect(sawBearer).toBe(true);
+  });
 });

--- a/app/src/views/admin/ManageUser.vue
+++ b/app/src/views/admin/ManageUser.vue
@@ -741,6 +741,12 @@ import {
 // Import the Pinia store
 import { useUiStore } from '@/stores/ui';
 
+// v11.0 closeout F2b: every authed call below routes through apiClient.
+// The request interceptor injects `Authorization: Bearer <token>` from
+// `useAuth().token.value`, so this view no longer reads the session
+// token from storage in 9 separate call sites.
+import { apiClient } from '@/api/client';
+
 // Define validation rules globally
 defineRule('required', required);
 defineRule('min', min);
@@ -1147,15 +1153,9 @@ export default {
 
       const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/bulk_approve`;
       try {
-        const response = await this.axios.post(
-          apiUrl,
-          {
-            user_ids: userIds,
-          },
-          {
-            headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
-          }
-        );
+        const response = await apiClient.raw.post(apiUrl, {
+          user_ids: userIds,
+        });
 
         if (response.status === 200) {
           this.makeToast(
@@ -1200,16 +1200,10 @@ export default {
 
       const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/bulk_assign_role`;
       try {
-        const response = await this.axios.post(
-          apiUrl,
-          {
-            user_ids: userIds,
-            role: selectedRole,
-          },
-          {
-            headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
-          }
-        );
+        const response = await apiClient.raw.post(apiUrl, {
+          user_ids: userIds,
+          role: selectedRole,
+        });
 
         if (response.status === 200) {
           this.makeToast(
@@ -1261,15 +1255,9 @@ export default {
 
       const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/bulk_delete`;
       try {
-        const response = await this.axios.post(
-          apiUrl,
-          {
-            user_ids: userIds,
-          },
-          {
-            headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
-          }
-        );
+        const response = await apiClient.raw.post(apiUrl, {
+          user_ids: userIds,
+        });
 
         if (response.status === 200) {
           this.makeToast(
@@ -1389,9 +1377,7 @@ export default {
       const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/table?${urlParam}`;
 
       try {
-        const response = await this.axios.get(apiUrl, {
-          headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
-        });
+        const response = await apiClient.raw.get(apiUrl);
         moduleApiCallInProgress = false;
         moduleLastApiResponse = response.data;
         this.applyApiResponse(response.data);
@@ -1487,9 +1473,7 @@ export default {
     async loadRoleList() {
       const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/role_list`;
       try {
-        const response = await this.axios.get(apiUrl, {
-          headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
-        });
+        const response = await apiClient.raw.get(apiUrl);
         this.role_options = response.data.map((item) => ({ value: item.role, text: item.role }));
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
@@ -1498,9 +1482,7 @@ export default {
     async loadUserList() {
       const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/list?roles=Curator,Reviewer`;
       try {
-        const response = await this.axios.get(apiUrl, {
-          headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
-        });
+        const response = await apiClient.raw.get(apiUrl);
         this.user_options = response.data.map((item) => ({
           value: item.user_id,
           text: item.user_name,
@@ -1518,9 +1500,8 @@ export default {
     async confirmDeleteUser() {
       const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/delete`;
       try {
-        const response = await this.axios.delete(apiUrl, {
+        const response = await apiClient.raw.delete(apiUrl, {
           data: { user_id: this.userToDelete.user_id },
-          headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
         });
         if (response.status === 200) {
           this.makeToast('User deleted successfully', 'Success', 'success');
@@ -1576,13 +1557,7 @@ export default {
         updatePayload.comment = this.userToUpdate.comment;
       }
       try {
-        const response = await this.axios.put(
-          apiUrl,
-          { user_details: updatePayload },
-          {
-            headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
-          }
-        );
+        const response = await apiClient.raw.put(apiUrl, { user_details: updatePayload });
         if (response.status === 200) {
           this.makeToast('User updated successfully', 'Success', 'success');
           this.loadData(); // Reload the table data
@@ -1682,18 +1657,12 @@ export default {
       const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/password/update`;
 
       try {
-        const response = await this.axios.put(
-          apiUrl,
-          {
-            user_id_pass_change: this.userToUpdate.user_id,
-            old_pass: '', // Admin can change password without knowing old password
-            new_pass_1: this.passwordChange.newPassword,
-            new_pass_2: this.passwordChange.confirmPassword,
-          },
-          {
-            headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
-          }
-        );
+        const response = await apiClient.raw.put(apiUrl, {
+          user_id_pass_change: this.userToUpdate.user_id,
+          old_pass: '', // Admin can change password without knowing old password
+          new_pass_1: this.passwordChange.newPassword,
+          new_pass_2: this.passwordChange.confirmPassword,
+        });
 
         if (response.status === 200) {
           this.makeToast(

--- a/app/src/views/curate/ApproveUser.spec.ts
+++ b/app/src/views/curate/ApproveUser.spec.ts
@@ -1,0 +1,184 @@
+// ApproveUser.spec.ts
+/**
+ * v11.0 closeout F2b — spec for `views/curate/ApproveUser.vue`.
+ *
+ * Four authed endpoints now route through `apiClient.raw.*`:
+ *
+ *   - GET /api/user/table        (`loadUserTableData`)
+ *   - GET /api/user/role_list    (`loadRoleList`)
+ *   - PUT /api/user/approval     (`handleUserApproval`)
+ *   - PUT /api/user/change_role  (`handleUserChangeRole`)
+ *
+ * Every call previously stamped its own
+ * `Authorization: Bearer ${localStorage.getItem('token')}` header — the
+ * migration delegates that to the apiClient request interceptor. This
+ * spec uses `primeAuth() + expectBearerHeader()` to prove the header is
+ * still injected after the refactor.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { http, HttpResponse } from 'msw';
+
+import '@/plugins/axios';
+import { server } from '@/test-utils/mocks/server';
+import { primeAuth } from '@/test-utils/primeAuth';
+import { expectBearerHeader } from '@/test-utils/expectBearerHeader';
+import { useAuth } from '@/composables/useAuth';
+import ApproveUser from './ApproveUser.vue';
+
+const makeToastSpy = vi.fn();
+const announceSpy = vi.fn();
+
+vi.mock('@/composables', () => ({
+  useToast: () => ({ makeToast: makeToastSpy }),
+  useColorAndSymbols: () => ({}),
+  useAriaLive: () => ({
+    message: '',
+    politeness: 'polite',
+    announce: announceSpy,
+  }),
+}));
+
+interface ApproveUserVm {
+  loadUserTableData: () => Promise<void>;
+  loadRoleList: () => Promise<void>;
+  handleUserApproval: (userId: number, approved: boolean) => Promise<void>;
+  handleUserChangeRole: (userId: number, role: string) => Promise<void>;
+  items_UsersTable: unknown[];
+  role_options: unknown[];
+}
+
+async function mountView() {
+  setActivePinia(createPinia());
+  const wrapper = mount(ApproveUser, {
+    global: {
+      directives: { 'b-tooltip': {}, 'b-toggle': {} },
+      stubs: {
+        AriaLiveRegion: { template: '<div />' },
+        BContainer: { template: '<div><slot /></div>' },
+        BRow: { template: '<div><slot /></div>' },
+        BCol: { template: '<div><slot /></div>' },
+        BCard: { template: '<div><slot name="header" /><slot /></div>' },
+        BButton: { template: '<button><slot /></button>' },
+        BBadge: { template: '<span><slot /></span>' },
+        BSpinner: { template: '<div />' },
+        BFormInput: { template: '<input />' },
+        BFormSelect: { template: '<select />' },
+        BInputGroup: { template: '<div><slot name="prepend" /><slot /></div>' },
+        BInputGroupText: { template: '<span><slot /></span>' },
+        BTable: {
+          props: ['items'],
+          template: '<table />',
+        },
+        BPagination: { template: '<nav />' },
+        BFormGroup: { template: '<div><slot /></div>' },
+        BFormTextarea: { template: '<textarea />' },
+        BForm: { template: '<form><slot /></form>' },
+        BModal: { template: '<div><slot /></div>' },
+        BPopover: { template: '<div />' },
+        BLink: { template: '<a><slot /></a>' },
+      },
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+beforeEach(() => {
+  makeToastSpy.mockClear();
+  announceSpy.mockClear();
+  vi.stubEnv('VITE_API_URL', '');
+});
+
+afterEach(() => {
+  useAuth().logout();
+  vi.unstubAllEnvs();
+});
+
+describe('ApproveUser — v11.0 closeout F2b apiClient migration', () => {
+  it('loadUserTableData() fetches /api/user/table with the Bearer header', async () => {
+    primeAuth('approve-users-token');
+
+    server.use(
+      http.get('/api/user/table', ({ request }) => {
+        expectBearerHeader(request, 'approve-users-token');
+        return HttpResponse.json([]);
+      }),
+      http.get('/api/user/role_list', () => HttpResponse.json([]))
+    );
+
+    const wrapper = await mountView();
+    const vm = wrapper.vm as unknown as ApproveUserVm;
+    await vm.loadUserTableData();
+    await flushPromises();
+    expect(Array.isArray(vm.items_UsersTable)).toBe(true);
+  });
+
+  it('loadRoleList() fetches /api/user/role_list with the Bearer header', async () => {
+    primeAuth('roles-token');
+
+    server.use(
+      http.get('/api/user/table', () => HttpResponse.json([])),
+      http.get('/api/user/role_list', ({ request }) => {
+        expectBearerHeader(request, 'roles-token');
+        return HttpResponse.json([{ role: 'Curator' }, { role: 'Reviewer' }]);
+      })
+    );
+
+    const wrapper = await mountView();
+    const vm = wrapper.vm as unknown as ApproveUserVm;
+    await vm.loadRoleList();
+    await flushPromises();
+    expect(vm.role_options).toEqual([
+      { value: 'Curator', text: 'Curator' },
+      { value: 'Reviewer', text: 'Reviewer' },
+    ]);
+  });
+
+  it('handleUserApproval() issues PUT /api/user/approval with the Bearer header', async () => {
+    primeAuth('approve-token');
+
+    // Initial mount hits both loaders — keep them quiet.
+    server.use(
+      http.get('/api/user/table', () => HttpResponse.json([])),
+      http.get('/api/user/role_list', () => HttpResponse.json([])),
+      http.put('/api/user/approval', ({ request }) => {
+        expectBearerHeader(request, 'approve-token');
+        // The view builds the URL as query-string params (user_id and
+        // status_approval). MSW path-matches the bare path.
+        const url = new URL(request.url);
+        expect(url.searchParams.get('user_id')).toBe('42');
+        expect(url.searchParams.get('status_approval')).toBe('true');
+        return HttpResponse.json({ message: 'Approved' });
+      })
+    );
+
+    const wrapper = await mountView();
+    await (wrapper.vm as unknown as ApproveUserVm).handleUserApproval(42, true);
+    await flushPromises();
+    // A success announce fires on 2xx.
+    expect(announceSpy).toHaveBeenCalled();
+  });
+
+  it('handleUserChangeRole() issues PUT /api/user/change_role with the Bearer header', async () => {
+    primeAuth('role-change-token');
+
+    server.use(
+      http.get('/api/user/table', () => HttpResponse.json([])),
+      http.get('/api/user/role_list', () => HttpResponse.json([])),
+      http.put('/api/user/change_role', ({ request }) => {
+        expectBearerHeader(request, 'role-change-token');
+        const url = new URL(request.url);
+        expect(url.searchParams.get('user_id')).toBe('42');
+        expect(url.searchParams.get('role_assigned')).toBe('Curator');
+        return HttpResponse.json({ message: 'Role updated' });
+      })
+    );
+
+    const wrapper = await mountView();
+    await (wrapper.vm as unknown as ApproveUserVm).handleUserChangeRole(42, 'Curator');
+    await flushPromises();
+  });
+});

--- a/app/src/views/curate/ApproveUser.vue
+++ b/app/src/views/curate/ApproveUser.vue
@@ -509,6 +509,11 @@
 import { useToast, useColorAndSymbols, useAriaLive } from '@/composables';
 import { useUiStore } from '@/stores/ui';
 import AriaLiveRegion from '@/components/accessibility/AriaLiveRegion.vue';
+// v11.0 closeout F2b: apiClient replaces `this.axios` + manual Bearer
+// header construction. The request interceptor reads
+// `useAuth().token.value` and injects `Authorization: Bearer <token>`
+// on every outbound call.
+import { apiClient } from '@/api/client';
 
 export default {
   name: 'ApproveUser',
@@ -641,11 +646,7 @@ export default {
       this.loadingUsersApprove = true;
       const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/table`;
       try {
-        const response = await this.axios.get(apiUrl, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        });
+        const response = await apiClient.raw.get(apiUrl);
         const data = response.data;
         let users = [];
         if (Array.isArray(data)) {
@@ -670,11 +671,7 @@ export default {
     async loadRoleList() {
       const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/role_list`;
       try {
-        const response = await this.axios.get(apiUrl, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('token')}`,
-          },
-        });
+        const response = await apiClient.raw.get(apiUrl);
         const data = response.data;
         this.role_options = Array.isArray(data)
           ? data.map((item) => ({ value: item.role, text: item.role }))
@@ -749,15 +746,7 @@ export default {
       const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/approval?user_id=${userId}&status_approval=${approved}`;
 
       try {
-        await this.axios.put(
-          apiUrl,
-          {},
-          {
-            headers: {
-              Authorization: `Bearer ${localStorage.getItem('token')}`,
-            },
-          }
-        );
+        await apiClient.raw.put(apiUrl, {});
         const message = approved ? 'User approved successfully.' : 'User application rejected.';
         this.makeToast(message, 'Success', approved ? 'success' : 'info');
         this.announce(message);
@@ -771,15 +760,7 @@ export default {
       const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/change_role?user_id=${userId}&role_assigned=${userRole}`;
 
       try {
-        await this.axios.put(
-          apiUrl,
-          {},
-          {
-            headers: {
-              Authorization: `Bearer ${localStorage.getItem('token')}`,
-            },
-          }
-        );
+        await apiClient.raw.put(apiUrl, {});
       } catch (e) {
         this.makeToast(e, 'Error', 'danger');
       }

--- a/app/src/views/curate/ModifyEntity.spec.ts
+++ b/app/src/views/curate/ModifyEntity.spec.ts
@@ -32,10 +32,21 @@
  *     path only. Covering the other three modals is a future phase concern.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, flushPromises, type VueWrapper } from '@vue/test-utils';
 import { createPinia } from 'pinia';
+import { http, HttpResponse } from 'msw';
 import { bootstrapStubs } from '@/test-utils';
+// v11.0 closeout F2b migrated the three write calls
+// (`POST /api/entity/rename`, `/api/entity/deactivate`, `/api/review/create`)
+// from `this.axios.post(...)` onto the shared apiClient. Loading `@/plugins/
+// axios` attaches the 401 interceptor and ensures the apiClient request
+// interceptor is initialised before the first outbound call.
+import '@/plugins/axios';
+import { server } from '@/test-utils/mocks/server';
+import { primeAuth } from '@/test-utils/primeAuth';
+import { expectBearerHeader } from '@/test-utils/expectBearerHeader';
+import { useAuth } from '@/composables/useAuth';
 import ModifyEntity from './ModifyEntity.vue';
 import { entityByIdOk, entityCreateConflict } from '@/test-utils/mocks/data/entities';
 
@@ -213,11 +224,38 @@ describe('ModifyEntity — functional (Phase C/C4)', () => {
   beforeEach(() => {
     makeToastSpy.mockClear();
     announceSpy.mockClear();
+    vi.stubEnv('VITE_API_URL', '');
+    // Seed a session so the apiClient request interceptor injects the
+    // Bearer on the migrated POSTs. The existing tests don't pin the
+    // header — the new F2b tests below do.
+    primeAuth('modify-entity-token');
+  });
+
+  afterEach(() => {
+    useAuth().logout();
+    vi.unstubAllEnvs();
   });
 
   describe('happy path — rename entity disease', () => {
     it('POSTs /api/entity/rename, surfaces success, and clears the selection (cache invalidation)', async () => {
+      // Loaders still run through `this.axios.get(...)` / `this.axios.put(...)`
+      // (those call sites are out of F2b scope); the axiosMock covers them.
+      // The MIGRATED write (rename POST) now goes through apiClient → the
+      // shared axios singleton → MSW. We capture the body via MSW and assert
+      // the same `rename_json.entity` shape the original spec checked.
       const axiosMock = createAxiosMock();
+
+      let capturedBody: unknown = null;
+      server.use(
+        http.post('/api/entity/rename', async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json(
+            { message: 'Entity successfully renamed.', entity_id: 501 },
+            { status: 200, statusText: 'OK' }
+          );
+        })
+      );
+
       const wrapper = await mountModifyEntity(axiosMock);
       await seedLoadedEntity(wrapper);
 
@@ -225,21 +263,15 @@ describe('ModifyEntity — functional (Phase C/C4)', () => {
       await vm.submitEntityRename();
       await flushPromises();
 
-      // 1. Exactly one POST went to /api/entity/rename with a wrapped payload
+      // 1. The POST hit /api/entity/rename with a wrapped payload
       //    (`rename_json`) shaped by the submissionSubmission class.
-      const renameCalls = axiosMock.post.mock.calls.filter((call) =>
-        String(call[0]).endsWith('/api/entity/rename')
-      );
-      expect(renameCalls).toHaveLength(1);
-
-      const [, payload] = renameCalls[0];
+      expect(capturedBody).not.toBeNull();
+      const payload = capturedBody as { rename_json: { entity: Record<string, unknown> } };
       expect(payload).toHaveProperty('rename_json');
-      const renameJson = (payload as { rename_json: { entity: Record<string, unknown> } })
-        .rename_json;
-      expect(renameJson).toHaveProperty('entity');
+      expect(payload.rename_json).toHaveProperty('entity');
       // The view mutates `entity_info.disease_ontology_id_version = ontology_input`
       // before wrapping — confirm the new ontology id is on the wire.
-      expect(renameJson.entity).toMatchObject({
+      expect(payload.rename_json.entity).toMatchObject({
         entity_id: entityByIdOk.entity_id,
         disease_ontology_id_version: 'MONDO:0000456_2025-01-01',
       });
@@ -264,19 +296,14 @@ describe('ModifyEntity — functional (Phase C/C4)', () => {
 
   describe('error path — duplicate entity (409 conflict)', () => {
     it('surfaces the 409 conflict description via the toast composable and keeps the selection intact', async () => {
-      const axiosMock = createAxiosMock();
-      // Reject the rename POST with an axios-shaped 409 carrying the
-      // conflict description from the B1 entity fixtures.
-      const conflictError = Object.assign(new Error('Request failed with status code 409'), {
-        isAxiosError: true,
-        response: {
-          status: 409,
-          statusText: 'Conflict',
-          data: entityCreateConflict,
-        },
-      });
-      axiosMock.post.mockRejectedValueOnce(conflictError);
+      // Reject the migrated rename POST with the conflict shape from B1.
+      server.use(
+        http.post('/api/entity/rename', () =>
+          HttpResponse.json(entityCreateConflict, { status: 409 })
+        )
+      );
 
+      const axiosMock = createAxiosMock();
       const wrapper = await mountModifyEntity(axiosMock);
       await seedLoadedEntity(wrapper);
 
@@ -284,13 +311,7 @@ describe('ModifyEntity — functional (Phase C/C4)', () => {
       await vm.submitEntityRename();
       await flushPromises();
 
-      // 1. The rename POST was still attempted (otherwise the 409 never fires).
-      const renameCalls = axiosMock.post.mock.calls.filter((call) =>
-        String(call[0]).endsWith('/api/entity/rename')
-      );
-      expect(renameCalls).toHaveLength(1);
-
-      // 2. makeToast was called with the error variant and the rejected
+      // 1. makeToast was called with the error variant and the rejected
       //    axios error object (the view forwards `e` through to the toast
       //    composable, which typically renders `e.response.data.error`).
       const dangerToasts = makeToastSpy.mock.calls.filter((call) => call[2] === 'danger');
@@ -303,14 +324,120 @@ describe('ModifyEntity — functional (Phase C/C4)', () => {
       expect(dangerArg.response?.status).toBe(409);
       expect(dangerArg.response?.data?.error).toBe(entityCreateConflict.error);
 
-      // 3. Screen reader was told the operation failed (assertive politeness).
+      // 2. Screen reader was told the operation failed (assertive politeness).
       expect(announceSpy).toHaveBeenCalledWith('Failed to update disease name', 'assertive');
 
-      // 4. On failure, the view does NOT resetForm — the selection must
+      // 3. On failure, the view does NOT resetForm — the selection must
       //    survive so the user can fix the input and retry. Verify the
       //    entity is still loaded post-failure.
       expect(vm.entity_loaded).toBe(true);
       expect(vm.entity_info).toMatchObject({ entity_id: entityByIdOk.entity_id });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // v11.0 closeout F2b — Bearer-header contract on each of the three migrated
+  // write paths. Pins the apiClient interceptor injection so regressions in
+  // this view (or in F1's `apiClient`/`useAuth()` plumbing) surface loudly.
+  // -------------------------------------------------------------------------
+  describe('v11.0 closeout F2b — apiClient Bearer header contract', () => {
+    it('submitEntityRename() carries Authorization: Bearer <token>', async () => {
+      let sawBearer = false;
+      server.use(
+        http.post('/api/entity/rename', ({ request }) => {
+          expectBearerHeader(request, 'modify-entity-token');
+          sawBearer = true;
+          return HttpResponse.json({ message: 'ok', entity_id: 501 });
+        })
+      );
+
+      const axiosMock = createAxiosMock();
+      const wrapper = await mountModifyEntity(axiosMock);
+      await seedLoadedEntity(wrapper);
+
+      await (wrapper.vm as unknown as ModifyEntityVM).submitEntityRename();
+      await flushPromises();
+      expect(sawBearer).toBe(true);
+    });
+
+    it('submitEntityDeactivation() carries Authorization: Bearer <token>', async () => {
+      let sawBearer = false;
+      server.use(
+        http.post('/api/entity/deactivate', ({ request }) => {
+          expectBearerHeader(request, 'modify-entity-token');
+          sawBearer = true;
+          return HttpResponse.json({ message: 'ok' });
+        })
+      );
+
+      const axiosMock = createAxiosMock();
+      const wrapper = await mountModifyEntity(axiosMock);
+      await seedLoadedEntity(wrapper);
+
+      const vm = wrapper.vm as unknown as ModifyEntityVM & {
+        submitEntityDeactivation: () => Promise<void>;
+        deactivate_check: boolean;
+        replace_entity_input: number | null;
+      };
+      vm.deactivate_check = true;
+      vm.replace_entity_input = null;
+
+      await vm.submitEntityDeactivation();
+      await flushPromises();
+      expect(sawBearer).toBe(true);
+    });
+
+    it('submitReviewChange() carries Authorization: Bearer <token>', async () => {
+      let sawBearer = false;
+      server.use(
+        http.post('/api/review/create', ({ request }) => {
+          expectBearerHeader(request, 'modify-entity-token');
+          sawBearer = true;
+          return HttpResponse.json({ message: 'ok' });
+        })
+      );
+
+      const axiosMock = createAxiosMock();
+      const wrapper = await mountModifyEntity(axiosMock);
+      await seedLoadedEntity(wrapper);
+
+      // Loose cast: the component exposes a narrower `review_info` type
+      // on its instance, but we only need to set the fields the view's
+      // `submitReviewChange()` reads before the POST. `unknown` as an
+      // intermediate escape hatch keeps vue-tsc quiet.
+      const vm = wrapper.vm as unknown as {
+        submitReviewChange: () => Promise<void>;
+        hasReviewChanges: boolean;
+        review_info: unknown;
+        select_additional_references: string[];
+        select_gene_reviews: string[];
+        select_phenotype: string[];
+        select_variation: string[];
+        $refs: Record<string, { hide: () => void }>;
+      };
+      // Bypass the silent-skip early return that fires when hasReviewChanges
+      // is false. We reach into the instance here (same pattern the happy-
+      // path test uses to seed `entity_info`).
+      Object.defineProperty(vm, 'hasReviewChanges', {
+        value: true,
+        configurable: true,
+      });
+      vm.review_info = {
+        entity_id: entityByIdOk.entity_id,
+        literature: {},
+        phenotypes: [],
+        variation_ontology: [],
+        synopsis: '',
+        comment: '',
+      };
+      vm.select_additional_references = [];
+      vm.select_gene_reviews = [];
+      vm.select_phenotype = [];
+      vm.select_variation = [];
+
+      await vm.submitReviewChange();
+      await flushPromises();
+      expect(sawBearer).toBe(true);
     });
   });
 

--- a/app/src/views/curate/ModifyEntity.vue
+++ b/app/src/views/curate/ModifyEntity.vue
@@ -769,6 +769,11 @@ import Phenotype from '@/assets/js/classes/submission/submissionPhenotype';
 import Variation from '@/assets/js/classes/submission/submissionVariation';
 import Literature from '@/assets/js/classes/submission/submissionLiterature';
 
+// v11.0 closeout F2b: apiClient handles Bearer header injection via the
+// shared request interceptor; call sites no longer read localStorage
+// directly.
+import { apiClient } from '@/api/client';
+
 export default {
   name: 'ModifyEntity',
   components: {
@@ -1299,15 +1304,7 @@ export default {
       const submission = new Submission(this.entity_info);
 
       try {
-        const response = await this.axios.post(
-          apiUrl,
-          { rename_json: submission },
-          {
-            headers: {
-              Authorization: `Bearer ${localStorage.getItem('token')}`,
-            },
-          }
-        );
+        const response = await apiClient.raw.post(apiUrl, { rename_json: submission });
 
         this.makeToast(
           `${'The new disease name for this entity has been submitted ' + '(status '}${
@@ -1340,15 +1337,7 @@ export default {
       const submission = new Submission(this.entity_info);
 
       try {
-        const response = await this.axios.post(
-          apiUrl,
-          { deactivate_json: submission },
-          {
-            headers: {
-              Authorization: `Bearer ${localStorage.getItem('token')}`,
-            },
-          }
-        );
+        const response = await apiClient.raw.post(apiUrl, { deactivate_json: submission });
 
         this.makeToast(
           `${'The deactivation for this entity has been submitted ' + '(status '}${
@@ -1408,15 +1397,7 @@ export default {
 
       // perform update POST request
       try {
-        const response = await this.axios.post(
-          apiUrl,
-          { review_json: this.review_info },
-          {
-            headers: {
-              Authorization: `Bearer ${localStorage.getItem('token')}`,
-            },
-          }
-        );
+        const response = await apiClient.raw.post(apiUrl, { review_json: this.review_info });
 
         this.makeToast(
           `${'The new review for this entity has been submitted ' + '(status '}${


### PR DESCRIPTION
## Summary
- Migrates 9 Tier-2 files (34 authed usages) to `apiClient`.
- RegisterView custom `doUserLogOut` and IconPairDropdownMenu duplicate logout logic routed through `useAuth().logout()` — no component may now call `localStorage.removeItem('token'|'user')` directly.
- Removes the 9 F2b files from `CLOSEOUT_NO_LOCAL_STORAGE_TOKEN.ignores`.
- Adds 8 new specs; enhances RegisterView.spec.ts to cover the `useAuth().logout()` path and the updated `mounted()` guard.

## v11.0 closeout context
F2b of the v11.0 closeout. Parallel with F2a/F2c/F2d/F2e; after F1 merged (#276).

## Mechanical gates
- \`npm run lint\` green
- \`npm run type-check && npm run type-check:strict\` green
- \`npm run test:unit\` green
- Grep for localStorage.token/user in the 9 F2b files: 0

## CI note
Full \`make ci-local\` deferred to GitHub Actions per \`CLAUDE.md\` Host-Env Workaround.

## Test plan
- [ ] CI green
- [ ] RegisterView mounted guard uses useAuth().isAuthenticated.value, not localStorage.user
- [ ] IconPairDropdownMenu logout routes through useAuth().logout()