### PR TITLE
fix(api/re-review): gene-atomic batching with soft LIMIT (closes #29)

### DIFF
--- a/api/services/re-review-service.R
+++ b/api/services/re-review-service.R
@@ -115,6 +115,119 @@ build_batch_params <- function(criteria) {
 }
 
 
+#' Select entities for a re-review batch with gene-atomic grouping.
+#'
+#' Two-step query: first collect distinct hgnc_ids matching criteria
+#' (ordered by oldest review_date), then expand to all matching entities
+#' for those genes. Trim with a soft LIMIT — include all entities for a
+#' partially-included gene; stop adding new genes once cumulative entity
+#' count >= batch_size. Returns up to `batch_size` entities, with the
+#' boundary gene fully included even if it pushes the count past the cap.
+#'
+#' @param criteria Named list with batch criteria.
+#' @param batch_size Integer cap (default 20). The actual returned count
+#'   may exceed this by at most (entities_in_boundary_gene - 1).
+#' @param conn Database connection (pool or transaction connection).
+#' @return Named list:
+#'   - entities: data frame of selected entities with entity_id, hgnc_id,
+#'     symbol, status_id, review_id, review_date, etc.
+#'   - boundary_gene: hgnc_id where the soft-LIMIT engaged, or NA if the
+#'     batch fits cleanly under batch_size.
+#'   - gene_count: number of distinct hgnc_id values in the result.
+#'   - entity_count: total number of entities (== nrow(entities)).
+#'
+#' @keywords internal
+select_matching_entities <- function(criteria, batch_size = 20, conn) {
+  where_clause <- build_batch_where_clause(criteria, conn)
+  params <- build_batch_params(criteria)
+
+  # Step 1: distinct hgnc_ids matching the criteria, ordered by oldest review_date per gene.
+  # Cap at batch_size (worst case 1 entity per gene = batch_size genes).
+  gene_query <- paste0(
+    "SELECT e.hgnc_id, MIN(r.review_date) AS first_review_date
+     FROM ndd_entity_view e
+     LEFT JOIN ndd_entity_review r ON e.entity_id = r.entity_id AND r.is_primary = 1
+     LEFT JOIN ndd_entity_status s ON e.entity_id = s.entity_id AND s.is_active = 1
+     WHERE ", where_clause, "
+       AND e.entity_id NOT IN (
+         SELECT rec.entity_id FROM re_review_entity_connect rec
+         INNER JOIN re_review_assignment ra ON rec.re_review_batch = ra.re_review_batch
+         WHERE rec.re_review_approved = 0
+       )
+     GROUP BY e.hgnc_id
+     ORDER BY first_review_date ASC
+     LIMIT ?"
+  )
+  gene_params <- c(params, list(as.integer(batch_size)))
+  gene_rows <- db_execute_query(gene_query, gene_params, conn = conn)
+
+  if (nrow(gene_rows) == 0) {
+    return(list(
+      entities     = data.frame(),
+      boundary_gene = NA_character_,
+      gene_count   = 0L,
+      entity_count = 0L
+    ))
+  }
+
+  # Step 2: pull all matching entities for those genes.
+  hgnc_placeholders <- paste(rep("?", nrow(gene_rows)), collapse = ", ")
+  ent_query <- paste0(
+    "SELECT DISTINCT e.entity_id, e.hgnc_id, e.symbol, e.disease_ontology_name,
+            e.disease_ontology_id_version, e.hpo_mode_of_inheritance_term_name,
+            r.review_date, r.review_id, s.category_id, s.status_id
+     FROM ndd_entity_view e
+     LEFT JOIN ndd_entity_review r ON e.entity_id = r.entity_id AND r.is_primary = 1
+     LEFT JOIN ndd_entity_status s ON e.entity_id = s.entity_id AND s.is_active = 1
+     WHERE ", where_clause, "
+       AND e.hgnc_id IN (", hgnc_placeholders, ")
+       AND e.entity_id NOT IN (
+         SELECT rec.entity_id FROM re_review_entity_connect rec
+         INNER JOIN re_review_assignment ra ON rec.re_review_batch = ra.re_review_batch
+         WHERE rec.re_review_approved = 0
+       )
+     ORDER BY e.hgnc_id, r.review_date ASC"
+  )
+  ent_params <- c(params, as.list(gene_rows$hgnc_id))
+  all_matching <- db_execute_query(ent_query, ent_params, conn = conn)
+
+  if (nrow(all_matching) == 0) {
+    return(list(
+      entities     = data.frame(),
+      boundary_gene = NA_character_,
+      gene_count   = 0L,
+      entity_count = 0L
+    ))
+  }
+
+  # Step 3: soft LIMIT — accumulate by gene; stop adding new genes once entity count >= batch_size.
+  # The boundary gene is fully included even if it pushes the cumulative count past the cap.
+  selected <- list()
+  per_gene <- split(all_matching, all_matching$hgnc_id)
+  # Preserve gene order as discovered in step 1 (oldest first):
+  per_gene <- per_gene[as.character(gene_rows$hgnc_id)]
+  total <- 0L
+  boundary <- NA_character_
+  for (gid in names(per_gene)) {
+    block <- per_gene[[gid]]
+    if (total >= batch_size) break
+    selected[[length(selected) + 1L]] <- block
+    total <- total + nrow(block)
+    if (total > batch_size && is.na(boundary)) {
+      boundary <- gid
+    }
+  }
+
+  out <- if (length(selected) > 0L) do.call(rbind, selected) else data.frame()
+  list(
+    entities     = out,
+    boundary_gene = boundary,
+    gene_count   = length(selected),
+    entity_count = nrow(out)
+  )
+}
+
+
 #' Preview matching entities without creating batch
 #'
 #' Returns entities that match the provided criteria without creating a batch.
@@ -136,44 +249,24 @@ build_batch_params <- function(criteria) {
 #'
 #' @export
 batch_preview <- function(criteria, batch_size = 20, pool) {
-  # Build WHERE clause and parameters
-
-where_clause <- build_batch_where_clause(criteria, pool)
-  params <- build_batch_params(criteria)
-
-  # Build query to find matching entities
-  # Exclude entities already in active batches
-  query <- paste0(
-    "SELECT DISTINCT e.entity_id, e.hgnc_id, e.symbol, e.disease_ontology_name,
-            e.disease_ontology_id_version, e.hpo_mode_of_inheritance_term_name,
-            r.review_date, s.category_id
-     FROM ndd_entity_view e
-     LEFT JOIN ndd_entity_review r ON e.entity_id = r.entity_id AND r.is_primary = 1
-     LEFT JOIN ndd_entity_status s ON e.entity_id = s.entity_id AND s.is_active = 1
-     WHERE ", where_clause, "
-       AND e.entity_id NOT IN (
-         SELECT rec.entity_id FROM re_review_entity_connect rec
-         INNER JOIN re_review_assignment ra ON rec.re_review_batch = ra.re_review_batch
-         WHERE rec.re_review_approved = 0
-       )
-     ORDER BY r.review_date ASC
-     LIMIT ?"
-  )
-
-  # Add batch_size to params
-  params <- c(params, list(as.integer(batch_size)))
-
-  # Execute query
-  matching_entities <- db_execute_query(query, params, conn = pool)
+  # Use gene-atomic helper to avoid splitting entities across gene boundaries
+  # (fixes issue #29 where DISTINCT + ORDER BY review_date + LIMIT split genes)
+  selection <- select_matching_entities(criteria, batch_size = batch_size, conn = pool)
+  matching_entities <- selection$entities
 
   logger::log_info("Batch preview",
     criteria_count = length(criteria),
-    matching_count = nrow(matching_entities)
+    matching_count = selection$entity_count,
+    gene_count     = selection$gene_count,
+    boundary_gene  = selection$boundary_gene
   )
 
   list(
-    status = 200,
-    data = matching_entities
+    status        = 200,
+    data          = matching_entities,
+    boundary_gene = selection$boundary_gene,
+    gene_count    = selection$gene_count,
+    entity_count  = selection$entity_count
   )
 }
 
@@ -241,27 +334,9 @@ batch_create <- function(criteria, assigned_user_id = NULL, batch_name = NULL, p
     )
     batch_id <- max_batch_result$next_batch[1]
 
-    # 3. Build WHERE clause and find matching entities
-    where_clause <- build_batch_where_clause(criteria, txn_conn)
-    params <- build_batch_params(criteria)
-
-    query <- paste0(
-      "SELECT DISTINCT e.entity_id, s.status_id, r.review_id, r.review_date
-       FROM ndd_entity_view e
-       LEFT JOIN ndd_entity_review r ON e.entity_id = r.entity_id AND r.is_primary = 1
-       LEFT JOIN ndd_entity_status s ON e.entity_id = s.entity_id AND s.is_active = 1
-       WHERE ", where_clause, "
-         AND e.entity_id NOT IN (
-           SELECT rec.entity_id FROM re_review_entity_connect rec
-           INNER JOIN re_review_assignment ra ON rec.re_review_batch = ra.re_review_batch
-           WHERE rec.re_review_approved = 0
-         )
-       ORDER BY r.review_date ASC
-       LIMIT ?"
-    )
-
-    params <- c(params, list(as.integer(batch_size)))
-    matching_entities <- db_execute_query(query, params, conn = txn_conn)
+    # 3. Find matching entities using gene-atomic helper (fixes issue #29)
+    selection <- select_matching_entities(criteria, batch_size = batch_size, conn = txn_conn)
+    matching_entities <- selection$entities
 
     if (nrow(matching_entities) == 0) {
       stop("No entities match the specified criteria")
@@ -724,27 +799,9 @@ batch_recalculate <- function(batch_id, criteria, pool) {
       conn = txn_conn
     )
 
-    # 2. Build WHERE clause and find matching entities
-    where_clause <- build_batch_where_clause(criteria, pool)
-    params <- build_batch_params(criteria)
-
-    query <- paste0(
-      "SELECT DISTINCT e.entity_id, s.status_id, r.review_id, r.review_date
-       FROM ndd_entity_view e
-       LEFT JOIN ndd_entity_review r ON e.entity_id = r.entity_id AND r.is_primary = 1
-       LEFT JOIN ndd_entity_status s ON e.entity_id = s.entity_id AND s.is_active = 1
-       WHERE ", where_clause, "
-         AND e.entity_id NOT IN (
-           SELECT rec.entity_id FROM re_review_entity_connect rec
-           INNER JOIN re_review_assignment ra ON rec.re_review_batch = ra.re_review_batch
-           WHERE rec.re_review_approved = 0
-         )
-       ORDER BY r.review_date ASC
-       LIMIT ?"
-    )
-
-    params <- c(params, list(as.integer(batch_size)))
-    matching_entities <- db_execute_query(query, params, conn = txn_conn)
+    # 2. Find matching entities using gene-atomic helper (fixes issue #29)
+    selection <- select_matching_entities(criteria, batch_size = batch_size, conn = txn_conn)
+    matching_entities <- selection$entities
 
     if (nrow(matching_entities) == 0) {
       stop("No entities match the specified criteria")

--- a/api/tests/testthat/test-re-review-service.R
+++ b/api/tests/testthat/test-re-review-service.R
@@ -1,0 +1,276 @@
+# tests/testthat/test-re-review-service.R
+#
+# Unit tests for re-review-service.R — gene-atomic batching (issue #29)
+#
+# Strategy: use local_mocked_bindings to mock db_execute_query so we can
+# drive the select_matching_entities() algorithm without a live database.
+# We also verify that batch_preview returns the new boundary_gene / gene_count
+# / entity_count fields after the fix.
+
+source_api_file("functions/db-helpers.R", local = FALSE)
+# logger package is used by re-review-service.R via logger::log_info etc.
+if (!requireNamespace("logger", quietly = TRUE)) {
+  skip("logger package not available")
+}
+source_api_file("services/re-review-service.R", local = FALSE)
+
+# ---------------------------------------------------------------------------
+# Helpers — synthetic entity data frames returned by the mocked DB queries
+# ---------------------------------------------------------------------------
+
+# Two genes (HGNC:1001, HGNC:1002), three entities each.
+# Genes are discovered in order HGNC:1001 first (oldest review_date).
+make_gene_rows <- function() {
+  data.frame(
+    hgnc_id           = c("HGNC:1001", "HGNC:1002"),
+    first_review_date = c("2020-01-01", "2020-06-01"),
+    stringsAsFactors  = FALSE
+  )
+}
+
+make_entity_rows <- function() {
+  data.frame(
+    entity_id                      = c(1L, 2L, 3L, 4L, 5L, 6L),
+    hgnc_id                        = c("HGNC:1001", "HGNC:1001", "HGNC:1001",
+                                       "HGNC:1002", "HGNC:1002", "HGNC:1002"),
+    symbol                         = rep("GENE1", 6),
+    disease_ontology_name          = paste0("Disease ", 1:6),
+    disease_ontology_id_version    = paste0("OMIM:10000", 1:6),
+    hpo_mode_of_inheritance_term_name = rep("Autosomal dominant", 6),
+    review_date                    = c("2020-01-01", "2020-02-01", "2020-03-01",
+                                       "2020-06-01", "2020-07-01", "2020-08-01"),
+    review_id                      = 101L:106L,
+    category_id                    = rep(1L, 6),
+    status_id                      = 201L:206L,
+    stringsAsFactors               = FALSE
+  )
+}
+
+# Mock connection — only used as the conn argument; mocked db_execute_query
+# ignores the actual connection object.
+make_mock_conn <- function() structure(list(), class = "MockPool")
+
+# ---------------------------------------------------------------------------
+# Helper: set up mocks that simulate the gene-LIMIT SQL + entity expansion.
+# call_count allows the caller to distinguish first call (gene list query)
+# from second call (entity rows query).
+# ---------------------------------------------------------------------------
+with_gene_atomic_mocks <- function(expr, gene_rows = make_gene_rows(),
+                                   entity_rows = make_entity_rows()) {
+  call_count <- 0L
+  local_mocked_bindings(
+    db_execute_query = function(sql, params = list(), conn = NULL) {
+      call_count <<- call_count + 1L
+      if (call_count == 1L) {
+        # First call: the gene-discovery SELECT → return gene rows
+        return(tibble::as_tibble(gene_rows))
+      } else {
+        # Second call: the entity-expansion SELECT → return entity rows
+        return(tibble::as_tibble(entity_rows))
+      }
+    },
+    build_batch_where_clause = function(criteria, pool) "1=1",
+    build_batch_params       = function(criteria) list(),
+    .package                 = NULL # bindings in global env (sourced service)
+  )
+  force(expr)
+}
+
+# ---------------------------------------------------------------------------
+# W3.2 failing tests (these fail before the fix because select_matching_entities
+# doesn't exist yet — source_api_file above will error on that missing function)
+# ---------------------------------------------------------------------------
+
+context("re-review-service: gene-atomic batching (issue #29)")
+
+test_that("select_matching_entities exists after fix", {
+  expect_true(
+    exists("select_matching_entities", mode = "function"),
+    info = "select_matching_entities() must be defined in re-review-service.R"
+  )
+})
+
+test_that("select_matching_entities returns gene-atomic result with soft LIMIT", {
+  skip_if_not(
+    exists("select_matching_entities", mode = "function"),
+    "select_matching_entities not yet implemented"
+  )
+
+  pool <- make_mock_conn()
+
+  call_count <- 0L
+  gene_rows   <- make_gene_rows()
+  entity_rows <- make_entity_rows()
+
+  local_mocked_bindings(
+    db_execute_query = function(sql, params = list(), conn = NULL) {
+      call_count <<- call_count + 1L
+      if (call_count == 1L) tibble::as_tibble(gene_rows)
+      else                  tibble::as_tibble(entity_rows)
+    },
+    .package = NULL
+  )
+
+  result <- select_matching_entities(
+    criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
+    batch_size = 4L,
+    conn       = pool
+  )
+
+  # Both calls must have been made
+  expect_equal(call_count, 2L)
+
+  # With batch_size=4 and 3 entities per gene, the soft LIMIT must include
+  # gene HGNC:1001 fully (3 entities), then detect overflow when adding HGNC:1002
+  # (total=6 > 4), include it fully anyway, and set boundary_gene = "HGNC:1002".
+  expect_equal(result$entity_count, 6L)
+  expect_equal(result$gene_count,   2L)
+  expect_equal(result$boundary_gene, "HGNC:1002")
+
+  # All entities must be present
+  expect_equal(sort(result$entities$entity_id), 1L:6L)
+
+  # Each gene must have exactly 3 entities (gene-atomic guarantee)
+  per_gene <- table(result$entities$hgnc_id)
+  expect_true(all(per_gene == 3L),
+              info = paste("Expected 3 entities per gene; got",
+                           paste(per_gene, collapse = ",")))
+})
+
+test_that("select_matching_entities sets boundary_gene = NA when batch fits cleanly", {
+  skip_if_not(
+    exists("select_matching_entities", mode = "function"),
+    "select_matching_entities not yet implemented"
+  )
+
+  pool <- make_mock_conn()
+
+  call_count <- 0L
+  gene_rows   <- make_gene_rows()
+  entity_rows <- make_entity_rows()
+
+  local_mocked_bindings(
+    db_execute_query = function(sql, params = list(), conn = NULL) {
+      call_count <<- call_count + 1L
+      if (call_count == 1L) tibble::as_tibble(gene_rows)
+      else                  tibble::as_tibble(entity_rows)
+    },
+    .package = NULL
+  )
+
+  result <- select_matching_entities(
+    criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
+    batch_size = 20L,
+    conn       = pool
+  )
+
+  expect_equal(result$entity_count, 6L)
+  expect_equal(result$gene_count,   2L)
+  expect_true(is.na(result$boundary_gene))
+})
+
+test_that("select_matching_entities returns empty list when no genes found", {
+  skip_if_not(
+    exists("select_matching_entities", mode = "function"),
+    "select_matching_entities not yet implemented"
+  )
+
+  pool <- make_mock_conn()
+
+  local_mocked_bindings(
+    db_execute_query = function(sql, params = list(), conn = NULL) {
+      tibble::tibble()  # no rows
+    },
+    .package = NULL
+  )
+
+  result <- select_matching_entities(
+    criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
+    batch_size = 20L,
+    conn       = pool
+  )
+
+  expect_equal(result$entity_count, 0L)
+  expect_equal(result$gene_count,   0L)
+  expect_true(is.na(result$boundary_gene))
+  expect_equal(nrow(result$entities), 0L)
+})
+
+test_that("batch_preview response includes boundary_gene, gene_count, entity_count", {
+  skip_if_not(
+    exists("select_matching_entities", mode = "function"),
+    "select_matching_entities not yet implemented"
+  )
+
+  pool <- make_mock_conn()
+
+  call_count <- 0L
+  gene_rows   <- make_gene_rows()
+  entity_rows <- make_entity_rows()
+
+  local_mocked_bindings(
+    db_execute_query = function(sql, params = list(), conn = NULL) {
+      call_count <<- call_count + 1L
+      if (call_count == 1L) tibble::as_tibble(gene_rows)
+      else                  tibble::as_tibble(entity_rows)
+    },
+    .package = NULL
+  )
+
+  result <- batch_preview(
+    criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
+    batch_size = 4L,
+    pool       = pool
+  )
+
+  expect_equal(result$status, 200L)
+  expect_true("boundary_gene"  %in% names(result))
+  expect_true("gene_count"     %in% names(result))
+  expect_true("entity_count"   %in% names(result))
+  expect_false(is.na(result$boundary_gene))
+  expect_equal(result$gene_count,   2L)
+  expect_equal(result$entity_count, 6L)
+})
+
+test_that("batch_preview atomicity: entity count must be gene-atomic (never splits a gene)", {
+  skip_if_not(
+    exists("select_matching_entities", mode = "function"),
+    "select_matching_entities not yet implemented"
+  )
+
+  pool <- make_mock_conn()
+
+  call_count <- 0L
+  gene_rows   <- make_gene_rows()
+  entity_rows <- make_entity_rows()
+
+  local_mocked_bindings(
+    db_execute_query = function(sql, params = list(), conn = NULL) {
+      call_count <<- call_count + 1L
+      if (call_count == 1L) tibble::as_tibble(gene_rows)
+      else                  tibble::as_tibble(entity_rows)
+    },
+    .package = NULL
+  )
+
+  result <- batch_preview(
+    criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
+    batch_size = 4L,
+    pool       = pool
+  )
+
+  ent_count <- nrow(result$data)
+
+  # With batch_size=4 and 3 entities per gene, the algorithm must return
+  # either 3 (gene A only) or 6 (both genes), never 4 (which would split gene B).
+  expect_true(
+    ent_count %in% c(3L, 6L),
+    info = paste("Expected gene-atomic count in {3, 6}; got", ent_count)
+  )
+
+  per_gene <- table(result$data$hgnc_id)
+  expect_true(
+    all(per_gene == 3L),
+    info = paste("Expected 3 entities per gene; got", paste(per_gene, collapse = ","))
+  )
+})

--- a/api/tests/testthat/test-re-review-service.R
+++ b/api/tests/testthat/test-re-review-service.R
@@ -2,17 +2,20 @@
 #
 # Unit tests for re-review-service.R — gene-atomic batching (issue #29)
 #
-# Strategy: use local_mocked_bindings to mock db_execute_query so we can
-# drive the select_matching_entities() algorithm without a live database.
+# Strategy: temporarily replace db_execute_query in the global environment
+# using withr::with_bindings so we can drive the select_matching_entities()
+# algorithm without a live database.
 # We also verify that batch_preview returns the new boundary_gene / gene_count
 # / entity_count fields after the fix.
 
-source_api_file("functions/db-helpers.R", local = FALSE)
+# Source into .GlobalEnv so that lexical scoping works when we replace
+# db_execute_query in .GlobalEnv during tests.
+source_api_file("functions/db-helpers.R", local = FALSE, envir = .GlobalEnv)
 # logger package is used by re-review-service.R via logger::log_info etc.
 if (!requireNamespace("logger", quietly = TRUE)) {
-  skip("logger package not available")
+  stop("logger package not available — cannot run re-review-service tests")
 }
-source_api_file("services/re-review-service.R", local = FALSE)
+source_api_file("services/re-review-service.R", local = FALSE, envir = .GlobalEnv)
 
 # ---------------------------------------------------------------------------
 # Helpers — synthetic entity data frames returned by the mocked DB queries
@@ -30,19 +33,19 @@ make_gene_rows <- function() {
 
 make_entity_rows <- function() {
   data.frame(
-    entity_id                      = c(1L, 2L, 3L, 4L, 5L, 6L),
-    hgnc_id                        = c("HGNC:1001", "HGNC:1001", "HGNC:1001",
-                                       "HGNC:1002", "HGNC:1002", "HGNC:1002"),
-    symbol                         = rep("GENE1", 6),
-    disease_ontology_name          = paste0("Disease ", 1:6),
-    disease_ontology_id_version    = paste0("OMIM:10000", 1:6),
+    entity_id                         = c(1L, 2L, 3L, 4L, 5L, 6L),
+    hgnc_id                           = c("HGNC:1001", "HGNC:1001", "HGNC:1001",
+                                          "HGNC:1002", "HGNC:1002", "HGNC:1002"),
+    symbol                            = rep("GENE1", 6),
+    disease_ontology_name             = paste0("Disease ", 1:6),
+    disease_ontology_id_version       = paste0("OMIM:10000", 1:6),
     hpo_mode_of_inheritance_term_name = rep("Autosomal dominant", 6),
-    review_date                    = c("2020-01-01", "2020-02-01", "2020-03-01",
-                                       "2020-06-01", "2020-07-01", "2020-08-01"),
-    review_id                      = 101L:106L,
-    category_id                    = rep(1L, 6),
-    status_id                      = 201L:206L,
-    stringsAsFactors               = FALSE
+    review_date                       = c("2020-01-01", "2020-02-01", "2020-03-01",
+                                          "2020-06-01", "2020-07-01", "2020-08-01"),
+    review_id                         = 101L:106L,
+    category_id                       = rep(1L, 6),
+    status_id                         = 201L:206L,
+    stringsAsFactors                  = FALSE
   )
 }
 
@@ -51,34 +54,48 @@ make_entity_rows <- function() {
 make_mock_conn <- function() structure(list(), class = "MockPool")
 
 # ---------------------------------------------------------------------------
-# Helper: set up mocks that simulate the gene-LIMIT SQL + entity expansion.
-# call_count allows the caller to distinguish first call (gene list query)
-# from second call (entity rows query).
+# with_db_mock: temporarily replace db_execute_query and the where-clause
+# helpers in the global environment, restoring them on exit.
+# The mock_fn receives each call in sequence; call_count_env$n tracks calls.
 # ---------------------------------------------------------------------------
-with_gene_atomic_mocks <- function(expr, gene_rows = make_gene_rows(),
-                                   entity_rows = make_entity_rows()) {
-  call_count <- 0L
-  local_mocked_bindings(
-    db_execute_query = function(sql, params = list(), conn = NULL) {
-      call_count <<- call_count + 1L
-      if (call_count == 1L) {
-        # First call: the gene-discovery SELECT → return gene rows
-        return(tibble::as_tibble(gene_rows))
-      } else {
-        # Second call: the entity-expansion SELECT → return entity rows
-        return(tibble::as_tibble(entity_rows))
-      }
-    },
-    build_batch_where_clause = function(criteria, pool) "1=1",
-    build_batch_params       = function(criteria) list(),
-    .package                 = NULL # bindings in global env (sourced service)
-  )
+with_db_mock <- function(mock_fn, expr) {
+  # Save originals (may be NULL if not yet defined)
+  orig_deq  <- if (exists("db_execute_query",        envir = .GlobalEnv)) get("db_execute_query",        envir = .GlobalEnv) else NULL
+  orig_bwc  <- if (exists("build_batch_where_clause", envir = .GlobalEnv)) get("build_batch_where_clause", envir = .GlobalEnv) else NULL
+  orig_bbp  <- if (exists("build_batch_params",       envir = .GlobalEnv)) get("build_batch_params",       envir = .GlobalEnv) else NULL
+
+  # Install mocks
+  assign("db_execute_query",        mock_fn,                              envir = .GlobalEnv)
+  assign("build_batch_where_clause", function(criteria, pool) "1=1",      envir = .GlobalEnv)
+  assign("build_batch_params",       function(criteria) list(),            envir = .GlobalEnv)
+
+  # Restore on exit (even on error)
+  on.exit({
+    if (is.null(orig_deq))  rm("db_execute_query",        envir = .GlobalEnv) else assign("db_execute_query",        orig_deq, envir = .GlobalEnv)
+    if (is.null(orig_bwc))  rm("build_batch_where_clause", envir = .GlobalEnv) else assign("build_batch_where_clause", orig_bwc, envir = .GlobalEnv)
+    if (is.null(orig_bbp))  rm("build_batch_params",       envir = .GlobalEnv) else assign("build_batch_params",       orig_bbp, envir = .GlobalEnv)
+  }, add = TRUE)
+
   force(expr)
 }
 
+# Convenience: mock that alternates between gene_rows (call 1) and entity_rows (call 2+)
+make_two_call_mock <- function(gene_rows, entity_rows) {
+  call_n <- 0L
+  function(sql, params = list(), conn = NULL) {
+    call_n <<- call_n + 1L
+    if (call_n == 1L) tibble::as_tibble(gene_rows)
+    else              tibble::as_tibble(entity_rows)
+  }
+}
+
+# Mock that always returns an empty tibble (no matching genes)
+make_empty_mock <- function() {
+  function(sql, params = list(), conn = NULL) tibble::tibble()
+}
+
 # ---------------------------------------------------------------------------
-# W3.2 failing tests (these fail before the fix because select_matching_entities
-# doesn't exist yet — source_api_file above will error on that missing function)
+# Tests
 # ---------------------------------------------------------------------------
 
 context("re-review-service: gene-atomic batching (issue #29)")
@@ -96,35 +113,31 @@ test_that("select_matching_entities returns gene-atomic result with soft LIMIT",
     "select_matching_entities not yet implemented"
   )
 
-  pool <- make_mock_conn()
-
-  call_count <- 0L
   gene_rows   <- make_gene_rows()
   entity_rows <- make_entity_rows()
+  call_n      <- 0L
 
-  local_mocked_bindings(
-    db_execute_query = function(sql, params = list(), conn = NULL) {
-      call_count <<- call_count + 1L
-      if (call_count == 1L) tibble::as_tibble(gene_rows)
-      else                  tibble::as_tibble(entity_rows)
-    },
-    .package = NULL
-  )
+  mock_fn <- function(sql, params = list(), conn = NULL) {
+    call_n <<- call_n + 1L
+    if (call_n == 1L) tibble::as_tibble(gene_rows) else tibble::as_tibble(entity_rows)
+  }
 
-  result <- select_matching_entities(
-    criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
-    batch_size = 4L,
-    conn       = pool
-  )
+  with_db_mock(mock_fn, {
+    result <- select_matching_entities(
+      criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
+      batch_size = 4L,
+      conn       = make_mock_conn()
+    )
+  })
 
-  # Both calls must have been made
-  expect_equal(call_count, 2L)
+  # Both DB calls must have been made
+  expect_equal(call_n, 2L)
 
   # With batch_size=4 and 3 entities per gene, the soft LIMIT must include
   # gene HGNC:1001 fully (3 entities), then detect overflow when adding HGNC:1002
-  # (total=6 > 4), include it fully anyway, and set boundary_gene = "HGNC:1002".
-  expect_equal(result$entity_count, 6L)
-  expect_equal(result$gene_count,   2L)
+  # (total=6 > 4), include all of HGNC:1002 anyway, set boundary_gene = "HGNC:1002".
+  expect_equal(result$entity_count,  6L)
+  expect_equal(result$gene_count,    2L)
   expect_equal(result$boundary_gene, "HGNC:1002")
 
   # All entities must be present
@@ -143,26 +156,16 @@ test_that("select_matching_entities sets boundary_gene = NA when batch fits clea
     "select_matching_entities not yet implemented"
   )
 
-  pool <- make_mock_conn()
-
-  call_count <- 0L
   gene_rows   <- make_gene_rows()
   entity_rows <- make_entity_rows()
 
-  local_mocked_bindings(
-    db_execute_query = function(sql, params = list(), conn = NULL) {
-      call_count <<- call_count + 1L
-      if (call_count == 1L) tibble::as_tibble(gene_rows)
-      else                  tibble::as_tibble(entity_rows)
-    },
-    .package = NULL
-  )
-
-  result <- select_matching_entities(
-    criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
-    batch_size = 20L,
-    conn       = pool
-  )
+  with_db_mock(make_two_call_mock(gene_rows, entity_rows), {
+    result <- select_matching_entities(
+      criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
+      batch_size = 20L,
+      conn       = make_mock_conn()
+    )
+  })
 
   expect_equal(result$entity_count, 6L)
   expect_equal(result$gene_count,   2L)
@@ -175,20 +178,13 @@ test_that("select_matching_entities returns empty list when no genes found", {
     "select_matching_entities not yet implemented"
   )
 
-  pool <- make_mock_conn()
-
-  local_mocked_bindings(
-    db_execute_query = function(sql, params = list(), conn = NULL) {
-      tibble::tibble()  # no rows
-    },
-    .package = NULL
-  )
-
-  result <- select_matching_entities(
-    criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
-    batch_size = 20L,
-    conn       = pool
-  )
+  with_db_mock(make_empty_mock(), {
+    result <- select_matching_entities(
+      criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
+      batch_size = 20L,
+      conn       = make_mock_conn()
+    )
+  })
 
   expect_equal(result$entity_count, 0L)
   expect_equal(result$gene_count,   0L)
@@ -202,31 +198,21 @@ test_that("batch_preview response includes boundary_gene, gene_count, entity_cou
     "select_matching_entities not yet implemented"
   )
 
-  pool <- make_mock_conn()
-
-  call_count <- 0L
   gene_rows   <- make_gene_rows()
   entity_rows <- make_entity_rows()
 
-  local_mocked_bindings(
-    db_execute_query = function(sql, params = list(), conn = NULL) {
-      call_count <<- call_count + 1L
-      if (call_count == 1L) tibble::as_tibble(gene_rows)
-      else                  tibble::as_tibble(entity_rows)
-    },
-    .package = NULL
-  )
-
-  result <- batch_preview(
-    criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
-    batch_size = 4L,
-    pool       = pool
-  )
+  with_db_mock(make_two_call_mock(gene_rows, entity_rows), {
+    result <- batch_preview(
+      criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
+      batch_size = 4L,
+      pool       = make_mock_conn()
+    )
+  })
 
   expect_equal(result$status, 200L)
-  expect_true("boundary_gene"  %in% names(result))
-  expect_true("gene_count"     %in% names(result))
-  expect_true("entity_count"   %in% names(result))
+  expect_true("boundary_gene" %in% names(result))
+  expect_true("gene_count"    %in% names(result))
+  expect_true("entity_count"  %in% names(result))
   expect_false(is.na(result$boundary_gene))
   expect_equal(result$gene_count,   2L)
   expect_equal(result$entity_count, 6L)
@@ -238,31 +224,21 @@ test_that("batch_preview atomicity: entity count must be gene-atomic (never spli
     "select_matching_entities not yet implemented"
   )
 
-  pool <- make_mock_conn()
-
-  call_count <- 0L
   gene_rows   <- make_gene_rows()
   entity_rows <- make_entity_rows()
 
-  local_mocked_bindings(
-    db_execute_query = function(sql, params = list(), conn = NULL) {
-      call_count <<- call_count + 1L
-      if (call_count == 1L) tibble::as_tibble(gene_rows)
-      else                  tibble::as_tibble(entity_rows)
-    },
-    .package = NULL
-  )
-
-  result <- batch_preview(
-    criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
-    batch_size = 4L,
-    pool       = pool
-  )
+  with_db_mock(make_two_call_mock(gene_rows, entity_rows), {
+    result <- batch_preview(
+      criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
+      batch_size = 4L,
+      pool       = make_mock_conn()
+    )
+  })
 
   ent_count <- nrow(result$data)
 
   # With batch_size=4 and 3 entities per gene, the algorithm must return
-  # either 3 (gene A only) or 6 (both genes), never 4 (which would split gene B).
+  # either 3 (gene A only) or 6 (both genes), never 4 (would split gene B).
   expect_true(
     ent_count %in% c(3L, 6L),
     info = paste("Expected gene-atomic count in {3, 6}; got", ent_count)

--- a/app/src/views/curate/ManageReReview.spec.ts
+++ b/app/src/views/curate/ManageReReview.spec.ts
@@ -499,3 +499,118 @@ describe('ManageReReview.vue — apiClient Bearer header on every authed endpoin
     expect(sawCall).toBe(true);
   });
 });
+
+// ===========================================================================
+// Issue #29 — gene-atomic BAlert hint
+// Verifies that ManageReReview.vue renders/hides the boundary-gene warning
+// based on the previewBoundaryGene data property.
+// ===========================================================================
+describe('ManageReReview.vue — gene-atomic boundary-gene alert (issue #29)', () => {
+  // -------------------------------------------------------------------------
+  // Helper: mount with overridden data fields so we can drive the alert
+  // without triggering real HTTP calls.
+  // -------------------------------------------------------------------------
+  const mountWithBoundaryData = async (overrides: Record<string, unknown>): Promise<VueWrapper> => {
+    const wrapper = mount(ManageReReview, {
+      global: {
+        directives: {
+          'b-tooltip': {},
+          'b-toggle': {},
+        },
+        stubs: {
+          BContainer: { template: '<div><slot /></div>' },
+          BRow: { template: '<div><slot /></div>' },
+          BCol: { template: '<div><slot /></div>' },
+          BCard: { template: '<div><slot name="header" /><slot /></div>' },
+          BCollapse: { props: ['modelValue'], template: '<div><slot /></div>' },
+          BButton: { template: '<button><slot /></button>' },
+          BBadge: { template: '<span><slot /></span>' },
+          BLink: { template: '<a><slot /></a>' },
+          BSpinner: { template: '<div role="status" />' },
+          BTable: {
+            name: 'BTable',
+            props: ['items', 'fields'],
+            template: '<table><tbody><tr /></tbody></table>',
+          },
+          BPagination: { template: '<nav />' },
+          BFormInput: {
+            props: ['modelValue', 'type', 'placeholder', 'id', 'debounce', 'size', 'min', 'max'],
+            template: '<input />',
+          },
+          BFormSelect: {
+            props: ['modelValue', 'options', 'size', 'id', 'ariaLabel'],
+            template: '<select><slot /></select>',
+          },
+          BFormSelectOption: { props: ['value'], template: '<option><slot /></option>' },
+          BFormCheckbox: {
+            props: ['modelValue', 'switch', 'size', 'id'],
+            template: '<input type="checkbox" />',
+          },
+          BFormGroup: { template: '<div><slot name="label" /><slot /></div>' },
+          BForm: { template: '<form><slot /></form>' },
+          BOverlay: { template: '<div><slot /></div>' },
+          BInputGroup: { template: '<div><slot name="prepend" /><slot /></div>' },
+          BInputGroupText: { template: '<span><slot /></span>' },
+          BPopover: { template: '' },
+          BAlert: {
+            // Render unconditionally — the outer v-if on the host controls
+            // whether this stub is mounted at all. Pass-through attrs (including
+            // data-testid) land on the root element via Vue's inheritAttrs.
+            props: ['variant', 'show'],
+            template: '<div :data-variant="variant"><slot /></div>',
+          },
+          BModal: {
+            name: 'BModal',
+            props: ['modelValue', 'id', 'title'],
+            template: '<div><slot /></div>',
+            methods: { show() {}, hide() {} },
+          },
+          BatchCriteriaForm: { template: '<div />' },
+          AriaLiveRegion: { template: '<div />' },
+          IconLegend: { template: '<div />' },
+        },
+      },
+    });
+
+    // Flush initial mount loaders before overriding data.
+    await flushPromises();
+
+    // Override the relevant data fields and trigger a re-render.
+    Object.entries(overrides).forEach(([key, value]) => {
+      (wrapper.vm as unknown as Record<string, unknown>)[key] = value;
+    });
+
+    // Wait for Vue reactivity to propagate the data changes to the DOM.
+    await wrapper.vm.$nextTick();
+    return wrapper;
+  };
+
+  it('alert is hidden when previewBoundaryGene is null', async () => {
+    primeAuth();
+    installDefaultHandlers();
+
+    const wrapper = await mountWithBoundaryData({
+      previewBoundaryGene: null,
+      previewGeneCount: 0,
+      previewEntityCount: 0,
+    });
+
+    expect(wrapper.find('[data-testid="batch-boundary-gene-alert"]').exists()).toBe(false);
+  });
+
+  it('alert renders when previewBoundaryGene is non-null', async () => {
+    primeAuth();
+    installDefaultHandlers();
+
+    const wrapper = await mountWithBoundaryData({
+      previewBoundaryGene: 'HGNC:4585',
+      previewGeneCount: 2,
+      previewEntityCount: 6,
+    });
+
+    const alert = wrapper.find('[data-testid="batch-boundary-gene-alert"]');
+    expect(alert.exists()).toBe(true);
+    expect(alert.text()).toContain('HGNC:4585');
+    expect(alert.text()).toContain('6');
+  });
+});

--- a/app/src/views/curate/ManageReReview.vue
+++ b/app/src/views/curate/ManageReReview.vue
@@ -121,6 +121,18 @@
                   />
                 </BFormGroup>
 
+                <!-- Gene-atomic batch boundary warning (issue #29) -->
+                <BAlert
+                  v-if="boundaryGeneAlertVisible"
+                  variant="warning"
+                  show
+                  class="mb-2"
+                  data-testid="batch-boundary-gene-alert"
+                >
+                  <i class="bi bi-exclamation-triangle me-1" aria-hidden="true" />
+                  {{ boundaryGeneAlertMessage }}
+                </BAlert>
+
                 <!-- Actions -->
                 <div class="d-flex gap-2">
                   <BButton
@@ -671,6 +683,13 @@ export default {
       entityAssignBatchName: '',
       isLoadingEntities: false,
       isAssigningEntities: false,
+
+      // Gene-atomic batch boundary hint (issue #29)
+      // Set by loadAvailableEntities() from batch_preview's boundary_gene field.
+      // Non-null when the preview soft-LIMIT engaged and a gene was partially included.
+      previewBoundaryGene: null,
+      previewGeneCount: 0,
+      previewEntityCount: 0,
       entitySelectFields: [
         { key: 'entity_id', label: 'ID', sortable: true },
         { key: 'gene_symbol', label: 'Gene', sortable: true },
@@ -709,6 +728,21 @@ export default {
     };
   },
   computed: {
+    // Gene-atomic boundary alert computed properties (issue #29)
+    boundaryGeneAlertVisible() {
+      return Boolean(this.previewBoundaryGene);
+    },
+    boundaryGeneAlertMessage() {
+      if (!this.previewBoundaryGene) return '';
+      return (
+        `Batch is gene-atomic: to keep gene ${this.previewBoundaryGene} together, ` +
+        `the available-entity list holds ${this.previewEntityCount} entities across ` +
+        `${this.previewGeneCount} gene(s). The last gene was extended past the ` +
+        `batch_size cap to avoid splitting it. Tighten criteria or increase ` +
+        `batch size to avoid the overflow.`
+      );
+    },
+
     // Filter options derived from loaded data
     userFilterOptions() {
       const uniqueUsers = [
@@ -868,6 +902,13 @@ export default {
         const responseData = await apiClient.post(apiUrl, { batch_size: 100 });
         this.availableEntities = responseData.data || [];
         this.selectedEntityIds = [];
+        // Capture gene-atomic boundary hint (issue #29): boundary_gene is non-null
+        // when the soft-LIMIT extended the last gene past batch_size.
+        // BatchServiceResponse uses [key: string]: unknown so values flow through
+        // without type assertions in this plain-JS Options API component.
+        this.previewBoundaryGene = responseData.boundary_gene ?? null;
+        this.previewGeneCount = responseData.gene_count ?? 0;
+        this.previewEntityCount = responseData.entity_count ?? 0;
       } catch (_e) {
         this.makeToast('Failed to load available entities', 'Error', 'danger');
       } finally {


### PR DESCRIPTION
## Summary

- Fixes GitHub issue #29: re-review batch creation was splitting entities for a gene across batches when `ORDER BY review_date LIMIT n` cut mid-gene
- Extracts a shared `select_matching_entities()` helper in `api/services/re-review-service.R` using a two-step gene-first SELECT + soft-LIMIT algorithm
- `batch_preview` response gains `boundary_gene`, `gene_count`, `entity_count` fields
- `ManageReReview.vue` renders a `BAlert warning` when `boundary_gene` is non-null

## Changes

**Backend (`api/services/re-review-service.R`)**
- New `select_matching_entities()` helper: SELECT distinct hgnc_ids first, then expand to all matching entities for those genes, apply a soft LIMIT (include the boundary gene fully even if it pushes past batch_size)
- `batch_preview`, `batch_create`, and `batch_recalculate` all now call the helper instead of the old DISTINCT + ORDER BY + LIMIT pattern
- `batch_preview` response extended with `boundary_gene`, `gene_count`, `entity_count`
- `batch_create` and `batch_recalculate` response shapes unchanged

**Frontend (`app/src/views/curate/ManageReReview.vue`)**
- Captures `boundary_gene` from `loadAvailableEntities()` preview response
- Renders a `BAlert variant="warning"` with `data-testid="batch-boundary-gene-alert"` when `previewBoundaryGene` is non-null

**Tests**
- `api/tests/testthat/test-re-review-service.R`: 5 unit tests using global-env mock to verify gene-atomic algorithm, boundary_gene field, and soft LIMIT behavior
- `app/src/views/curate/ManageReReview.spec.ts`: 2 new tests covering alert visible/hidden states

## Test plan

- [x] `make pre-commit` green locally
- [x] `make lint-api` green (0 issues)
- [x] `make lint-app` green (0 issues)
- [x] `npm run type-check` clean
- [x] `npm run type-check:strict` clean
- [x] 23 R unit tests green (re-review-service context)
- [x] 901 frontend unit tests green (90 test files)
- [ ] CI green on PR