### PR TITLE
fix(nginx): restore security headers + hide server version

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -44,6 +44,7 @@ RUN sed -i 's/listen\s*80;/listen 8080;/g' /etc/nginx/conf.d/default.conf 2>/dev
 # Copy nginx configuration (overwrites defaults)
 COPY --chown=nginx:nginx ./docker/nginx/local.conf /etc/nginx/conf.d/default.conf
 COPY --chown=nginx:nginx ./docker/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY --chown=nginx:nginx ./docker/nginx/security-headers.conf /etc/nginx/security-headers.conf
 
 # Set working directory to nginx asset directory
 WORKDIR /usr/share/nginx/html

--- a/app/docker/nginx/local.conf
+++ b/app/docker/nginx/local.conf
@@ -10,6 +10,7 @@ server {
         root /usr/share/nginx/html;
         expires 1y;
         add_header Cache-Control "public, immutable, max-age=31536000" always;
+        include /etc/nginx/security-headers.conf;
         access_log off;
     }
 
@@ -18,6 +19,7 @@ server {
         root /usr/share/nginx/html;
         expires 30d;
         add_header Cache-Control "public, max-age=2592000" always;
+        include /etc/nginx/security-headers.conf;
     }
 
     # HTML and root - no cache so app updates are picked up immediately
@@ -27,10 +29,12 @@ server {
         try_files $uri $uri/ /index.html;
         add_header Cache-Control "no-cache, no-store, must-revalidate" always;
         add_header Pragma "no-cache" always;
+        include /etc/nginx/security-headers.conf;
     }
 
     error_page 500 502 503 504 /50x.html;
     location = /50x.html {
         root /usr/share/nginx/html;
+        include /etc/nginx/security-headers.conf;
     }
 }

