### PR TITLE
fix(api/renv): pin PPM snapshot to 2026-04-22, bump mirai/nanonext pair

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -22,7 +22,11 @@ FROM rocker/r-ver:4.5.3 AS base
 
 # Set R repository to Posit Package Manager for pre-compiled Linux binaries
 # rocker/r-ver:4.5.3 uses Ubuntu 24.04 (noble) with ICU 74, so we use noble binaries
-ENV RENV_CONFIG_REPOS_OVERRIDE="https://packagemanager.posit.co/cran/__linux__/noble/latest"
+#
+# IMPORTANT: pin to a dated snapshot (not /latest) so that CRAN pruning old
+# versions cannot silently drift the build. Bump this date intentionally,
+# together with renv.lock "Repositories.URL", when refreshing dependencies.
+ENV RENV_CONFIG_REPOS_OVERRIDE="https://packagemanager.posit.co/cran/__linux__/noble/2026-04-22"
 
 # Disable pak to avoid version conflicts
 ENV RENV_CONFIG_PAK_ENABLED=FALSE

--- a/api/renv.lock
+++ b/api/renv.lock
@@ -4,7 +4,7 @@
     "Repositories": [
       {
         "Name": "CRAN",
-        "URL": "https://packagemanager.posit.co/cran/latest"
+        "URL": "https://packagemanager.posit.co/cran/2026-04-22"
       }
     ]
   },
@@ -6618,7 +6618,7 @@
     },
     "mirai": {
       "Package": "mirai",
-      "Version": "2.5.3",
+      "Version": "2.6.1",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Minimalist Async Evaluation Framework for R",
@@ -6631,7 +6631,7 @@
         "R (>= 3.6)"
       ],
       "Imports": [
-        "nanonext (>= 1.7.2)"
+        "nanonext (>= 1.8.0)"
       ],
       "Suggests": [
         "cli",
@@ -6745,7 +6745,7 @@
     },
     "nanonext": {
       "Package": "nanonext",
-      "Version": "1.7.2",
+      "Version": "1.8.2",
       "Source": "Repository",
       "Type": "Package",
       "Title": "NNG (Nanomsg Next Gen) Lightweight Messaging Library",


### PR DESCRIPTION
## Summary

Production API crashloops after fresh rebuild today (2026-04-22) with:

\`\`\`
Error: package or namespace load failed for 'mirai':
 object '.read_header' is not exported by 'namespace:nanonext'
Execution halted
\`\`\`

Root cause and evidence in **#294**. This PR is the proper fix.

## What changes

| File | Change |
|---|---|
| \`api/Dockerfile\` | \`ENV RENV_CONFIG_REPOS_OVERRIDE\`: \`.../noble/latest\` → \`.../noble/2026-04-22\` |
| \`api/renv.lock\` Repositories URL | \`/cran/latest\` → \`/cran/2026-04-22\` |
| \`api/renv.lock\` mirai | \`2.5.3\` → \`2.6.1\`, Imports floor \`nanonext (>= 1.7.2)\` → \`(>= 1.8.0)\` |
| \`api/renv.lock\` nanonext | \`1.7.2\` → \`1.8.2\` |

Total: 5 value edits across 2 files (+4/-4 lines of semantics, +4 lines of explanatory comment).

## Why mirai 2.6.1 is safe for sysndd

I audited every \`mirai::\` call site:

- \`api/bootstrap/setup_workers.R\`: \`mirai::daemons\`, \`mirai::everywhere\` — API-stable.
- \`api/bootstrap/mount_endpoints.R\`: \`mirai::daemons(0)\` — API-stable.
- \`api/functions/job-manager.R\`: \`mirai::mirai\`, \`mirai::unresolved\`, \`mirai::is_mirai_error\`, \`mirai::is_error_value\` — API-stable.
- \`api/endpoints/health_endpoints.R\`: \`mirai::status()\` — API-stable.

The only breaking change in mirai 2.6.0 was \`race_mirai()\` (now returns index instead of list). **sysndd does not use \`race_mirai\`** (grepped).

2.6.1 contains only bug fixes on top of 2.6.0.

## Why date-pinned PPM URL

The lockfile alone is not sufficient to guarantee reproducible rebuilds if the repo URL points at a rolling \"latest\" snapshot. The lockfile pin for \`nanonext = 1.7.2\` was ignored by \`renv::restore\` today specifically because:

1. PPM \`/cran/latest\` no longer serves \`nanonext 1.7.2\` (CRAN pruned it, only in Archive).
2. \`mirai\`'s \`Imports: nanonext (>= 1.7.2)\` declares a **floor**, satisfied by the 1.8.2 that PPM offered.
3. \`renv::restore\` resolved to 1.8.2, silently — a known behaviour (rstudio/renv#643, #641).

Date-pinned PPM URLs (\`/cran/2026-04-22\` — verified live, serves both mirai 2.6.1 and nanonext 1.8.2) remove this class of failure: the repo itself only exposes versions available on that date, so a lockfile pin to a superseded version cannot be \"upgraded\" silently. **Future refreshes** are explicit: bump the date in the two files together with any version changes.

## Verification

On production (sysndd.dbmr.unibe.ch, 130.92.252.79):

- Built a patch image \`FROM sysndd-api:latest\` that upgrades only mirai to 2.6.1; \`library(mirai); daemons(1); m <- mirai::mirai(1+1); m[]\` returns \`2\` as expected.
- Deployed via \`docker compose up -d --no-deps --force-recreate api\`.
- \`/api/health\` returns 200 through Traefik; all 5 containers healthy.
- Old image retained as rollback: \`sysndd-api:broken-nanonext-1.8.2-pre-patch\`.

A clean rebuild with this PR's Dockerfile+lockfile is **not** yet done on production — I wanted to ship the in-repo fix for review first. Once merged, next rebuild will pull the date-pinned 2.6.1 + 1.8.2 pair directly via renv::restore.

## Test plan

- [ ] \`DOCKER_BUILDKIT=1 docker build -t sysndd-api:latest -f api/Dockerfile api/\` succeeds
- [ ] \`docker run --rm --entrypoint bash sysndd-api:latest -c 'R -e \"packageVersion(\\\"mirai\\\"); packageVersion(\\\"nanonext\\\"); library(mirai)\"'\` prints \`2.6.1\`, \`1.8.2\`, no errors
- [ ] Existing API test suite still passes
- [ ] Deploy to staging/prod, \`/api/health\` returns 200

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)