### PR TITLE
chore(release): bump frontend to 0.11.11

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysndd",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysndd",
-      "version": "0.11.10",
+      "version": "0.11.11",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@unhead/vue": "^3.0.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Patch bump after the v11.0 closeout + dependabot updates landed on master.

### Frontend changes since 0.11.10
- **v11.0 closeout F1** (#276) — apiClient interceptor establishes the single Bearer injection point; ESLint \`no-restricted-syntax\` guardrail at \`error\` severity; shared \`primeAuth\` + \`expectBearerHeader\` test-utils.
- **v11.0 closeout F2 + F1 test-followup** (#283 combined) — all 25 inline \`Authorization: Bearer \${localStorage.getItem('token')}\` sites migrated to \`apiClient\`; 2 enumerated exceptions (LoginView bootstrap + PasswordResetView route-param JWT) documented with specs; 28 new regression tests pin the interceptor contract + every ESLint bypass path (\`window.localStorage.*\`, \`globalThis.localStorage.*\`, computed-property variants).
- **v11.0 closeout F3** (#284) — coverage ratchet reconciled to post-migration measured floor (25 / 19 / 19 / 24, up from 13 / 9 / 12 / 13); parent spec §4.6 + §3 Phase E gate narrative amended. Checkpoint #3 walked.
- **Dockerfile base image** — \`fholzer/nginx-brotli\` v1.28.0 → v1.29.8 (#285).

### CI / tooling (no runtime impact)
- \`actions/upload-pages-artifact\` v4 → v5 (#286).

### API
**Unchanged.** \`api/version_spec.json\` stays at 0.11.8 — the closeout was frontend-only; no endpoint / schema / DB migrations.

### Git tag
\`v11.0\` was applied at F3's merge commit (\`160137c3\`).

## Test plan
- [x] \`app/package.json\` + \`app/package-lock.json\` match on 0.11.11
- [ ] CI green