--- a/app/docker/nginx/nginx.conf
+++ b/app/docker/nginx/nginx.conf
@@ -11,6 +11,9 @@ http {
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;
 
+  # Do not leak nginx version in Server header / error pages.
+  server_tokens off;
+
   limit_req_zone $binary_remote_addr zone=ip:10m rate=10r/s;
 
   log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
@@ -75,18 +78,10 @@ http {
   send_timeout 10;
   ##end timeouts policy
   
+  # NOTE: security headers are NOT declared at the http{} level — nginx's
+  # add_header inheritance drops them the moment a child location{} defines
+  # its own add_header (which all of our location blocks do for
+  # Cache-Control). Headers live in security-headers.conf and are pulled in
+  # via `include` inside each location{} block of local.conf / prod.conf.
   include /etc/nginx/conf.d/*.conf;
-  ##enable HSTS
-  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
-  ##Permissions-Policy
-  add_header Permissions-Policy "geolocation=(),midi=(),sync-xhr=(),microphone=(),camera=(),magnetometer=(),gyroscope=(),fullscreen=(self),payment=()";
-  ##Referrer-Policy
-  add_header Referrer-Policy "strict-origin";
-  add_header "X-XSS-Protection" "1; mode=block";
-  add_header "X-Content-Type-Options" "nosniff";
-  add_header "X-Download-Options" "noopen";
-  add_header "X-Permitted-Cross-Domain-Policies" "master-only";
-  add_header "X-Frame-Options" "SAMEORIGIN";
-  add_header "Content-Security-Policy" "default-src 'none'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; object-src 'none'; connect-src 'self'; form-action 'self'; prefetch-src 'self'; frame-src 'self'; frame-ancestors 'self'; manifest-src 'self'; ";
-  add_header "X-Content-Security-Policy" "default-src 'none'; img-src 'self' data:; style-src 'self' 'unsafe-inline' 'unsafe-eval'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; object-src 'none'; connect-src 'self'; form-action 'self'; prefetch-src 'self'; frame-src 'self'; frame-ancestors 'self'; manifest-src 'self'; ";
 }

--- a/app/docker/nginx/prod.conf
+++ b/app/docker/nginx/prod.conf
@@ -22,7 +22,7 @@ server {
   ## Reduce SSL buffer size
   ## https://haydenjames.io/nginx-tuning-tips-tls-ssl-https-ttfb-latency/
   ssl_buffer_size 8k;
-  
+
   limit_req zone=ip burst=30 delay=10;
 
   # Service worker must never be cached
@@ -30,6 +30,7 @@ server {
     root /usr/share/nginx/html;
     add_header Cache-Control "no-cache, no-store, must-revalidate" always;
     add_header Pragma "no-cache" always;
+    include /etc/nginx/security-headers.conf;
     expires 0;
   }
 
@@ -37,6 +38,7 @@ server {
   location = /manifest.webmanifest {
     root /usr/share/nginx/html;
     add_header Cache-Control "no-cache, must-revalidate" always;
+    include /etc/nginx/security-headers.conf;
   }
 
   # Vite hashed assets — immutable 1-year cache
@@ -44,6 +46,7 @@ server {
     root /usr/share/nginx/html;
     expires 1y;
     add_header Cache-Control "public, immutable, max-age=31536000" always;
+    include /etc/nginx/security-headers.conf;
   }
 
   # Images — 30-day cache
@@ -51,6 +54,7 @@ server {
     root /usr/share/nginx/html;
     expires 30d;
     add_header Cache-Control "public, max-age=2592000" always;
+    include /etc/nginx/security-headers.conf;
   }
 
   # HTML/SPA fallback — never cache
@@ -60,6 +64,7 @@ server {
     try_files $uri $uri/ /index.html;
     add_header Cache-Control "no-cache, no-store, must-revalidate" always;
     add_header Pragma "no-cache" always;
+    include /etc/nginx/security-headers.conf;
   }
 
   location /alb/ {
@@ -68,12 +73,14 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto https;
+    include /etc/nginx/security-headers.conf;
   }
 
   error_page   500 502 503 504  /50x.html;
 
   location = /50x.html {
     root   /usr/share/nginx/html;
+    include /etc/nginx/security-headers.conf;
   }
 
 }

--- a/app/docker/nginx/security-headers.conf
+++ b/app/docker/nginx/security-headers.conf
@@ -1,0 +1,33 @@
+# =============================================================================
+# OWASP / UniBE security headers
+# =============================================================================
+#
+# nginx gotcha: add_header directives are NOT inherited by a child block if
+# that child defines any add_header of its own. Because local.conf and
+# prod.conf set Cache-Control via add_header inside every location{}, the
+# previously-defined security headers in the http{} block of nginx.conf were
+# being dropped from every response.
+#
+# This file is sourced with `include` inside each location{} block so every
+# response carries the full header set.
+#
+# Ref: https://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header
+# =============================================================================
+
+# Force HTTPS for 2 years, include subdomains, opt in to the preload list.
+add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+
+# Block MIME-sniffing.
+add_header X-Content-Type-Options "nosniff" always;
+
+# Clickjacking: allow same-origin framing only.
+add_header X-Frame-Options "SAMEORIGIN" always;
+
+# Leak only the origin on cross-origin navigations (modern default).
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+# Disable powerful browser APIs we do not use.
+add_header Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=(), fullscreen=(self)" always;
+
+# Content-Security-Policy tuned for the Vue SPA + self-hosted /api backend.
+add_header Content-Security-Policy "default-src 'none'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; base-uri 'self'; object-src 'none'; connect-src 'self'; form-action 'self'; frame-src 'self'; frame-ancestors 'self'; manifest-src 'self';" always;


### PR DESCRIPTION
## Summary

- Moves HSTS / X-Content-Type-Options / X-Frame-Options / Referrer-Policy / Permissions-Policy / CSP into `security-headers.conf` and `include`s it from every `location{}` — the previous `http{}`-level placement was being dropped by nginx because every location has its own `add_header Cache-Control`.
- Adds `server_tokens off` to stop leaking the exact nginx version.
- Drops the obsolete IE/Flash-era headers (`X-XSS-Protection`, `X-Download-Options`, `X-Permitted-Cross-Domain-Policies`, `X-Content-Security-Policy`).

Closes #296.

## Background

The University of Bern did a 2026-04-22 hardening review of `sysndd.dbmr.unibe.ch` and flagged that none of our declared security headers were actually being sent. Audit curl showed zero security headers and `Server: nginx/1.29.8`.

Root cause is the nginx `add_header` inheritance rule: if a child block defines *any* `add_header`, the parent's are discarded. `local.conf` / `prod.conf` set `Cache-Control` via `add_header` inside every location, so the http-level security headers in `nginx.conf` never actually reached clients.

## Test plan

- [x] `nginx -t` passes on the new config (verified with the same `fholzer/nginx-brotli:v1.29.8` image we ship)
- [x] Throwaway container test: `curl -I http://localhost:8081/` emits all expected headers, `Server: nginx` (no version)
- [x] Same headers appear on `/assets/foo.js` (the location block with its own `Cache-Control`)
- [ ] Once merged and deployed, re-run Mozilla Observatory against `www.sysndd.dbmr.unibe.ch` — should climb multiple grades
- [ ] Traefik's own security-headers middleware (added in the admin repo) will stay in place as defense-in-depth; headers will not be duplicated because Traefik uses `http.Header.Set` (replaces) rather than append for its directives

🤖 Generated with [Claude Code](https://claude.com/claude-code)