### PR TITLE
feat(v11.2): decompose ManageUser + ModifyEntity, fix #29 entity-batch grouping

### DIFF
--- a/.planning/reviews/2026-04-23-codebase-review.md
+++ b/.planning/reviews/2026-04-23-codebase-review.md
@@ -5,6 +5,19 @@
 **Branch:** `master`  
 **Baseline compared:** `.planning/reviews/2026-04-11-codebase-review.md`
 
+## Status update (2026-04-26, post v11.2-monolith-cleanup PR)
+
+| Finding | Status | Where |
+|---|---|---|
+| **P2.7** Large frontend monoliths | ✅ DONE | `Review.vue` decomposed in v11.1 W6. v11.2: `ManageUser.vue` 1701→577 LoC (W1) into 4 composables + 7 sub-components; `ModifyEntity.vue` 1522→537 LoC (W2) into 4 composables + 5 sub-components alongside existing `useStatusForm`. |
+
+**Open issues status:**
+
+- **#29** (entity-batch grouping) — ✅ Closed; gene-atomic batching with soft-LIMIT in `api/services/re-review-service.R` `select_matching_entities()` (W3); `ManageReReview.vue` warns pre-create when criteria would split a gene. Algorithm-only fix per spec — no DB migration; existing split batches remain.
+- **#299, #300, #154, #98, #175, #105, #89, #55, #54, #48, #46, #37, #33, #32, #25, #22, #15, #14** — unchanged from v11.1's status; not in v11.2 scope.
+
+**Net result:** P2.7 fully resolved; #29 closed.
+
 ## Status update (2026-04-25, post v11.1-finish-hardening PR #306)
 
 | Finding | Status | Where |
@@ -14,7 +27,7 @@
 | **P1.4** Async job state in-memory | ✅ DONE | Durable-jobs MVP shipped in PR #305; v11.1 W3 added typed `@/api/jobs.ts` client + Vitest+MSW spec |
 | **P1.5** Frontend architecture migration incomplete | ✅ DONE | W3 filled all 24 typed-API stubs; W4/W5/W6/W7 migrated ~40 call sites; precise grep gates return zero `this.axios.*` and zero raw `axios` value-imports in `views/`+`components/` |
 | **P2.6** Type safety / strict mode | ⚠️ EXPANDED | FU#6 global ratchet covers most of `src/` minus 28 documented exclusions in 9 cohorts; 7 strict scopes pass (router, api, types, composables-auth, plugins-axios, views-review, global) |
-| **P2.7** Large frontend monoliths | 🔄 PARTIAL | `Review.vue` decomposed 1441→514 LoC (W6) into 4 composables + 5 components. **Still monolithic:** `ManageUser.vue` (1701 LoC), `ModifyEntity.vue` (1500+ LoC, migrated but not decomposed — explicit out-of-scope per v11.1 spec) |
+| **P2.7** Large frontend monoliths | ✅ DONE | `Review.vue` decomposed 1441→514 LoC in v11.1 W6. `ManageUser.vue` 1701→577 LoC (v11.2 W1). `ModifyEntity.vue` 1522→537 LoC (v11.2 W2). Each into 4 composables + sub-components. |
 | **P2.8** Auth-state cleanup reactive drift | ✅ DONE | W2: `useAuth.handle401()` is single owner; `axios.ts` 401 interceptor delegates via lazy import; idempotent under concurrent rejections; `localStorage.removeItem` grep in `app/src/plugins/` returns empty |
 | **P2.9** CSP/HSTS deployment policy | ⚠️ PARTIAL | W1: ADR `.planning/decisions/2026-04-25-csp-hsts-policy.md` + audit script `app/scripts/audit-csp-violations.mjs` + Playwright security-headers spec; #300 fully addressed; #299 **partially** addressed (`'unsafe-inline'` dropped from `script-src`; `'unsafe-eval'` retained for vendor JS — Vue runtime template compiler in `ManageAbout.vue`, NGL Web Workers, markdown-it transforms — rationale in ADR) |
 | **P3.10** Browser-level regression coverage | ⚠️ LOCAL-ONLY | Playwright deep-flow + smoke + security-headers suite added in Wave 0 (10+ specs); `app/tests/e2e/`. **CI workflow deleted** (`.github/workflows/playwright.yml` removed) — suite is local-only for ad-hoc regression checks. Locked `it.todo` in `Review.spec.ts` resolved (W6). 893+ Vitest tests across 90 files |
@@ -24,7 +37,7 @@
 - **#299** (CSP) — ⚠️ Partially closed; `'unsafe-inline'` for `script-src` replaced by sha256 hashes, `'unsafe-eval'` retained intentionally with documented rationale. Full close requires NGL replacement + `ManageAbout.vue` template-compiler removal — both outside v11.1 scope.
 - **#300** (HSTS) — ✅ Closed; preload+includeSubDomains policy formalised in ADR.
 - **#154** (durable queue) — 🔄 Rescoped; durable-jobs MVP shipped, Redis queue + heavy/light worker split deferred to follow-up issue.
-- **#29, #98, #175, #105, #89, #55, #54, #48, #46, #37, #33, #32, #25, #22, #15, #14** — unchanged; not in v11.1 scope.
+- **#98, #175, #105, #89, #55, #54, #48, #46, #37, #33, #32, #25, #22, #15, #14** — unchanged; not in v11.1 scope. (#29 closed in v11.2.)
 
 **Net result:** 4 of 5 P1 findings resolved (1.2 was pre-PR), 1 of 4 P2 findings resolved + 3 partial, 1 P3 partial.
 
@@ -371,3 +384,32 @@ The following targets were added in v11.1 closeout to prevent the multi-bug reco
 ### Backlog (no PR needed yet, just tracked)
 
 `#175` (PubTator gene-count normalization), `#105` (automated log cleanup), `#89` (curation/correlation links), `#55` (review-status removal), `#54` (re-review refusal), `#48` (PubTator query/gene-list endpoint), `#46` (GeneReviews update), `#37` (direct-approval option), `#33` (DB creation scripts), `#32` (admin phenotype view), `#25` (CSR/cert automation), `#22` (DB version), `#15` (variant annotation search), `#14` (new GeneReview articles).
+
+---
+
+## What's next after v11.2 (2026-04-26 update)
+
+PR for `feature/v11.2-monolith-cleanup` lands the three remaining items from v11.1's "What's next" list. Remaining work, in priority order:
+
+### Smaller cleanups (carried forward, plus items surfaced during v11.2)
+
+1. The remaining `as unknown as` cast in `CreateEntity.vue → buildSubmissionObject()` — blocked on porting `app/src/assets/js/classes/submission/` JS classes to TS. Now also affects the new W2 composables (`useEntityInfo`, `useEntityMutations`) which import the same JS classes.
+2. `new Blob([blob])` redundant-wrap sweep across `ManageBackups.vue`, `PanelsTable.vue`, `TablesLogs.vue`, `useTableMethods.ts`.
+3. Type-only `import type ... from 'axios'` cleanup — opportunistic per-file.
+4. Strict-scope cohort cleanup beyond what v11.2 W1/W2 added — the new `views/admin/composables/**` and `views/curate/composables/**` directories were not added to the per-scope strict list because they hit existing TOAST-SHIM (`makeToast` arity) and NULL-NARROW (`string | null` vs `string | undefined`) cohorts. Address those at the shared-utility level first.
+5. Drop `'unsafe-eval'` from CSP — full close of #299.
+6. **`apiClient.raw.*` → typed-client adoption** in the new W1/W2 composables (`useUserData`, `useUserMutations`, `useBulkUserActions`, `useEntityMutations`). The composables call `apiClient.raw.*` to mirror the pre-decompose call sites; typed clients in `app/src/api/user.ts` and `app/src/api/entity.ts` already exist for every endpoint and would shed several `as any` casts.
+7. **Tighten `useUserModals` typing** from `ref<Partial<UserSummary>>({})` to `ref<UserSummary | null>(null)` — eliminates the 4 `as any` casts in `ManageUser.vue`'s shell.
+8. **W3 follow-up tests** — add explicit "single-gene-exact-fit" and "first-gene-overflow" cases to `test-re-review-service.R` so a future maintainer changing the soft-LIMIT comparison from `> batch_size` to `>=` would be caught.
+9. **Type plumbing for `boundary_gene` / `gene_count` / `entity_count`** in `app/src/api/re_review.ts`'s `previewReReviewBatch` return type — currently consumed via the typed client's `[key: string]: unknown` index signature; explicit fields would improve IDE support.
+10. **Decomposition of `views/curate/ManageReReview.vue`** (1084 LoC) and `views/curate/ApproveUser.vue` (828 LoC) — not flagged in the original monolith list but worth queuing for a future pass; W3 only touched ManageReReview for the UI hint.
+
+### Forward-looking (carried forward)
+
+11. **Redis queue + heavy/light worker split** (originally #154) — durable-jobs MVP is in production; queue/worker split is the layered next step.
+12. **`make playwright-stack` automation in CI** — manual after v11.1's lean-CI choice. Re-introduce as `workflow_dispatch` lane if E2E coverage in CI becomes valuable.
+13. **GHA Node 24 forced rollout** — June 2026 deadline.
+
+### Backlog (unchanged from v11.1)
+
+`#98` (replace VariO ontology), `#175`, `#105`, `#89`, `#55`, `#54`, `#48`, `#46`, `#37`, `#33`, `#32`, `#25`, `#22`, `#15`, `#14`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ In the dev/prod containers, source directories such as `api/functions`, `api/ser
 - `make pre-commit` now uses the fast API PR gate to keep local iteration close to pull-request CI; use `make ci-local` before handoff and `make test-api` when you need the full API suite locally.
 - Host-side R quality targets in `Makefile` use `Rscript --no-init-file` to avoid Conda/miniforge bootstrap interference before the repo's own script entrypoints run.
 - On Conda/miniforge R installs, `Makefile` derives `HOST_R_LD_LIBRARY_PATH` from `R RHOME` and prepends the sibling `mariadb/` runtime directory so `RMariaDB` can load successfully. Override `HOST_R_LD_LIBRARY_PATH` if the MariaDB client runtime lives elsewhere.
+- `batch_preview()` and `batch_create()` in `api/services/re-review-service.R` use a **soft LIMIT** (gene-atomic): the returned entity count may exceed `batch_size` to keep all entities for a partially-included gene in the same batch. Callers that assumed strict LIMIT for sizing UI elements must read the response length, not the requested cap. The `boundary_gene` field on the preview response is non-null when the soft-LIMIT engaged.
 
 ## Environment Notes
 

--- a/api/services/re-review-service.R
+++ b/api/services/re-review-service.R
@@ -115,6 +115,119 @@ build_batch_params <- function(criteria) {
 }
 
 
+#' Select entities for a re-review batch with gene-atomic grouping.
+#'
+#' Two-step query: first collect distinct hgnc_ids matching criteria
+#' (ordered by oldest review_date), then expand to all matching entities
+#' for those genes. Trim with a soft LIMIT — include all entities for a
+#' partially-included gene; stop adding new genes once cumulative entity
+#' count >= batch_size. Returns up to `batch_size` entities, with the
+#' boundary gene fully included even if it pushes the count past the cap.
+#'
+#' @param criteria Named list with batch criteria.
+#' @param batch_size Integer cap (default 20). The actual returned count
+#'   may exceed this by at most (entities_in_boundary_gene - 1).
+#' @param conn Database connection (pool or transaction connection).
+#' @return Named list:
+#'   - entities: data frame of selected entities with entity_id, hgnc_id,
+#'     symbol, status_id, review_id, review_date, etc.
+#'   - boundary_gene: hgnc_id where the soft-LIMIT engaged, or NA if the
+#'     batch fits cleanly under batch_size.
+#'   - gene_count: number of distinct hgnc_id values in the result.
+#'   - entity_count: total number of entities (== nrow(entities)).
+#'
+#' @keywords internal
+select_matching_entities <- function(criteria, batch_size = 20, conn) {
+  where_clause <- build_batch_where_clause(criteria, conn)
+  params <- build_batch_params(criteria)
+
+  # Step 1: distinct hgnc_ids matching the criteria, ordered by oldest review_date per gene.
+  # Cap at batch_size (worst case 1 entity per gene = batch_size genes).
+  gene_query <- paste0(
+    "SELECT e.hgnc_id, MIN(r.review_date) AS first_review_date
+     FROM ndd_entity_view e
+     LEFT JOIN ndd_entity_review r ON e.entity_id = r.entity_id AND r.is_primary = 1
+     LEFT JOIN ndd_entity_status s ON e.entity_id = s.entity_id AND s.is_active = 1
+     WHERE ", where_clause, "
+       AND e.entity_id NOT IN (
+         SELECT rec.entity_id FROM re_review_entity_connect rec
+         INNER JOIN re_review_assignment ra ON rec.re_review_batch = ra.re_review_batch
+         WHERE rec.re_review_approved = 0
+       )
+     GROUP BY e.hgnc_id
+     ORDER BY first_review_date ASC
+     LIMIT ?"
+  )
+  gene_params <- c(params, list(as.integer(batch_size)))
+  gene_rows <- db_execute_query(gene_query, gene_params, conn = conn)
+
+  if (nrow(gene_rows) == 0) {
+    return(list(
+      entities     = data.frame(),
+      boundary_gene = NA_character_,
+      gene_count   = 0L,
+      entity_count = 0L
+    ))
+  }
+
+  # Step 2: pull all matching entities for those genes.
+  hgnc_placeholders <- paste(rep("?", nrow(gene_rows)), collapse = ", ")
+  ent_query <- paste0(
+    "SELECT DISTINCT e.entity_id, e.hgnc_id, e.symbol, e.disease_ontology_name,
+            e.disease_ontology_id_version, e.hpo_mode_of_inheritance_term_name,
+            r.review_date, r.review_id, s.category_id, s.status_id
+     FROM ndd_entity_view e
+     LEFT JOIN ndd_entity_review r ON e.entity_id = r.entity_id AND r.is_primary = 1
+     LEFT JOIN ndd_entity_status s ON e.entity_id = s.entity_id AND s.is_active = 1
+     WHERE ", where_clause, "
+       AND e.hgnc_id IN (", hgnc_placeholders, ")
+       AND e.entity_id NOT IN (
+         SELECT rec.entity_id FROM re_review_entity_connect rec
+         INNER JOIN re_review_assignment ra ON rec.re_review_batch = ra.re_review_batch
+         WHERE rec.re_review_approved = 0
+       )
+     ORDER BY e.hgnc_id, r.review_date ASC"
+  )
+  ent_params <- c(params, as.list(gene_rows$hgnc_id))
+  all_matching <- db_execute_query(ent_query, ent_params, conn = conn)
+
+  if (nrow(all_matching) == 0) {
+    return(list(
+      entities     = data.frame(),
+      boundary_gene = NA_character_,
+      gene_count   = 0L,
+      entity_count = 0L
+    ))
+  }
+
+  # Step 3: soft LIMIT — accumulate by gene; stop adding new genes once entity count >= batch_size.
+  # The boundary gene is fully included even if it pushes the cumulative count past the cap.
+  selected <- list()
+  per_gene <- split(all_matching, all_matching$hgnc_id)
+  # Preserve gene order as discovered in step 1 (oldest first):
+  per_gene <- per_gene[as.character(gene_rows$hgnc_id)]
+  total <- 0L
+  boundary <- NA_character_
+  for (gid in names(per_gene)) {
+    block <- per_gene[[gid]]
+    if (total >= batch_size) break
+    selected[[length(selected) + 1L]] <- block
+    total <- total + nrow(block)
+    if (total > batch_size && is.na(boundary)) {
+      boundary <- gid
+    }
+  }
+
+  out <- if (length(selected) > 0L) do.call(rbind, selected) else data.frame()
+  list(
+    entities     = out,
+    boundary_gene = boundary,
+    gene_count   = length(selected),
+    entity_count = nrow(out)
+  )
+}
+
+
 #' Preview matching entities without creating batch
 #'
 #' Returns entities that match the provided criteria without creating a batch.
@@ -136,44 +249,24 @@ build_batch_params <- function(criteria) {
 #'
 #' @export
 batch_preview <- function(criteria, batch_size = 20, pool) {
-  # Build WHERE clause and parameters
-
-where_clause <- build_batch_where_clause(criteria, pool)
-  params <- build_batch_params(criteria)
-
-  # Build query to find matching entities
-  # Exclude entities already in active batches
-  query <- paste0(
-    "SELECT DISTINCT e.entity_id, e.hgnc_id, e.symbol, e.disease_ontology_name,
-            e.disease_ontology_id_version, e.hpo_mode_of_inheritance_term_name,
-            r.review_date, s.category_id
-     FROM ndd_entity_view e
-     LEFT JOIN ndd_entity_review r ON e.entity_id = r.entity_id AND r.is_primary = 1
-     LEFT JOIN ndd_entity_status s ON e.entity_id = s.entity_id AND s.is_active = 1
-     WHERE ", where_clause, "
-       AND e.entity_id NOT IN (
-         SELECT rec.entity_id FROM re_review_entity_connect rec
-         INNER JOIN re_review_assignment ra ON rec.re_review_batch = ra.re_review_batch
-         WHERE rec.re_review_approved = 0
-       )
-     ORDER BY r.review_date ASC
-     LIMIT ?"
-  )
-
-  # Add batch_size to params
-  params <- c(params, list(as.integer(batch_size)))
-
-  # Execute query
-  matching_entities <- db_execute_query(query, params, conn = pool)
+  # Use gene-atomic helper to avoid splitting entities across gene boundaries
+  # (fixes issue #29 where DISTINCT + ORDER BY review_date + LIMIT split genes)
+  selection <- select_matching_entities(criteria, batch_size = batch_size, conn = pool)
+  matching_entities <- selection$entities
 
   logger::log_info("Batch preview",
     criteria_count = length(criteria),
-    matching_count = nrow(matching_entities)
+    matching_count = selection$entity_count,
+    gene_count     = selection$gene_count,
+    boundary_gene  = selection$boundary_gene
   )
 
   list(
-    status = 200,
-    data = matching_entities
+    status        = 200,
+    data          = matching_entities,
+    boundary_gene = selection$boundary_gene,
+    gene_count    = selection$gene_count,
+    entity_count  = selection$entity_count
   )
 }
 
@@ -241,27 +334,9 @@ batch_create <- function(criteria, assigned_user_id = NULL, batch_name = NULL, p
     )
     batch_id <- max_batch_result$next_batch[1]
 
-    # 3. Build WHERE clause and find matching entities
-    where_clause <- build_batch_where_clause(criteria, txn_conn)
-    params <- build_batch_params(criteria)
-
-    query <- paste0(
-      "SELECT DISTINCT e.entity_id, s.status_id, r.review_id, r.review_date
-       FROM ndd_entity_view e
-       LEFT JOIN ndd_entity_review r ON e.entity_id = r.entity_id AND r.is_primary = 1
-       LEFT JOIN ndd_entity_status s ON e.entity_id = s.entity_id AND s.is_active = 1
-       WHERE ", where_clause, "
-         AND e.entity_id NOT IN (
-           SELECT rec.entity_id FROM re_review_entity_connect rec
-           INNER JOIN re_review_assignment ra ON rec.re_review_batch = ra.re_review_batch
-           WHERE rec.re_review_approved = 0
-         )
-       ORDER BY r.review_date ASC
-       LIMIT ?"
-    )
-
-    params <- c(params, list(as.integer(batch_size)))
-    matching_entities <- db_execute_query(query, params, conn = txn_conn)
+    # 3. Find matching entities using gene-atomic helper (fixes issue #29)
+    selection <- select_matching_entities(criteria, batch_size = batch_size, conn = txn_conn)
+    matching_entities <- selection$entities
 
     if (nrow(matching_entities) == 0) {
       stop("No entities match the specified criteria")
@@ -724,27 +799,9 @@ batch_recalculate <- function(batch_id, criteria, pool) {
       conn = txn_conn
     )
 
-    # 2. Build WHERE clause and find matching entities
-    where_clause <- build_batch_where_clause(criteria, pool)
-    params <- build_batch_params(criteria)
-
-    query <- paste0(
-      "SELECT DISTINCT e.entity_id, s.status_id, r.review_id, r.review_date
-       FROM ndd_entity_view e
-       LEFT JOIN ndd_entity_review r ON e.entity_id = r.entity_id AND r.is_primary = 1
-       LEFT JOIN ndd_entity_status s ON e.entity_id = s.entity_id AND s.is_active = 1
-       WHERE ", where_clause, "
-         AND e.entity_id NOT IN (
-           SELECT rec.entity_id FROM re_review_entity_connect rec
-           INNER JOIN re_review_assignment ra ON rec.re_review_batch = ra.re_review_batch
-           WHERE rec.re_review_approved = 0
-         )
-       ORDER BY r.review_date ASC
-       LIMIT ?"
-    )
-
-    params <- c(params, list(as.integer(batch_size)))
-    matching_entities <- db_execute_query(query, params, conn = txn_conn)
+    # 2. Find matching entities using gene-atomic helper (fixes issue #29)
+    selection <- select_matching_entities(criteria, batch_size = batch_size, conn = txn_conn)
+    matching_entities <- selection$entities
 
     if (nrow(matching_entities) == 0) {
       stop("No entities match the specified criteria")

--- a/api/tests/testthat/test-re-review-service.R
+++ b/api/tests/testthat/test-re-review-service.R
@@ -1,0 +1,276 @@
+# tests/testthat/test-re-review-service.R
+#
+# Unit tests for re-review-service.R — gene-atomic batching (issue #29)
+#
+# Strategy: use local_mocked_bindings to mock db_execute_query so we can
+# drive the select_matching_entities() algorithm without a live database.
+# We also verify that batch_preview returns the new boundary_gene / gene_count
+# / entity_count fields after the fix.
+
+source_api_file("functions/db-helpers.R", local = FALSE)
+# logger package is used by re-review-service.R via logger::log_info etc.
+if (!requireNamespace("logger", quietly = TRUE)) {
+  skip("logger package not available")
+}
+source_api_file("services/re-review-service.R", local = FALSE)
+
+# ---------------------------------------------------------------------------
+# Helpers — synthetic entity data frames returned by the mocked DB queries
+# ---------------------------------------------------------------------------
+
+# Two genes (HGNC:1001, HGNC:1002), three entities each.
+# Genes are discovered in order HGNC:1001 first (oldest review_date).
+make_gene_rows <- function() {
+  data.frame(
+    hgnc_id           = c("HGNC:1001", "HGNC:1002"),
+    first_review_date = c("2020-01-01", "2020-06-01"),
+    stringsAsFactors  = FALSE
+  )
+}
+
+make_entity_rows <- function() {
+  data.frame(
+    entity_id                      = c(1L, 2L, 3L, 4L, 5L, 6L),
+    hgnc_id                        = c("HGNC:1001", "HGNC:1001", "HGNC:1001",
+                                       "HGNC:1002", "HGNC:1002", "HGNC:1002"),
+    symbol                         = rep("GENE1", 6),
+    disease_ontology_name          = paste0("Disease ", 1:6),
+    disease_ontology_id_version    = paste0("OMIM:10000", 1:6),
+    hpo_mode_of_inheritance_term_name = rep("Autosomal dominant", 6),
+    review_date                    = c("2020-01-01", "2020-02-01", "2020-03-01",
+                                       "2020-06-01", "2020-07-01", "2020-08-01"),
+    review_id                      = 101L:106L,
+    category_id                    = rep(1L, 6),
+    status_id                      = 201L:206L,
+    stringsAsFactors               = FALSE
+  )
+}
+
+# Mock connection — only used as the conn argument; mocked db_execute_query
+# ignores the actual connection object.
+make_mock_conn <- function() structure(list(), class = "MockPool")
+
+# ---------------------------------------------------------------------------
+# Helper: set up mocks that simulate the gene-LIMIT SQL + entity expansion.
+# call_count allows the caller to distinguish first call (gene list query)
+# from second call (entity rows query).
+# ---------------------------------------------------------------------------
+with_gene_atomic_mocks <- function(expr, gene_rows = make_gene_rows(),
+                                   entity_rows = make_entity_rows()) {
+  call_count <- 0L
+  local_mocked_bindings(
+    db_execute_query = function(sql, params = list(), conn = NULL) {
+      call_count <<- call_count + 1L
+      if (call_count == 1L) {
+        # First call: the gene-discovery SELECT → return gene rows
+        return(tibble::as_tibble(gene_rows))
+      } else {
+        # Second call: the entity-expansion SELECT → return entity rows
+        return(tibble::as_tibble(entity_rows))
+      }
+    },
+    build_batch_where_clause = function(criteria, pool) "1=1",
+    build_batch_params       = function(criteria) list(),
+    .package                 = NULL # bindings in global env (sourced service)
+  )
+  force(expr)
+}
+
+# ---------------------------------------------------------------------------
+# W3.2 failing tests (these fail before the fix because select_matching_entities
+# doesn't exist yet — source_api_file above will error on that missing function)
+# ---------------------------------------------------------------------------
+
+context("re-review-service: gene-atomic batching (issue #29)")
+
+test_that("select_matching_entities exists after fix", {
+  expect_true(
+    exists("select_matching_entities", mode = "function"),
+    info = "select_matching_entities() must be defined in re-review-service.R"
+  )
+})
+
+test_that("select_matching_entities returns gene-atomic result with soft LIMIT", {
+  skip_if_not(
+    exists("select_matching_entities", mode = "function"),
+    "select_matching_entities not yet implemented"
+  )
+
+  pool <- make_mock_conn()
+
+  call_count <- 0L
+  gene_rows   <- make_gene_rows()
+  entity_rows <- make_entity_rows()
+
+  local_mocked_bindings(
+    db_execute_query = function(sql, params = list(), conn = NULL) {
+      call_count <<- call_count + 1L
+      if (call_count == 1L) tibble::as_tibble(gene_rows)
+      else                  tibble::as_tibble(entity_rows)
+    },
+    .package = NULL
+  )
+
+  result <- select_matching_entities(
+    criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
+    batch_size = 4L,
+    conn       = pool
+  )
+
+  # Both calls must have been made
+  expect_equal(call_count, 2L)
+
+  # With batch_size=4 and 3 entities per gene, the soft LIMIT must include
+  # gene HGNC:1001 fully (3 entities), then detect overflow when adding HGNC:1002
+  # (total=6 > 4), include it fully anyway, and set boundary_gene = "HGNC:1002".
+  expect_equal(result$entity_count, 6L)
+  expect_equal(result$gene_count,   2L)
+  expect_equal(result$boundary_gene, "HGNC:1002")
+
+  # All entities must be present
+  expect_equal(sort(result$entities$entity_id), 1L:6L)
+
+  # Each gene must have exactly 3 entities (gene-atomic guarantee)
+  per_gene <- table(result$entities$hgnc_id)
+  expect_true(all(per_gene == 3L),
+              info = paste("Expected 3 entities per gene; got",
+                           paste(per_gene, collapse = ",")))
+})
+
+test_that("select_matching_entities sets boundary_gene = NA when batch fits cleanly", {
+  skip_if_not(
+    exists("select_matching_entities", mode = "function"),
+    "select_matching_entities not yet implemented"
+  )
+
+  pool <- make_mock_conn()
+
+  call_count <- 0L
+  gene_rows   <- make_gene_rows()
+  entity_rows <- make_entity_rows()
+
+  local_mocked_bindings(
+    db_execute_query = function(sql, params = list(), conn = NULL) {
+      call_count <<- call_count + 1L
+      if (call_count == 1L) tibble::as_tibble(gene_rows)
+      else                  tibble::as_tibble(entity_rows)
+    },
+    .package = NULL
+  )
+
+  result <- select_matching_entities(
+    criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
+    batch_size = 20L,
+    conn       = pool
+  )
+
+  expect_equal(result$entity_count, 6L)
+  expect_equal(result$gene_count,   2L)
+  expect_true(is.na(result$boundary_gene))
+})
+
+test_that("select_matching_entities returns empty list when no genes found", {
+  skip_if_not(
+    exists("select_matching_entities", mode = "function"),
+    "select_matching_entities not yet implemented"
+  )
+
+  pool <- make_mock_conn()
+
+  local_mocked_bindings(
+    db_execute_query = function(sql, params = list(), conn = NULL) {
+      tibble::tibble()  # no rows
+    },
+    .package = NULL
+  )
+
+  result <- select_matching_entities(
+    criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
+    batch_size = 20L,
+    conn       = pool
+  )
+
+  expect_equal(result$entity_count, 0L)
+  expect_equal(result$gene_count,   0L)
+  expect_true(is.na(result$boundary_gene))
+  expect_equal(nrow(result$entities), 0L)
+})
+
+test_that("batch_preview response includes boundary_gene, gene_count, entity_count", {
+  skip_if_not(
+    exists("select_matching_entities", mode = "function"),
+    "select_matching_entities not yet implemented"
+  )
+
+  pool <- make_mock_conn()
+
+  call_count <- 0L
+  gene_rows   <- make_gene_rows()
+  entity_rows <- make_entity_rows()
+
+  local_mocked_bindings(
+    db_execute_query = function(sql, params = list(), conn = NULL) {
+      call_count <<- call_count + 1L
+      if (call_count == 1L) tibble::as_tibble(gene_rows)
+      else                  tibble::as_tibble(entity_rows)
+    },
+    .package = NULL
+  )
+
+  result <- batch_preview(
+    criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
+    batch_size = 4L,
+    pool       = pool
+  )
+
+  expect_equal(result$status, 200L)
+  expect_true("boundary_gene"  %in% names(result))
+  expect_true("gene_count"     %in% names(result))
+  expect_true("entity_count"   %in% names(result))
+  expect_false(is.na(result$boundary_gene))
+  expect_equal(result$gene_count,   2L)
+  expect_equal(result$entity_count, 6L)
+})
+
+test_that("batch_preview atomicity: entity count must be gene-atomic (never splits a gene)", {
+  skip_if_not(
+    exists("select_matching_entities", mode = "function"),
+    "select_matching_entities not yet implemented"
+  )
+
+  pool <- make_mock_conn()
+
+  call_count <- 0L
+  gene_rows   <- make_gene_rows()
+  entity_rows <- make_entity_rows()
+
+  local_mocked_bindings(
+    db_execute_query = function(sql, params = list(), conn = NULL) {
+      call_count <<- call_count + 1L
+      if (call_count == 1L) tibble::as_tibble(gene_rows)
+      else                  tibble::as_tibble(entity_rows)
+    },
+    .package = NULL
+  )
+
+  result <- batch_preview(
+    criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
+    batch_size = 4L,
+    pool       = pool
+  )
+
+  ent_count <- nrow(result$data)
+
+  # With batch_size=4 and 3 entities per gene, the algorithm must return
+  # either 3 (gene A only) or 6 (both genes), never 4 (which would split gene B).
+  expect_true(
+    ent_count %in% c(3L, 6L),
+    info = paste("Expected gene-atomic count in {3, 6}; got", ent_count)
+  )
+
+  per_gene <- table(result$data$hgnc_id)
+  expect_true(
+    all(per_gene == 3L),
+    info = paste("Expected 3 entities per gene; got", paste(per_gene, collapse = ","))
+  )
+})

--- a/api/tests/testthat/test-re-review-service.R
+++ b/api/tests/testthat/test-re-review-service.R
@@ -2,17 +2,20 @@
 #
 # Unit tests for re-review-service.R — gene-atomic batching (issue #29)
 #
-# Strategy: use local_mocked_bindings to mock db_execute_query so we can
-# drive the select_matching_entities() algorithm without a live database.
+# Strategy: temporarily replace db_execute_query in the global environment
+# using withr::with_bindings so we can drive the select_matching_entities()
+# algorithm without a live database.
 # We also verify that batch_preview returns the new boundary_gene / gene_count
 # / entity_count fields after the fix.
 
-source_api_file("functions/db-helpers.R", local = FALSE)
+# Source into .GlobalEnv so that lexical scoping works when we replace
+# db_execute_query in .GlobalEnv during tests.
+source_api_file("functions/db-helpers.R", local = FALSE, envir = .GlobalEnv)
 # logger package is used by re-review-service.R via logger::log_info etc.
 if (!requireNamespace("logger", quietly = TRUE)) {
-  skip("logger package not available")
+  stop("logger package not available — cannot run re-review-service tests")
 }
-source_api_file("services/re-review-service.R", local = FALSE)
+source_api_file("services/re-review-service.R", local = FALSE, envir = .GlobalEnv)
 
 # ---------------------------------------------------------------------------
 # Helpers — synthetic entity data frames returned by the mocked DB queries
@@ -30,19 +33,19 @@ make_gene_rows <- function() {
 
 make_entity_rows <- function() {
   data.frame(
-    entity_id                      = c(1L, 2L, 3L, 4L, 5L, 6L),
-    hgnc_id                        = c("HGNC:1001", "HGNC:1001", "HGNC:1001",
-                                       "HGNC:1002", "HGNC:1002", "HGNC:1002"),
-    symbol                         = rep("GENE1", 6),
-    disease_ontology_name          = paste0("Disease ", 1:6),
-    disease_ontology_id_version    = paste0("OMIM:10000", 1:6),
+    entity_id                         = c(1L, 2L, 3L, 4L, 5L, 6L),
+    hgnc_id                           = c("HGNC:1001", "HGNC:1001", "HGNC:1001",
+                                          "HGNC:1002", "HGNC:1002", "HGNC:1002"),
+    symbol                            = rep("GENE1", 6),
+    disease_ontology_name             = paste0("Disease ", 1:6),
+    disease_ontology_id_version       = paste0("OMIM:10000", 1:6),
     hpo_mode_of_inheritance_term_name = rep("Autosomal dominant", 6),
-    review_date                    = c("2020-01-01", "2020-02-01", "2020-03-01",
-                                       "2020-06-01", "2020-07-01", "2020-08-01"),
-    review_id                      = 101L:106L,
-    category_id                    = rep(1L, 6),
-    status_id                      = 201L:206L,
-    stringsAsFactors               = FALSE
+    review_date                       = c("2020-01-01", "2020-02-01", "2020-03-01",
+                                          "2020-06-01", "2020-07-01", "2020-08-01"),
+    review_id                         = 101L:106L,
+    category_id                       = rep(1L, 6),
+    status_id                         = 201L:206L,
+    stringsAsFactors                  = FALSE
   )
 }
 
@@ -51,34 +54,48 @@ make_entity_rows <- function() {
 make_mock_conn <- function() structure(list(), class = "MockPool")
 
 # ---------------------------------------------------------------------------
-# Helper: set up mocks that simulate the gene-LIMIT SQL + entity expansion.
-# call_count allows the caller to distinguish first call (gene list query)
-# from second call (entity rows query).
+# with_db_mock: temporarily replace db_execute_query and the where-clause
+# helpers in the global environment, restoring them on exit.
+# The mock_fn receives each call in sequence; call_count_env$n tracks calls.
 # ---------------------------------------------------------------------------
-with_gene_atomic_mocks <- function(expr, gene_rows = make_gene_rows(),
-                                   entity_rows = make_entity_rows()) {
-  call_count <- 0L
-  local_mocked_bindings(
-    db_execute_query = function(sql, params = list(), conn = NULL) {
-      call_count <<- call_count + 1L
-      if (call_count == 1L) {
-        # First call: the gene-discovery SELECT → return gene rows
-        return(tibble::as_tibble(gene_rows))
-      } else {
-        # Second call: the entity-expansion SELECT → return entity rows
-        return(tibble::as_tibble(entity_rows))
-      }
-    },
-    build_batch_where_clause = function(criteria, pool) "1=1",
-    build_batch_params       = function(criteria) list(),
-    .package                 = NULL # bindings in global env (sourced service)
-  )
+with_db_mock <- function(mock_fn, expr) {
+  # Save originals (may be NULL if not yet defined)
+  orig_deq  <- if (exists("db_execute_query",        envir = .GlobalEnv)) get("db_execute_query",        envir = .GlobalEnv) else NULL
+  orig_bwc  <- if (exists("build_batch_where_clause", envir = .GlobalEnv)) get("build_batch_where_clause", envir = .GlobalEnv) else NULL
+  orig_bbp  <- if (exists("build_batch_params",       envir = .GlobalEnv)) get("build_batch_params",       envir = .GlobalEnv) else NULL
+
+  # Install mocks
+  assign("db_execute_query",        mock_fn,                              envir = .GlobalEnv)
+  assign("build_batch_where_clause", function(criteria, pool) "1=1",      envir = .GlobalEnv)
+  assign("build_batch_params",       function(criteria) list(),            envir = .GlobalEnv)
+
+  # Restore on exit (even on error)
+  on.exit({
+    if (is.null(orig_deq))  rm("db_execute_query",        envir = .GlobalEnv) else assign("db_execute_query",        orig_deq, envir = .GlobalEnv)
+    if (is.null(orig_bwc))  rm("build_batch_where_clause", envir = .GlobalEnv) else assign("build_batch_where_clause", orig_bwc, envir = .GlobalEnv)
+    if (is.null(orig_bbp))  rm("build_batch_params",       envir = .GlobalEnv) else assign("build_batch_params",       orig_bbp, envir = .GlobalEnv)
+  }, add = TRUE)
+
   force(expr)
 }
 
+# Convenience: mock that alternates between gene_rows (call 1) and entity_rows (call 2+)
+make_two_call_mock <- function(gene_rows, entity_rows) {
+  call_n <- 0L
+  function(sql, params = list(), conn = NULL) {
+    call_n <<- call_n + 1L
+    if (call_n == 1L) tibble::as_tibble(gene_rows)
+    else              tibble::as_tibble(entity_rows)
+  }
+}
+
+# Mock that always returns an empty tibble (no matching genes)
+make_empty_mock <- function() {
+  function(sql, params = list(), conn = NULL) tibble::tibble()
+}
+
 # ---------------------------------------------------------------------------
-# W3.2 failing tests (these fail before the fix because select_matching_entities
-# doesn't exist yet — source_api_file above will error on that missing function)
+# Tests
 # ---------------------------------------------------------------------------
 
 context("re-review-service: gene-atomic batching (issue #29)")
@@ -96,35 +113,31 @@ test_that("select_matching_entities returns gene-atomic result with soft LIMIT",
     "select_matching_entities not yet implemented"
   )
 
-  pool <- make_mock_conn()
-
-  call_count <- 0L
   gene_rows   <- make_gene_rows()
   entity_rows <- make_entity_rows()
+  call_n      <- 0L
 
-  local_mocked_bindings(
-    db_execute_query = function(sql, params = list(), conn = NULL) {
-      call_count <<- call_count + 1L
-      if (call_count == 1L) tibble::as_tibble(gene_rows)
-      else                  tibble::as_tibble(entity_rows)
-    },
-    .package = NULL
-  )
+  mock_fn <- function(sql, params = list(), conn = NULL) {
+    call_n <<- call_n + 1L
+    if (call_n == 1L) tibble::as_tibble(gene_rows) else tibble::as_tibble(entity_rows)
+  }
 
-  result <- select_matching_entities(
-    criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
-    batch_size = 4L,
-    conn       = pool
-  )
+  with_db_mock(mock_fn, {
+    result <- select_matching_entities(
+      criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
+      batch_size = 4L,
+      conn       = make_mock_conn()
+    )
+  })
 
-  # Both calls must have been made
-  expect_equal(call_count, 2L)
+  # Both DB calls must have been made
+  expect_equal(call_n, 2L)
 
   # With batch_size=4 and 3 entities per gene, the soft LIMIT must include
   # gene HGNC:1001 fully (3 entities), then detect overflow when adding HGNC:1002
-  # (total=6 > 4), include it fully anyway, and set boundary_gene = "HGNC:1002".
-  expect_equal(result$entity_count, 6L)
-  expect_equal(result$gene_count,   2L)
+  # (total=6 > 4), include all of HGNC:1002 anyway, set boundary_gene = "HGNC:1002".
+  expect_equal(result$entity_count,  6L)
+  expect_equal(result$gene_count,    2L)
   expect_equal(result$boundary_gene, "HGNC:1002")
 
   # All entities must be present
@@ -143,26 +156,16 @@ test_that("select_matching_entities sets boundary_gene = NA when batch fits clea
     "select_matching_entities not yet implemented"
   )
 
-  pool <- make_mock_conn()
-
-  call_count <- 0L
   gene_rows   <- make_gene_rows()
   entity_rows <- make_entity_rows()
 
-  local_mocked_bindings(
-    db_execute_query = function(sql, params = list(), conn = NULL) {
-      call_count <<- call_count + 1L
-      if (call_count == 1L) tibble::as_tibble(gene_rows)
-      else                  tibble::as_tibble(entity_rows)
-    },
-    .package = NULL
-  )
-
-  result <- select_matching_entities(
-    criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
-    batch_size = 20L,
-    conn       = pool
-  )
+  with_db_mock(make_two_call_mock(gene_rows, entity_rows), {
+    result <- select_matching_entities(
+      criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
+      batch_size = 20L,
+      conn       = make_mock_conn()
+    )
+  })
 
   expect_equal(result$entity_count, 6L)
   expect_equal(result$gene_count,   2L)
@@ -175,20 +178,13 @@ test_that("select_matching_entities returns empty list when no genes found", {
     "select_matching_entities not yet implemented"
   )
 
-  pool <- make_mock_conn()
-
-  local_mocked_bindings(
-    db_execute_query = function(sql, params = list(), conn = NULL) {
-      tibble::tibble()  # no rows
-    },
-    .package = NULL
-  )
-
-  result <- select_matching_entities(
-    criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
-    batch_size = 20L,
-    conn       = pool
-  )
+  with_db_mock(make_empty_mock(), {
+    result <- select_matching_entities(
+      criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
+      batch_size = 20L,
+      conn       = make_mock_conn()
+    )
+  })
 
   expect_equal(result$entity_count, 0L)
   expect_equal(result$gene_count,   0L)
@@ -202,31 +198,21 @@ test_that("batch_preview response includes boundary_gene, gene_count, entity_cou
     "select_matching_entities not yet implemented"
   )
 
-  pool <- make_mock_conn()
-
-  call_count <- 0L
   gene_rows   <- make_gene_rows()
   entity_rows <- make_entity_rows()
 
-  local_mocked_bindings(
-    db_execute_query = function(sql, params = list(), conn = NULL) {
-      call_count <<- call_count + 1L
-      if (call_count == 1L) tibble::as_tibble(gene_rows)
-      else                  tibble::as_tibble(entity_rows)
-    },
-    .package = NULL
-  )
-
-  result <- batch_preview(
-    criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
-    batch_size = 4L,
-    pool       = pool
-  )
+  with_db_mock(make_two_call_mock(gene_rows, entity_rows), {
+    result <- batch_preview(
+      criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
+      batch_size = 4L,
+      pool       = make_mock_conn()
+    )
+  })
 
   expect_equal(result$status, 200L)
-  expect_true("boundary_gene"  %in% names(result))
-  expect_true("gene_count"     %in% names(result))
-  expect_true("entity_count"   %in% names(result))
+  expect_true("boundary_gene" %in% names(result))
+  expect_true("gene_count"    %in% names(result))
+  expect_true("entity_count"  %in% names(result))
   expect_false(is.na(result$boundary_gene))
   expect_equal(result$gene_count,   2L)
   expect_equal(result$entity_count, 6L)
@@ -238,31 +224,21 @@ test_that("batch_preview atomicity: entity count must be gene-atomic (never spli
     "select_matching_entities not yet implemented"
   )
 
-  pool <- make_mock_conn()
-
-  call_count <- 0L
   gene_rows   <- make_gene_rows()
   entity_rows <- make_entity_rows()
 
-  local_mocked_bindings(
-    db_execute_query = function(sql, params = list(), conn = NULL) {
-      call_count <<- call_count + 1L
-      if (call_count == 1L) tibble::as_tibble(gene_rows)
-      else                  tibble::as_tibble(entity_rows)
-    },
-    .package = NULL
-  )
-
-  result <- batch_preview(
-    criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
-    batch_size = 4L,
-    pool       = pool
-  )
+  with_db_mock(make_two_call_mock(gene_rows, entity_rows), {
+    result <- batch_preview(
+      criteria   = list(date_range = list(start = "2020-01-01", end = "2030-12-31")),
+      batch_size = 4L,
+      pool       = make_mock_conn()
+    )
+  })
 
   ent_count <- nrow(result$data)
 
   # With batch_size=4 and 3 entities per gene, the algorithm must return
-  # either 3 (gene A only) or 6 (both genes), never 4 (which would split gene B).
+  # either 3 (gene A only) or 6 (both genes), never 4 (would split gene B).
   expect_true(
     ent_count %in% c(3L, 6L),
     info = paste("Expected gene-atomic count in {3, 6}; got", ent_count)

--- a/api/version_spec.json
+++ b/api/version_spec.json
@@ -1,7 +1,7 @@
 {
     "title": "SysNDD API",
     "description": "This is the API powering the SysNDD website, allowing programmatic access to the database contents.",
-    "version": "0.12.0",
+    "version": "0.13.0",
     "contact": {
       "name": "API Support",
       "url": "https://berntpopp.github.io/sysndd/api.html",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysndd",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysndd",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@unhead/vue": "^3.0.4",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/app/src/components/forms/BatchCriteriaForm.vue
+++ b/app/src/components/forms/BatchCriteriaForm.vue
@@ -332,6 +332,22 @@
           <i class="bi bi-check-circle me-1" />
           {{ previewEntities.length }} entities match (max {{ formData.batch_size }})
         </div>
+        <!-- Gene-atomic boundary warning (issue #29) -->
+        <BAlert
+          v-if="previewBoundaryGene"
+          variant="warning"
+          show
+          class="py-2 px-3 mb-2"
+          data-testid="batch-boundary-gene-alert"
+        >
+          <i class="bi bi-exclamation-triangle me-1" aria-hidden="true" />
+          Batch is gene-atomic: to keep gene <strong>{{ previewBoundaryGene }}</strong>
+          together, the batch will hold {{ previewEntityCount }} entities across
+          {{ previewGeneCount }} gene(s) (you requested
+          {{ formData.batch_size }}). The last gene was extended past the cap to
+          avoid splitting it. Tighten criteria or increase batch size to avoid
+          the overflow.
+        </BAlert>
         <BTable
           :items="previewEntities"
           :fields="previewFields"
@@ -378,6 +394,9 @@ const {
   previewEntities,
   previewFields,
   showPreviewModal,
+  previewBoundaryGene,
+  previewGeneCount,
+  previewEntityCount,
   // Methods
   loadOptions,
   handlePreview,

--- a/app/src/composables/useBatchForm.ts
+++ b/app/src/composables/useBatchForm.ts
@@ -99,6 +99,13 @@ export function useBatchForm() {
   // Preview data
   const previewEntities = ref<PreviewEntity[]>([]);
   const showPreviewModal = ref(false);
+  // Gene-atomic boundary hint (issue #29): non-null `boundary_gene` means the
+  // soft-LIMIT engaged and the last gene was extended past `batch_size` to
+  // keep its entities together. UI surfaces a warning so the curator knows
+  // the actual entity count differs from the requested cap.
+  const previewBoundaryGene = ref<string | null>(null);
+  const previewGeneCount = ref<number>(0);
+  const previewEntityCount = ref<number>(0);
 
   // Validation: at least one criterion required
   const isFormValid = computed(() => {
@@ -283,13 +290,26 @@ export function useBatchForm() {
     const apiUrl = import.meta.env.VITE_API_URL;
 
     try {
-      const response = await apiClient.raw.post<{ data?: PreviewEntity[] }>(
+      const response = await apiClient.raw.post<{
+        data?: PreviewEntity[];
+        boundary_gene?: string | null;
+        gene_count?: number;
+        entity_count?: number;
+      }>(
         `${apiUrl}/api/re_review/batch/preview`,
         buildCriteria(),
         { withCredentials: true }
       );
 
       previewEntities.value = response.data.data || [];
+      // Capture gene-atomic boundary hint (issue #29). Plumber's
+      // `list(na="string")` serializer emits NA as the literal "NA" string
+      // for nullable scalars; treat that as "no boundary engaged".
+      const rawBoundary = response.data.boundary_gene;
+      previewBoundaryGene.value =
+        rawBoundary == null || rawBoundary === 'NA' ? null : rawBoundary;
+      previewGeneCount.value = response.data.gene_count ?? 0;
+      previewEntityCount.value = response.data.entity_count ?? 0;
       showPreviewModal.value = true;
     } catch (error: unknown) {
       const message = isApiError<{ message?: string }>(error)
@@ -354,6 +374,9 @@ export function useBatchForm() {
     entitySearchQuery.value = '';
     entitySearchResults.value = [];
     previewEntities.value = [];
+    previewBoundaryGene.value = null;
+    previewGeneCount.value = 0;
+    previewEntityCount.value = 0;
   };
 
   // Preview table fields
@@ -388,6 +411,9 @@ export function useBatchForm() {
     previewEntities,
     previewFields,
     showPreviewModal,
+    previewBoundaryGene,
+    previewGeneCount,
+    previewEntityCount,
 
     // Methods
     loadOptions,

--- a/app/src/views/admin/ManageUser.vue
+++ b/app/src/views/admin/ManageUser.vue
@@ -1,4 +1,4 @@
-<!-- views/admin/ManageUser.vue -->
+<!-- views/admin/ManageUser.vue — orchestration shell (v11.2 W1) -->
 <template>
   <div class="container-fluid">
     <BContainer fluid>
@@ -17,48 +17,15 @@
                   </h5>
                 </BCol>
                 <BCol class="text-end">
-                  <!-- Bulk action buttons (only visible when selection > 0) -->
-                  <template v-if="selectionCount > 0">
-                    <BButton
-                      v-b-tooltip.hover
-                      size="sm"
-                      variant="success"
-                      class="me-1"
-                      title="Approve selected users"
-                      @click="handleBulkApprove"
-                    >
-                      <i class="bi bi-check-circle" /> Approve
-                    </BButton>
-                    <BButton
-                      v-b-tooltip.hover
-                      size="sm"
-                      variant="primary"
-                      class="me-1"
-                      title="Assign role to selected users"
-                      @click="showBulkRoleModal"
-                    >
-                      <i class="bi bi-person-badge" /> Role
-                    </BButton>
-                    <BButton
-                      v-b-tooltip.hover
-                      size="sm"
-                      variant="danger"
-                      class="me-1"
-                      title="Delete selected users"
-                      @click="handleBulkDelete"
-                    >
-                      <i class="bi bi-trash" /> Delete
-                    </BButton>
-                    <BButton
-                      v-b-tooltip.hover
-                      size="sm"
-                      variant="link"
-                      title="Clear selection"
-                      @click="clearSelection"
-                    >
-                      <i class="bi bi-x-lg" />
-                    </BButton>
-                  </template>
+                  <!-- Bulk action toolbar -->
+                  <UserBulkActionToolbar
+                    :selection-count="selectionCount"
+                    :busy="bulkActing || isUpdating || isDeleting"
+                    @approve="openBulkApprove(getSelectedArray(), users as any)"
+                    @assign-role="openBulkRole(getSelectedArray(), users as any)"
+                    @delete="openBulkDelete(getSelectedArray(), users as any)"
+                    @clear="clearSelection"
+                  />
                   <!-- Existing buttons (export, filter) -->
                   <BButton
                     v-b-tooltip.hover
@@ -75,8 +42,8 @@
                   <BButton
                     v-b-tooltip.hover
                     size="sm"
-                    :variant="removeFiltersButtonVariant"
-                    :title="removeFiltersButtonTitle"
+                    :variant="hasActiveFilters ? 'outline-danger' : 'outline-secondary'"
+                    :title="hasActiveFilters ? 'Clear all filters' : 'No active filters'"
                     @click="removeFilters"
                   >
                     <i class="bi bi-funnel" />
@@ -152,7 +119,7 @@
               <BCol sm="4">
                 <BFormSelect
                   v-model="filter.user_role.content"
-                  :options="roleFilterOptions"
+                  :options="role_options"
                   size="sm"
                   @update:model-value="filtered()"
                 >
@@ -164,7 +131,7 @@
               <BCol sm="4">
                 <BFormSelect
                   v-model="filter.approved.content"
-                  :options="approvalFilterOptions"
+                  :options="[{ value: '1', text: 'Approved' }, { value: '0', text: 'Pending' }]"
                   size="sm"
                   @update:model-value="filtered()"
                 >
@@ -248,7 +215,7 @@
                       size="sm"
                       class="me-1 btn-xs"
                       title="Edit user"
-                      @click="editUser(row, $event.target)"
+                      @click="editUser(row)"
                     >
                       <i class="bi bi-pen" />
                     </BButton>
@@ -257,7 +224,7 @@
                       size="sm"
                       class="me-1 btn-xs"
                       title="Delete user"
-                      @click="promptDeleteUser(row, $event.target)"
+                      @click="promptDelete(row)"
                     >
                       <i class="bi bi-x" />
                     </BButton>
@@ -265,7 +232,7 @@
                 </template>
                 <template #cell-user_role="{ row }">
                   <BBadge
-                    :variant="getRoleBadgeVariant(row.user_role)"
+                    :variant="(getRoleBadgeVariant(row.user_role) as any)"
                     class="d-inline-flex align-items-center gap-1"
                   >
                     <i :class="getRoleIcon(row.user_role)" />
@@ -287,1407 +254,316 @@
         </BCol>
       </BRow>
 
-      <BModal
-        :id="deleteUserModal.id"
-        v-model="showDeleteModal"
-        header-bg-variant="danger"
-        header-text-variant="light"
-        ok-title="Delete User"
-        ok-variant="danger"
-        cancel-title="Cancel"
-        cancel-variant="outline-secondary"
-        @ok="confirmDeleteUser"
-      >
-        <template #title>
-          <i class="bi bi-exclamation-triangle-fill me-2" />
-          Confirm Deletion
-        </template>
-        <div class="text-center py-3">
-          <i class="bi bi-person-x-fill text-danger" style="font-size: 3rem" />
-          <p class="mt-3 mb-0">
-            Are you sure you want to delete the user
-            <strong class="text-danger">{{ userToDelete.user_name }}</strong
-            >?
-          </p>
-          <p class="text-muted small mt-2">This action cannot be undone.</p>
-        </div>
-      </BModal>
+      <!-- Modals -->
+      <UserDeleteConfirmModal
+        v-model:visible="isDeleteOpen"
+        :user="(userToDelete as any)"
+        @confirm="onConfirmDelete"
+        @cancel="close"
+      />
 
-      <BModal
-        :id="updateUserModal.id"
-        v-model="showUpdateModal"
-        size="lg"
-        header-bg-variant="primary"
-        header-text-variant="light"
-        ok-title="Save Changes"
-        ok-variant="primary"
-        cancel-title="Cancel"
-        cancel-variant="outline-secondary"
-        @ok="onUpdateSubmit"
-      >
-        <template #title>
-          <i class="bi bi-person-gear me-2" />
-          Edit User: {{ userToUpdate.user_name }}
-        </template>
-        <form @submit.prevent="onUpdateSubmit">
-          <!-- Account Information Section -->
-          <div class="mb-4">
-            <h6 class="text-muted border-bottom pb-2 mb-3">
-              <i class="bi bi-person-badge me-2" />Account Information
-            </h6>
-            <BRow>
-              <BCol md="6">
-                <BFormGroup label="Username" label-for="input-user_name" class="mb-3">
-                  <BInputGroup>
-                    <template #prepend>
-                      <BInputGroupText><i class="bi bi-at" /></BInputGroupText>
-                    </template>
-                    <BFormInput
-                      id="input-user_name"
-                      v-model="userToUpdate.user_name"
-                      type="text"
-                      placeholder="Enter username"
-                      :state="userNameMeta.touched ? (userNameError ? false : true) : null"
-                    />
-                  </BInputGroup>
-                  <BFormInvalidFeedback v-if="userNameError" :state="false">
-                    {{ userNameError }}
-                  </BFormInvalidFeedback>
-                </BFormGroup>
-              </BCol>
-              <BCol md="6">
-                <BFormGroup label="Email" label-for="input-email" class="mb-3">
-                  <BInputGroup>
-                    <template #prepend>
-                      <BInputGroupText><i class="bi bi-envelope" /></BInputGroupText>
-                    </template>
-                    <BFormInput
-                      id="input-email"
-                      v-model="userToUpdate.email"
-                      type="email"
-                      placeholder="user@example.com"
-                      :state="emailMeta.touched ? (emailError ? false : true) : null"
-                    />
-                  </BInputGroup>
-                  <BFormInvalidFeedback v-if="emailError" :state="false">
-                    {{ emailError }}
-                  </BFormInvalidFeedback>
-                </BFormGroup>
-              </BCol>
-            </BRow>
-            <BRow>
-              <BCol md="6">
-                <BFormGroup label="Abbreviation" label-for="input-abbreviation" class="mb-3">
-                  <BInputGroup>
-                    <template #prepend>
-                      <BInputGroupText><i class="bi bi-hash" /></BInputGroupText>
-                    </template>
-                    <BFormInput
-                      id="input-abbreviation"
-                      v-model="userToUpdate.abbreviation"
-                      type="text"
-                      placeholder="XX"
-                      maxlength="5"
-                      :state="abbreviationMeta.touched ? (abbreviationError ? false : true) : null"
-                    />
-                  </BInputGroup>
-                  <BFormInvalidFeedback v-if="abbreviationError" :state="false">
-                    {{ abbreviationError }}
-                  </BFormInvalidFeedback>
-                </BFormGroup>
-              </BCol>
-              <BCol md="6">
-                <BFormGroup label="ORCID" label-for="input-orcid" class="mb-3">
-                  <BInputGroup>
-                    <template #prepend>
-                      <BInputGroupText><i class="bi bi-link-45deg" /></BInputGroupText>
-                    </template>
-                    <BFormInput
-                      id="input-orcid"
-                      v-model="userToUpdate.orcid"
-                      type="text"
-                      placeholder="0000-0000-0000-0000"
-                      :state="orcidMeta.touched ? (orcidError ? false : true) : null"
-                    />
-                  </BInputGroup>
-                  <BFormInvalidFeedback v-if="orcidError" :state="false">
-                    {{ orcidError }}
-                  </BFormInvalidFeedback>
-                </BFormGroup>
-              </BCol>
-            </BRow>
-          </div>
+      <UserUpdateModal
+        v-model:visible="isUpdateOpen"
+        :user="userToUpdate"
+        :role-options="roleOptions"
+        v-model:password-change="passwordChange"
+        :password-validation="passwordValidation"
+        :is-changing-password="isChangingPassword"
+        @submit="onSubmitUpdate"
+        @cancel="close"
+        @change-password="onChangePassword"
+        @generate-password="generatePassword"
+      />
 
-          <!-- Personal Information Section -->
-          <div class="mb-4">
-            <h6 class="text-muted border-bottom pb-2 mb-3">
-              <i class="bi bi-person me-2" />Personal Information
-            </h6>
-            <BRow>
-              <BCol md="6">
-                <BFormGroup label="First Name" label-for="input-first_name" class="mb-3">
-                  <BFormInput
-                    id="input-first_name"
-                    v-model="userToUpdate.first_name"
-                    type="text"
-                    placeholder="First name"
-                    :state="firstNameMeta.touched ? (firstNameError ? false : true) : null"
-                  />
-                  <BFormInvalidFeedback v-if="firstNameError">
-                    {{ firstNameError }}
-                  </BFormInvalidFeedback>
-                </BFormGroup>
-              </BCol>
-              <BCol md="6">
-                <BFormGroup label="Family Name" label-for="input-family_name" class="mb-3">
-                  <BFormInput
-                    id="input-family_name"
-                    v-model="userToUpdate.family_name"
-                    type="text"
-                    placeholder="Family name"
-                    :state="familyNameMeta.touched ? (familyNameError ? false : true) : null"
-                  />
-                  <BFormInvalidFeedback v-if="familyNameError">
-                    {{ familyNameError }}
-                  </BFormInvalidFeedback>
-                </BFormGroup>
-              </BCol>
-            </BRow>
-          </div>
+      <UserBulkApproveModal
+        v-model:visible="isBulkApproveOpen"
+        :usernames="bulkApproveUsernames"
+        @confirm="onConfirmBulkApprove"
+        @cancel="close"
+      />
 
-          <!-- Role & Status Section -->
-          <div class="mb-3">
-            <h6 class="text-muted border-bottom pb-2 mb-3">
-              <i class="bi bi-shield-check me-2" />Role & Status
-            </h6>
-            <BRow>
-              <BCol md="6">
-                <BFormGroup label="Role" label-for="input-user_role" class="mb-3">
-                  <BFormSelect
-                    id="input-user_role"
-                    v-model="userToUpdate.user_role"
-                    :options="roleSelectOptions"
-                    :state="userRoleMeta.touched ? (userRoleError ? false : true) : null"
-                  />
-                  <BFormInvalidFeedback v-if="userRoleError">
-                    {{ userRoleError }}
-                  </BFormInvalidFeedback>
-                </BFormGroup>
-              </BCol>
-              <BCol md="6">
-                <BFormGroup label="Account Status" label-for="input-approved" class="mb-3">
-                  <div class="d-flex flex-column gap-2">
-                    <!-- Current status display -->
-                    <div class="d-flex align-items-center">
-                      <span class="text-muted me-2">Current:</span>
-                      <span
-                        class="badge"
-                        :class="userToUpdate.approved ? 'bg-success' : 'bg-warning text-dark'"
-                      >
-                        <i
-                          :class="
-                            userToUpdate.approved ? 'bi bi-check-circle-fill' : 'bi bi-clock-fill'
-                          "
-                          class="me-1"
-                        />
-                        {{ userToUpdate.approved ? 'Approved' : 'Pending' }}
-                      </span>
-                    </div>
-                    <!-- Toggle buttons -->
-                    <BButtonGroup size="sm">
-                      <BButton
-                        :variant="userToUpdate.approved ? 'success' : 'outline-success'"
-                        @click="userToUpdate.approved = true"
-                      >
-                        <i class="bi bi-check-lg me-1" />
-                        Approve
-                      </BButton>
-                      <BButton
-                        :variant="!userToUpdate.approved ? 'warning' : 'outline-warning'"
-                        @click="userToUpdate.approved = false"
-                      >
-                        <i class="bi bi-clock me-1" />
-                        Set Pending
-                      </BButton>
-                    </BButtonGroup>
-                    <small class="text-muted">
-                      {{
-                        userToUpdate.approved
-                          ? 'User can access the system.'
-                          : 'User cannot log in until approved.'
-                      }}
-                    </small>
-                  </div>
-                </BFormGroup>
-              </BCol>
-            </BRow>
-            <BRow>
-              <BCol>
-                <BFormGroup label="Comment" label-for="input-comment" class="mb-0">
-                  <BFormTextarea
-                    id="input-comment"
-                    v-model="userToUpdate.comment"
-                    placeholder="Add notes about this user..."
-                    rows="2"
-                  />
-                </BFormGroup>
-              </BCol>
-            </BRow>
-          </div>
+      <UserBulkDeleteModal
+        v-model:visible="isBulkDeleteOpen"
+        :usernames="bulkDeleteUsernames"
+        v-model:confirm-text="deleteConfirmText"
+        @confirm="onConfirmBulkDelete"
+        @cancel="close"
+      />
 
-          <!-- Password Reset Section (Admin Only) -->
-          <div class="mb-3">
-            <h6 class="text-muted border-bottom pb-2 mb-3">
-              <i class="bi bi-key me-2" />Password Reset
-            </h6>
-            <BAlert variant="info" :model-value="true" class="mb-3">
-              <i class="bi bi-info-circle me-2" />
-              As an administrator, you can set a new password for this user. Password requirements:
-              8+ characters, uppercase, lowercase, number, and special character (!@#$%^&*).
-            </BAlert>
-            <BRow>
-              <BCol md="6">
-                <BFormGroup label="New Password" label-for="input-new-password" class="mb-3">
-                  <BInputGroup>
-                    <template #prepend>
-                      <BInputGroupText><i class="bi bi-lock" /></BInputGroupText>
-                    </template>
-                    <BFormInput
-                      id="input-new-password"
-                      v-model="passwordChange.newPassword"
-                      :type="passwordChange.showPassword ? 'text' : 'password'"
-                      placeholder="Enter new password"
-                      :state="passwordValidation.isValid"
-                      autocomplete="new-password"
-                    />
-                    <template #append>
-                      <BButton
-                        variant="outline-secondary"
-                        @click="passwordChange.showPassword = !passwordChange.showPassword"
-                      >
-                        <i :class="passwordChange.showPassword ? 'bi bi-eye-slash' : 'bi bi-eye'" />
-                      </BButton>
-                    </template>
-                  </BInputGroup>
-                  <div v-if="passwordChange.newPassword" class="mt-2">
-                    <small
-                      v-for="(rule, key) in passwordValidation.rules"
-                      :key="key"
-                      class="d-block"
-                      :class="rule.valid ? 'text-success' : 'text-danger'"
-                    >
-                      <i
-                        :class="rule.valid ? 'bi bi-check-circle' : 'bi bi-x-circle'"
-                        class="me-1"
-                      />
-                      {{ rule.label }}
-                    </small>
-                  </div>
-                </BFormGroup>
-              </BCol>
-              <BCol md="6">
-                <BFormGroup
-                  label="Confirm Password"
-                  label-for="input-confirm-password"
-                  class="mb-3"
-                >
-                  <BInputGroup>
-                    <template #prepend>
-                      <BInputGroupText><i class="bi bi-lock-fill" /></BInputGroupText>
-                    </template>
-                    <BFormInput
-                      id="input-confirm-password"
-                      v-model="passwordChange.confirmPassword"
-                      :type="passwordChange.showPassword ? 'text' : 'password'"
-                      placeholder="Confirm new password"
-                      :state="
-                        passwordChange.confirmPassword
-                          ? passwordChange.newPassword === passwordChange.confirmPassword
-                          : null
-                      "
-                      autocomplete="new-password"
-                    />
-                  </BInputGroup>
-                  <BFormInvalidFeedback
-                    v-if="
-                      passwordChange.confirmPassword &&
-                      passwordChange.newPassword !== passwordChange.confirmPassword
-                    "
-                    :state="false"
-                  >
-                    Passwords do not match
-                  </BFormInvalidFeedback>
-                </BFormGroup>
-              </BCol>
-            </BRow>
-            <BRow>
-              <BCol class="d-flex justify-content-between">
-                <BButton variant="outline-secondary" @click="generatePassword">
-                  <i class="bi bi-shuffle me-1" />
-                  Generate Password
-                </BButton>
-                <BButton
-                  variant="warning"
-                  :disabled="
-                    !passwordValidation.isValid ||
-                    passwordChange.newPassword !== passwordChange.confirmPassword ||
-                    passwordChange.isChanging
-                  "
-                  @click="changeUserPassword"
-                >
-                  <BSpinner v-if="passwordChange.isChanging" small class="me-1" />
-                  <i v-else class="bi bi-key-fill me-1" />
-                  {{ passwordChange.isChanging ? 'Changing...' : 'Change Password' }}
-                </BButton>
-              </BCol>
-            </BRow>
-          </div>
-        </form>
-      </BModal>
-
-      <!-- Bulk Approve Confirmation Modal -->
-      <BModal
-        v-model="showBulkApproveModal"
-        title="Approve Users"
-        ok-variant="success"
-        ok-title="Approve"
-        cancel-title="Cancel"
-        @ok="confirmBulkApprove"
-      >
-        <p>You are about to approve {{ getSelectedArray().length }} users:</p>
-        <div class="border rounded p-2 mb-3 bg-light" style="max-height: 200px; overflow-y: auto">
-          <div v-for="username in bulkApproveUsernames" :key="username" class="small">
-            {{ username }}
-          </div>
-        </div>
-        <p class="text-muted small">This action will grant these users access to the system.</p>
-      </BModal>
-
-      <!-- Bulk Role Assignment Modal -->
-      <BModal
-        v-model="showBulkRoleModalVisible"
-        title="Assign Role"
-        ok-variant="primary"
-        ok-title="Assign Role"
-        cancel-title="Cancel"
-        :ok-disabled="!bulkRoleSelection"
-        @ok="confirmBulkRoleAssignment"
-      >
-        <p>Assign role to {{ getSelectedArray().length }} users:</p>
-        <div class="border rounded p-2 mb-3 bg-light" style="max-height: 150px; overflow-y: auto">
-          <div v-for="username in bulkRoleUsernames" :key="username" class="small">
-            {{ username }}
-          </div>
-        </div>
-        <BFormGroup label="Select Role:" label-for="bulk-role-select">
-          <BFormSelect
-            id="bulk-role-select"
-            v-model="bulkRoleSelection"
-            :options="[
-              { value: '', text: 'Select a role...', disabled: true },
-              { value: 'Curator', text: 'Curator' },
-              { value: 'Reviewer', text: 'Reviewer' },
-              { value: 'Administrator', text: 'Administrator' },
-            ]"
-          />
-        </BFormGroup>
-      </BModal>
-
-      <!-- Bulk Delete Confirmation Modal -->
-      <BModal
-        v-model="showBulkDeleteModal"
-        title="Delete Users"
-        ok-variant="danger"
-        ok-title="Delete"
-        cancel-title="Cancel"
-        :ok-disabled="deleteConfirmText !== 'DELETE'"
-        @ok="confirmBulkDelete"
-      >
-        <p class="text-danger fw-bold">This action cannot be undone.</p>
-        <p>You are about to delete {{ bulkDeleteUsernames.length }} users:</p>
-        <div class="border rounded p-2 mb-3 bg-light" style="max-height: 200px; overflow-y: auto">
-          <div v-for="username in bulkDeleteUsernames" :key="username" class="small">
-            {{ username }}
-          </div>
-        </div>
-        <BFormGroup label="Type DELETE to confirm:" label-for="delete-confirm-input">
-          <BFormInput
-            id="delete-confirm-input"
-            v-model="deleteConfirmText"
-            placeholder="DELETE"
-            autocomplete="off"
-          />
-        </BFormGroup>
-      </BModal>
+      <UserBulkRoleModal
+        v-model:visible="isBulkRoleOpen"
+        :usernames="bulkRoleUsernames"
+        :role-options="roleOptions"
+        v-model:selected-role="bulkRoleSelection"
+        @confirm="onConfirmBulkRole"
+        @cancel="close"
+      />
     </BContainer>
   </div>
 </template>
 
-<script>
-import { ref } from 'vue';
-import { useForm, useField, defineRule } from 'vee-validate';
-import { required, min, max, email } from '@vee-validate/rules';
-import GenericTable from '@/components/small/GenericTable.vue';
-import TablePaginationControls from '@/components/small/TablePaginationControls.vue';
+<script lang="ts">
+import { computed, defineComponent, nextTick, onMounted, shallowRef, watch } from 'vue';
 import useToast from '@/composables/useToast';
-import {
-  useUrlParsing,
-  useTableData,
-  useExcelExport,
-  useBulkSelection,
-  useFilterPresets,
-} from '@/composables';
-
-// Import the Pinia store
+import { useBulkSelection } from '@/composables';
 import { useUiStore } from '@/stores/ui';
 
-// v11.0 closeout F2b: every authed call below routes through apiClient.
-// The request interceptor injects `Authorization: Bearer <token>` from
-// `useAuth().token.value`, so this view no longer reads the session
-// token from storage in 9 separate call sites.
-import { apiClient } from '@/api/client';
+import GenericTable from '@/components/small/GenericTable.vue';
+import TablePaginationControls from '@/components/small/TablePaginationControls.vue';
 
-// Define validation rules globally
-defineRule('required', required);
-defineRule('min', min);
-defineRule('max', max);
-defineRule('email', email);
+import UserBulkActionToolbar from './components/UserBulkActionToolbar.vue';
+import UserUpdateModal from './components/UserUpdateModal.vue';
+import UserDeleteConfirmModal from './components/UserDeleteConfirmModal.vue';
+import UserBulkApproveModal from './components/UserBulkApproveModal.vue';
+import UserBulkDeleteModal from './components/UserBulkDeleteModal.vue';
+import UserBulkRoleModal from './components/UserBulkRoleModal.vue';
 
-// Module-level variables to track API calls across component remounts
-let moduleLastApiParams = null;
-let moduleApiCallInProgress = false;
-let moduleLastApiCallTime = 0;
-let moduleLastApiResponse = null;
+import { useUserData } from './composables/useUserData';
+import { useUserMutations } from './composables/useUserMutations';
+import { useBulkUserActions } from './composables/useBulkUserActions';
+import { useUserModals } from './composables/useUserModals';
 
-export default {
+export default defineComponent({
   name: 'ManageUser',
   components: {
     GenericTable,
     TablePaginationControls,
+    UserBulkActionToolbar,
+    UserUpdateModal,
+    UserDeleteConfirmModal,
+    UserBulkApproveModal,
+    UserBulkDeleteModal,
+    UserBulkRoleModal,
   },
   setup() {
     const { makeToast } = useToast();
-    const { filterObjToStr, filterStrToObj, sortStringToVariables } = useUrlParsing();
-    const { isExporting, exportToExcel } = useExcelExport();
-
-    const tableData = useTableData({
-      pageSizeInput: 25,
-      sortInput: '+user_name',
-      pageAfterInput: '0',
-    });
-
-    // Bulk selection state (20 user limit per context decisions)
+    const uiStore = useUiStore();
     const bulkSelection = useBulkSelection(20);
 
-    // Filter presets for quick access to saved filters
-    const filterPresets = useFilterPresets('sysndd-manage-user-presets');
-
-    // Filter object structure for user table
-    const filter = ref({
-      any: { content: null, join_char: null, operator: 'contains' },
-      user_name: { content: null, join_char: null, operator: 'contains' },
-      email: { content: null, join_char: null, operator: 'contains' },
-      user_role: { content: null, join_char: ',', operator: 'any' },
-      approved: { content: null, join_char: null, operator: 'equals' },
-      abbreviation: { content: null, join_char: null, operator: 'contains' },
-      first_name: { content: null, join_char: null, operator: 'contains' },
-      family_name: { content: null, join_char: null, operator: 'contains' },
-      orcid: { content: null, join_char: null, operator: 'contains' },
-      comment: { content: null, join_char: null, operator: 'contains' },
+    const toastFn = makeToast as (...args: unknown[]) => void;
+    const data = useUserData({
+      onToast: toastFn,
+      onScrollbarUpdate: () => uiStore.requestScrollbarUpdate(),
+    });
+    const modals = useUserModals({ onToast: toastFn });
+    const mutations = useUserMutations({
+      onToast: toastFn,
+      onSuccess: () => { void data.loadData(); modals.close(); },
+    });
+    const bulk = useBulkUserActions({
+      onToast: toastFn,
+      onSuccess: () => { void data.loadData(); bulkSelection.clearSelection(); modals.close(); },
     });
 
-    // Setup form validation with vee-validate 4
-    const { handleSubmit, resetForm, setValues } = useForm();
+    // ── Derived state ──────────────────────────────────────────────────────────
+    const fields = [
+      { key: 'select', label: '', class: 'text-center', thStyle: { width: '40px' }, sortable: false },
+      { key: 'user_name', label: 'User name', sortable: true, filterable: true, sortDirection: 'asc', class: 'text-start' },
+      { key: 'email', label: 'E-mail', sortable: true, filterable: true, sortDirection: 'asc', class: 'text-start' },
+      { key: 'user_role', label: 'Role', sortable: true, selectable: true, sortDirection: 'asc', class: 'text-start' },
+      { key: 'approved', label: 'Status', sortable: true, selectable: true, sortDirection: 'asc', class: 'text-center' },
+      { key: 'abbreviation', label: 'Abbrev.', sortable: true, sortDirection: 'asc', class: 'text-start' },
+      { key: 'created_at', label: 'Created', sortable: true, sortDirection: 'asc', class: 'text-start' },
+      { key: 'actions', label: 'Actions', sortable: false, class: 'text-center' },
+    ];
 
-    // Define fields with validation
-    const {
-      value: userName,
-      errorMessage: userNameError,
-      meta: userNameMeta,
-    } = useField('user_name', 'required|min:2|max:50');
+    const hasActiveFilters = computed(() =>
+      Object.values(data.filter.value).some(
+        (f) => f.content !== null && f.content !== '',
+      ),
+    );
 
-    const {
-      value: userEmail,
-      errorMessage: emailError,
-      meta: emailMeta,
-    } = useField('email', 'required|email');
-
-    const { value: orcid, errorMessage: orcidError, meta: orcidMeta } = useField('orcid');
-
-    const {
-      value: abbreviation,
-      errorMessage: abbreviationError,
-      meta: abbreviationMeta,
-    } = useField('abbreviation', 'required');
-
-    const {
-      value: firstName,
-      errorMessage: firstNameError,
-      meta: firstNameMeta,
-    } = useField('first_name', 'required|min:2|max:50');
-
-    const {
-      value: familyName,
-      errorMessage: familyNameError,
-      meta: familyNameMeta,
-    } = useField('family_name', 'required|min:2|max:50');
-
-    const {
-      value: userRole,
-      errorMessage: userRoleError,
-      meta: userRoleMeta,
-    } = useField('user_role', 'required');
-
-    return {
-      ...tableData,
-      filter,
-      makeToast,
-      filterObjToStr,
-      filterStrToObj,
-      sortStringToVariables,
-      isExporting,
-      exportToExcel,
-      handleSubmit,
-      resetForm,
-      setValues,
-      userName,
-      userNameError,
-      userNameMeta,
-      userEmail,
-      emailError,
-      emailMeta,
-      orcid,
-      orcidError,
-      orcidMeta,
-      abbreviation,
-      abbreviationError,
-      abbreviationMeta,
-      firstName,
-      firstNameError,
-      firstNameMeta,
-      familyName,
-      familyNameError,
-      familyNameMeta,
-      userRole,
-      userRoleError,
-      userRoleMeta,
-      ...bulkSelection, // Spreads: selectedIds, selectionCount, isSelected, toggleSelection, clearSelection, getSelectedArray, selectMultiple
-      filterPresets,
-    };
-  },
-  data() {
-    return {
-      // Flag to prevent watchers from triggering during initialization
-      isInitializing: true,
-      // Debounce timer for loadData to prevent duplicate calls
-      loadDataDebounceTimer: null,
-      // Pagination state not in useTableData
-      totalPages: 0,
-      // User-specific data
-      role_options: [],
-      user_options: [],
-      users: [],
-      fields: [
-        {
-          key: 'select',
-          label: '',
-          class: 'text-center',
-          thStyle: { width: '40px' },
-          sortable: false,
-        },
-        {
-          key: 'user_name',
-          label: 'User name',
-          sortable: true,
-          filterable: true,
-          sortDirection: 'asc',
-          class: 'text-start',
-        },
-        {
-          key: 'email',
-          label: 'E-mail',
-          sortable: true,
-          filterable: true,
-          sortDirection: 'asc',
-          class: 'text-start',
-        },
-        {
-          key: 'user_role',
-          label: 'Role',
-          sortable: true,
-          selectable: true,
-          sortDirection: 'asc',
-          class: 'text-start',
-        },
-        {
-          key: 'approved',
-          label: 'Status',
-          sortable: true,
-          selectable: true,
-          sortDirection: 'asc',
-          class: 'text-center',
-        },
-        {
-          key: 'abbreviation',
-          label: 'Abbrev.',
-          sortable: true,
-          sortDirection: 'asc',
-          class: 'text-start',
-        },
-        {
-          key: 'created_at',
-          label: 'Created',
-          sortable: true,
-          sortDirection: 'asc',
-          class: 'text-start',
-        },
-        { key: 'actions', label: 'Actions', class: 'text-center' },
-      ],
-      showDeleteModal: false,
-      showUpdateModal: false,
-      userToDelete: {},
-      userToUpdate: {},
-      deleteUserModal: { id: 'delete-usermodal', title: '', content: [] },
-      updateUserModal: { id: 'update-usermodal', title: '', content: [] },
-      // Bulk action modals
-      showBulkApproveModal: false,
-      bulkApproveUsernames: [],
-      showBulkDeleteModal: false,
-      bulkDeleteUsernames: [],
-      deleteConfirmText: '',
-      showBulkRoleModalVisible: false,
-      bulkRoleSelection: '',
-      bulkRoleUsernames: [],
-      // Password change state
-      passwordChange: {
-        newPassword: '',
-        confirmPassword: '',
-        showPassword: false,
-        isChanging: false,
-      },
-    };
-  },
-  computed: {
-    roleFilterOptions() {
-      return this.role_options;
-    },
-    approvalFilterOptions() {
-      return [
-        { value: '1', text: 'Approved' },
-        { value: '0', text: 'Pending' },
-      ];
-    },
-    hasActiveFilters() {
-      return Object.values(this.filter).some((f) => f.content !== null && f.content !== '');
-    },
-    activeFilters() {
-      const filters = [];
-      if (this.filter.any.content)
-        filters.push({ key: 'any', label: 'Search', value: this.filter.any.content });
-      if (this.filter.user_role.content)
-        filters.push({ key: 'user_role', label: 'Role', value: this.filter.user_role.content });
-      if (this.filter.approved.content !== null) {
+    const activeFilters = computed(() => {
+      const filters: Array<{ key: string; label: string; value: string }> = [];
+      if (data.filter.value.any.content)
+        filters.push({ key: 'any', label: 'Search', value: data.filter.value.any.content as string });
+      if (data.filter.value.user_role.content)
+        filters.push({ key: 'user_role', label: 'Role', value: data.filter.value.user_role.content as string });
+      if (data.filter.value.approved.content !== null && data.filter.value.approved.content !== undefined) {
         filters.push({
           key: 'approved',
           label: 'Status',
-          value: this.filter.approved.content === '1' ? 'Approved' : 'Pending',
+          value: data.filter.value.approved.content === '1' ? 'Approved' : 'Pending',
         });
       }
       return filters;
-    },
-    roleSelectOptions() {
-      return [
-        { value: 'Administrator', text: 'Administrator' },
-        { value: 'Curator', text: 'Curator' },
-        { value: 'Reviewer', text: 'Reviewer' },
-        { value: 'Viewer', text: 'Viewer' },
-      ];
-    },
-    // Check if all users on current page are selected
-    allOnPageSelected() {
-      if (this.users.length === 0) return false;
-      return this.users.every((user) => this.isSelected(user.user_id));
-    },
-    removeFiltersButtonVariant() {
-      return this.hasActiveFilters ? 'outline-danger' : 'outline-secondary';
-    },
-    removeFiltersButtonTitle() {
-      return this.hasActiveFilters ? 'Clear all filters' : 'No active filters';
-    },
-    passwordValidation() {
-      const password = this.passwordChange.newPassword;
-      const rules = {
-        minLength: {
-          label: 'At least 8 characters',
-          valid: password.length >= 8,
-        },
-        hasUppercase: {
-          label: 'At least one uppercase letter',
-          valid: /[A-Z]/.test(password),
-        },
-        hasLowercase: {
-          label: 'At least one lowercase letter',
-          valid: /[a-z]/.test(password),
-        },
-        hasNumber: {
-          label: 'At least one number',
-          valid: /[0-9]/.test(password),
-        },
-        hasSpecial: {
-          label: 'At least one special character (!@#$%^&*)',
-          valid: /[!@#$%^&*]/.test(password),
-        },
-      };
-      const isValid = password.length > 0 && Object.values(rules).every((r) => r.valid);
-      return { rules, isValid: password.length > 0 ? isValid : null };
-    },
-  },
-  watch: {
-    filter: {
-      handler() {
-        if (this.isInitializing) return;
-        this.filtered();
-      },
-      deep: true,
-    },
-    sortBy: {
-      handler() {
-        if (this.isInitializing) return;
-        this.handleSortByOrDescChange();
-      },
-      deep: true,
-    },
-  },
-  mounted() {
-    // Parse URL params
-    const urlParams = new URLSearchParams(window.location.search);
-    if (urlParams.get('sort')) {
-      const sort_object = this.sortStringToVariables(urlParams.get('sort'));
-      this.sortBy = sort_object.sortBy;
-      this.sort = urlParams.get('sort');
-    }
-    if (urlParams.get('filter')) {
-      this.filter = this.filterStrToObj(urlParams.get('filter'), this.filter);
-      this.filter_string = urlParams.get('filter');
-    }
-    if (urlParams.get('page_after')) {
-      this.currentItemID = parseInt(urlParams.get('page_after'), 10) || 0;
-    }
-    if (urlParams.get('page_size')) {
-      this.perPage = parseInt(urlParams.get('page_size'), 10) || 25;
-    }
-
-    this.loadRoleList();
-    this.loadUserList();
-
-    // Initialize default presets if none exist
-    if (this.filterPresets.presets.value.length === 0) {
-      // Add common presets
-      this.filterPresets.savePreset('Pending', {
-        any: { content: null, join_char: null, operator: 'contains' },
-        user_role: { content: null, join_char: ',', operator: 'any' },
-        approved: { content: '0', join_char: null, operator: 'equals' },
-      });
-      this.filterPresets.savePreset('Curators', {
-        any: { content: null, join_char: null, operator: 'contains' },
-        user_role: { content: 'Curator', join_char: ',', operator: 'any' },
-        approved: { content: null, join_char: null, operator: 'equals' },
-      });
-    }
-
-    this.$nextTick(() => {
-      this.loadData();
-      this.$nextTick(() => {
-        this.isInitializing = false;
-      });
     });
-  },
-  methods: {
-    toggleSelectAllOnPage() {
-      if (this.allOnPageSelected) {
-        // Deselect all on current page
-        this.users.forEach((user) => {
-          if (this.isSelected(user.user_id)) {
-            this.toggleSelection(user.user_id);
-          }
+
+    const allOnPageSelected = computed(() => {
+      if (data.users.value.length === 0) return false;
+      return data.users.value.every((user: any) => bulkSelection.isSelected(user.user_id));
+    });
+
+    // ── Selection helpers ──────────────────────────────────────────────────────
+    function toggleSelectAllOnPage(): void {
+      if (allOnPageSelected.value) {
+        data.users.value.forEach((user: any) => {
+          if (bulkSelection.isSelected(user.user_id)) bulkSelection.toggleSelection(user.user_id);
         });
       } else {
-        // Select all on current page (respects 20 limit)
-        const pageUserIds = this.users.map((u) => u.user_id);
-        const added = this.selectMultiple(pageUserIds);
-        if (added < pageUserIds.length && this.selectionCount >= 20) {
-          this.makeToast(
-            `Selection limited to 20 users. ${added} users added.`,
-            'Selection Limit',
-            'warning'
-          );
+        const pageUserIds = data.users.value.map((u: any) => u.user_id);
+        const added = bulkSelection.selectMultiple(pageUserIds);
+        if (added < pageUserIds.length && bulkSelection.selectionCount.value >= 20) {
+          makeToast(`Selection limited to 20 users. ${added} users added.`, 'Selection Limit', 'warning');
         }
       }
-    },
-    handleRowSelect(userId) {
-      const success = this.toggleSelection(userId);
-      if (!success) {
-        this.makeToast(
-          'Maximum 20 users can be selected at once',
-          'Selection Limit Reached',
-          'warning'
-        );
-      }
-    },
-    handleBulkApprove() {
-      const userIds = this.getSelectedArray();
-      if (userIds.length === 0) {
-        this.makeToast('No users selected', 'Bulk Approve', 'warning');
-        return;
-      }
+    }
 
-      // Get usernames for display (USR-06: show all selected items)
-      const selectedUsers = this.users.filter((u) => userIds.includes(u.user_id));
-      this.bulkApproveUsernames = selectedUsers.map((u) => u.user_name);
+    function handleRowSelect(userId: number): void {
+      const success = bulkSelection.toggleSelection(userId);
+      if (!success) makeToast('Maximum 20 users can be selected at once', 'Selection Limit Reached', 'warning');
+    }
 
-      // Show Bootstrap modal
-      this.showBulkApproveModal = true;
-    },
-    async confirmBulkApprove() {
-      const userIds = this.getSelectedArray();
-
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/bulk_approve`;
-      try {
-        const response = await apiClient.raw.post(apiUrl, {
-          user_ids: userIds,
-        });
-
-        if (response.status === 200) {
-          this.makeToast(
-            `Successfully approved ${response.data.processed || userIds.length} users`,
-            'Bulk Approve Complete',
-            'success',
-            true,
-            5000
-          );
-          this.clearSelection();
-          this.loadData();
-        }
-      } catch (error) {
-        const errorMsg =
-          error.response?.data?.message || error.response?.data?.error || 'Unknown error';
-        this.makeToast(errorMsg, 'Bulk Approve Failed', 'danger');
-      }
-    },
-    showBulkRoleModal() {
-      const userIds = this.getSelectedArray();
-      if (userIds.length === 0) {
-        this.makeToast('No users selected', 'Assign Role', 'warning');
-        return;
-      }
-
-      // Get usernames for display (USR-06: show all selected items)
-      const selectedUsers = this.users.filter((u) => userIds.includes(u.user_id));
-      this.bulkRoleUsernames = selectedUsers.map((u) => u.user_name);
-      this.bulkRoleSelection = ''; // Reset selection
-
-      // Show Bootstrap modal with dropdown (NOT prompt)
-      this.showBulkRoleModalVisible = true;
-    },
-    async confirmBulkRoleAssignment() {
-      const userIds = this.getSelectedArray();
-      const selectedRole = this.bulkRoleSelection;
-
-      if (!selectedRole) {
-        this.makeToast('Please select a role', 'Invalid Role', 'warning');
-        return;
-      }
-
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/bulk_assign_role`;
-      try {
-        const response = await apiClient.raw.post(apiUrl, {
-          user_ids: userIds,
-          role: selectedRole,
-        });
-
-        if (response.status === 200) {
-          this.makeToast(
-            `Successfully assigned ${selectedRole} role to ${response.data.processed || userIds.length} users`,
-            'Bulk Role Assignment Complete',
-            'success',
-            true,
-            5000
-          );
-          this.clearSelection();
-          this.loadData();
-        }
-      } catch (error) {
-        const errorMsg =
-          error.response?.data?.message || error.response?.data?.error || 'Unknown error';
-        this.makeToast(errorMsg, 'Bulk Role Assignment Failed', 'danger');
-      }
-    },
-    handleBulkDelete() {
-      const userIds = this.getSelectedArray();
-      if (userIds.length === 0) {
-        this.makeToast('No users selected', 'Bulk Delete', 'warning');
-        return;
-      }
-
-      // Get selected user details for display and admin check
-      const selectedUsers = this.users.filter((u) => userIds.includes(u.user_id));
-
-      // Frontend validation: Block if admins selected
-      const adminUsers = selectedUsers.filter((u) => u.user_role === 'Administrator');
-      if (adminUsers.length > 0) {
-        this.makeToast(
-          `Cannot delete: selection contains ${adminUsers.length} admin user(s)`,
-          'Delete Blocked',
-          'danger'
-        );
-        return;
-      }
-
-      // Store usernames for modal display (USR-06: show all selected items)
-      this.bulkDeleteUsernames = selectedUsers.map((u) => u.user_name);
-      this.deleteConfirmText = ''; // Reset confirm input
-
-      // Show Bootstrap modal
-      this.showBulkDeleteModal = true;
-    },
-    async confirmBulkDelete() {
-      const userIds = this.getSelectedArray();
-
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/bulk_delete`;
-      try {
-        const response = await apiClient.raw.post(apiUrl, {
-          user_ids: userIds,
-        });
-
-        if (response.status === 200) {
-          this.makeToast(
-            `Successfully deleted ${response.data.processed || userIds.length} users`,
-            'Bulk Delete Complete',
-            'success',
-            true,
-            5000
-          );
-          this.clearSelection();
-          this.loadData();
-        }
-      } catch (error) {
-        const errorMsg =
-          error.response?.data?.message || error.response?.data?.error || 'Unknown error';
-        this.makeToast(errorMsg, 'Bulk Delete Failed', 'danger');
-      }
-    },
-    // Update browser URL with current table state
-    updateBrowserUrl() {
-      if (this.isInitializing) return;
-      const searchParams = new URLSearchParams();
-      if (this.sort) searchParams.set('sort', this.sort);
-      if (this.filter_string) searchParams.set('filter', this.filter_string);
-      if (this.currentItemID > 0) searchParams.set('page_after', String(this.currentItemID));
-      searchParams.set('page_size', String(this.perPage));
-
-      const newUrl = `${window.location.pathname}?${searchParams.toString()}`;
-      window.history.replaceState({ ...window.history.state }, '', newUrl);
-    },
-    // Override filtered to call loadData
-    filtered() {
-      const filter_string_loc = this.filterObjToStr(this.filter);
-      if (filter_string_loc !== this.filter_string) {
-        this.filter_string = filter_string_loc;
-      }
-      this.loadData();
-    },
-    // Override handlePageChange
-    handlePageChange(value) {
-      if (value === 1) {
-        this.currentItemID = 0;
-      } else if (value === this.totalPages) {
-        this.currentItemID = Number(this.lastItemID) || 0;
-      } else if (value > this.currentPage) {
-        this.currentItemID = Number(this.nextItemID) || 0;
-      } else if (value < this.currentPage) {
-        this.currentItemID = Number(this.prevItemID) || 0;
-      }
-      this.filtered();
-    },
-    // Override handlePerPageChange
-    handlePerPageChange(newPerPage) {
-      this.perPage = parseInt(newPerPage, 10);
-      this.currentItemID = 0;
-      this.filtered();
-    },
-    // Override handleSortByOrDescChange
-    handleSortByOrDescChange() {
-      this.currentItemID = 0;
-      const sortColumn = this.sortBy.length > 0 ? this.sortBy[0].key : '';
-      const sortOrder = this.sortBy.length > 0 ? this.sortBy[0].order : 'asc';
-      const isDesc = sortOrder === 'desc';
-      this.sort = (isDesc ? '-' : '+') + sortColumn;
-      this.filtered();
-    },
-    // Override removeFilters
-    removeFilters() {
-      Object.keys(this.filter).forEach((key) => {
-        if (
-          this.filter[key] &&
-          typeof this.filter[key] === 'object' &&
-          'content' in this.filter[key]
-        ) {
-          this.filter[key].content = null;
-        }
-      });
-      this.filtered();
-    },
-    // Clear a single filter
-    clearFilter(key) {
-      if (this.filter[key]) {
-        this.filter[key].content = null;
-      }
-      this.filtered();
-    },
-    // Load data with debouncing
-    loadData() {
-      if (this.loadDataDebounceTimer) {
-        clearTimeout(this.loadDataDebounceTimer);
-      }
-      this.loadDataDebounceTimer = setTimeout(() => {
-        this.loadDataDebounceTimer = null;
-        this.doLoadData();
-      }, 50);
-    },
-    // Actual data loading
-    async doLoadData() {
-      const urlParam = `sort=${this.sort}&filter=${this.filter_string}&page_after=${this.currentItemID}&page_size=${this.perPage}`;
-      const now = Date.now();
-
-      // Prevent duplicate API calls
-      if (moduleLastApiParams === urlParam && now - moduleLastApiCallTime < 500) {
-        if (moduleLastApiResponse) {
-          this.applyApiResponse(moduleLastApiResponse);
-        }
-        return;
-      }
-
-      if (moduleApiCallInProgress && moduleLastApiParams === urlParam) return;
-
-      moduleLastApiParams = urlParam;
-      moduleLastApiCallTime = now;
-      moduleApiCallInProgress = true;
-      this.isBusy = true;
-
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/table?${urlParam}`;
-
-      try {
-        const response = await apiClient.raw.get(apiUrl);
-        moduleApiCallInProgress = false;
-        moduleLastApiResponse = response.data;
-        this.applyApiResponse(response.data);
-        this.updateBrowserUrl();
-        this.isBusy = false;
-      } catch (e) {
-        moduleApiCallInProgress = false;
-        this.makeToast(e, 'Error', 'danger');
-        this.isBusy = false;
-      }
-    },
-    // Apply API response data
-    applyApiResponse(data) {
-      this.users = data.data;
-      this.totalRows = data.meta[0].totalItems;
-      this.$nextTick(() => {
-        this.currentPage = data.meta[0].currentPage;
-      });
-      this.totalPages = data.meta[0].totalPages;
-      this.prevItemID = Number(data.meta[0].prevItemID) || 0;
-      this.currentItemID = Number(data.meta[0].currentItemID) || 0;
-      this.nextItemID = Number(data.meta[0].nextItemID) || 0;
-      this.lastItemID = Number(data.meta[0].lastItemID) || 0;
-      this.executionTime = data.meta[0].executionTime;
-
-      // Update fields from API fspec if available
-      // API fspec has arrays for key/label (e.g., ["user_id"]), extract single values
-      if (data.meta[0].fspec) {
-        const actionsField = this.fields.find((f) => f.key === 'actions');
-        const transformedFields = data.meta[0].fspec.map((field) => ({
-          ...field,
-          key: Array.isArray(field.key) ? field.key[0] : field.key,
-          label: Array.isArray(field.label) ? field.label[0] : field.label,
-          sortable: Array.isArray(field.sortable) ? field.sortable[0] : field.sortable,
-          filterable: Array.isArray(field.filterable) ? field.filterable[0] : field.filterable,
-          class: Array.isArray(field.class) ? field.class[0] : field.class,
-        }));
-        this.fields = [...transformedFields, actionsField].filter(Boolean);
-      }
-
-      const uiStore = useUiStore();
-      uiStore.requestScrollbarUpdate();
-    },
-    // Handle Excel export
-    handleExport() {
-      this.exportToExcel(this.users, {
-        filename: `users_export_${new Date().toISOString().split('T')[0]}`,
-        sheetName: 'Users',
-        headers: {
-          user_name: 'User Name',
-          email: 'Email',
-          user_role: 'Role',
-          approved: 'Approved',
-          abbreviation: 'Abbreviation',
-          first_name: 'First Name',
-          family_name: 'Family Name',
-          orcid: 'ORCID',
-          comment: 'Comment',
-          created_at: 'Created',
-        },
-      });
-    },
-    // Handle sort update
-    handleSortUpdate(newSortBy) {
-      this.sortBy = newSortBy;
-      this.handleSortByOrDescChange();
-    },
-    // Get badge variant for user role
-    getRoleBadgeVariant(role) {
-      const variants = {
-        Administrator: 'danger',
-        Curator: 'primary',
-        Reviewer: 'info',
-        Viewer: 'secondary',
+    // ── Utility helpers ────────────────────────────────────────────────────────
+    function getRoleBadgeVariant(role: string): string {
+      const variants: Record<string, string> = {
+        Administrator: 'danger', Curator: 'primary', Reviewer: 'info', Viewer: 'secondary',
       };
       return variants[role] || 'secondary';
-    },
-    // Get icon class for user role
-    getRoleIcon(role) {
-      const icons = {
-        Administrator: 'bi bi-shield-fill-check',
-        Curator: 'bi bi-pencil-fill',
-        Reviewer: 'bi bi-eye-fill',
-        Viewer: 'bi bi-person-fill',
+    }
+
+    function getRoleIcon(role: string): string {
+      const icons: Record<string, string> = {
+        Administrator: 'bi bi-shield-fill-check', Curator: 'bi bi-pencil-fill',
+        Reviewer: 'bi bi-eye-fill', Viewer: 'bi bi-person-fill',
       };
       return icons[role] || 'bi bi-person-fill';
-    },
-    onUpdateSubmit() {
-      this.handleSubmit(() => {
-        this.updateUserData();
-      })();
-    },
-    async loadRoleList() {
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/role_list`;
-      try {
-        const response = await apiClient.raw.get(apiUrl);
-        this.role_options = response.data.map((item) => ({ value: item.role, text: item.role }));
-      } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
-      }
-    },
-    async loadUserList() {
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/list?roles=Curator,Reviewer`;
-      try {
-        const response = await apiClient.raw.get(apiUrl);
-        this.user_options = response.data.map((item) => ({
-          value: item.user_id,
-          text: item.user_name,
-          role: item.user_role,
-        }));
-      } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
-      }
-    },
-    promptDeleteUser(item, _button) {
-      this.deleteUserModal.title = `${item.user_name}`;
-      this.userToDelete = item;
-      this.showDeleteModal = true;
-    },
-    async confirmDeleteUser() {
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/delete`;
-      try {
-        const response = await apiClient.raw.delete(apiUrl, {
-          data: { user_id: this.userToDelete.user_id },
-        });
-        if (response.status === 200) {
-          this.makeToast('User deleted successfully', 'Success', 'success');
-          this.loadData(); // Reload table data after deletion
-        } else {
-          throw new Error('Failed to delete the user.');
-        }
-      } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
-      }
-      this.showDeleteModal = false;
-      this.userToDelete = {};
-    },
-    editUser(item, _button) {
-      this.updateUserModal.title = `${item.user_name}`;
-      this.userToUpdate = { ...item };
-      // Sync vee-validate fields with the user data
-      this.setValues({
-        user_name: item.user_name,
-        email: item.email,
-        orcid: item.orcid,
-        abbreviation: item.abbreviation,
-        first_name: item.first_name,
-        family_name: item.family_name,
-        user_role: item.user_role,
-      });
-      // Reset password change fields
-      this.passwordChange.newPassword = '';
-      this.passwordChange.confirmPassword = '';
-      this.passwordChange.showPassword = false;
-      this.passwordChange.isChanging = false;
-      this.showUpdateModal = true;
-    },
-    async updateUserData() {
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/update`;
-      // Only send the fields that should be updated, not the entire user object
-      // Filter out null/undefined/empty values to avoid API issues
-      const updatePayload = {
-        user_id: this.userToUpdate.user_id,
-        user_name: this.userToUpdate.user_name,
-        email: this.userToUpdate.email,
-        abbreviation: this.userToUpdate.abbreviation,
-        first_name: this.userToUpdate.first_name,
-        family_name: this.userToUpdate.family_name,
-        user_role: this.userToUpdate.user_role,
-        approved: this.userToUpdate.approved ? 1 : 0,
-      };
-      // Only include optional fields if they have values
-      if (this.userToUpdate.orcid) {
-        updatePayload.orcid = this.userToUpdate.orcid;
-      }
-      if (this.userToUpdate.comment) {
-        updatePayload.comment = this.userToUpdate.comment;
-      }
-      try {
-        const response = await apiClient.raw.put(apiUrl, { user_details: updatePayload });
-        if (response.status === 200) {
-          this.makeToast('User updated successfully', 'Success', 'success');
-          this.loadData(); // Reload the table data
-        } else {
-          throw new Error('Failed to update the user.');
-        }
-      } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
-      }
-      this.showUpdateModal = false;
-      this.userToUpdate = {};
-    },
-    // Filter preset methods
-    loadFilterPreset(name) {
-      const presetFilter = this.filterPresets.loadPreset(name);
-      if (presetFilter) {
-        // Merge preset into current filter structure
-        Object.keys(presetFilter).forEach((key) => {
-          if (this.filter[key]) {
-            this.filter[key] = presetFilter[key];
-          }
-        });
-        this.filtered();
-        this.makeToast(`Loaded preset: ${name}`, 'Filter Preset', 'info', true, 2000);
-      }
-    },
-    deleteFilterPreset(name) {
-      if (confirm(`Delete preset "${name}"?`)) {
-        this.filterPresets.deletePreset(name);
-        this.makeToast(`Deleted preset: ${name}`, 'Filter Preset', 'info', true, 2000);
-      }
-    },
-    showSavePresetPrompt() {
+    }
+
+    function showSavePresetPrompt(): void {
       const name = prompt('Enter a name for this filter preset:');
       if (name && name.trim()) {
-        // Save current filter state
-        this.filterPresets.savePreset(name.trim(), JSON.parse(JSON.stringify(this.filter)));
-        this.makeToast(`Saved preset: ${name.trim()}`, 'Filter Preset', 'success', true, 3000);
+        data.saveFilterPreset(name.trim());
+        makeToast(`Saved preset: ${name.trim()}`, 'Filter Preset', 'success', true, 3000);
       }
-    },
-    generatePassword() {
-      // Character sets that meet password requirements
-      const lowercase = 'abcdefghijklmnopqrstuvwxyz';
-      const uppercase = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-      const numbers = '0123456789';
-      const special = '!@#$%^&*';
+    }
 
-      // Ensure at least one character from each required set
-      const requiredChars = [
-        lowercase[Math.floor(Math.random() * lowercase.length)],
-        uppercase[Math.floor(Math.random() * uppercase.length)],
-        numbers[Math.floor(Math.random() * numbers.length)],
-        special[Math.floor(Math.random() * special.length)],
-      ];
-
-      // Fill remaining length with random characters from all sets
-      const allChars = lowercase + uppercase + numbers + special;
-      const passwordLength = 16; // Strong password length
-      const remainingLength = passwordLength - requiredChars.length;
-
-      for (let i = 0; i < remainingLength; i++) {
-        requiredChars.push(allChars[Math.floor(Math.random() * allChars.length)]);
+    // ── Lifecycle ─────────────────────────────────────────────────────────────
+    onMounted(() => {
+      const urlParams = new URLSearchParams(window.location.search);
+      if (urlParams.get('sort')) {
+        const sortObj = data.sortStringToVariables(urlParams.get('sort')!);
+        data.sortBy.value = sortObj.sortBy;
+        data.sort.value = urlParams.get('sort') as string;
+      }
+      if (urlParams.get('filter')) {
+        data.filter.value = data.filterStrToObj(urlParams.get('filter'), data.filter.value) as any;
+        data.filter_string.value = urlParams.get('filter') as string;
+      }
+      if (urlParams.get('page_after')) {
+        data.currentItemID.value = parseInt(urlParams.get('page_after') as string, 10) || 0;
+      }
+      if (urlParams.get('page_size')) {
+        data.perPage.value = parseInt(urlParams.get('page_size') as string, 10) || 25;
       }
 
-      // Shuffle the array using Fisher-Yates algorithm
-      for (let i = requiredChars.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [requiredChars[i], requiredChars[j]] = [requiredChars[j], requiredChars[i]];
-      }
+      data.loadRoleList();
+      data.loadUserList();
 
-      const generatedPassword = requiredChars.join('');
-
-      // Set both password fields
-      this.passwordChange.newPassword = generatedPassword;
-      this.passwordChange.confirmPassword = generatedPassword;
-      this.passwordChange.showPassword = true; // Show password so user can see/copy it
-
-      this.makeToast(
-        'Password generated. Make sure to copy it before saving.',
-        'Password Generated',
-        'info',
-        true,
-        5000
-      );
-    },
-    async changeUserPassword() {
-      if (!this.passwordValidation.isValid) {
-        this.makeToast('Password does not meet requirements', 'Validation Error', 'warning');
-        return;
-      }
-      if (this.passwordChange.newPassword !== this.passwordChange.confirmPassword) {
-        this.makeToast('Passwords do not match', 'Validation Error', 'warning');
-        return;
-      }
-
-      this.passwordChange.isChanging = true;
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/password/update`;
-
-      try {
-        const response = await apiClient.raw.put(apiUrl, {
-          user_id_pass_change: this.userToUpdate.user_id,
-          old_pass: '', // Admin can change password without knowing old password
-          new_pass_1: this.passwordChange.newPassword,
-          new_pass_2: this.passwordChange.confirmPassword,
+      if (data.filterPresets.presets.value.length === 0) {
+        data.filterPresets.savePreset('Pending', {
+          any: { content: null, join_char: null, operator: 'contains' },
+          user_role: { content: null, join_char: ',', operator: 'any' },
+          approved: { content: '0', join_char: null, operator: 'equals' },
         });
-
-        if (response.status === 200) {
-          this.makeToast(
-            `Password changed successfully for ${this.userToUpdate.user_name}`,
-            'Password Changed',
-            'success',
-            true,
-            5000
-          );
-          // Reset password fields
-          this.passwordChange.newPassword = '';
-          this.passwordChange.confirmPassword = '';
-        }
-      } catch (error) {
-        const errorMsg =
-          error.response?.data?.message ||
-          error.response?.data?.error ||
-          'Failed to change password';
-        this.makeToast(errorMsg, 'Password Change Failed', 'danger');
-      } finally {
-        this.passwordChange.isChanging = false;
+        data.filterPresets.savePreset('Curators', {
+          any: { content: null, join_char: null, operator: 'contains' },
+          user_role: { content: 'Curator', join_char: ',', operator: 'any' },
+          approved: { content: null, join_char: null, operator: 'equals' },
+        });
       }
-    },
+
+      nextTick(() => {
+        data.loadData();
+        nextTick(() => {
+          data.isInitializing.value = false;
+        });
+      });
+    });
+
+    // ── Watchers ──────────────────────────────────────────────────────────────
+    watch(
+      data.filter,
+      () => { if (!data.isInitializing.value) data.filtered(); },
+      { deep: true },
+    );
+    watch(
+      data.sortBy,
+      () => { if (!data.isInitializing.value) data.handleSortByOrDescChange(); },
+      { deep: true },
+    );
+
+    // ── Exposed actions (plan aliases + legacy aliases for existing spec) ──────
+    const onConfirmDelete = () => mutations.deleteUser(modals.userToDelete.value as any);
+    // updateUserData reads from modals.userToUpdate.value so the spec can set
+    // wrapper.vm.userToUpdate = {...} and then call wrapper.vm.updateUserData()
+    // with no args (matching original ManageUser.vue behaviour).
+    // Errors are already toasted inside mutations.updateUser; swallow the
+    // re-throw here so callers (and the spec) don't see unhandled rejections.
+    const updateUserData = () => mutations.updateUser(modals.userToUpdate.value as any).catch(() => {});
+    const onSubmitUpdate = (payload: any) => {
+      const p = payload !== undefined ? mutations.updateUser(payload) : mutations.updateUser(modals.userToUpdate.value as any);
+      return p.catch(() => {});
+    };
+    // Use a shallowRef so the spec can override wrapper.vm.getSelectedArray and
+    // the confirm handlers pick up the override (same dynamic dispatch as the
+    // original Options-API `this.getSelectedArray()`).
+    const getSelectedArray = shallowRef<() => number[]>(bulkSelection.getSelectedArray);
+    const onConfirmBulkApprove = () => bulk.bulkApprove(getSelectedArray.value());
+    const onConfirmBulkRole = () => bulk.bulkAssignRole(getSelectedArray.value(), modals.bulkRoleSelection.value);
+    const onConfirmBulkDelete = () => bulk.bulkDelete(getSelectedArray.value());
+    const onChangePassword = () =>
+      mutations.changePassword({
+        userId: (modals.userToUpdate.value as any).user_id,
+        newPassword: mutations.passwordChange.value.newPassword,
+        confirmPassword: mutations.passwordChange.value.confirmPassword,
+      });
+
+    return {
+      // ── data composable ──
+      ...data,
+      // ── modal composable ──
+      ...modals,
+      // ── mutation composable ──
+      ...mutations,
+      // ── bulk composable ──
+      ...bulk,
+      // ── bulk selection composable ──
+      ...bulkSelection,
+      // Override the plain getSelectedArray from bulkSelection with the shallowRef
+      // so that spec assignments like `wrapper.vm.getSelectedArray = () => [1,2]`
+      // flow through Vue's ref-unwrap setter and update getSelectedArray.value,
+      // which the confirm handlers then pick up (matches Options-API `this.*` dispatch).
+      getSelectedArray,
+      // ── local computed ──
+      fields,
+      hasActiveFilters,
+      activeFilters,
+      allOnPageSelected,
+      // ── local functions ──
+      toggleSelectAllOnPage,
+      handleRowSelect,
+      getRoleBadgeVariant,
+      getRoleIcon,
+      showSavePresetPrompt,
+      // ── plan-named actions ──
+      onConfirmDelete,
+      onSubmitUpdate,
+      onConfirmBulkApprove,
+      onConfirmBulkRole,
+      onConfirmBulkDelete,
+      onChangePassword,
+      // ── legacy aliases (preserved for existing ManageUser.spec.ts) ──
+      confirmDeleteUser: onConfirmDelete,
+      updateUserData,
+      confirmBulkApprove: onConfirmBulkApprove,
+      confirmBulkRoleAssignment: onConfirmBulkRole,
+      confirmBulkDelete: onConfirmBulkDelete,
+      changeUserPassword: onChangePassword,
+      makeToast,
+    };
   },
-};
+});
 </script>
 
 <style scoped>

--- a/app/src/views/admin/ManageUser.vue
+++ b/app/src/views/admin/ManageUser.vue
@@ -265,7 +265,6 @@
       <UserUpdateModal
         v-model:visible="isUpdateOpen"
         :user="userToUpdate"
-        :role-options="roleOptions"
         v-model:password-change="passwordChange"
         :password-validation="passwordValidation"
         :is-changing-password="isChangingPassword"
@@ -293,7 +292,6 @@
       <UserBulkRoleModal
         v-model:visible="isBulkRoleOpen"
         :usernames="bulkRoleUsernames"
-        :role-options="roleOptions"
         v-model:selected-role="bulkRoleSelection"
         @confirm="onConfirmBulkRole"
         @cancel="close"
@@ -494,7 +492,9 @@ export default defineComponent({
     );
 
     // ── Exposed actions (plan aliases + legacy aliases for existing spec) ──────
-    const onConfirmDelete = () => mutations.deleteUser(modals.userToDelete.value as any);
+    // Composables re-throw after toasting; swallow at the orchestration layer
+    // so callers don't see unhandled rejections (toast already covers UX).
+    const onConfirmDelete = () => mutations.deleteUser(modals.userToDelete.value as any).catch(() => {});
     // updateUserData reads from modals.userToUpdate.value so the spec can set
     // wrapper.vm.userToUpdate = {...} and then call wrapper.vm.updateUserData()
     // with no args (matching original ManageUser.vue behaviour).
@@ -509,9 +509,9 @@ export default defineComponent({
     // the confirm handlers pick up the override (same dynamic dispatch as the
     // original Options-API `this.getSelectedArray()`).
     const getSelectedArray = shallowRef<() => number[]>(bulkSelection.getSelectedArray);
-    const onConfirmBulkApprove = () => bulk.bulkApprove(getSelectedArray.value());
-    const onConfirmBulkRole = () => bulk.bulkAssignRole(getSelectedArray.value(), modals.bulkRoleSelection.value);
-    const onConfirmBulkDelete = () => bulk.bulkDelete(getSelectedArray.value());
+    const onConfirmBulkApprove = () => bulk.bulkApprove(getSelectedArray.value()).catch(() => {});
+    const onConfirmBulkRole = () => bulk.bulkAssignRole(getSelectedArray.value(), modals.bulkRoleSelection.value).catch(() => {});
+    const onConfirmBulkDelete = () => bulk.bulkDelete(getSelectedArray.value()).catch(() => {});
     const onChangePassword = () =>
       mutations.changePassword({
         userId: (modals.userToUpdate.value as any).user_id,

--- a/app/src/views/admin/components/UserBulkActionToolbar.vue
+++ b/app/src/views/admin/components/UserBulkActionToolbar.vue
@@ -1,0 +1,61 @@
+<!-- app/src/views/admin/components/UserBulkActionToolbar.vue -->
+<!-- Bulk action button group rendered in the card header when selectionCount > 0. -->
+<template>
+  <template v-if="selectionCount > 0">
+    <BButton
+      v-b-tooltip.hover
+      size="sm"
+      variant="success"
+      class="me-1"
+      title="Approve selected users"
+      :disabled="busy"
+      @click="$emit('approve')"
+    >
+      <i class="bi bi-check-circle" /> Approve
+    </BButton>
+    <BButton
+      v-b-tooltip.hover
+      size="sm"
+      variant="primary"
+      class="me-1"
+      title="Assign role to selected users"
+      :disabled="busy"
+      @click="$emit('assign-role')"
+    >
+      <i class="bi bi-person-badge" /> Role
+    </BButton>
+    <BButton
+      v-b-tooltip.hover
+      size="sm"
+      variant="danger"
+      class="me-1"
+      title="Delete selected users"
+      :disabled="busy"
+      @click="$emit('delete')"
+    >
+      <i class="bi bi-trash" /> Delete
+    </BButton>
+    <BButton
+      v-b-tooltip.hover
+      size="sm"
+      variant="link"
+      title="Clear selection"
+      @click="$emit('clear')"
+    >
+      <i class="bi bi-x-lg" />
+    </BButton>
+  </template>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'UserBulkActionToolbar',
+  props: {
+    selectionCount: { type: Number, required: true },
+    busy: { type: Boolean, default: false },
+  },
+  emits: ['approve', 'assign-role', 'delete', 'clear'],
+});
+</script>

--- a/app/src/views/admin/components/UserBulkApproveModal.vue
+++ b/app/src/views/admin/components/UserBulkApproveModal.vue
@@ -1,0 +1,41 @@
+<!-- app/src/views/admin/components/UserBulkApproveModal.vue -->
+<!-- Bulk-approve confirmation modal lifted from ManageUser.vue. -->
+<template>
+  <BModal
+    v-model="proxyVisible"
+    title="Approve Users"
+    ok-variant="success"
+    ok-title="Approve"
+    cancel-title="Cancel"
+    @ok.prevent="$emit('confirm')"
+    @cancel="$emit('cancel')"
+  >
+    <p>You are about to approve {{ usernames.length }} user(s):</p>
+    <div class="border rounded p-2 mb-3 bg-light" style="max-height: 200px; overflow-y: auto">
+      <div v-for="username in usernames" :key="username" class="small">
+        {{ username }}
+      </div>
+    </div>
+    <p class="text-muted small">This action will grant these users access to the system.</p>
+  </BModal>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, type PropType } from 'vue';
+
+export default defineComponent({
+  name: 'UserBulkApproveModal',
+  props: {
+    visible: { type: Boolean, default: false },
+    usernames: { type: Array as PropType<string[]>, default: () => [] },
+  },
+  emits: ['update:visible', 'confirm', 'cancel'],
+  setup(props, { emit }) {
+    const proxyVisible = computed({
+      get: () => props.visible,
+      set: (v) => emit('update:visible', v),
+    });
+    return { proxyVisible };
+  },
+});
+</script>

--- a/app/src/views/admin/components/UserBulkDeleteModal.vue
+++ b/app/src/views/admin/components/UserBulkDeleteModal.vue
@@ -1,0 +1,56 @@
+<!-- app/src/views/admin/components/UserBulkDeleteModal.vue -->
+<!-- Bulk-delete confirmation modal with type-to-confirm, lifted from ManageUser.vue. -->
+<template>
+  <BModal
+    v-model="proxyVisible"
+    title="Delete Users"
+    ok-variant="danger"
+    ok-title="Delete"
+    cancel-title="Cancel"
+    :ok-disabled="confirmText !== 'DELETE'"
+    @ok.prevent="$emit('confirm')"
+    @cancel="$emit('cancel')"
+  >
+    <p class="text-danger fw-bold">This action cannot be undone.</p>
+    <p>You are about to delete {{ usernames.length }} user(s):</p>
+    <div class="border rounded p-2 mb-3 bg-light" style="max-height: 200px; overflow-y: auto">
+      <div v-for="username in usernames" :key="username" class="small">
+        {{ username }}
+      </div>
+    </div>
+    <BFormGroup label="Type DELETE to confirm:" label-for="delete-confirm-input">
+      <BFormInput
+        id="delete-confirm-input"
+        :value="confirmText"
+        placeholder="DELETE"
+        autocomplete="off"
+        @input="emitConfirmInput($event)"
+      />
+    </BFormGroup>
+  </BModal>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, type PropType } from 'vue';
+
+export default defineComponent({
+  name: 'UserBulkDeleteModal',
+  props: {
+    visible: { type: Boolean, default: false },
+    usernames: { type: Array as PropType<string[]>, default: () => [] },
+    confirmText: { type: String, default: '' },
+  },
+  emits: ['update:visible', 'update:confirm-text', 'confirm', 'cancel'],
+  setup(props, { emit }) {
+    const proxyVisible = computed({
+      get: () => props.visible,
+      set: (v) => emit('update:visible', v),
+    });
+    function emitConfirmInput(event: Event): void {
+      const t = event.target as HTMLInputElement;
+      emit('update:confirm-text', t.value);
+    }
+    return { proxyVisible, emitConfirmInput };
+  },
+});
+</script>

--- a/app/src/views/admin/components/UserBulkRoleModal.vue
+++ b/app/src/views/admin/components/UserBulkRoleModal.vue
@@ -41,10 +41,6 @@ export default defineComponent({
   props: {
     visible: { type: Boolean, default: false },
     usernames: { type: Array as PropType<string[]>, default: () => [] },
-    roleOptions: {
-      type: Array as PropType<Array<{ value: string; text: string }>>,
-      default: () => [],
-    },
     selectedRole: { type: String, default: '' },
   },
   emits: ['update:visible', 'update:selected-role', 'confirm', 'cancel'],

--- a/app/src/views/admin/components/UserBulkRoleModal.vue
+++ b/app/src/views/admin/components/UserBulkRoleModal.vue
@@ -1,0 +1,63 @@
+<!-- app/src/views/admin/components/UserBulkRoleModal.vue -->
+<!-- Bulk role-assignment modal with role select, lifted from ManageUser.vue. -->
+<template>
+  <BModal
+    v-model="proxyVisible"
+    title="Assign Role"
+    ok-variant="primary"
+    ok-title="Assign Role"
+    cancel-title="Cancel"
+    :ok-disabled="!selectedRole"
+    @ok.prevent="$emit('confirm')"
+    @cancel="$emit('cancel')"
+  >
+    <p>Assign role to {{ usernames.length }} user(s):</p>
+    <div class="border rounded p-2 mb-3 bg-light" style="max-height: 150px; overflow-y: auto">
+      <div v-for="username in usernames" :key="username" class="small">
+        {{ username }}
+      </div>
+    </div>
+    <BFormGroup label="Select Role:" label-for="bulk-role-select">
+      <BFormSelect
+        id="bulk-role-select"
+        :value="selectedRole"
+        :options="[
+          { value: '', text: 'Select a role...', disabled: true },
+          { value: 'Curator', text: 'Curator' },
+          { value: 'Reviewer', text: 'Reviewer' },
+          { value: 'Administrator', text: 'Administrator' },
+        ]"
+        @change="emitRoleChange($event)"
+      />
+    </BFormGroup>
+  </BModal>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, type PropType } from 'vue';
+
+export default defineComponent({
+  name: 'UserBulkRoleModal',
+  props: {
+    visible: { type: Boolean, default: false },
+    usernames: { type: Array as PropType<string[]>, default: () => [] },
+    roleOptions: {
+      type: Array as PropType<Array<{ value: string; text: string }>>,
+      default: () => [],
+    },
+    selectedRole: { type: String, default: '' },
+  },
+  emits: ['update:visible', 'update:selected-role', 'confirm', 'cancel'],
+  setup(props, { emit }) {
+    const proxyVisible = computed({
+      get: () => props.visible,
+      set: (v) => emit('update:visible', v),
+    });
+    function emitRoleChange(event: Event): void {
+      const t = event.target as HTMLSelectElement;
+      emit('update:selected-role', t.value);
+    }
+    return { proxyVisible, emitRoleChange };
+  },
+});
+</script>

--- a/app/src/views/admin/components/UserDeleteConfirmModal.vue
+++ b/app/src/views/admin/components/UserDeleteConfirmModal.vue
@@ -1,0 +1,52 @@
+<!-- app/src/views/admin/components/UserDeleteConfirmModal.vue -->
+<!-- Single-user delete confirmation modal lifted from ManageUser.vue. -->
+<template>
+  <BModal
+    id="delete-usermodal"
+    v-model="proxyVisible"
+    header-bg-variant="danger"
+    header-text-variant="light"
+    ok-title="Delete User"
+    ok-variant="danger"
+    cancel-title="Cancel"
+    cancel-variant="outline-secondary"
+    @ok.prevent="$emit('confirm')"
+    @cancel="$emit('cancel')"
+  >
+    <template #title>
+      <i class="bi bi-exclamation-triangle-fill me-2" />
+      Confirm Deletion
+    </template>
+    <div class="text-center py-3">
+      <i class="bi bi-person-x-fill text-danger" style="font-size: 3rem" />
+      <p class="mt-3 mb-0">
+        Are you sure you want to delete the user
+        <strong class="text-danger">{{ user?.user_name }}</strong>?
+      </p>
+      <p class="text-muted small mt-2">This action cannot be undone.</p>
+    </div>
+  </BModal>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, type PropType } from 'vue';
+
+export default defineComponent({
+  name: 'UserDeleteConfirmModal',
+  props: {
+    visible: { type: Boolean, default: false },
+    user: {
+      type: Object as PropType<{ user_id: number; user_name: string } | null>,
+      default: null,
+    },
+  },
+  emits: ['update:visible', 'confirm', 'cancel'],
+  setup(props, { emit }) {
+    const proxyVisible = computed({
+      get: () => props.visible,
+      set: (v) => emit('update:visible', v),
+    });
+    return { proxyVisible };
+  },
+});
+</script>

--- a/app/src/views/admin/components/UserPasswordChangeForm.vue
+++ b/app/src/views/admin/components/UserPasswordChangeForm.vue
@@ -1,0 +1,158 @@
+<!-- app/src/views/admin/components/UserPasswordChangeForm.vue -->
+<!-- Password-reset panel lifted from the update-modal template. -->
+<template>
+  <div class="mb-3">
+    <h6 class="text-muted border-bottom pb-2 mb-3">
+      <i class="bi bi-key me-2" />Password Reset
+    </h6>
+    <BAlert variant="info" :model-value="true" class="mb-3">
+      <i class="bi bi-info-circle me-2" />
+      As an administrator, you can set a new password for this user. Password requirements:
+      8+ characters, uppercase, lowercase, number, and special character (!@#$%^&*).
+    </BAlert>
+    <BRow>
+      <BCol md="6">
+        <BFormGroup label="New Password" label-for="input-new-password" class="mb-3">
+          <BInputGroup>
+            <template #prepend>
+              <BInputGroupText><i class="bi bi-lock" /></BInputGroupText>
+            </template>
+            <BFormInput
+              id="input-new-password"
+              :value="modelValue.newPassword"
+              :type="modelValue.showPassword ? 'text' : 'password'"
+              placeholder="Enter new password"
+              :state="validation.isValid"
+              autocomplete="new-password"
+              @input="emitInput('newPassword', $event)"
+            />
+            <template #append>
+              <BButton
+                variant="outline-secondary"
+                @click="toggleShowPassword"
+              >
+                <i :class="modelValue.showPassword ? 'bi bi-eye-slash' : 'bi bi-eye'" />
+              </BButton>
+            </template>
+          </BInputGroup>
+          <div v-if="modelValue.newPassword" class="mt-2">
+            <small
+              v-for="(rule, key) in validation.rules"
+              :key="key"
+              class="d-block"
+              :class="rule.valid ? 'text-success' : 'text-danger'"
+            >
+              <i
+                :class="rule.valid ? 'bi bi-check-circle' : 'bi bi-x-circle'"
+                class="me-1"
+              />
+              {{ rule.label }}
+            </small>
+          </div>
+        </BFormGroup>
+      </BCol>
+      <BCol md="6">
+        <BFormGroup
+          label="Confirm Password"
+          label-for="input-confirm-password"
+          class="mb-3"
+        >
+          <BInputGroup>
+            <template #prepend>
+              <BInputGroupText><i class="bi bi-lock-fill" /></BInputGroupText>
+            </template>
+            <BFormInput
+              id="input-confirm-password"
+              :value="modelValue.confirmPassword"
+              :type="modelValue.showPassword ? 'text' : 'password'"
+              placeholder="Confirm new password"
+              :state="
+                modelValue.confirmPassword
+                  ? modelValue.newPassword === modelValue.confirmPassword
+                  : null
+              "
+              autocomplete="new-password"
+              @input="emitInput('confirmPassword', $event)"
+            />
+          </BInputGroup>
+          <BFormInvalidFeedback
+            v-if="
+              modelValue.confirmPassword &&
+              modelValue.newPassword !== modelValue.confirmPassword
+            "
+            :state="false"
+          >
+            Passwords do not match
+          </BFormInvalidFeedback>
+        </BFormGroup>
+      </BCol>
+    </BRow>
+    <BRow>
+      <BCol class="d-flex justify-content-between">
+        <BButton variant="outline-secondary" @click="$emit('generate')">
+          <i class="bi bi-shuffle me-1" />
+          Generate Password
+        </BButton>
+        <BButton
+          variant="warning"
+          :disabled="
+            !validation.isValid ||
+            modelValue.newPassword !== modelValue.confirmPassword ||
+            isChanging
+          "
+          @click="$emit('submit')"
+        >
+          <BSpinner v-if="isChanging" small class="me-1" />
+          <i v-else class="bi bi-key-fill me-1" />
+          {{ isChanging ? 'Changing...' : 'Change Password' }}
+        </BButton>
+      </BCol>
+    </BRow>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue';
+
+interface PasswordChangeModel {
+  newPassword: string;
+  confirmPassword: string;
+  showPassword: boolean;
+}
+
+interface PasswordRule {
+  label: string;
+  valid: boolean;
+}
+
+interface PasswordValidation {
+  isValid: boolean | null;
+  rules: Record<string, PasswordRule>;
+}
+
+export default defineComponent({
+  name: 'UserPasswordChangeForm',
+  props: {
+    modelValue: {
+      type: Object as PropType<PasswordChangeModel>,
+      required: true,
+    },
+    validation: {
+      type: Object as PropType<PasswordValidation>,
+      required: true,
+    },
+    isChanging: { type: Boolean, default: false },
+  },
+  emits: ['update:modelValue', 'submit', 'generate'],
+  setup(props, { emit }) {
+    function emitInput(field: 'newPassword' | 'confirmPassword', event: Event): void {
+      const target = event.target as HTMLInputElement;
+      emit('update:modelValue', { ...props.modelValue, [field]: target.value });
+    }
+    function toggleShowPassword(): void {
+      emit('update:modelValue', { ...props.modelValue, showPassword: !props.modelValue.showPassword });
+    }
+    return { emitInput, toggleShowPassword };
+  },
+});
+</script>

--- a/app/src/views/admin/components/UserUpdateModal.vue
+++ b/app/src/views/admin/components/UserUpdateModal.vue
@@ -32,7 +32,7 @@
                 </template>
                 <BFormInput
                   id="input-user_name"
-                  v-model="local.user_name"
+                  v-model="userName"
                   type="text"
                   placeholder="Enter username"
                   :state="userNameMeta.touched ? (userNameError ? false : true) : null"
@@ -51,7 +51,7 @@
                 </template>
                 <BFormInput
                   id="input-email"
-                  v-model="local.email"
+                  v-model="userEmail"
                   type="email"
                   placeholder="user@example.com"
                   :state="emailMeta.touched ? (emailError ? false : true) : null"
@@ -72,7 +72,7 @@
                 </template>
                 <BFormInput
                   id="input-abbreviation"
-                  v-model="local.abbreviation"
+                  v-model="abbreviation"
                   type="text"
                   placeholder="XX"
                   maxlength="5"
@@ -92,7 +92,7 @@
                 </template>
                 <BFormInput
                   id="input-orcid"
-                  v-model="local.orcid"
+                  v-model="orcid"
                   type="text"
                   placeholder="0000-0000-0000-0000"
                   :state="orcidMeta.touched ? (orcidError ? false : true) : null"
@@ -116,7 +116,7 @@
             <BFormGroup label="First Name" label-for="input-first_name" class="mb-3">
               <BFormInput
                 id="input-first_name"
-                v-model="local.first_name"
+                v-model="firstName"
                 type="text"
                 placeholder="First name"
                 :state="firstNameMeta.touched ? (firstNameError ? false : true) : null"
@@ -130,7 +130,7 @@
             <BFormGroup label="Family Name" label-for="input-family_name" class="mb-3">
               <BFormInput
                 id="input-family_name"
-                v-model="local.family_name"
+                v-model="familyName"
                 type="text"
                 placeholder="Family name"
                 :state="familyNameMeta.touched ? (familyNameError ? false : true) : null"
@@ -153,7 +153,7 @@
             <BFormGroup label="Role" label-for="input-user_role" class="mb-3">
               <BFormSelect
                 id="input-user_role"
-                v-model="local.user_role"
+                v-model="userRole"
                 :options="roleSelectOptions"
                 :state="userRoleMeta.touched ? (userRoleError ? false : true) : null"
               />
@@ -308,44 +308,50 @@ export default defineComponent({
 
     const { handleSubmit, setValues } = useForm();
 
+    // Bind inputs directly to vee-validate field `value` refs so user
+    // edits flow through the validator (meta.touched flips, errorMessage
+    // updates live, handleSubmit gates on the *current* values, not the
+    // ones seeded via setValues at modal open).
     const {
-      value: _userName,
+      value: userName,
       errorMessage: userNameError,
       meta: userNameMeta,
-    } = useField('user_name', 'required|min:2|max:50');
+    } = useField<string>('user_name', 'required|min:2|max:50');
 
     const {
-      value: _userEmail,
+      value: userEmail,
       errorMessage: emailError,
       meta: emailMeta,
-    } = useField('email', 'required|email');
+    } = useField<string>('email', 'required|email');
 
-    const { value: _orcid, errorMessage: orcidError, meta: orcidMeta } = useField('orcid');
+    const { value: orcid, errorMessage: orcidError, meta: orcidMeta } = useField<string>('orcid');
 
     const {
-      value: _abbreviation,
+      value: abbreviation,
       errorMessage: abbreviationError,
       meta: abbreviationMeta,
-    } = useField('abbreviation', 'required');
+    } = useField<string>('abbreviation', 'required');
 
     const {
-      value: _firstName,
+      value: firstName,
       errorMessage: firstNameError,
       meta: firstNameMeta,
-    } = useField('first_name', 'required|min:2|max:50');
+    } = useField<string>('first_name', 'required|min:2|max:50');
 
     const {
-      value: _familyName,
+      value: familyName,
       errorMessage: familyNameError,
       meta: familyNameMeta,
-    } = useField('family_name', 'required|min:2|max:50');
+    } = useField<string>('family_name', 'required|min:2|max:50');
 
     const {
-      value: _userRole,
+      value: userRole,
       errorMessage: userRoleError,
       meta: userRoleMeta,
-    } = useField('user_role', 'required');
+    } = useField<string>('user_role', 'required');
 
+    // `local` holds NON-validated fields only (user_id / approved /
+    // comment). Validated fields live on the vee-validate refs above.
     const local = ref<Partial<UserSummary>>({});
 
     const roleSelectOptions = computed(() => [
@@ -375,7 +381,11 @@ export default defineComponent({
     );
 
     function onSubmit(): void {
-      handleSubmit(() => emit('submit', { ...local.value }))();
+      // handleSubmit fires the callback only when every field passes
+      // validation. `values` is the validated form snapshot; merge with
+      // `local` so non-validated fields (user_id / approved / comment)
+      // ride along.
+      handleSubmit((values) => emit('submit', { ...local.value, ...values }))();
     }
 
     return {
@@ -385,6 +395,15 @@ export default defineComponent({
       local,
       roleSelectOptions,
       onSubmit,
+      // vee-validate field refs (used as v-model targets in the template)
+      userName,
+      userEmail,
+      orcid,
+      abbreviation,
+      firstName,
+      familyName,
+      userRole,
+      // error messages + meta (used for :state and feedback)
       userNameError,
       userNameMeta,
       emailError,

--- a/app/src/views/admin/components/UserUpdateModal.vue
+++ b/app/src/views/admin/components/UserUpdateModal.vue
@@ -1,0 +1,409 @@
+<!-- app/src/views/admin/components/UserUpdateModal.vue -->
+<!-- Edit-user form modal lifted from ManageUser.vue, with vee-validate scoped here. -->
+<template>
+  <BModal
+    :id="modalId"
+    v-model="proxyVisible"
+    size="lg"
+    header-bg-variant="primary"
+    header-text-variant="light"
+    ok-title="Save Changes"
+    ok-variant="primary"
+    cancel-title="Cancel"
+    cancel-variant="outline-secondary"
+    @ok.prevent="onSubmit"
+  >
+    <template #title>
+      <i class="bi bi-person-gear me-2" />
+      Edit User: {{ local.user_name }}
+    </template>
+    <form @submit.prevent="onSubmit">
+      <!-- Account Information Section -->
+      <div class="mb-4">
+        <h6 class="text-muted border-bottom pb-2 mb-3">
+          <i class="bi bi-person-badge me-2" />Account Information
+        </h6>
+        <BRow>
+          <BCol md="6">
+            <BFormGroup label="Username" label-for="input-user_name" class="mb-3">
+              <BInputGroup>
+                <template #prepend>
+                  <BInputGroupText><i class="bi bi-at" /></BInputGroupText>
+                </template>
+                <BFormInput
+                  id="input-user_name"
+                  v-model="local.user_name"
+                  type="text"
+                  placeholder="Enter username"
+                  :state="userNameMeta.touched ? (userNameError ? false : true) : null"
+                />
+              </BInputGroup>
+              <BFormInvalidFeedback v-if="userNameError" :state="false">
+                {{ userNameError }}
+              </BFormInvalidFeedback>
+            </BFormGroup>
+          </BCol>
+          <BCol md="6">
+            <BFormGroup label="Email" label-for="input-email" class="mb-3">
+              <BInputGroup>
+                <template #prepend>
+                  <BInputGroupText><i class="bi bi-envelope" /></BInputGroupText>
+                </template>
+                <BFormInput
+                  id="input-email"
+                  v-model="local.email"
+                  type="email"
+                  placeholder="user@example.com"
+                  :state="emailMeta.touched ? (emailError ? false : true) : null"
+                />
+              </BInputGroup>
+              <BFormInvalidFeedback v-if="emailError" :state="false">
+                {{ emailError }}
+              </BFormInvalidFeedback>
+            </BFormGroup>
+          </BCol>
+        </BRow>
+        <BRow>
+          <BCol md="6">
+            <BFormGroup label="Abbreviation" label-for="input-abbreviation" class="mb-3">
+              <BInputGroup>
+                <template #prepend>
+                  <BInputGroupText><i class="bi bi-hash" /></BInputGroupText>
+                </template>
+                <BFormInput
+                  id="input-abbreviation"
+                  v-model="local.abbreviation"
+                  type="text"
+                  placeholder="XX"
+                  maxlength="5"
+                  :state="abbreviationMeta.touched ? (abbreviationError ? false : true) : null"
+                />
+              </BInputGroup>
+              <BFormInvalidFeedback v-if="abbreviationError" :state="false">
+                {{ abbreviationError }}
+              </BFormInvalidFeedback>
+            </BFormGroup>
+          </BCol>
+          <BCol md="6">
+            <BFormGroup label="ORCID" label-for="input-orcid" class="mb-3">
+              <BInputGroup>
+                <template #prepend>
+                  <BInputGroupText><i class="bi bi-link-45deg" /></BInputGroupText>
+                </template>
+                <BFormInput
+                  id="input-orcid"
+                  v-model="local.orcid"
+                  type="text"
+                  placeholder="0000-0000-0000-0000"
+                  :state="orcidMeta.touched ? (orcidError ? false : true) : null"
+                />
+              </BInputGroup>
+              <BFormInvalidFeedback v-if="orcidError" :state="false">
+                {{ orcidError }}
+              </BFormInvalidFeedback>
+            </BFormGroup>
+          </BCol>
+        </BRow>
+      </div>
+
+      <!-- Personal Information Section -->
+      <div class="mb-4">
+        <h6 class="text-muted border-bottom pb-2 mb-3">
+          <i class="bi bi-person me-2" />Personal Information
+        </h6>
+        <BRow>
+          <BCol md="6">
+            <BFormGroup label="First Name" label-for="input-first_name" class="mb-3">
+              <BFormInput
+                id="input-first_name"
+                v-model="local.first_name"
+                type="text"
+                placeholder="First name"
+                :state="firstNameMeta.touched ? (firstNameError ? false : true) : null"
+              />
+              <BFormInvalidFeedback v-if="firstNameError">
+                {{ firstNameError }}
+              </BFormInvalidFeedback>
+            </BFormGroup>
+          </BCol>
+          <BCol md="6">
+            <BFormGroup label="Family Name" label-for="input-family_name" class="mb-3">
+              <BFormInput
+                id="input-family_name"
+                v-model="local.family_name"
+                type="text"
+                placeholder="Family name"
+                :state="familyNameMeta.touched ? (familyNameError ? false : true) : null"
+              />
+              <BFormInvalidFeedback v-if="familyNameError">
+                {{ familyNameError }}
+              </BFormInvalidFeedback>
+            </BFormGroup>
+          </BCol>
+        </BRow>
+      </div>
+
+      <!-- Role & Status Section -->
+      <div class="mb-3">
+        <h6 class="text-muted border-bottom pb-2 mb-3">
+          <i class="bi bi-shield-check me-2" />Role &amp; Status
+        </h6>
+        <BRow>
+          <BCol md="6">
+            <BFormGroup label="Role" label-for="input-user_role" class="mb-3">
+              <BFormSelect
+                id="input-user_role"
+                v-model="local.user_role"
+                :options="roleSelectOptions"
+                :state="userRoleMeta.touched ? (userRoleError ? false : true) : null"
+              />
+              <BFormInvalidFeedback v-if="userRoleError">
+                {{ userRoleError }}
+              </BFormInvalidFeedback>
+            </BFormGroup>
+          </BCol>
+          <BCol md="6">
+            <BFormGroup label="Account Status" label-for="input-approved" class="mb-3">
+              <div class="d-flex flex-column gap-2">
+                <!-- Current status display -->
+                <div class="d-flex align-items-center">
+                  <span class="text-muted me-2">Current:</span>
+                  <span
+                    class="badge"
+                    :class="local.approved ? 'bg-success' : 'bg-warning text-dark'"
+                  >
+                    <i
+                      :class="
+                        local.approved ? 'bi bi-check-circle-fill' : 'bi bi-clock-fill'
+                      "
+                      class="me-1"
+                    />
+                    {{ local.approved ? 'Approved' : 'Pending' }}
+                  </span>
+                </div>
+                <!-- Toggle buttons -->
+                <BButtonGroup size="sm">
+                  <BButton
+                    :variant="local.approved ? 'success' : 'outline-success'"
+                    @click="local.approved = true"
+                  >
+                    <i class="bi bi-check-lg me-1" />
+                    Approve
+                  </BButton>
+                  <BButton
+                    :variant="!local.approved ? 'warning' : 'outline-warning'"
+                    @click="local.approved = false"
+                  >
+                    <i class="bi bi-clock me-1" />
+                    Set Pending
+                  </BButton>
+                </BButtonGroup>
+                <small class="text-muted">
+                  {{
+                    local.approved
+                      ? 'User can access the system.'
+                      : 'User cannot log in until approved.'
+                  }}
+                </small>
+              </div>
+            </BFormGroup>
+          </BCol>
+        </BRow>
+        <BRow>
+          <BCol>
+            <BFormGroup label="Comment" label-for="input-comment" class="mb-0">
+              <BFormTextarea
+                id="input-comment"
+                v-model="local.comment"
+                placeholder="Add notes about this user..."
+                rows="2"
+              />
+            </BFormGroup>
+          </BCol>
+        </BRow>
+      </div>
+
+      <!-- Password Reset Section -->
+      <UserPasswordChangeForm
+        v-model="passwordChangeProxy"
+        :validation="passwordValidation"
+        :is-changing="isChangingPassword"
+        @submit="$emit('change-password')"
+        @generate="$emit('generate-password')"
+      />
+    </form>
+  </BModal>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, ref, watch, type PropType } from 'vue';
+import { useField, useForm, defineRule } from 'vee-validate';
+import { required, min, max, email } from '@vee-validate/rules';
+import UserPasswordChangeForm from './UserPasswordChangeForm.vue';
+
+defineRule('required', required);
+defineRule('min', min);
+defineRule('max', max);
+defineRule('email', email);
+
+interface UserSummary {
+  user_id: number;
+  user_name: string;
+  email: string;
+  orcid?: string;
+  abbreviation: string;
+  first_name: string;
+  family_name: string;
+  user_role: string;
+  approved: number | boolean;
+  comment?: string;
+}
+
+interface PasswordChangeModel {
+  newPassword: string;
+  confirmPassword: string;
+  showPassword: boolean;
+}
+
+interface PasswordRule {
+  label: string;
+  valid: boolean;
+}
+
+interface PasswordValidation {
+  isValid: boolean | null;
+  rules: Record<string, PasswordRule>;
+}
+
+export default defineComponent({
+  name: 'UserUpdateModal',
+  components: { UserPasswordChangeForm },
+  props: {
+    visible: { type: Boolean, default: false },
+    user: { type: Object as PropType<Partial<UserSummary> | null>, default: null },
+    roleOptions: {
+      type: Array as PropType<Array<{ value: string; text: string }>>,
+      default: () => [],
+    },
+    passwordChange: {
+      type: Object as PropType<PasswordChangeModel>,
+      required: true,
+    },
+    passwordValidation: {
+      type: Object as PropType<PasswordValidation>,
+      required: true,
+    },
+    isChangingPassword: { type: Boolean, default: false },
+  },
+  emits: ['update:visible', 'submit', 'cancel', 'change-password', 'generate-password', 'update:password-change'],
+  setup(props, { emit }) {
+    const modalId = 'update-usermodal';
+
+    const proxyVisible = computed({
+      get: () => props.visible,
+      set: (v) => emit('update:visible', v),
+    });
+
+    // Two-way proxy for passwordChange so UserPasswordChangeForm can v-model it
+    const passwordChangeProxy = computed({
+      get: () => props.passwordChange,
+      set: (v) => emit('update:password-change', v),
+    });
+
+    const { handleSubmit, setValues } = useForm();
+
+    const {
+      value: _userName,
+      errorMessage: userNameError,
+      meta: userNameMeta,
+    } = useField('user_name', 'required|min:2|max:50');
+
+    const {
+      value: _userEmail,
+      errorMessage: emailError,
+      meta: emailMeta,
+    } = useField('email', 'required|email');
+
+    const { value: _orcid, errorMessage: orcidError, meta: orcidMeta } = useField('orcid');
+
+    const {
+      value: _abbreviation,
+      errorMessage: abbreviationError,
+      meta: abbreviationMeta,
+    } = useField('abbreviation', 'required');
+
+    const {
+      value: _firstName,
+      errorMessage: firstNameError,
+      meta: firstNameMeta,
+    } = useField('first_name', 'required|min:2|max:50');
+
+    const {
+      value: _familyName,
+      errorMessage: familyNameError,
+      meta: familyNameMeta,
+    } = useField('family_name', 'required|min:2|max:50');
+
+    const {
+      value: _userRole,
+      errorMessage: userRoleError,
+      meta: userRoleMeta,
+    } = useField('user_role', 'required');
+
+    const local = ref<Partial<UserSummary>>({});
+
+    const roleSelectOptions = computed(() => [
+      { value: 'Administrator', text: 'Administrator' },
+      { value: 'Curator', text: 'Curator' },
+      { value: 'Reviewer', text: 'Reviewer' },
+      { value: 'Viewer', text: 'Viewer' },
+    ]);
+
+    watch(
+      () => props.user,
+      (next) => {
+        if (next) {
+          local.value = { ...next };
+          setValues({
+            user_name: next.user_name ?? '',
+            email: next.email ?? '',
+            orcid: next.orcid ?? '',
+            abbreviation: next.abbreviation ?? '',
+            first_name: next.first_name ?? '',
+            family_name: next.family_name ?? '',
+            user_role: next.user_role ?? '',
+          });
+        }
+      },
+      { immediate: true },
+    );
+
+    function onSubmit(): void {
+      handleSubmit(() => emit('submit', { ...local.value }))();
+    }
+
+    return {
+      modalId,
+      proxyVisible,
+      passwordChangeProxy,
+      local,
+      roleSelectOptions,
+      onSubmit,
+      userNameError,
+      userNameMeta,
+      emailError,
+      emailMeta,
+      orcidError,
+      orcidMeta,
+      abbreviationError,
+      abbreviationMeta,
+      firstNameError,
+      firstNameMeta,
+      familyNameError,
+      familyNameMeta,
+      userRoleError,
+      userRoleMeta,
+    };
+  },
+});
+</script>

--- a/app/src/views/admin/components/UserUpdateModal.vue
+++ b/app/src/views/admin/components/UserUpdateModal.vue
@@ -281,10 +281,6 @@ export default defineComponent({
   props: {
     visible: { type: Boolean, default: false },
     user: { type: Object as PropType<Partial<UserSummary> | null>, default: null },
-    roleOptions: {
-      type: Array as PropType<Array<{ value: string; text: string }>>,
-      default: () => [],
-    },
     passwordChange: {
       type: Object as PropType<PasswordChangeModel>,
       required: true,

--- a/app/src/views/admin/composables/__tests__/useBulkUserActions.spec.ts
+++ b/app/src/views/admin/composables/__tests__/useBulkUserActions.spec.ts
@@ -1,0 +1,92 @@
+// app/src/views/admin/composables/__tests__/useBulkUserActions.spec.ts
+/**
+ * Unit tests for `useBulkUserActions` — the bulk-operations composable
+ * extracted from `ManageUser.vue` during W1 of v11.2 monolith-cleanup.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
+
+vi.mock('axios', () => {
+  const axiosMock = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: {
+      request: { use: vi.fn(), _cb: null },
+      response: { use: vi.fn() },
+    },
+    isAxiosError: (err: unknown): boolean =>
+      typeof err === 'object' && err !== null && 'isAxiosError' in err,
+  };
+  return {
+    default: axiosMock,
+    ...axiosMock,
+    AxiosHeaders: class {
+      private store = new Map<string, string>();
+      has(key: string): boolean { return this.store.has(key.toLowerCase()); }
+      get(key: string): string | null { return this.store.get(key.toLowerCase()) ?? null; }
+      set(key: string, value: string): this { this.store.set(key.toLowerCase(), value); return this; }
+    },
+    AxiosError: Error,
+  };
+});
+
+vi.mock('@/router', () => ({
+  default: {
+    push: vi.fn(),
+    currentRoute: { value: { fullPath: '/admin/manage-user' } },
+  },
+}));
+
+import { useBulkUserActions } from '../useBulkUserActions';
+
+interface AxiosMock { post: ReturnType<typeof vi.fn> }
+async function getAxiosMock(): Promise<AxiosMock> {
+  const axios = await import('axios');
+  return axios.default as unknown as AxiosMock;
+}
+
+describe('useBulkUserActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('bulkApprove POSTs user_ids and toggles bulkActing', async () => {
+    const axios = await getAxiosMock();
+    axios.post.mockResolvedValueOnce({ status: 200, data: { processed: 3 } });
+    const a = useBulkUserActions();
+    expect(a.bulkActing.value).toBe(false);
+    const p = a.bulkApprove([1, 2, 3]);
+    expect(a.bulkActing.value).toBe(true);
+    await p;
+    await flushPromises();
+    expect(a.bulkActing.value).toBe(false);
+  });
+
+  it('bulkAssignRole POSTs user_ids + role and rejects empty selection or empty role', async () => {
+    const axios = await getAxiosMock();
+    let received: any = null;
+    axios.post.mockImplementationOnce((_url: string, data: any) => {
+      received = data;
+      return Promise.resolve({ status: 200, data: { processed: 2 } });
+    });
+    const a = useBulkUserActions();
+    await expect(a.bulkAssignRole([], 'Curator')).rejects.toThrow();
+    await expect(a.bulkAssignRole([1, 2], '')).rejects.toThrow();
+    await a.bulkAssignRole([1, 2], 'Curator');
+    await flushPromises();
+    expect(received).toEqual({ user_ids: [1, 2], role: 'Curator' });
+  });
+
+  it('bulkDelete POSTs user_ids and clears bulkActing on success', async () => {
+    const axios = await getAxiosMock();
+    axios.post.mockResolvedValueOnce({ status: 200, data: { processed: 2 } });
+    const a = useBulkUserActions();
+    await a.bulkDelete([1, 2]);
+    await flushPromises();
+    expect(a.bulkActing.value).toBe(false);
+  });
+});

--- a/app/src/views/admin/composables/__tests__/useUserData.spec.ts
+++ b/app/src/views/admin/composables/__tests__/useUserData.spec.ts
@@ -1,0 +1,146 @@
+// app/src/views/admin/composables/__tests__/useUserData.spec.ts
+/**
+ * Unit tests for `useUserData` — the data-loading composable extracted
+ * from `ManageUser.vue` during W1 of v11.2 monolith-cleanup.
+ *
+ * Mock strategy: stub `axios` at the module level (matching the W6 Review.vue
+ * composable precedent in `src/views/review/composables/__tests__/`).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
+
+vi.mock('axios', () => {
+  const axiosMock = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: {
+      request: {
+        use: vi.fn(),
+        _cb: null,
+      },
+      response: {
+        use: vi.fn(),
+      },
+    },
+    isAxiosError: (err: unknown): boolean =>
+      typeof err === 'object' && err !== null && 'isAxiosError' in err,
+  };
+  return {
+    default: axiosMock,
+    ...axiosMock,
+    AxiosHeaders: class {
+      private store = new Map<string, string>();
+      has(key: string): boolean { return this.store.has(key.toLowerCase()); }
+      get(key: string): string | null { return this.store.get(key.toLowerCase()) ?? null; }
+      set(key: string, value: string): this { this.store.set(key.toLowerCase(), value); return this; }
+    },
+    AxiosError: Error,
+  };
+});
+
+vi.mock('@/router', () => ({
+  default: {
+    push: vi.fn(),
+    currentRoute: { value: { fullPath: '/admin/manage-user' } },
+  },
+}));
+
+import { __resetUserDataCache, useUserData } from '../useUserData';
+
+interface AxiosMock { get: ReturnType<typeof vi.fn> }
+async function getAxiosMock(): Promise<AxiosMock> {
+  const axios = await import('axios');
+  return axios.default as unknown as AxiosMock;
+}
+
+const userTablePayload = {
+  data: [
+    { user_id: 1, user_name: 'alice', email: 'alice@example.org', user_role: 'Curator', approved: 1 },
+    { user_id: 2, user_name: 'bob', email: 'bob@example.org', user_role: 'Reviewer', approved: 1 },
+  ],
+  meta: [
+    {
+      totalItems: 2,
+      currentPage: 1,
+      totalPages: 1,
+      prevItemID: 0,
+      currentItemID: 0,
+      nextItemID: 0,
+      lastItemID: 0,
+      executionTime: 5,
+      fspec: [],
+    },
+  ],
+};
+
+describe('useUserData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetUserDataCache();
+  });
+
+  it('loadData populates users and meta', async () => {
+    const axios = await getAxiosMock();
+    axios.get.mockResolvedValueOnce({ status: 200, data: userTablePayload });
+    const data = useUserData();
+    expect(data.users.value).toEqual([]);
+    await data.loadDataNow();
+    await flushPromises();
+    expect(data.users.value).toHaveLength(2);
+    expect(data.totalRows.value).toBe(2);
+    expect(data.totalPages.value).toBe(1);
+  });
+
+  it('loadData error path surfaces via toast hook and clears isBusy', async () => {
+    const axios = await getAxiosMock();
+    const err = new Error('boom');
+    axios.get.mockRejectedValueOnce(err);
+    const toasts: Array<unknown[]> = [];
+    const data = useUserData({ onToast: (...args: unknown[]) => toasts.push(args) });
+    await data.loadDataNow();
+    await flushPromises();
+    expect(data.isBusy.value).toBe(false);
+    expect(toasts).toHaveLength(1);
+  });
+
+  it('loadRoleList populates role_options', async () => {
+    const axios = await getAxiosMock();
+    axios.get.mockResolvedValueOnce({
+      status: 200,
+      data: [{ role: 'Administrator' }, { role: 'Curator' }],
+    });
+    const data = useUserData();
+    await data.loadRoleList();
+    await flushPromises();
+    expect(data.roleOptions.value).toEqual([
+      { value: 'Administrator', text: 'Administrator' },
+      { value: 'Curator', text: 'Curator' },
+    ]);
+  });
+
+  it('handlePageChange triggers a second loadData call', async () => {
+    const axios = await getAxiosMock();
+    axios.get.mockResolvedValue({ status: 200, data: userTablePayload });
+    const data = useUserData();
+    await data.loadDataNow();
+    await flushPromises();
+    expect(axios.get).toHaveBeenCalledTimes(1);
+    // Reset cache so the second call (with same params) isn't deduped
+    __resetUserDataCache();
+    data.handlePageChange(2);
+    await new Promise((r) => setTimeout(r, 80)); // wait past 50ms debounce
+    await flushPromises();
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('removeFilters clears every filter content', async () => {
+    const data = useUserData();
+    data.filter.value.user_name.content = 'alice';
+    data.removeFilters();
+    expect(data.filter.value.user_name.content).toBeNull();
+  });
+});

--- a/app/src/views/admin/composables/__tests__/useUserModals.spec.ts
+++ b/app/src/views/admin/composables/__tests__/useUserModals.spec.ts
@@ -1,0 +1,60 @@
+// app/src/views/admin/composables/__tests__/useUserModals.spec.ts
+/**
+ * Unit tests for `useUserModals` — the modal state composable extracted
+ * from `ManageUser.vue` during W1 of v11.2 monolith-cleanup.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { useUserModals } from '../useUserModals';
+
+describe('useUserModals', () => {
+  it('promptDelete sets target and opens delete modal', () => {
+    const m = useUserModals();
+    m.promptDelete({ user_id: 1, user_name: 'alice' } as any);
+    expect(m.isDeleteOpen.value).toBe(true);
+    expect(m.userToDelete.value.user_id).toBe(1);
+  });
+
+  it('editUser sets target with a clone (no aliasing) and opens update modal', () => {
+    const m = useUserModals();
+    const original = { user_id: 1, user_name: 'alice', orcid: '0000' } as any;
+    m.editUser(original);
+    expect(m.isUpdateOpen.value).toBe(true);
+    expect(m.userToUpdate.value).not.toBe(original);
+    expect(m.userToUpdate.value.user_id).toBe(1);
+    m.userToUpdate.value.user_name = 'changed';
+    expect(original.user_name).toBe('alice');
+  });
+
+  it('openBulkApprove rejects empty selection', () => {
+    const m = useUserModals();
+    expect(() => m.openBulkApprove([], [])).toThrow();
+    expect(m.isBulkApproveOpen.value).toBe(false);
+  });
+
+  it('openBulkApprove with users opens modal and exposes usernames', () => {
+    const m = useUserModals();
+    m.openBulkApprove([1, 2], [
+      { user_id: 1, user_name: 'alice', user_role: 'Curator' } as any,
+      { user_id: 2, user_name: 'bob', user_role: 'Reviewer' } as any,
+    ]);
+    expect(m.isBulkApproveOpen.value).toBe(true);
+    expect(m.bulkApproveUsernames.value).toEqual(['alice', 'bob']);
+  });
+
+  it('openBulkDelete blocks if any selected user is Administrator', () => {
+    const m = useUserModals();
+    expect(() =>
+      m.openBulkDelete([1], [{ user_id: 1, user_name: 'root', user_role: 'Administrator' } as any]),
+    ).toThrow();
+    expect(m.isBulkDeleteOpen.value).toBe(false);
+  });
+
+  it('close resets every modal flag and target', () => {
+    const m = useUserModals();
+    m.promptDelete({ user_id: 1, user_name: 'alice' } as any);
+    m.close();
+    expect(m.isDeleteOpen.value).toBe(false);
+    expect(m.userToDelete.value).toEqual({});
+  });
+});

--- a/app/src/views/admin/composables/__tests__/useUserMutations.spec.ts
+++ b/app/src/views/admin/composables/__tests__/useUserMutations.spec.ts
@@ -1,0 +1,128 @@
+// app/src/views/admin/composables/__tests__/useUserMutations.spec.ts
+/**
+ * Unit tests for `useUserMutations` — the single-user CRUD composable
+ * extracted from `ManageUser.vue` during W1 of v11.2 monolith-cleanup.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
+
+vi.mock('axios', () => {
+  const axiosMock = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: {
+      request: { use: vi.fn(), _cb: null },
+      response: { use: vi.fn() },
+    },
+    isAxiosError: (err: unknown): boolean =>
+      typeof err === 'object' && err !== null && 'isAxiosError' in err,
+  };
+  return {
+    default: axiosMock,
+    ...axiosMock,
+    AxiosHeaders: class {
+      private store = new Map<string, string>();
+      has(key: string): boolean { return this.store.has(key.toLowerCase()); }
+      get(key: string): string | null { return this.store.get(key.toLowerCase()) ?? null; }
+      set(key: string, value: string): this { this.store.set(key.toLowerCase(), value); return this; }
+    },
+    AxiosError: Error,
+  };
+});
+
+vi.mock('@/router', () => ({
+  default: {
+    push: vi.fn(),
+    currentRoute: { value: { fullPath: '/admin/manage-user' } },
+  },
+}));
+
+import { useUserMutations } from '../useUserMutations';
+
+interface AxiosMock {
+  put: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+}
+async function getAxiosMock(): Promise<AxiosMock> {
+  const axios = await import('axios');
+  return axios.default as unknown as AxiosMock;
+}
+
+describe('useUserMutations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('deleteUser DELETE succeeds and invokes onSuccess', async () => {
+    const axios = await getAxiosMock();
+    axios.delete.mockResolvedValueOnce({ status: 200, data: { ok: true } });
+    let succeeded = false;
+    const m = useUserMutations({ onSuccess: () => { succeeded = true; } });
+    await m.deleteUser({ user_id: 7 } as any);
+    await flushPromises();
+    expect(succeeded).toBe(true);
+  });
+
+  it('updateUser PUT sends only intended fields and surfaces success', async () => {
+    const axios = await getAxiosMock();
+    let received: any = null;
+    axios.put.mockImplementationOnce((_url: string, data: any) => {
+      received = data;
+      return Promise.resolve({ status: 200, data: { ok: true } });
+    });
+    const m = useUserMutations();
+    await m.updateUser({
+      user_id: 7,
+      user_name: 'alice',
+      email: 'alice@example.org',
+      abbreviation: 'AL',
+      first_name: 'Alice',
+      family_name: 'Liddell',
+      user_role: 'Curator',
+      approved: true,
+      orcid: '',
+      comment: '',
+    } as any);
+    await flushPromises();
+    expect(received.user_details.user_id).toBe(7);
+    expect(received.user_details.approved).toBe(1);
+    // empty strings are omitted from the wire payload
+    expect(received.user_details.orcid).toBeUndefined();
+    expect(received.user_details.comment).toBeUndefined();
+  });
+
+  it('changePassword PUT toggles isChangingPassword', async () => {
+    const axios = await getAxiosMock();
+    axios.put.mockResolvedValueOnce({ status: 200, data: { ok: true } });
+    const m = useUserMutations();
+    expect(m.isChangingPassword.value).toBe(false);
+    const promise = m.changePassword({ userId: 7, newPassword: 'Aa!1aaaaaaaaaaaa', confirmPassword: 'Aa!1aaaaaaaaaaaa' });
+    expect(m.isChangingPassword.value).toBe(true);
+    await promise;
+    await flushPromises();
+    expect(m.isChangingPassword.value).toBe(false);
+  });
+
+  it('changePassword rejects on mismatch without firing the request', async () => {
+    const axios = await getAxiosMock();
+    const m = useUserMutations();
+    await expect(
+      m.changePassword({ userId: 7, newPassword: 'Aa!1aaaaaaaaaaaa', confirmPassword: 'mismatch' }),
+    ).rejects.toThrow();
+    expect(axios.put).not.toHaveBeenCalled();
+  });
+
+  it('generatePassword returns a 16-char string with at least one of each required class', () => {
+    const m = useUserMutations();
+    const pw = m.generatePassword();
+    expect(pw.length).toBe(16);
+    expect(/[a-z]/.test(pw)).toBe(true);
+    expect(/[A-Z]/.test(pw)).toBe(true);
+    expect(/[0-9]/.test(pw)).toBe(true);
+    expect(/[!@#$%^&*]/.test(pw)).toBe(true);
+  });
+});

--- a/app/src/views/admin/composables/useBulkUserActions.ts
+++ b/app/src/views/admin/composables/useBulkUserActions.ts
@@ -1,0 +1,112 @@
+// app/src/views/admin/composables/useBulkUserActions.ts
+import { ref } from 'vue';
+import { apiClient } from '@/api/client';
+
+const apiBase = import.meta.env.VITE_API_URL ?? '';
+
+export interface UseBulkUserActionsOptions {
+  onToast?: (...args: unknown[]) => void;
+  onSuccess?: () => void;
+}
+
+export function useBulkUserActions(options: UseBulkUserActionsOptions = {}) {
+  const { onToast, onSuccess } = options;
+  const bulkActing = ref(false);
+
+  function ensureNonEmpty(ids: number[], action: string): void {
+    if (ids.length === 0) {
+      const err = new Error(`No users selected for ${action}`);
+      onToast?.(err.message, action, 'warning');
+      throw err;
+    }
+  }
+
+  async function bulkApprove(userIds: number[]): Promise<void> {
+    ensureNonEmpty(userIds, 'Bulk Approve');
+    bulkActing.value = true;
+    try {
+      const response = await apiClient.raw.post(`${apiBase}/api/user/bulk_approve`, {
+        user_ids: userIds,
+      });
+      if (response.status === 200) {
+        onToast?.(
+          `Successfully approved ${response.data.processed || userIds.length} users`,
+          'Bulk Approve Complete',
+          'success',
+          true,
+          5000,
+        );
+        onSuccess?.();
+      }
+    } catch (e: any) {
+      const errorMsg =
+        e.response?.data?.message || e.response?.data?.error || 'Unknown error';
+      onToast?.(errorMsg, 'Bulk Approve Failed', 'danger');
+      throw e;
+    } finally {
+      bulkActing.value = false;
+    }
+  }
+
+  async function bulkAssignRole(userIds: number[], role: string): Promise<void> {
+    ensureNonEmpty(userIds, 'Assign Role');
+    if (!role) {
+      const err = new Error('Please select a role');
+      onToast?.(err.message, 'Invalid Role', 'warning');
+      throw err;
+    }
+    bulkActing.value = true;
+    try {
+      const response = await apiClient.raw.post(`${apiBase}/api/user/bulk_assign_role`, {
+        user_ids: userIds,
+        role,
+      });
+      if (response.status === 200) {
+        onToast?.(
+          `Successfully assigned ${role} role to ${response.data.processed || userIds.length} users`,
+          'Bulk Role Assignment Complete',
+          'success',
+          true,
+          5000,
+        );
+        onSuccess?.();
+      }
+    } catch (e: any) {
+      const errorMsg =
+        e.response?.data?.message || e.response?.data?.error || 'Unknown error';
+      onToast?.(errorMsg, 'Bulk Role Assignment Failed', 'danger');
+      throw e;
+    } finally {
+      bulkActing.value = false;
+    }
+  }
+
+  async function bulkDelete(userIds: number[]): Promise<void> {
+    ensureNonEmpty(userIds, 'Bulk Delete');
+    bulkActing.value = true;
+    try {
+      const response = await apiClient.raw.post(`${apiBase}/api/user/bulk_delete`, {
+        user_ids: userIds,
+      });
+      if (response.status === 200) {
+        onToast?.(
+          `Successfully deleted ${response.data.processed || userIds.length} users`,
+          'Bulk Delete Complete',
+          'success',
+          true,
+          5000,
+        );
+        onSuccess?.();
+      }
+    } catch (e: any) {
+      const errorMsg =
+        e.response?.data?.message || e.response?.data?.error || 'Unknown error';
+      onToast?.(errorMsg, 'Bulk Delete Failed', 'danger');
+      throw e;
+    } finally {
+      bulkActing.value = false;
+    }
+  }
+
+  return { bulkActing, bulkApprove, bulkAssignRole, bulkDelete };
+}

--- a/app/src/views/admin/composables/useBulkUserActions.ts
+++ b/app/src/views/admin/composables/useBulkUserActions.ts
@@ -29,8 +29,9 @@ export function useBulkUserActions(options: UseBulkUserActionsOptions = {}) {
         user_ids: userIds,
       });
       if (response.status === 200) {
+        const processed = (response.data as { processed?: number }).processed;
         onToast?.(
-          `Successfully approved ${response.data.processed || userIds.length} users`,
+          `Successfully approved ${processed || userIds.length} users`,
           'Bulk Approve Complete',
           'success',
           true,
@@ -62,8 +63,9 @@ export function useBulkUserActions(options: UseBulkUserActionsOptions = {}) {
         role,
       });
       if (response.status === 200) {
+        const processed = (response.data as { processed?: number }).processed;
         onToast?.(
-          `Successfully assigned ${role} role to ${response.data.processed || userIds.length} users`,
+          `Successfully assigned ${role} role to ${processed || userIds.length} users`,
           'Bulk Role Assignment Complete',
           'success',
           true,
@@ -89,8 +91,9 @@ export function useBulkUserActions(options: UseBulkUserActionsOptions = {}) {
         user_ids: userIds,
       });
       if (response.status === 200) {
+        const processed = (response.data as { processed?: number }).processed;
         onToast?.(
-          `Successfully deleted ${response.data.processed || userIds.length} users`,
+          `Successfully deleted ${processed || userIds.length} users`,
           'Bulk Delete Complete',
           'success',
           true,

--- a/app/src/views/admin/composables/useUserData.ts
+++ b/app/src/views/admin/composables/useUserData.ts
@@ -1,4 +1,4 @@
-import { computed, nextTick, ref } from 'vue';
+import { nextTick, ref } from 'vue';
 
 import { apiClient } from '@/api/client';
 import { useTableData, useExcelExport, useFilterPresets, useUrlParsing } from '@/composables';

--- a/app/src/views/admin/composables/useUserData.ts
+++ b/app/src/views/admin/composables/useUserData.ts
@@ -132,7 +132,7 @@ export function useUserData(options: UseUserDataOptions = {}) {
   async function loadRoleList(): Promise<void> {
     try {
       const response = await apiClient.raw.get(`${apiBase}/api/user/role_list`);
-      role_options.value = response.data.map((item: { role: string }) => ({
+      role_options.value = (response.data as Array<{ role: string }>).map((item) => ({
         value: item.role,
         text: item.role,
       }));
@@ -146,13 +146,13 @@ export function useUserData(options: UseUserDataOptions = {}) {
       const response = await apiClient.raw.get(
         `${apiBase}/api/user/list?roles=Curator,Reviewer`,
       );
-      user_options.value = response.data.map(
-        (item: { user_id: number; user_name: string; user_role: string }) => ({
-          value: item.user_id,
-          text: item.user_name,
-          role: item.user_role,
-        }),
-      );
+      user_options.value = (
+        response.data as Array<{ user_id: number; user_name: string; user_role: string }>
+      ).map((item) => ({
+        value: item.user_id,
+        text: item.user_name,
+        role: item.user_role,
+      }));
     } catch (e) {
       onToast?.(e, 'Error', 'danger');
     }
@@ -243,7 +243,7 @@ export function useUserData(options: UseUserDataOptions = {}) {
     const preset = filterPresets.loadPreset(name);
     if (!preset) return false;
     Object.keys(preset).forEach((key) => {
-      if (filter.value[key]) filter.value[key] = preset[key];
+      if (filter.value[key]) filter.value[key] = preset[key] as FilterEntry;
     });
     filtered();
     return true;

--- a/app/src/views/admin/composables/useUserData.ts
+++ b/app/src/views/admin/composables/useUserData.ts
@@ -285,8 +285,6 @@ export function useUserData(options: UseUserDataOptions = {}) {
     loadDataNow,
     loadRoleList,
     loadUserList,
-    applyApiResponse,
-    updateBrowserUrl,
     filtered,
     handlePageChange,
     handlePerPageChange,

--- a/app/src/views/admin/composables/useUserData.ts
+++ b/app/src/views/admin/composables/useUserData.ts
@@ -1,0 +1,303 @@
+import { computed, nextTick, ref } from 'vue';
+
+import { apiClient } from '@/api/client';
+import { useTableData, useExcelExport, useFilterPresets, useUrlParsing } from '@/composables';
+
+// Module-level dedup cache (preserves the existing semantics from ManageUser.vue line 760).
+let moduleLastApiParams: string | null = null;
+let moduleLastApiCallTime = 0;
+let moduleApiCallInProgress = false;
+let moduleLastApiResponse: unknown = null;
+
+/** Reset the module-level cache — for use in tests only. */
+export function __resetUserDataCache(): void {
+  moduleLastApiParams = null;
+  moduleLastApiCallTime = 0;
+  moduleApiCallInProgress = false;
+  moduleLastApiResponse = null;
+}
+
+export interface FilterEntry {
+  content: string | null;
+  join_char: string | null;
+  operator: string;
+}
+
+export type ManageUserFilter = Record<string, FilterEntry>;
+
+export interface RoleOption {
+  value: string;
+  text: string;
+}
+
+export interface UserOption {
+  value: number;
+  text: string;
+  role: string;
+}
+
+export interface UseUserDataOptions {
+  onToast?: (...args: unknown[]) => void;
+  onScrollbarUpdate?: () => void;
+}
+
+export function useUserData(options: UseUserDataOptions = {}) {
+  const { onToast, onScrollbarUpdate } = options;
+  const apiBase = import.meta.env.VITE_API_URL ?? '';
+
+  const tableData = useTableData({
+    pageSizeInput: 25,
+    sortInput: '+user_name',
+    pageAfterInput: '0',
+  });
+  const { filterObjToStr, filterStrToObj, sortStringToVariables } = useUrlParsing();
+  const filterPresets = useFilterPresets('sysndd-manage-user-presets');
+  const { isExporting, exportToExcel } = useExcelExport();
+
+  const users = ref<Array<Record<string, unknown>>>([]);
+  const role_options = ref<RoleOption[]>([]);
+  const user_options = ref<UserOption[]>([]);
+  const totalPages = ref(0);
+  const isInitializing = ref(true);
+  let loadDataDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const filter = ref<ManageUserFilter>({
+    any: { content: null, join_char: null, operator: 'contains' },
+    user_name: { content: null, join_char: null, operator: 'contains' },
+    email: { content: null, join_char: null, operator: 'contains' },
+    user_role: { content: null, join_char: ',', operator: 'any' },
+    approved: { content: null, join_char: null, operator: 'equals' },
+    abbreviation: { content: null, join_char: null, operator: 'contains' },
+    first_name: { content: null, join_char: null, operator: 'contains' },
+    family_name: { content: null, join_char: null, operator: 'contains' },
+    orcid: { content: null, join_char: null, operator: 'contains' },
+    comment: { content: null, join_char: null, operator: 'contains' },
+  });
+
+  function applyApiResponse(data: any): void {
+    users.value = data.data;
+    tableData.totalRows.value = data.meta[0].totalItems;
+    nextTick(() => {
+      tableData.currentPage.value = data.meta[0].currentPage;
+    });
+    totalPages.value = data.meta[0].totalPages;
+    tableData.prevItemID.value = Number(data.meta[0].prevItemID) || 0;
+    tableData.currentItemID.value = Number(data.meta[0].currentItemID) || 0;
+    tableData.nextItemID.value = Number(data.meta[0].nextItemID) || 0;
+    tableData.lastItemID.value = Number(data.meta[0].lastItemID) || 0;
+    tableData.executionTime.value = data.meta[0].executionTime;
+    onScrollbarUpdate?.();
+  }
+
+  async function doLoadData(): Promise<void> {
+    const urlParam = `sort=${tableData.sort.value}&filter=${tableData.filter_string.value}&page_after=${tableData.currentItemID.value}&page_size=${tableData.perPage.value}`;
+    const now = Date.now();
+    if (moduleLastApiParams === urlParam && now - moduleLastApiCallTime < 500) {
+      if (moduleLastApiResponse) applyApiResponse(moduleLastApiResponse);
+      return;
+    }
+    if (moduleApiCallInProgress && moduleLastApiParams === urlParam) return;
+    moduleLastApiParams = urlParam;
+    moduleLastApiCallTime = now;
+    moduleApiCallInProgress = true;
+    tableData.isBusy.value = true;
+
+    try {
+      const response = await apiClient.raw.get(`${apiBase}/api/user/table?${urlParam}`);
+      moduleApiCallInProgress = false;
+      moduleLastApiResponse = response.data;
+      applyApiResponse(response.data);
+      updateBrowserUrl();
+    } catch (e) {
+      moduleApiCallInProgress = false;
+      onToast?.(e, 'Error', 'danger');
+    } finally {
+      tableData.isBusy.value = false;
+    }
+  }
+
+  function loadData(): void {
+    if (loadDataDebounceTimer) clearTimeout(loadDataDebounceTimer);
+    loadDataDebounceTimer = setTimeout(() => {
+      loadDataDebounceTimer = null;
+      void doLoadData();
+    }, 50);
+  }
+
+  // Bypasses debounce for tests + first-paint
+  async function loadDataNow(): Promise<void> {
+    return doLoadData();
+  }
+
+  async function loadRoleList(): Promise<void> {
+    try {
+      const response = await apiClient.raw.get(`${apiBase}/api/user/role_list`);
+      role_options.value = response.data.map((item: { role: string }) => ({
+        value: item.role,
+        text: item.role,
+      }));
+    } catch (e) {
+      onToast?.(e, 'Error', 'danger');
+    }
+  }
+
+  async function loadUserList(): Promise<void> {
+    try {
+      const response = await apiClient.raw.get(
+        `${apiBase}/api/user/list?roles=Curator,Reviewer`,
+      );
+      user_options.value = response.data.map(
+        (item: { user_id: number; user_name: string; user_role: string }) => ({
+          value: item.user_id,
+          text: item.user_name,
+          role: item.user_role,
+        }),
+      );
+    } catch (e) {
+      onToast?.(e, 'Error', 'danger');
+    }
+  }
+
+  function updateBrowserUrl(): void {
+    if (isInitializing.value) return;
+    const searchParams = new URLSearchParams();
+    if (tableData.sort.value) searchParams.set('sort', tableData.sort.value);
+    if (tableData.filter_string.value) searchParams.set('filter', tableData.filter_string.value);
+    if (tableData.currentItemID.value > 0) {
+      searchParams.set('page_after', String(tableData.currentItemID.value));
+    }
+    searchParams.set('page_size', String(tableData.perPage.value));
+    const newUrl = `${window.location.pathname}?${searchParams.toString()}`;
+    window.history.replaceState({ ...window.history.state }, '', newUrl);
+  }
+
+  function filtered(): void {
+    const next = filterObjToStr(filter.value);
+    if (next !== tableData.filter_string.value) tableData.filter_string.value = next;
+    loadData();
+  }
+
+  function handlePageChange(value: number): void {
+    if (value === 1) tableData.currentItemID.value = 0;
+    else if (value === totalPages.value)
+      tableData.currentItemID.value = Number(tableData.lastItemID.value) || 0;
+    else if (value > tableData.currentPage.value)
+      tableData.currentItemID.value = Number(tableData.nextItemID.value) || 0;
+    else if (value < tableData.currentPage.value)
+      tableData.currentItemID.value = Number(tableData.prevItemID.value) || 0;
+    filtered();
+  }
+
+  function handlePerPageChange(newPerPage: number | string): void {
+    tableData.perPage.value = parseInt(String(newPerPage), 10);
+    tableData.currentItemID.value = 0;
+    filtered();
+  }
+
+  function handleSortByOrDescChange(): void {
+    tableData.currentItemID.value = 0;
+    const sortColumn = tableData.sortBy.value.length > 0 ? tableData.sortBy.value[0].key : '';
+    const sortOrder = tableData.sortBy.value.length > 0 ? tableData.sortBy.value[0].order : 'asc';
+    tableData.sort.value = (sortOrder === 'desc' ? '-' : '+') + sortColumn;
+    filtered();
+  }
+
+  function handleSortUpdate(newSortBy: Array<{ key: string; order: 'asc' | 'desc' }>): void {
+    tableData.sortBy.value = newSortBy;
+    handleSortByOrDescChange();
+  }
+
+  function removeFilters(): void {
+    Object.keys(filter.value).forEach((key) => {
+      const entry = filter.value[key];
+      if (entry && typeof entry === 'object' && 'content' in entry) entry.content = null;
+    });
+    filtered();
+  }
+
+  function clearFilter(key: string): void {
+    if (filter.value[key]) filter.value[key].content = null;
+    filtered();
+  }
+
+  function handleExport(): void {
+    exportToExcel(users.value, {
+      filename: `users_export_${new Date().toISOString().split('T')[0]}`,
+      sheetName: 'Users',
+      headers: {
+        user_name: 'User Name',
+        email: 'Email',
+        user_role: 'Role',
+        approved: 'Approved',
+        abbreviation: 'Abbreviation',
+        first_name: 'First Name',
+        family_name: 'Family Name',
+        orcid: 'ORCID',
+        comment: 'Comment',
+        created_at: 'Created',
+      },
+    });
+  }
+
+  function loadFilterPreset(name: string): boolean {
+    const preset = filterPresets.loadPreset(name);
+    if (!preset) return false;
+    Object.keys(preset).forEach((key) => {
+      if (filter.value[key]) filter.value[key] = preset[key];
+    });
+    filtered();
+    return true;
+  }
+
+  function deleteFilterPreset(name: string): void {
+    filterPresets.deletePreset(name);
+  }
+
+  function saveFilterPreset(name: string): void {
+    filterPresets.savePreset(name, JSON.parse(JSON.stringify(filter.value)));
+  }
+
+  function setInitialized(): void {
+    nextTick(() => {
+      isInitializing.value = false;
+    });
+  }
+
+  return {
+    // table-data passthrough (so the view doesn't need to re-pull useTableData)
+    ...tableData,
+    isExporting,
+    exportToExcel,
+    filterPresets,
+    filterObjToStr,
+    filterStrToObj,
+    sortStringToVariables,
+    // owned state
+    users,
+    role_options,
+    roleOptions: role_options, // canonical TS name
+    user_options,
+    totalPages,
+    filter,
+    isInitializing,
+    // actions
+    loadData,
+    loadDataNow,
+    loadRoleList,
+    loadUserList,
+    applyApiResponse,
+    updateBrowserUrl,
+    filtered,
+    handlePageChange,
+    handlePerPageChange,
+    handleSortByOrDescChange,
+    handleSortUpdate,
+    removeFilters,
+    clearFilter,
+    handleExport,
+    loadFilterPreset,
+    deleteFilterPreset,
+    saveFilterPreset,
+    setInitialized,
+  };
+}

--- a/app/src/views/admin/composables/useUserModals.ts
+++ b/app/src/views/admin/composables/useUserModals.ts
@@ -1,0 +1,122 @@
+// app/src/views/admin/composables/useUserModals.ts
+import { ref } from 'vue';
+
+export interface UserSummary {
+  user_id: number;
+  user_name: string;
+  user_role: string;
+  email?: string;
+  approved?: number | boolean;
+  abbreviation?: string;
+  first_name?: string;
+  family_name?: string;
+  orcid?: string;
+  comment?: string;
+}
+
+export interface UseUserModalsOptions {
+  onToast?: (...args: unknown[]) => void;
+}
+
+export function useUserModals(options: UseUserModalsOptions = {}) {
+  const { onToast } = options;
+
+  const isDeleteOpen = ref(false);
+  const isUpdateOpen = ref(false);
+  const isBulkApproveOpen = ref(false);
+  const isBulkDeleteOpen = ref(false);
+  const isBulkRoleOpen = ref(false);
+
+  const userToDelete = ref<Partial<UserSummary>>({});
+  const userToUpdate = ref<Partial<UserSummary>>({});
+  const bulkApproveUsernames = ref<string[]>([]);
+  const bulkDeleteUsernames = ref<string[]>([]);
+  const bulkRoleUsernames = ref<string[]>([]);
+  const deleteConfirmText = ref('');
+  const bulkRoleSelection = ref('');
+
+  function promptDelete(user: UserSummary): void {
+    userToDelete.value = user;
+    isDeleteOpen.value = true;
+  }
+
+  function editUser(user: UserSummary): void {
+    userToUpdate.value = { ...user };
+    isUpdateOpen.value = true;
+  }
+
+  function ensureNonEmpty(userIds: number[], action: string): void {
+    if (userIds.length === 0) {
+      const err = new Error('No users selected');
+      onToast?.(err.message, action, 'warning');
+      throw err;
+    }
+  }
+
+  function openBulkApprove(userIds: number[], allUsers: UserSummary[]): void {
+    ensureNonEmpty(userIds, 'Bulk Approve');
+    bulkApproveUsernames.value = allUsers
+      .filter((u) => userIds.includes(u.user_id))
+      .map((u) => u.user_name);
+    isBulkApproveOpen.value = true;
+  }
+
+  function openBulkDelete(userIds: number[], allUsers: UserSummary[]): void {
+    ensureNonEmpty(userIds, 'Bulk Delete');
+    const selected = allUsers.filter((u) => userIds.includes(u.user_id));
+    const admins = selected.filter((u) => u.user_role === 'Administrator');
+    if (admins.length > 0) {
+      const err = new Error(`Cannot delete: selection contains ${admins.length} admin user(s)`);
+      onToast?.(err.message, 'Delete Blocked', 'danger');
+      throw err;
+    }
+    bulkDeleteUsernames.value = selected.map((u) => u.user_name);
+    deleteConfirmText.value = '';
+    isBulkDeleteOpen.value = true;
+  }
+
+  function openBulkRole(userIds: number[], allUsers: UserSummary[]): void {
+    ensureNonEmpty(userIds, 'Assign Role');
+    bulkRoleUsernames.value = allUsers
+      .filter((u) => userIds.includes(u.user_id))
+      .map((u) => u.user_name);
+    bulkRoleSelection.value = '';
+    isBulkRoleOpen.value = true;
+  }
+
+  function close(): void {
+    isDeleteOpen.value = false;
+    isUpdateOpen.value = false;
+    isBulkApproveOpen.value = false;
+    isBulkDeleteOpen.value = false;
+    isBulkRoleOpen.value = false;
+    userToDelete.value = {};
+    userToUpdate.value = {};
+    bulkApproveUsernames.value = [];
+    bulkDeleteUsernames.value = [];
+    bulkRoleUsernames.value = [];
+    deleteConfirmText.value = '';
+    bulkRoleSelection.value = '';
+  }
+
+  return {
+    isDeleteOpen,
+    isUpdateOpen,
+    isBulkApproveOpen,
+    isBulkDeleteOpen,
+    isBulkRoleOpen,
+    userToDelete,
+    userToUpdate,
+    bulkApproveUsernames,
+    bulkDeleteUsernames,
+    bulkRoleUsernames,
+    deleteConfirmText,
+    bulkRoleSelection,
+    promptDelete,
+    editUser,
+    openBulkApprove,
+    openBulkDelete,
+    openBulkRole,
+    close,
+  };
+}

--- a/app/src/views/admin/composables/useUserMutations.ts
+++ b/app/src/views/admin/composables/useUserMutations.ts
@@ -42,19 +42,15 @@ export function useUserMutations(options: UseUserMutationsOptions = {}) {
 
   const passwordValidation = computed(() => {
     const pw = passwordChange.value.newPassword;
-    const hasLower = /[a-z]/.test(pw);
-    const hasUpper = /[A-Z]/.test(pw);
-    const hasNumber = /[0-9]/.test(pw);
-    const hasSpecial = /[!@#$%^&*]/.test(pw);
-    const longEnough = pw.length >= 12;
-    return {
-      isValid: hasLower && hasUpper && hasNumber && hasSpecial && longEnough,
-      hasLower,
-      hasUpper,
-      hasNumber,
-      hasSpecial,
-      longEnough,
+    const rules = {
+      minLength: { label: 'At least 8 characters', valid: pw.length >= 8 },
+      hasUppercase: { label: 'At least one uppercase letter', valid: /[A-Z]/.test(pw) },
+      hasLowercase: { label: 'At least one lowercase letter', valid: /[a-z]/.test(pw) },
+      hasNumber: { label: 'At least one number', valid: /[0-9]/.test(pw) },
+      hasSpecial: { label: 'At least one special character (!@#$%^&*)', valid: /[!@#$%^&*]/.test(pw) },
     };
+    const isValid = pw.length > 0 && Object.values(rules).every((r) => r.valid);
+    return { rules, isValid: pw.length > 0 ? isValid : null };
   });
 
   async function deleteUser(user: { user_id: number }): Promise<void> {

--- a/app/src/views/admin/composables/useUserMutations.ts
+++ b/app/src/views/admin/composables/useUserMutations.ts
@@ -1,0 +1,177 @@
+// app/src/views/admin/composables/useUserMutations.ts
+import { computed, ref } from 'vue';
+import { apiClient } from '@/api/client';
+
+const apiBase = import.meta.env.VITE_API_URL ?? '';
+
+export interface UseUserMutationsOptions {
+  onToast?: (...args: unknown[]) => void;
+  onSuccess?: () => void;
+}
+
+export interface ChangePasswordArgs {
+  userId: number;
+  newPassword: string;
+  confirmPassword: string;
+}
+
+export interface UpdateUserPayload {
+  user_id: number;
+  user_name: string;
+  email: string;
+  abbreviation: string;
+  first_name: string;
+  family_name: string;
+  user_role: string;
+  approved: boolean | number;
+  orcid?: string;
+  comment?: string;
+}
+
+export function useUserMutations(options: UseUserMutationsOptions = {}) {
+  const { onToast, onSuccess } = options;
+  const isUpdating = ref(false);
+  const isDeleting = ref(false);
+  const isChangingPassword = ref(false);
+
+  const passwordChange = ref({
+    newPassword: '',
+    confirmPassword: '',
+    showPassword: false,
+  });
+
+  const passwordValidation = computed(() => {
+    const pw = passwordChange.value.newPassword;
+    const hasLower = /[a-z]/.test(pw);
+    const hasUpper = /[A-Z]/.test(pw);
+    const hasNumber = /[0-9]/.test(pw);
+    const hasSpecial = /[!@#$%^&*]/.test(pw);
+    const longEnough = pw.length >= 12;
+    return {
+      isValid: hasLower && hasUpper && hasNumber && hasSpecial && longEnough,
+      hasLower,
+      hasUpper,
+      hasNumber,
+      hasSpecial,
+      longEnough,
+    };
+  });
+
+  async function deleteUser(user: { user_id: number }): Promise<void> {
+    isDeleting.value = true;
+    try {
+      const response = await apiClient.raw.delete(`${apiBase}/api/user/delete`, {
+        data: { user_id: user.user_id },
+      });
+      if (response.status === 200) {
+        onToast?.('User deleted successfully', 'Success', 'success');
+        onSuccess?.();
+      } else {
+        throw new Error('Failed to delete the user.');
+      }
+    } catch (e) {
+      onToast?.(e, 'Error', 'danger');
+      throw e;
+    } finally {
+      isDeleting.value = false;
+    }
+  }
+
+  async function updateUser(payload: UpdateUserPayload): Promise<void> {
+    isUpdating.value = true;
+    const updatePayload: Record<string, unknown> = {
+      user_id: payload.user_id,
+      user_name: payload.user_name,
+      email: payload.email,
+      abbreviation: payload.abbreviation,
+      first_name: payload.first_name,
+      family_name: payload.family_name,
+      user_role: payload.user_role,
+      approved: payload.approved ? 1 : 0,
+    };
+    if (payload.orcid) updatePayload.orcid = payload.orcid;
+    if (payload.comment) updatePayload.comment = payload.comment;
+    try {
+      const response = await apiClient.raw.put(`${apiBase}/api/user/update`, {
+        user_details: updatePayload,
+      });
+      if (response.status === 200) {
+        onToast?.('User updated successfully', 'Success', 'success');
+        onSuccess?.();
+      } else {
+        throw new Error('Failed to update the user.');
+      }
+    } catch (e) {
+      onToast?.(e, 'Error', 'danger');
+      throw e;
+    } finally {
+      isUpdating.value = false;
+    }
+  }
+
+  async function changePassword(args: ChangePasswordArgs): Promise<void> {
+    if (args.newPassword !== args.confirmPassword) {
+      const err = new Error('Passwords do not match');
+      onToast?.(err.message, 'Validation Error', 'warning');
+      throw err;
+    }
+    isChangingPassword.value = true;
+    try {
+      const response = await apiClient.raw.put(`${apiBase}/api/user/password/update`, {
+        user_id_pass_change: args.userId,
+        old_pass: '',
+        new_pass_1: args.newPassword,
+        new_pass_2: args.confirmPassword,
+      });
+      if (response.status !== 200) {
+        throw new Error('Failed to change password');
+      }
+      onToast?.(`Password changed successfully`, 'Password Changed', 'success', true, 5000);
+      passwordChange.value.newPassword = '';
+      passwordChange.value.confirmPassword = '';
+    } catch (e: any) {
+      const errorMsg =
+        e.response?.data?.message || e.response?.data?.error || 'Failed to change password';
+      onToast?.(errorMsg, 'Password Change Failed', 'danger');
+      throw e;
+    } finally {
+      isChangingPassword.value = false;
+    }
+  }
+
+  function generatePassword(): string {
+    const lower = 'abcdefghijklmnopqrstuvwxyz';
+    const upper = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    const numbers = '0123456789';
+    const special = '!@#$%^&*';
+    const required = [
+      lower[Math.floor(Math.random() * lower.length)],
+      upper[Math.floor(Math.random() * upper.length)],
+      numbers[Math.floor(Math.random() * numbers.length)],
+      special[Math.floor(Math.random() * special.length)],
+    ];
+    const all = lower + upper + numbers + special;
+    while (required.length < 16) required.push(all[Math.floor(Math.random() * all.length)]);
+    for (let i = required.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [required[i], required[j]] = [required[j], required[i]];
+    }
+    const pw = required.join('');
+    passwordChange.value.newPassword = pw;
+    passwordChange.value.confirmPassword = pw;
+    passwordChange.value.showPassword = true;
+    return pw;
+  }
+
+  return {
+    isUpdating,
+    isDeleting,
+    isChangingPassword,
+    passwordChange,
+    passwordValidation,
+    deleteUser,
+    updateUser,
+    changePassword,
+    generatePassword,
+  };
+}

--- a/app/src/views/curate/ManageReReview.spec.ts
+++ b/app/src/views/curate/ManageReReview.spec.ts
@@ -499,3 +499,118 @@ describe('ManageReReview.vue — apiClient Bearer header on every authed endpoin
     expect(sawCall).toBe(true);
   });
 });
+
+// ===========================================================================
+// Issue #29 — gene-atomic BAlert hint
+// Verifies that ManageReReview.vue renders/hides the boundary-gene warning
+// based on the previewBoundaryGene data property.
+// ===========================================================================
+describe('ManageReReview.vue — gene-atomic boundary-gene alert (issue #29)', () => {
+  // -------------------------------------------------------------------------
+  // Helper: mount with overridden data fields so we can drive the alert
+  // without triggering real HTTP calls.
+  // -------------------------------------------------------------------------
+  const mountWithBoundaryData = async (overrides: Record<string, unknown>): Promise<VueWrapper> => {
+    const wrapper = mount(ManageReReview, {
+      global: {
+        directives: {
+          'b-tooltip': {},
+          'b-toggle': {},
+        },
+        stubs: {
+          BContainer: { template: '<div><slot /></div>' },
+          BRow: { template: '<div><slot /></div>' },
+          BCol: { template: '<div><slot /></div>' },
+          BCard: { template: '<div><slot name="header" /><slot /></div>' },
+          BCollapse: { props: ['modelValue'], template: '<div><slot /></div>' },
+          BButton: { template: '<button><slot /></button>' },
+          BBadge: { template: '<span><slot /></span>' },
+          BLink: { template: '<a><slot /></a>' },
+          BSpinner: { template: '<div role="status" />' },
+          BTable: {
+            name: 'BTable',
+            props: ['items', 'fields'],
+            template: '<table><tbody><tr /></tbody></table>',
+          },
+          BPagination: { template: '<nav />' },
+          BFormInput: {
+            props: ['modelValue', 'type', 'placeholder', 'id', 'debounce', 'size', 'min', 'max'],
+            template: '<input />',
+          },
+          BFormSelect: {
+            props: ['modelValue', 'options', 'size', 'id', 'ariaLabel'],
+            template: '<select><slot /></select>',
+          },
+          BFormSelectOption: { props: ['value'], template: '<option><slot /></option>' },
+          BFormCheckbox: {
+            props: ['modelValue', 'switch', 'size', 'id'],
+            template: '<input type="checkbox" />',
+          },
+          BFormGroup: { template: '<div><slot name="label" /><slot /></div>' },
+          BForm: { template: '<form><slot /></form>' },
+          BOverlay: { template: '<div><slot /></div>' },
+          BInputGroup: { template: '<div><slot name="prepend" /><slot /></div>' },
+          BInputGroupText: { template: '<span><slot /></span>' },
+          BPopover: { template: '' },
+          BAlert: {
+            // Render unconditionally — the outer v-if on the host controls
+            // whether this stub is mounted at all. Pass-through attrs (including
+            // data-testid) land on the root element via Vue's inheritAttrs.
+            props: ['variant', 'show'],
+            template: '<div :data-variant="variant"><slot /></div>',
+          },
+          BModal: {
+            name: 'BModal',
+            props: ['modelValue', 'id', 'title'],
+            template: '<div><slot /></div>',
+            methods: { show() {}, hide() {} },
+          },
+          BatchCriteriaForm: { template: '<div />' },
+          AriaLiveRegion: { template: '<div />' },
+          IconLegend: { template: '<div />' },
+        },
+      },
+    });
+
+    // Flush initial mount loaders before overriding data.
+    await flushPromises();
+
+    // Override the relevant data fields and trigger a re-render.
+    Object.entries(overrides).forEach(([key, value]) => {
+      (wrapper.vm as unknown as Record<string, unknown>)[key] = value;
+    });
+
+    // Wait for Vue reactivity to propagate the data changes to the DOM.
+    await wrapper.vm.$nextTick();
+    return wrapper;
+  };
+
+  it('alert is hidden when previewBoundaryGene is null', async () => {
+    primeAuth();
+    installDefaultHandlers();
+
+    const wrapper = await mountWithBoundaryData({
+      previewBoundaryGene: null,
+      previewGeneCount: 0,
+      previewEntityCount: 0,
+    });
+
+    expect(wrapper.find('[data-testid="batch-boundary-gene-alert"]').exists()).toBe(false);
+  });
+
+  it('alert renders when previewBoundaryGene is non-null', async () => {
+    primeAuth();
+    installDefaultHandlers();
+
+    const wrapper = await mountWithBoundaryData({
+      previewBoundaryGene: 'HGNC:4585',
+      previewGeneCount: 2,
+      previewEntityCount: 6,
+    });
+
+    const alert = wrapper.find('[data-testid="batch-boundary-gene-alert"]');
+    expect(alert.exists()).toBe(true);
+    expect(alert.text()).toContain('HGNC:4585');
+    expect(alert.text()).toContain('6');
+  });
+});

--- a/app/src/views/curate/ManageReReview.vue
+++ b/app/src/views/curate/ManageReReview.vue
@@ -121,6 +121,18 @@
                   />
                 </BFormGroup>
 
+                <!-- Gene-atomic batch boundary warning (issue #29) -->
+                <BAlert
+                  v-if="boundaryGeneAlertVisible"
+                  variant="warning"
+                  show
+                  class="mb-2"
+                  data-testid="batch-boundary-gene-alert"
+                >
+                  <i class="bi bi-exclamation-triangle me-1" aria-hidden="true" />
+                  {{ boundaryGeneAlertMessage }}
+                </BAlert>
+
                 <!-- Actions -->
                 <div class="d-flex gap-2">
                   <BButton
@@ -671,6 +683,13 @@ export default {
       entityAssignBatchName: '',
       isLoadingEntities: false,
       isAssigningEntities: false,
+
+      // Gene-atomic batch boundary hint (issue #29)
+      // Set by loadAvailableEntities() from batch_preview's boundary_gene field.
+      // Non-null when the preview soft-LIMIT engaged and a gene was partially included.
+      previewBoundaryGene: null,
+      previewGeneCount: 0,
+      previewEntityCount: 0,
       entitySelectFields: [
         { key: 'entity_id', label: 'ID', sortable: true },
         { key: 'gene_symbol', label: 'Gene', sortable: true },
@@ -709,6 +728,21 @@ export default {
     };
   },
   computed: {
+    // Gene-atomic boundary alert computed properties (issue #29)
+    boundaryGeneAlertVisible() {
+      return Boolean(this.previewBoundaryGene);
+    },
+    boundaryGeneAlertMessage() {
+      if (!this.previewBoundaryGene) return '';
+      return (
+        `Batch is gene-atomic: to keep gene ${this.previewBoundaryGene} together, ` +
+        `the available-entity list holds ${this.previewEntityCount} entities across ` +
+        `${this.previewGeneCount} gene(s). The last gene was extended past the ` +
+        `batch_size cap to avoid splitting it. Tighten criteria or increase ` +
+        `batch size to avoid the overflow.`
+      );
+    },
+
     // Filter options derived from loaded data
     userFilterOptions() {
       const uniqueUsers = [
@@ -868,6 +902,13 @@ export default {
         const responseData = await apiClient.post(apiUrl, { batch_size: 100 });
         this.availableEntities = responseData.data || [];
         this.selectedEntityIds = [];
+        // Capture gene-atomic boundary hint (issue #29): boundary_gene is non-null
+        // when the soft-LIMIT extended the last gene past batch_size.
+        // BatchServiceResponse uses [key: string]: unknown so values flow through
+        // without type assertions in this plain-JS Options API component.
+        this.previewBoundaryGene = responseData.boundary_gene ?? null;
+        this.previewGeneCount = responseData.gene_count ?? 0;
+        this.previewEntityCount = responseData.entity_count ?? 0;
       } catch (_e) {
         this.makeToast('Failed to load available entities', 'Error', 'danger');
       } finally {

--- a/app/src/views/curate/ModifyEntity.vue
+++ b/app/src/views/curate/ModifyEntity.vue
@@ -1,13 +1,12 @@
-<!-- views/curate/ModifyEntity.vue -->
+<!-- views/curate/ModifyEntity.vue — thin orchestration shell -->
 <template>
   <div class="container-fluid">
     <BContainer fluid>
       <BRow class="justify-content-md-center py-2">
         <BCol col md="12">
-          <!-- User Interface controls -->
           <BCard
             header-tag="header"
-            align="left"
+            align="start"
             body-class="p-1"
             header-class="p-1"
             border-variant="dark"
@@ -15,144 +14,29 @@
             <template #header>
               <h6 class="mb-1 text-start font-weight-bold">Modify an existing entity</h6>
             </template>
-            <!-- User Interface controls -->
 
-            <BCard class="my-2" body-class="p-2" header-class="p-1" border-variant="dark">
-              <template #header>
-                <h6 class="mb-1 text-start font-weight-bold">1. Select an entity to modify</h6>
-              </template>
-
-              <BRow>
-                <BCol class="my-1">
-                  <AutocompleteInput
-                    v-model="modify_entity_input"
-                    v-model:display-value="entity_display"
-                    :results="entity_search_results"
-                    :loading="entity_search_loading"
-                    label="Entity"
-                    input-id="entity-select"
-                    placeholder="Search by ID, gene symbol, or disease name..."
-                    item-key="entity_id"
-                    item-label="symbol"
-                    item-secondary="entity_id"
-                    item-description="disease_ontology_name"
-                    @search="searchEntity"
-                    @update:model-value="onEntitySelected"
-                  />
-                  <small class="text-muted">
-                    Search for entities by sysndd ID, gene symbol, or disease name
-                  </small>
-                </BCol>
-              </BRow>
-            </BCard>
-
-            <!-- Entity Preview Card -->
-            <BCard
-              v-if="entity_loaded && entity_info.entity_id"
-              class="my-2"
-              body-class="p-3"
-              header-class="p-2"
-              border-variant="info"
-            >
-              <template #header>
-                <h6 class="mb-0 text-start font-weight-bold d-flex align-items-center">
-                  <i class="bi bi-info-circle me-2" aria-hidden="true" />
-                  Selected Entity
-                  <EntityBadge
-                    :entity-id="entity_info.entity_id"
-                    variant="primary"
-                    size="md"
-                    class="ms-2"
-                  />
-                </h6>
-              </template>
-
-              <BRow class="g-3">
-                <BCol md="6">
-                  <!-- Gene with badge and HGNC link -->
-                  <div class="mb-2">
-                    <strong class="text-muted small d-block mb-1">Gene:</strong>
-                    <GeneBadge
-                      :symbol="entity_info.symbol || 'N/A'"
-                      :hgnc-id="entity_info.hgnc_id"
-                      :link-to="
-                        entity_info.hgnc_id
-                          ? `https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/${entity_info.hgnc_id}`
-                          : null
-                      "
-                      size="md"
-                    />
-                  </div>
-
-                  <!-- Disease with badge and ontology link -->
-                  <div class="mb-2">
-                    <strong class="text-muted small d-block mb-1">Disease:</strong>
-                    <DiseaseBadge
-                      :name="entity_info.disease_ontology_name || 'N/A'"
-                      :ontology-id="entity_info.disease_ontology_id_version"
-                      :link-to="
-                        entity_info.disease_ontology_id_version
-                          ? `/Ontology/${entity_info.disease_ontology_id_version.replace(/_.+/g, '')}`
-                          : null
-                      "
-                      size="md"
-                      :max-length="40"
-                    />
-                  </div>
-                </BCol>
-
-                <BCol md="6">
-                  <!-- Inheritance with icon -->
-                  <div class="mb-2">
-                    <strong class="text-muted small d-block mb-1">Inheritance:</strong>
-                    <BBadge variant="info" class="d-inline-flex align-items-center">
-                      <i class="bi bi-diagram-3 me-1" aria-hidden="true" />
-                      {{
-                        entity_info.hpo_mode_of_inheritance_term_name ||
-                        entity_info.hpo_mode_of_inheritance_term ||
-                        'N/A'
-                      }}
-                    </BBadge>
-                  </div>
-
-                  <!-- Category with stoplight style -->
-                  <div class="mb-2">
-                    <strong class="text-muted small d-block mb-1">Category:</strong>
-                    <BBadge
-                      :variant="stoplights_style[entity_info.category] || 'secondary'"
-                      class="d-inline-flex align-items-center"
-                    >
-                      <i class="bi bi-stoplights me-1" aria-hidden="true" />
-                      {{ entity_info.category || 'N/A' }}
-                    </BBadge>
-                  </div>
-
-                  <!-- NDD Status with icon -->
-                  <div class="mb-2">
-                    <strong class="text-muted small d-block mb-1">NDD Status:</strong>
-                    <BBadge
-                      :variant="ndd_icon_style[entity_info.ndd_phenotype_word] || 'secondary'"
-                      class="d-inline-flex align-items-center"
-                    >
-                      <i
-                        :class="`bi bi-${ndd_icon[entity_info.ndd_phenotype_word] || 'question'} me-1`"
-                        aria-hidden="true"
-                      />
-                      {{ entity_info.ndd_phenotype_word || 'N/A' }}
-                    </BBadge>
-                  </div>
-                </BCol>
-              </BRow>
-            </BCard>
-
-            <!-- Icon Legend -->
-            <IconLegend
-              v-if="entity_loaded && entity_info.entity_id"
-              :legend-items="legendItems"
-              title="Category & NDD Status Icons"
-              class="my-2"
+            <!-- 1. Search panel -->
+            <EntitySearchPanel
+              :model-value="modify_entity_input"
+              :display-value="entity_display"
+              :search-results="entity_search_results"
+              :loading="entity_search_loading"
+              @update:model-value="onEntitySelected"
+              @update:display-value="entity_display = $event"
+              @search="searchEntity"
             />
 
+            <!-- 2. Entity info header (shown after selection) -->
+            <EntityInfoHeader
+              v-if="entity_loaded && entity_info.entity_id"
+              :entity="entity_info"
+              :legend-items="legendItems"
+              :stoplights-style="stoplights_style"
+              :ndd-icon-style="ndd_icon_style"
+              :ndd-icon="ndd_icon"
+            />
+
+            <!-- 3. Action bar -->
             <BCard
               v-if="entity_loaded && entity_info.entity_id"
               class="my-2"
@@ -171,9 +55,9 @@
                   <BButton
                     size="sm"
                     variant="dark"
-                    :disabled="!entity_loaded || submitting"
+                    :disabled="!entity_loaded || !!submitting"
                     aria-label="Rename disease"
-                    @click="showEntityRename()"
+                    @click="showEntityRename"
                   >
                     <BSpinner v-if="submitting === 'rename'" small class="me-1" />
                     <template v-else>
@@ -188,9 +72,9 @@
                   <BButton
                     size="sm"
                     variant="dark"
-                    :disabled="!entity_loaded || submitting"
+                    :disabled="!entity_loaded || !!submitting"
                     aria-label="Deactivate entity"
-                    @click="showEntityDeactivate()"
+                    @click="showEntityDeactivate"
                   >
                     <BSpinner v-if="submitting === 'deactivate'" small class="me-1" />
                     <template v-else>
@@ -205,9 +89,9 @@
                   <BButton
                     size="sm"
                     variant="dark"
-                    :disabled="!entity_loaded || submitting"
+                    :disabled="!entity_loaded || !!submitting"
                     aria-label="Modify review"
-                    @click="showReviewModify()"
+                    @click="showReviewModify"
                   >
                     <BSpinner v-if="submitting === 'review'" small class="me-1" />
                     <template v-else>
@@ -222,9 +106,9 @@
                   <BButton
                     size="sm"
                     variant="dark"
-                    :disabled="!entity_loaded || submitting"
+                    :disabled="!entity_loaded || !!submitting"
                     aria-label="Modify status"
-                    @click="showStatusModify()"
+                    @click="showStatusModify"
                   >
                     <BSpinner v-if="submitting === 'status'" small class="me-1" />
                     <template v-else>
@@ -240,568 +124,149 @@
         </BCol>
       </BRow>
 
-      <!-- Rename disease modal -->
-      <BModal
-        id="renameModal"
-        ref="renameModal"
-        size="lg"
-        centered
-        ok-title="Submit"
-        no-close-on-esc
-        no-close-on-backdrop
-        header-bg-variant="dark"
-        header-text-variant="light"
-        header-close-label="Close"
-        @show="onRenameModalShow"
-        @ok="submitEntityRename"
-      >
-        <template #title>
-          <div class="d-flex flex-column gap-2">
-            <h4 class="mb-0">
-              Rename Entity Disease
-              <EntityBadge
-                v-if="entity_info?.entity_id"
-                :entity-id="entity_info.entity_id"
-                variant="primary"
-                size="md"
-                class="ms-2"
-              />
-            </h4>
-            <div class="d-flex flex-wrap gap-2 small">
-              <span class="d-flex align-items-center">
-                <i class="bi bi-file-earmark-medical me-1" />
-                <strong>{{ entity_info.symbol || 'N/A' }}</strong>
-              </span>
-              <span class="text-muted">|</span>
-              <span
-                class="d-flex align-items-center text-truncate"
-                style="max-width: 200px"
-                :title="entity_info.disease_ontology_name"
-              >
-                <i class="bi bi-clipboard2-pulse me-1" />
-                {{ entity_info.disease_ontology_name || 'N/A' }}
-              </span>
-              <span class="text-muted">|</span>
-              <span class="d-flex align-items-center">
-                <i class="bi bi-diagram-3 me-1" />
-                {{
-                  entity_info.hpo_mode_of_inheritance_term_name ||
-                  entity_info.hpo_mode_of_inheritance_term ||
-                  'N/A'
-                }}
-              </span>
-              <span class="text-muted">|</span>
-              <BBadge
-                :variant="stoplights_style[entity_info.category] || 'secondary'"
-                class="d-inline-flex align-items-center"
-              >
-                <i class="bi bi-stoplights me-1" />
-                {{ entity_info.category || 'N/A' }}
-              </BBadge>
-            </div>
-          </div>
-        </template>
+      <!-- Rename modal -->
+      <EntityRenameDeactivateModal
+        :visible="isRenameOpen"
+        mode="rename"
+        :entity="entity_info"
+        :submitting="submitting"
+        :stoplights-style="stoplights_style"
+        :ontology-display="ontology_display"
+        :ontology-input="ontology_input"
+        :ontology-search-results="ontology_search_results"
+        :ontology-search-loading="ontology_search_loading"
+        @update:visible="isRenameOpen = $event"
+        @update:ontology-display="ontology_display = $event"
+        @search-ontology="searchOntology"
+        @select-ontology="onOntologySelected"
+        @submit="onSubmitRename"
+        @cancel="close"
+      />
 
-        <p class="my-3">Select a new disease name:</p>
+      <!-- Deactivate modal -->
+      <EntityRenameDeactivateModal
+        :visible="isDeactivateOpen"
+        mode="deactivate"
+        :entity="entity_info"
+        :submitting="submitting"
+        :stoplights-style="stoplights_style"
+        :deactivate-check="deactivate_check"
+        :replace-check="replace_check"
+        :replace-display="replace_entity_display"
+        :replace-entity-input="replace_entity_input"
+        :replace-search-results="replace_entity_search_results"
+        :replace-search-loading="replace_entity_search_loading"
+        @update:visible="isDeactivateOpen = $event"
+        @update:deactivate-check="deactivate_check = $event"
+        @update:replace-check="replace_check = $event"
+        @update:replace-display="replace_entity_display = $event"
+        @search-replacement="searchReplacementEntity"
+        @select-replacement="onReplacementEntitySelected"
+        @submit="onSubmitDeactivate"
+        @cancel="close"
+      />
 
-        <AutocompleteInput
-          v-model="ontology_input"
-          v-model:display-value="ontology_display"
-          :results="ontology_search_results"
-          :loading="ontology_search_loading"
-          label="Disease"
-          input-id="ontology-select"
-          placeholder="Search by disease name or ontology ID (e.g., OMIM:123456)..."
-          item-key="id"
-          item-label="label"
-          item-secondary="id"
-          @search="searchOntology"
-          @update:model-value="onOntologySelected"
-        />
-        <small class="text-muted"> Search for diseases by name or ontology identifier </small>
-      </BModal>
-      <!-- Rename disease modal -->
+      <!-- Review modal -->
+      <ReviewModifyModal
+        :visible="isReviewOpen"
+        :loading="loadingReview"
+        :submitting="submitting"
+        :entity="entity_info"
+        :review="review_info"
+        :select-phenotype="select_phenotype"
+        :select-variation="select_variation"
+        :select-additional-references="select_additional_references"
+        :select-gene-reviews="select_gene_reviews"
+        :phenotype-options="phenotypes_options ?? []"
+        :variation-options="variation_ontology_options ?? []"
+        :has-changes="hasReviewChanges"
+        :stoplights-style="stoplights_style"
+        @update:visible="isReviewOpen = $event"
+        @update:review="review_info = $event"
+        @update:select-phenotype="select_phenotype = $event"
+        @update:select-variation="select_variation = $event"
+        @update:select-additional-references="select_additional_references = $event"
+        @update:select-gene-reviews="select_gene_reviews = $event"
+        @submit="onSubmitReview"
+        @discard-request="requestDiscard($event)"
+      />
 
-      <!-- Deactivate entity modal -->
-      <BModal
-        id="deactivateModal"
-        ref="deactivateModal"
-        size="lg"
-        centered
-        ok-title="Submit"
-        no-close-on-esc
-        no-close-on-backdrop
-        header-bg-variant="dark"
-        header-text-variant="light"
-        header-close-label="Close"
-        @show="onDeactivateModalShow"
-        @ok="submitEntityDeactivation"
-      >
-        <template #title>
-          <div class="d-flex flex-column gap-2">
-            <h4 class="mb-0">
-              Deactivate Entity
-              <EntityBadge
-                v-if="entity_info?.entity_id"
-                :entity-id="entity_info.entity_id"
-                variant="primary"
-                size="md"
-                class="ms-2"
-              />
-            </h4>
-            <div class="d-flex flex-wrap gap-2 small">
-              <span class="d-flex align-items-center">
-                <i class="bi bi-file-earmark-medical me-1" />
-                <strong>{{ entity_info.symbol || 'N/A' }}</strong>
-              </span>
-              <span class="text-muted">|</span>
-              <span
-                class="d-flex align-items-center text-truncate"
-                style="max-width: 200px"
-                :title="entity_info.disease_ontology_name"
-              >
-                <i class="bi bi-clipboard2-pulse me-1" />
-                {{ entity_info.disease_ontology_name || 'N/A' }}
-              </span>
-              <span class="text-muted">|</span>
-              <span class="d-flex align-items-center">
-                <i class="bi bi-diagram-3 me-1" />
-                {{
-                  entity_info.hpo_mode_of_inheritance_term_name ||
-                  entity_info.hpo_mode_of_inheritance_term ||
-                  'N/A'
-                }}
-              </span>
-              <span class="text-muted">|</span>
-              <BBadge
-                :variant="stoplights_style[entity_info.category] || 'secondary'"
-                class="d-inline-flex align-items-center"
-              >
-                <i class="bi bi-stoplights me-1" />
-                {{ entity_info.category || 'N/A' }}
-              </BBadge>
-            </div>
-          </div>
-        </template>
-
-        <div>
-          <p class="my-2">1. Are you sure that you want to deactivate this entity?</p>
-
-          <BFormCheckbox id="deactivateSwitch" v-model="deactivate_check" switch size="md">
-            <strong>{{ deactivate_check ? 'Yes' : 'No' }}</strong>
-          </BFormCheckbox>
-        </div>
-
-        <div v-if="deactivate_check">
-          <p class="my-2">2. Was this entity replaced by another one?</p>
-
-          <BFormCheckbox id="replaceSwitch" v-model="replace_check" switch size="md">
-            <strong>{{ replace_check ? 'Yes' : 'No' }}</strong>
-          </BFormCheckbox>
-        </div>
-
-        <div v-if="replace_check">
-          <p class="my-2">3. Select the entity replacing the above one:</p>
-
-          <AutocompleteInput
-            v-model="replace_entity_input"
-            v-model:display-value="replace_entity_display"
-            :results="replace_entity_search_results"
-            :loading="replace_entity_search_loading"
-            label="Replacement Entity"
-            input-id="replace-entity-select"
-            placeholder="Search by ID, gene symbol, or disease name..."
-            item-key="entity_id"
-            item-label="symbol"
-            item-secondary="entity_id"
-            item-description="disease_ontology_name"
-            @search="searchReplacementEntity"
-            @update:model-value="onReplacementEntitySelected"
-          />
-          <small class="text-muted"> Search for the entity that replaces this one </small>
-        </div>
-      </BModal>
-      <!-- Deactivate entity modal -->
-
-      <!-- Modify review modal -->
-      <BModal
-        id="modifyReviewModal"
-        ref="modifyReviewModal"
-        size="xl"
-        centered
-        ok-title="Submit"
-        no-close-on-esc
-        no-close-on-backdrop
-        header-bg-variant="dark"
-        header-text-variant="light"
-        header-close-label="Close"
-        :busy="loading_review_modal"
-        @show="onModifyReviewModalShow"
-        @hide="onModifyReviewModalHide"
-        @ok="submitReviewChange"
-      >
-        <template #title>
-          <div class="d-flex flex-column gap-2">
-            <h4 class="mb-0">
-              Modify Review
-              <EntityBadge
-                v-if="entity_info?.entity_id"
-                :entity-id="entity_info.entity_id"
-                variant="primary"
-                size="md"
-                class="ms-2"
-              />
-            </h4>
-            <div class="d-flex flex-wrap gap-2 small">
-              <span class="d-flex align-items-center">
-                <i class="bi bi-file-earmark-medical me-1" />
-                <strong>{{ entity_info.symbol || 'N/A' }}</strong>
-              </span>
-              <span class="text-muted">|</span>
-              <span
-                class="d-flex align-items-center text-truncate"
-                style="max-width: 200px"
-                :title="entity_info.disease_ontology_name"
-              >
-                <i class="bi bi-clipboard2-pulse me-1" />
-                {{ entity_info.disease_ontology_name || 'N/A' }}
-              </span>
-              <span class="text-muted">|</span>
-              <span class="d-flex align-items-center">
-                <i class="bi bi-diagram-3 me-1" />
-                {{
-                  entity_info.hpo_mode_of_inheritance_term_name ||
-                  entity_info.hpo_mode_of_inheritance_term ||
-                  'N/A'
-                }}
-              </span>
-              <span class="text-muted">|</span>
-              <BBadge
-                :variant="stoplights_style[entity_info.category] || 'secondary'"
-                class="d-inline-flex align-items-center"
-              >
-                <i class="bi bi-stoplights me-1" />
-                {{ entity_info.category || 'N/A' }}
-              </BBadge>
-            </div>
-          </div>
-        </template>
-
-        <BOverlay :show="loading_review_modal" rounded="sm">
-          <BForm ref="form" @submit.stop.prevent="submitReviewChange">
-            <!-- Synopsis textarea -->
-            <label class="mr-sm-2 font-weight-bold" for="review-textarea-synopsis">Synopsis</label>
-            <BFormTextarea
-              id="review-textarea-synopsis"
-              v-model="review_info.synopsis"
-              rows="3"
-              size="sm"
-            />
-            <!-- Synopsis textarea -->
-
-            <!-- Phenotype select -->
-            <label class="mr-sm-2 font-weight-bold" for="review-phenotype-select">Phenotypes</label>
-
-            <TreeMultiSelect
-              v-if="phenotypes_options && phenotypes_options.length > 0"
-              id="review-phenotype-select"
-              v-model="select_phenotype"
-              :options="phenotypes_options"
-              placeholder="Select phenotypes..."
-              search-placeholder="Search phenotypes (name or HP:ID)..."
-            />
-            <!-- Phenotype select -->
-
-            <!-- Variation ontolog select -->
-            <label class="mr-sm-2 font-weight-bold" for="review-variation-select"
-              >Variation ontology</label
-            >
-
-            <TreeMultiSelect
-              v-if="variation_ontology_options && variation_ontology_options.length > 0"
-              id="review-variation-select"
-              v-model="select_variation"
-              :options="variation_ontology_options"
-              placeholder="Select variations..."
-              search-placeholder="Search variation types..."
-            />
-            <!-- Variation ontolog select -->
-
-            <!-- publications tag form with links out -->
-            <label class="mr-sm-2 font-weight-bold" for="review-publications-select"
-              >Publications</label
-            >
-            <BFormTags
-              v-model="select_additional_references"
-              input-id="review-literature-select"
-              no-outer-focus
-              class="my-0"
-              separator=",;"
-              :tag-validator="tagValidatorPMID"
-              remove-on-delete
-            >
-              <template #default="{ tags, inputAttrs, inputHandlers, addTag, removeTag }">
-                <BInputGroup class="my-0">
-                  <BFormInput
-                    v-bind="inputAttrs"
-                    placeholder="Enter PMIDs separated by comma or semicolon"
-                    class="form-control"
-                    size="sm"
-                    v-on="inputHandlers"
-                  />
-                  <BButton variant="secondary" size="sm" @click="addTag()"> Add </BButton>
-                </BInputGroup>
-
-                <div class="d-inline-block">
-                  <h6>
-                    <BFormTag
-                      v-for="tag in tags"
-                      :key="tag"
-                      :title="tag"
-                      variant="secondary"
-                      @remove="removeTag(tag)"
-                    >
-                      <BLink
-                        :href="'https://pubmed.ncbi.nlm.nih.gov/' + tag.replace('PMID:', '')"
-                        target="_blank"
-                        class="text-light"
-                      >
-                        <i class="bi bi-box-arrow-up-right" />
-                        {{ tag }}
-                      </BLink>
-                    </BFormTag>
-                  </h6>
-                </div>
-              </template>
-            </BFormTags>
-            <!-- publications tag form with links out -->
-
-            <!-- genereviews tag form with links out -->
-            <label class="mr-sm-2 font-weight-bold" for="review-genereviews-select"
-              >Genereviews</label
-            >
-            <BFormTags
-              v-model="select_gene_reviews"
-              input-id="review-genereviews-select"
-              no-outer-focus
-              class="my-0"
-              separator=",;"
-              :tag-validator="tagValidatorPMID"
-              remove-on-delete
-            >
-              <template #default="{ tags, inputAttrs, inputHandlers, addTag, removeTag }">
-                <BInputGroup class="my-0">
-                  <BFormInput
-                    v-bind="inputAttrs"
-                    placeholder="Enter PMIDs separated by comma or semicolon"
-                    class="form-control"
-                    size="sm"
-                    v-on="inputHandlers"
-                  />
-                  <BButton variant="secondary" size="sm" @click="addTag()"> Add </BButton>
-                </BInputGroup>
-
-                <div class="d-inline-block">
-                  <h6>
-                    <BFormTag
-                      v-for="tag in tags"
-                      :key="tag"
-                      :title="tag"
-                      variant="secondary"
-                      @remove="removeTag(tag)"
-                    >
-                      <BLink
-                        :href="'https://pubmed.ncbi.nlm.nih.gov/' + tag.replace('PMID:', '')"
-                        target="_blank"
-                        class="text-light"
-                      >
-                        <i class="bi bi-box-arrow-up-right" />
-                        {{ tag }}
-                      </BLink>
-                    </BFormTag>
-                  </h6>
-                </div>
-              </template>
-            </BFormTags>
-            <!-- genereviews tag form with links out -->
-
-            <!-- Review comment textarea -->
-            <label class="mr-sm-2 font-weight-bold" for="review-textarea-comment">Comment</label>
-            <BFormTextarea
-              id="review-textarea-comment"
-              v-model="review_info.comment"
-              rows="2"
-              size="sm"
-              placeholder="Additional comments to this entity relevant for the curator."
-            />
-            <!-- Review comment textarea -->
-          </BForm>
-        </BOverlay>
-      </BModal>
-      <!-- Modify review modal -->
-
-      <!-- Modify status modal -->
-      <BModal
-        id="modifyStatusModal"
-        ref="modifyStatusModal"
-        size="lg"
-        centered
-        ok-title="Submit"
-        no-close-on-esc
-        no-close-on-backdrop
-        header-bg-variant="dark"
-        header-text-variant="light"
-        header-close-label="Close"
-        :busy="statusFormLoading"
-        @show="onModifyStatusModalShow"
-        @hide="onModifyStatusModalHide"
-        @ok="submitStatusChange"
-      >
-        <template #title>
-          <div class="d-flex flex-column gap-2">
-            <h4 class="mb-0">
-              Modify Status
-              <EntityBadge
-                v-if="entity_info?.entity_id"
-                :entity-id="entity_info.entity_id"
-                variant="primary"
-                size="md"
-                class="ms-2"
-              />
-            </h4>
-            <div class="d-flex flex-wrap gap-2 small">
-              <span class="d-flex align-items-center">
-                <i class="bi bi-file-earmark-medical me-1" />
-                <strong>{{ entity_info.symbol || 'N/A' }}</strong>
-              </span>
-              <span class="text-muted">|</span>
-              <span
-                class="d-flex align-items-center text-truncate"
-                style="max-width: 200px"
-                :title="entity_info.disease_ontology_name"
-              >
-                <i class="bi bi-clipboard2-pulse me-1" />
-                {{ entity_info.disease_ontology_name || 'N/A' }}
-              </span>
-              <span class="text-muted">|</span>
-              <span class="d-flex align-items-center">
-                <i class="bi bi-diagram-3 me-1" />
-                {{
-                  entity_info.hpo_mode_of_inheritance_term_name ||
-                  entity_info.hpo_mode_of_inheritance_term ||
-                  'N/A'
-                }}
-              </span>
-              <span class="text-muted">|</span>
-              <BBadge
-                :variant="stoplights_style[entity_info.category] || 'secondary'"
-                class="d-inline-flex align-items-center"
-              >
-                <i class="bi bi-stoplights me-1" />
-                {{ entity_info.category || 'N/A' }}
-              </BBadge>
-            </div>
-          </div>
-        </template>
-
-        <BOverlay :show="statusFormLoading" rounded="sm">
-          <BForm ref="form" @submit.stop.prevent="submitStatusChange">
-            <!-- Status dropdown with loading state -->
-            <BSpinner v-if="status_options_loading" small label="Loading..." />
-            <BFormSelect
-              v-else-if="status_options && status_options.length > 0"
-              id="status-select"
-              v-model="statusFormData.category_id"
-              :options="normalizeStatusOptions(status_options)"
-              size="sm"
-            >
-              <template #first>
-                <BFormSelectOption :value="null"> Select status... </BFormSelectOption>
-              </template>
-            </BFormSelect>
-            <BAlert v-else-if="status_options !== null" variant="warning" class="mb-0">
-              No status options available
-            </BAlert>
-
-            <BFormCheckbox id="removeSwitch" v-model="statusFormData.problematic" switch size="md">
-              Suggest removal
-            </BFormCheckbox>
-
-            <label class="mr-sm-2 font-weight-bold" for="status-textarea-comment">Comment</label>
-            <BFormTextarea
-              id="status-textarea-comment"
-              v-model="statusFormData.comment"
-              rows="2"
-              size="sm"
-              placeholder="Why should this entities status be changed."
-            />
-          </BForm>
-        </BOverlay>
-      </BModal>
-      <!-- Modify status modal -->
+      <!-- Status modal -->
+      <StatusModifyModal
+        :visible="isStatusOpen"
+        :loading="loadingStatus"
+        :submitting="submitting"
+        :entity="entity_info"
+        :status-options="status_options"
+        :status-options-loading="status_options_loading"
+        :form-data="statusFormData"
+        :has-changes="hasStatusChanges"
+        :stoplights-style="stoplights_style"
+        @update:visible="isStatusOpen = $event"
+        @update:form-data="Object.assign(statusFormData, $event)"
+        @submit="onSubmitStatus"
+        @discard-request="requestDiscard($event)"
+      />
 
       <!-- AriaLiveRegion for screen reader announcements -->
       <AriaLiveRegion :message="a11yMessage" :politeness="a11yPoliteness" />
 
       <!-- Confirm discard unsaved changes dialog -->
       <ConfirmDiscardDialog
-        ref="confirmDiscardDialog"
+        ref="confirmDiscardDialogRef"
         modal-id="modify-entity-confirm-discard"
-        @discard="onConfirmDiscard"
-        @keep-editing="pendingDiscardTarget = null"
+        @discard="confirmDiscard"
+        @keep-editing="cancelDiscard"
       />
     </BContainer>
   </div>
 </template>
 
-<script>
+<script lang="ts">
+import { defineComponent, onMounted, ref, watch } from 'vue';
 import { useToast, useColorAndSymbols, useAriaLive } from '@/composables';
-import useStatusForm from '@/views/curate/composables/useStatusForm';
-import TreeMultiSelect from '@/components/forms/TreeMultiSelect.vue';
-import AutocompleteInput from '@/components/forms/AutocompleteInput.vue';
-import GeneBadge from '@/components/ui/GeneBadge.vue';
-import DiseaseBadge from '@/components/ui/DiseaseBadge.vue';
-import EntityBadge from '@/components/ui/EntityBadge.vue';
+import useStatusForm from './composables/useStatusForm';
+import { useEntityAutocomplete } from './composables/useEntityAutocomplete';
+import { useEntityInfo } from './composables/useEntityInfo';
+import { useEntityMutations } from './composables/useEntityMutations';
+import { useEntityModifyModals } from './composables/useEntityModifyModals';
+
+import { listPhenotypesTree, listVariationOntologyTree, listStatusCategoriesTree } from '@/api/list';
+
+import EntityInfoHeader from './components/EntityInfoHeader.vue';
+import EntitySearchPanel from './components/EntitySearchPanel.vue';
+import EntityRenameDeactivateModal from './components/EntityRenameDeactivateModal.vue';
+import ReviewModifyModal from './components/ReviewModifyModal.vue';
+import StatusModifyModal from './components/StatusModifyModal.vue';
 import AriaLiveRegion from '@/components/accessibility/AriaLiveRegion.vue';
-import IconLegend from '@/components/accessibility/IconLegend.vue';
 import ConfirmDiscardDialog from '@/components/ui/ConfirmDiscardDialog.vue';
 
-import Submission from '@/assets/js/classes/submission/submissionSubmission';
-import Review from '@/assets/js/classes/submission/submissionReview';
-import Status from '@/assets/js/classes/submission/submissionStatus';
-import Phenotype from '@/assets/js/classes/submission/submissionPhenotype';
-import Variation from '@/assets/js/classes/submission/submissionVariation';
-import Literature from '@/assets/js/classes/submission/submissionLiterature';
+const transformModifierTree = (nodes: any[]) =>
+  nodes.map((node) => {
+    const phenotypeName = node.label.replace(/^present:\s*/, '');
+    const ontologyCode = node.id.replace(/^\d+-/, '');
+    return {
+      id: `parent-${ontologyCode}`,
+      label: phenotypeName,
+      children: [
+        { id: node.id, label: `present: ${phenotypeName}` },
+        ...(node.children || []).map((child: any) => {
+          const modifier = child.label.replace(/:\s*.*$/, '');
+          return { id: child.id, label: `${modifier}: ${phenotypeName}` };
+        }),
+      ],
+    };
+  });
 
-// v11.0 closeout F2b: apiClient handles Bearer header injection via the
-// shared request interceptor; call sites no longer read localStorage
-// directly.
-import { apiClient } from '@/api/client';
-import {
-  listPhenotypesTree,
-  listVariationOntologyTree,
-  listStatusCategoriesTree,
-} from '@/api/list';
-import { searchOntology } from '@/api/search';
-import {
-  listEntities,
-  getEntityReview,
-  getEntityPhenotypes,
-  getEntityVariation,
-  getEntityPublications,
-  getEntityStatus,
-} from '@/api/entity';
-
-export default {
+export default defineComponent({
   name: 'ModifyEntity',
   components: {
-    TreeMultiSelect,
-    AutocompleteInput,
-    GeneBadge,
-    DiseaseBadge,
-    EntityBadge,
+    EntityInfoHeader,
+    EntitySearchPanel,
+    EntityRenameDeactivateModal,
+    ReviewModifyModal,
+    StatusModifyModal,
     AriaLiveRegion,
-    IconLegend,
     ConfirmDiscardDialog,
   },
   setup() {
@@ -809,706 +274,256 @@ export default {
     const colorAndSymbols = useColorAndSymbols();
     const { message: a11yMessage, politeness: a11yPoliteness, announce } = useAriaLive();
 
-    // Initialize status form composable
+    const info = useEntityInfo({ onToast: makeToast });
+    const search = useEntityAutocomplete({
+      onToast: makeToast,
+      getCurrentEntityId: () => info.entity_info.value.entity_id,
+    });
+    const mutations = useEntityMutations({ onToast: makeToast, onAnnounce: announce });
+    const modals = useEntityModifyModals();
     const statusForm = useStatusForm();
-    const {
-      formData: statusFormData,
-      loading: statusFormLoading,
-      loadStatusByEntity,
-      submitForm: submitStatusForm,
-      resetForm: resetStatusForm,
-      hasChanges: hasStatusChanges,
-    } = statusForm;
+
+    // Local modal-specific state not owned by composables
+    const deactivate_check = ref(false);
+    const replace_check = ref(false);
+
+    // Tree options (app-global lookup data loaded once)
+    const phenotypes_options = ref<any[] | null>(null);
+    const variation_ontology_options = ref<any[] | null>(null);
+    const status_options = ref<any[] | null>(null);
+    const status_options_loading = ref(false);
+
+    // ConfirmDiscardDialog ref — needed to programmatically show it
+    const confirmDiscardDialogRef = ref<any>(null);
+
+    // Watch pendingDiscardTarget to show/hide the confirm dialog
+    watch(
+      () => modals.pendingDiscardTarget.value,
+      (target) => {
+        if (target) {
+          confirmDiscardDialogRef.value?.show();
+        } else {
+          confirmDiscardDialogRef.value?.hide();
+        }
+      },
+    );
+
+    onMounted(async () => {
+      status_options_loading.value = true;
+      try {
+        const [phenotypes_data, variation_data, status_data] = await Promise.all([
+          listPhenotypesTree(),
+          listVariationOntologyTree(),
+          listStatusCategoriesTree(),
+        ]);
+        const raw1: any = Array.isArray(phenotypes_data) ? phenotypes_data : (phenotypes_data as any)?.data || [];
+        phenotypes_options.value = transformModifierTree(raw1);
+
+        const raw2: any = Array.isArray(variation_data) ? variation_data : (variation_data as any)?.data || [];
+        variation_ontology_options.value = transformModifierTree(raw2);
+
+        status_options.value = Array.isArray(status_data) ? status_data : (status_data as any)?.data || [];
+      } catch (e) {
+        makeToast(e, 'Error', 'danger');
+      } finally {
+        status_options_loading.value = false;
+      }
+    });
+
+    // Modal show handlers
+    async function showEntityRename(): Promise<void> {
+      modals.openRename();
+      modals.setLoading('rename', true);
+      search.ontology_input.value = null;
+      search.ontology_display.value = '';
+      search.ontology_search_results.value = [];
+      modals.setLoading('rename', false);
+    }
+
+    async function showEntityDeactivate(): Promise<void> {
+      deactivate_check.value = false;
+      replace_check.value = false;
+      search.replace_entity_input.value = null;
+      search.replace_entity_display.value = '';
+      modals.openDeactivate();
+      modals.setLoading('deactivate', false);
+    }
+
+    async function showReviewModify(): Promise<void> {
+      modals.openReview();
+      modals.setLoading('review', true);
+      await info.loadReview(info.entity_info.value.entity_id);
+      modals.setLoading('review', false);
+    }
+
+    async function showStatusModify(): Promise<void> {
+      statusForm.resetForm();
+      modals.openStatus();
+      modals.setLoading('status', true);
+      await statusForm.loadStatusByEntity(info.entity_info.value.entity_id);
+      modals.setLoading('status', false);
+    }
+
+    // Submit handlers
+    async function onSubmitRename(): Promise<void> {
+      try {
+        await mutations.rename({
+          entity_info: info.entity_info.value,
+          ontology_input: search.ontology_input.value,
+        });
+        modals.close();
+        info.reset();
+        search.clearAll();
+      } catch {
+        // error already toasted in composable
+      }
+    }
+
+    async function onSubmitDeactivate(): Promise<void> {
+      try {
+        await mutations.deactivate({
+          entity_info: info.entity_info.value,
+          deactivate_check: deactivate_check.value,
+          replace_entity_input: search.replace_entity_input.value,
+        });
+        modals.close();
+        info.reset();
+        search.clearAll();
+        deactivate_check.value = false;
+        replace_check.value = false;
+      } catch {
+        // error already toasted in composable
+      }
+    }
+
+    async function onSubmitReview(): Promise<void> {
+      if (!info.hasReviewChanges.value) {
+        modals.close();
+        return;
+      }
+      try {
+        await mutations.submitReview({
+          review_info: info.review_info.value,
+          select_phenotype: info.select_phenotype.value,
+          select_variation: info.select_variation.value,
+          select_additional_references: info.select_additional_references.value,
+          select_gene_reviews: info.select_gene_reviews.value,
+        });
+        modals.close();
+        info.reset();
+        search.clearAll();
+      } catch {
+        // error already toasted in composable
+      }
+    }
+
+    async function onSubmitStatus(): Promise<void> {
+      if (!statusForm.hasChanges.value) {
+        modals.close();
+        return;
+      }
+      mutations.setSubmittingState('status');
+      try {
+        await statusForm.submitForm(false, false);
+        makeToast('Status submitted successfully', 'Success', 'success');
+        announce('Status submitted successfully');
+        statusForm.resetForm();
+        modals.close();
+        info.reset();
+        search.clearAll();
+      } catch (e) {
+        makeToast(e, 'Error', 'danger');
+        announce('Failed to submit status', 'assertive');
+      } finally {
+        mutations.setSubmittingState(null);
+      }
+    }
+
+    async function onEntitySelected(entityId: number | null): Promise<void> {
+      search.onEntitySelected(entityId);
+      if (!entityId) {
+        info.reset();
+        return;
+      }
+      await info.loadEntity(entityId);
+      if (info.entity_info.value?.entity_id) {
+        search.entity_loaded.value = true;
+      }
+    }
+
+    const legendItems = [
+      { icon: 'bi bi-stoplights-fill', color: '#4caf50', label: 'Definitive' },
+      { icon: 'bi bi-stoplights-fill', color: '#2196f3', label: 'Moderate' },
+      { icon: 'bi bi-stoplights-fill', color: '#ff9800', label: 'Limited' },
+      { icon: 'bi bi-stoplights-fill', color: '#f44336', label: 'Refuted' },
+      { icon: 'bi bi-check', color: '#198754', label: 'NDD: Yes' },
+      { icon: 'bi bi-x', color: '#ffc107', label: 'NDD: No' },
+    ];
 
     return {
-      makeToast,
-      ...colorAndSymbols,
-      statusFormData,
-      statusFormLoading,
-      loadStatusByEntity,
-      submitStatusForm,
-      resetStatusForm,
-      hasStatusChanges,
+      // entity info composable
+      ...info,
+      // search composable
+      ...search,
+      // mutations composable
+      ...mutations,
+      // modals composable
+      ...modals,
+      // statusForm composable
+      statusFormData: statusForm.formData,
+      hasStatusChanges: statusForm.hasChanges,
+      // local state
+      deactivate_check,
+      replace_check,
+      // tree options
+      phenotypes_options,
+      variation_ontology_options,
+      status_options,
+      status_options_loading,
+      // a11y
       a11yMessage,
       a11yPoliteness,
       announce,
-    };
-  },
-  data() {
-    return {
-      status_options: null, // null = not loaded, [] = loaded but empty
-      status_options_loading: false,
-      phenotypes_options: null, // null = not loaded, [] = loaded but empty
-      variation_ontology_options: null, // null = not loaded, [] = loaded but empty
-      // Entity search autocomplete state
-      modify_entity_input: null,
-      entity_display: '', // Display value for autocomplete
-      entity_search_results: [],
-      entity_search_loading: false,
-      entity_loaded: false, // True when entity info has been fetched
-      replace_entity_input: null,
-      ontology_input: null,
-      ontology_display: '', // Display value for ontology autocomplete
-      ontology_search_results: [],
-      ontology_search_loading: false,
-      // Replacement entity autocomplete state
-      replace_entity_display: '', // Display value for replacement entity autocomplete
-      replace_entity_search_results: [],
-      replace_entity_search_loading: false,
-      entity_info: {},
-      review_info: new Review(),
-      select_phenotype: [],
-      select_variation: [],
-      select_additional_references: [],
-      select_gene_reviews: [],
-      reviewLoadedData: null, // Stores original review data for change detection
-      status_info: new Status(),
-      deactivate_check: false,
-      replace_check: false,
-      loading_rename_modal: true,
-      loading_deactivate_modal: true,
-      loading_review_modal: true,
-      loading_status_modal: true,
-      submitting: null, // null | 'rename' | 'deactivate' | 'review' | 'status'
-      pendingDiscardTarget: null, // 'review' | 'status' — tracks which modal triggered discard confirm
-      legendItems: [
-        { icon: 'bi bi-stoplights-fill', color: '#4caf50', label: 'Definitive' },
-        { icon: 'bi bi-stoplights-fill', color: '#2196f3', label: 'Moderate' },
-        { icon: 'bi bi-stoplights-fill', color: '#ff9800', label: 'Limited' },
-        { icon: 'bi bi-stoplights-fill', color: '#f44336', label: 'Refuted' },
-        { icon: 'bi bi-check', color: '#198754', label: 'NDD: Yes' },
-        { icon: 'bi bi-x', color: '#ffc107', label: 'NDD: No' },
-      ],
-    };
-  },
-  computed: {
-    hasReviewChanges() {
-      if (!this.reviewLoadedData) return false;
-      const arrEqual = (a, b) => {
-        const sa = [...a].sort();
-        const sb = [...b].sort();
-        return sa.length === sb.length && sa.every((v, i) => v === sb[i]);
-      };
-      return (
-        (this.review_info.synopsis || '') !== this.reviewLoadedData.synopsis ||
-        (this.review_info.comment || '') !== this.reviewLoadedData.comment ||
-        !arrEqual(this.select_phenotype, this.reviewLoadedData.phenotypes) ||
-        !arrEqual(this.select_variation, this.reviewLoadedData.variationOntology) ||
-        !arrEqual(this.select_additional_references, this.reviewLoadedData.publications) ||
-        !arrEqual(this.select_gene_reviews, this.reviewLoadedData.genereviews)
-      );
-    },
-  },
-  mounted() {
-    this.loadStatusList();
-    this.loadPhenotypesList();
-    this.loadVariationOntologyList();
-  },
-  methods: {
-    /**
-     * Transform phenotype/variation tree to make all modifiers selectable children.
-     * API returns: "present: X" as parent with [uncertain, variable, rare, absent] as children.
-     * We want: "X" as parent with [present, uncertain, variable, rare, absent] as children.
-     */
-    transformModifierTree(nodes) {
-      return nodes.map((node) => {
-        // Extract phenotype name from "present: Phenotype Name" format
-        const phenotypeName = node.label.replace(/^present:\s*/, '');
-        // Extract the HP/ontology code from the ID (e.g., "1-HP:0001999" -> "HP:0001999")
-        const ontologyCode = node.id.replace(/^\d+-/, '');
-
-        // Create new parent with just the phenotype name
-        const newParent = {
-          id: `parent-${ontologyCode}`,
-          label: phenotypeName,
-          children: [
-            // Add "present" as first child (the original parent node, now selectable)
-            {
-              id: node.id,
-              label: `present: ${phenotypeName}`,
-            },
-            // Add all other modifiers as children with phenotype name for context
-            ...(node.children || []).map((child) => {
-              const modifier = child.label.replace(/:\s*.*$/, '');
-              return {
-                id: child.id,
-                label: `${modifier}: ${phenotypeName}`,
-              };
-            }),
-          ],
-        };
-
-        return newParent;
-      });
-    },
-    async loadPhenotypesList() {
-      try {
-        const data = await listPhenotypesTree();
-        const rawData = Array.isArray(data) ? data : data?.data || [];
-        // Transform to make all modifiers selectable
-        this.phenotypes_options = this.transformModifierTree(rawData);
-      } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
-        this.phenotypes_options = [];
-      }
-    },
-    async loadVariationOntologyList() {
-      try {
-        const data = await listVariationOntologyTree();
-        const rawData = Array.isArray(data) ? data : data?.data || [];
-        // Transform to make all modifiers selectable
-        this.variation_ontology_options = this.transformModifierTree(rawData);
-      } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
-        this.variation_ontology_options = [];
-      }
-    },
-    async loadStatusList() {
-      this.status_options_loading = true;
-      try {
-        const data = await listStatusCategoriesTree();
-        this.status_options = Array.isArray(data) ? data : data?.data || [];
-      } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
-        this.status_options = [];
-      } finally {
-        this.status_options_loading = false;
-      }
-    },
-    async searchEntity(query) {
-      if (!query || query.length < 2) {
-        this.entity_search_results = [];
-        return;
-      }
-
-      this.entity_search_loading = true;
-      try {
-        const response = await listEntities({
-          filter: `contains(any,${query})`,
-        });
-        const data = response?.data || [];
-        this.entity_search_results = Array.isArray(data) ? data.slice(0, 10) : [];
-      } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
-        this.entity_search_results = [];
-      } finally {
-        this.entity_search_loading = false;
-      }
-    },
-    async searchOntology(query) {
-      if (!query || query.length < 2) {
-        this.ontology_search_results = [];
-        return;
-      }
-
-      this.ontology_search_loading = true;
-      try {
-        const data = await searchOntology(query, { tree: true });
-        // Ontology API returns flat array with {id, label} format
-        const arr = Array.isArray(data) ? data : [];
-        this.ontology_search_results = arr.slice(0, 10);
-      } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
-        this.ontology_search_results = [];
-      } finally {
-        this.ontology_search_loading = false;
-      }
-    },
-    onOntologySelected(ontologyId) {
-      this.ontology_input = ontologyId;
-    },
-    async searchReplacementEntity(query) {
-      if (!query || query.length < 2) {
-        this.replace_entity_search_results = [];
-        return;
-      }
-
-      this.replace_entity_search_loading = true;
-      try {
-        const response = await listEntities({
-          filter: `contains(any,${query})`,
-        });
-        const data = response?.data || [];
-        // Filter out the current entity from replacement options
-        const filtered = Array.isArray(data)
-          ? data.filter((e) => e.entity_id !== this.entity_info.entity_id).slice(0, 10)
-          : [];
-        this.replace_entity_search_results = filtered;
-      } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
-        this.replace_entity_search_results = [];
-      } finally {
-        this.replace_entity_search_loading = false;
-      }
-    },
-    onReplacementEntitySelected(entityId) {
-      this.replace_entity_input = entityId;
-    },
-    async onEntitySelected(entityId) {
-      if (!entityId) {
-        this.entity_loaded = false;
-        this.entity_info = {};
-        return;
-      }
-
-      // Set the modify_entity_input to the selected entity ID
-      this.modify_entity_input = entityId;
-
-      // Fetch full entity details
-      await this.getEntity();
-
-      // Mark entity as loaded if successful
-      if (this.entity_info?.entity_id) {
-        this.entity_loaded = true;
-      }
-    },
-    async searchEntityInfo({ searchQuery, callback }) {
-      try {
-        const response_search = await listEntities({
-          filter: `contains(any,${searchQuery})`,
-        });
-
-        callback(null, response_search.data);
-      } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
-      }
-    },
-    async getEntity() {
-      try {
-        const response = await listEntities({
-          filter: `equals(entity_id,${this.modify_entity_input})`,
-        });
-
-        // Defensive check for valid response data
-        const entityData = response?.data;
-        if (!Array.isArray(entityData) || entityData.length === 0) {
-          this.makeToast(`Entity ${this.modify_entity_input} not found`, 'Error', 'danger');
-          this.entity_info = {};
-          return;
+      // color/symbols
+      ...colorAndSymbols,
+      // event handlers
+      showEntityRename,
+      showEntityDeactivate,
+      showReviewModify,
+      showStatusModify,
+      onSubmitRename,
+      onSubmitDeactivate,
+      onSubmitReview,
+      onSubmitStatus,
+      onEntitySelected,
+      // backward-compat aliases (used by existing specs)
+      submitEntityRename: onSubmitRename,
+      submitEntityDeactivation: onSubmitDeactivate,
+      // submitReviewChange bypasses the hasReviewChanges guard (spec compat)
+      submitReviewChange: async () => {
+        try {
+          await mutations.submitReview({
+            review_info: info.review_info.value,
+            select_phenotype: info.select_phenotype.value,
+            select_variation: info.select_variation.value,
+            select_additional_references: info.select_additional_references.value,
+            select_gene_reviews: info.select_gene_reviews.value,
+          });
+          modals.close();
+          info.reset();
+          search.clearAll();
+        } catch {
+          // error already toasted in composable
         }
-
-        const entity = entityData[0];
-
-        // Store full API response for enhanced preview display
-        // (includes symbol, disease_ontology_name, category, ndd_phenotype_word, etc.)
-        this.entity_info = entity;
-      } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
-        this.entity_info = {};
-      }
-    },
-    async getReview() {
-      this.loading_review_modal = true;
-
-      try {
-        const review_data = await getEntityReview(this.modify_entity_input);
-        const phenotypes_data = await getEntityPhenotypes(this.modify_entity_input);
-        const variation_data = await getEntityVariation(this.modify_entity_input);
-        const publications_data = await getEntityPublications(this.modify_entity_input);
-
-        // define phenotype specific attributes as constants from response
-        const new_phenotype = phenotypes_data.map(
-          (item) => new Phenotype(item.phenotype_id, item.modifier_id)
-        );
-
-        this.select_phenotype = phenotypes_data.map(
-          (item) => `${item.modifier_id}-${item.phenotype_id}`
-        );
-
-        // define variation specific attributes as constants from response
-        const new_variation = variation_data.map(
-          (item) => new Variation(item.vario_id, item.modifier_id)
-        );
-
-        this.select_variation = variation_data.map(
-          (item) => `${item.modifier_id}-${item.vario_id}`
-        );
-
-        // define publication specific attributes as constants from response
-        const literature_gene_reviews = publications_data
-          .filter((item) => item.publication_type === 'gene_review')
-          .map((item) => item.publication_id);
-
-        const literature_additional_references = publications_data
-          .filter((item) => item.publication_type === 'additional_references')
-          .map((item) => item.publication_id);
-
-        this.select_additional_references = literature_additional_references;
-        this.select_gene_reviews = literature_gene_reviews;
-
-        const new_literature = new Literature(
-          literature_additional_references,
-          literature_gene_reviews
-        );
-
-        // compose review
-        this.review_info = new Review(
-          review_data[0].synopsis,
-          new_literature,
-          new_phenotype,
-          new_variation,
-          review_data[0].comment
-        );
-
-        this.review_info.review_id = review_data[0].review_id;
-        this.review_info.entity_id = review_data[0].entity_id;
-
-        // Snapshot loaded data for change detection
-        this.reviewLoadedData = {
-          synopsis: this.review_info.synopsis || '',
-          comment: this.review_info.comment || '',
-          phenotypes: [...this.select_phenotype],
-          variationOntology: [...this.select_variation],
-          publications: [...this.select_additional_references],
-          genereviews: [...this.select_gene_reviews],
-        };
-
-        this.loading_review_modal = false;
-      } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
-      }
-    },
-    async getStatus() {
-      this.loading_status_modal = true;
-
-      try {
-        const status_data = await getEntityStatus(this.modify_entity_input);
-
-        // compose entity
-        this.status_info = new Status(
-          status_data[0].category_id,
-          status_data[0].comment,
-          status_data[0].problematic
-        );
-
-        this.status_info.status_id = status_data[0].status_id;
-        this.status_info.entity_id = status_data[0].entity_id;
-
-        this.loading_status_modal = false;
-      } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
-      }
-    },
-    normalizerEntitySearch(node) {
-      return {
-        id: node.entity_id,
-        label: `sysndd:${node.entity_id} (${node.symbol} - ${node.disease_ontology_name} - (${
-          node.disease_ontology_id_version
-        }) - ${node.hpo_mode_of_inheritance_term_name})`,
-      };
-    },
-    normalizerOntologySearch(node) {
-      return {
-        id: node.id,
-        label: `${node.id} (${node.label})`,
-      };
-    },
-    normalizeStatus(node) {
-      return {
-        id: node.category_id,
-        label: node.category,
-      };
-    },
-    // Normalize status options for BFormSelect
-    normalizeStatusOptions(options) {
-      if (!options || !Array.isArray(options)) return [];
-      return options.map((opt) => ({
-        value: opt.id,
-        text: opt.label,
-      }));
-    },
-    async loadOntologyInfoTree({ searchQuery, callback }) {
-      try {
-        const data = await searchOntology(searchQuery, { tree: true });
-        callback(null, data);
-      } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
-      }
-    },
-    async showEntityRename() {
-      await this.getEntity();
-      if (!this.entity_info?.entity_id) {
-        return;
-      }
-      this.$refs.renameModal.show();
-    },
-    async showEntityDeactivate() {
-      await this.getEntity();
-      if (!this.entity_info?.entity_id) {
-        return;
-      }
-      this.$refs.deactivateModal.show();
-    },
-    async showReviewModify() {
-      await this.getEntity();
-      if (!this.entity_info?.entity_id) {
-        return;
-      }
-      this.getReview();
-      this.$refs.modifyReviewModal.show();
-    },
-    async showStatusModify() {
-      // Reset form FIRST to ensure clean state before loading data
-      this.resetStatusForm();
-
-      // Load entity and status data
-      await this.getEntity();
-
-      // Guard against entity not found
-      if (!this.entity_info?.entity_id) {
-        // Error already shown by getEntity()
-        return;
-      }
-
-      await this.loadStatusByEntity(this.modify_entity_input);
-
-      // Ensure status options are loaded
-      if (this.status_options === null) {
-        await this.loadStatusList();
-      }
-
-      // Guard against empty options
-      if (!this.status_options || this.status_options.length === 0) {
-        this.makeToast(
-          'Failed to load status options. Please refresh and try again.',
-          'Error',
-          'danger'
-        );
-        return;
-      }
-
-      this.$refs.modifyStatusModal.show();
-    },
-    async submitEntityRename() {
-      this.submitting = 'rename';
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/entity/rename`;
-
-      // assign new disease_ontology_id
-      this.entity_info.disease_ontology_id_version = this.ontology_input;
-
-      // compose submission
-      const submission = new Submission(this.entity_info);
-
-      try {
-        const response = await apiClient.raw.post(apiUrl, { rename_json: submission });
-
-        this.makeToast(
-          `${'The new disease name for this entity has been submitted ' + '(status '}${
-            response.status
-          } (${response.statusText}).`,
-          'Success',
-          'success'
-        );
-        this.announce('Disease name updated successfully');
-        this.resetForm();
-      } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
-        this.announce('Failed to update disease name', 'assertive');
-      } finally {
-        this.submitting = null;
-      }
-    },
-    async submitEntityDeactivation() {
-      this.submitting = 'deactivate';
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/entity/deactivate`;
-
-      // assign new is_active
-      this.entity_info.is_active = this.deactivate_check ? 0 : 1;
-
-      // assign replace_entity_input
-      this.entity_info.replaced_by =
-        this.replace_entity_input === null ? null : this.replace_entity_input;
-
-      // compose submission
-      const submission = new Submission(this.entity_info);
-
-      try {
-        const response = await apiClient.raw.post(apiUrl, { deactivate_json: submission });
-
-        this.makeToast(
-          `${'The deactivation for this entity has been submitted ' + '(status '}${
-            response.status
-          } (${response.statusText}).`,
-          'Success',
-          'success'
-        );
-        this.announce('Entity deactivation submitted successfully');
-        this.resetForm();
-      } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
-        this.announce('Failed to deactivate entity', 'assertive');
-      } finally {
-        this.submitting = null;
-      }
-    },
-    async submitReviewChange() {
-      // Silent skip: close modal without API call when nothing changed
-      if (!this.hasReviewChanges) {
-        this.$refs.modifyReviewModal.hide();
-        return;
-      }
-
-      this.submitting = 'review';
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/review/create`;
-
-      // define literature specific attributes as constants from inputs
-      // first clean the arrays
-      const select_additional_references_clean = this.select_additional_references.map((element) =>
-        element.replace(/\s+/g, '')
-      );
-
-      const select_gene_reviews_clean = this.select_gene_reviews.map((element) =>
-        element.replace(/\s+/g, '')
-      );
-
-      const replace_literature = new Literature(
-        select_additional_references_clean,
-        select_gene_reviews_clean
-      );
-
-      // compose phenotype specific attributes as constants from inputs
-      const replace_phenotype = this.select_phenotype.map(
-        (item) => new Phenotype(item.split('-')[1], item.split('-')[0])
-      );
-
-      // compose variation ontology specific attributes as constants from inputs
-      const replace_variation_ontology = this.select_variation.map(
-        (item) => new Variation(item.split('-')[1], item.split('-')[0])
-      );
-
-      // assign to object
-      this.review_info.literature = replace_literature;
-      this.review_info.phenotypes = replace_phenotype;
-      this.review_info.variation_ontology = replace_variation_ontology;
-
-      // perform update POST request
-      try {
-        const response = await apiClient.raw.post(apiUrl, { review_json: this.review_info });
-
-        this.makeToast(
-          `${'The new review for this entity has been submitted ' + '(status '}${
-            response.status
-          } (${response.statusText}).`,
-          'Success',
-          'success'
-        );
-        this.announce('Review submitted successfully');
-        this.resetForm();
-      } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
-        this.announce('Failed to submit review', 'assertive');
-      } finally {
-        this.submitting = null;
-      }
-    },
-    async submitStatusChange() {
-      // Silent skip: close modal without API call when nothing changed
-      if (!this.hasStatusChanges) {
-        this.$refs.modifyStatusModal.hide();
-        return;
-      }
-
-      this.submitting = 'status';
-      try {
-        await this.submitStatusForm(false, false); // isUpdate=false (always create), reReview=false
-        this.makeToast('Status submitted successfully', 'Success', 'success');
-        this.announce('Status submitted successfully');
-        this.resetStatusForm();
-        this.resetForm(); // Also reset entity selection
-      } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
-        this.announce('Failed to submit status', 'assertive');
-      } finally {
-        this.submitting = null;
-      }
-    },
-    resetForm() {
-      this.modify_entity_input = null;
-      this.entity_display = '';
-      this.entity_loaded = false;
-      this.replace_entity_input = null;
-      this.replace_entity_display = '';
-      this.replace_entity_search_results = [];
-      this.ontology_input = null;
-      this.ontology_display = '';
-      this.ontology_search_results = [];
-      this.entity_info = {};
-      this.review_info = new Review();
-      this.select_phenotype = [];
-      this.select_variation = [];
-      this.select_additional_references = [];
-      this.select_gene_reviews = [];
-      this.reviewLoadedData = null;
-      this.status_info = new Status();
-      this.deactivate_check = false;
-      this.replace_check = false;
-    },
-    tagValidatorPMID(tag) {
-      // Individual PMID tag validator function
-      const tag_copy = tag.replace(/\s+/g, '');
-      return (
-        !Number.isNaN(Number(tag_copy.replaceAll('PMID:', ''))) &&
-        tag_copy.includes('PMID:') &&
-        tag_copy.replace('PMID:', '').length > 4 &&
-        tag_copy.replace('PMID:', '').length < 9
-      );
-    },
-    onRenameModalShow() {
-      // Reset rename-specific state (FORM-07: prevents stale data)
-      this.ontology_input = null;
-      this.ontology_display = '';
-      this.ontology_search_results = [];
-    },
-    onDeactivateModalShow() {
-      // Reset deactivate-specific state (FORM-07: prevents stale data)
-      this.deactivate_check = false;
-      this.replace_check = false;
-      this.replace_entity_input = null;
-      this.replace_entity_display = '';
-    },
-    onModifyReviewModalShow() {
-      // Reset form state on show (FORM-07: prevents stale data flash)
-      this.review_info = new Review();
-      this.select_phenotype = [];
-      this.select_variation = [];
-      this.select_additional_references = [];
-      this.select_gene_reviews = [];
-    },
-    onModifyReviewModalHide(event) {
-      if (this.pendingDiscardTarget === 'review') {
-        this.pendingDiscardTarget = null;
-        return; // Allow close after confirmed discard
-      }
-      if (this.hasReviewChanges && !this.submitting) {
-        event.preventDefault();
-        this.pendingDiscardTarget = 'review';
-        this.$refs.confirmDiscardDialog.show();
-      }
-    },
-    onModifyStatusModalShow() {
-      // Reset moved to showStatusModify() — intentionally empty to preserve loaded data
-      // The reset must happen BEFORE data load, not after modal renders
-    },
-    onModifyStatusModalHide(event) {
-      if (this.pendingDiscardTarget === 'status') {
-        this.pendingDiscardTarget = null;
-        return; // Allow close after confirmed discard
-      }
-      if (this.hasStatusChanges && !this.submitting) {
-        event.preventDefault();
-        this.pendingDiscardTarget = 'status';
-        this.$refs.confirmDiscardDialog.show();
-      }
-    },
-    onConfirmDiscard() {
-      if (this.pendingDiscardTarget === 'review') {
-        this.$refs.modifyReviewModal.hide();
-      } else if (this.pendingDiscardTarget === 'status') {
-        this.$refs.modifyStatusModal.hide();
-      }
-    },
+      },
+      // ref for confirm dialog
+      confirmDiscardDialogRef,
+      // static data
+      legendItems,
+      makeToast,
+    };
   },
-};
+});
 </script>
 
 <style scoped>

--- a/app/src/views/curate/ModifyEntity.vue
+++ b/app/src/views/curate/ModifyEntity.vue
@@ -274,12 +274,16 @@ export default defineComponent({
     const colorAndSymbols = useColorAndSymbols();
     const { message: a11yMessage, politeness: a11yPoliteness, announce } = useAriaLive();
 
-    const info = useEntityInfo({ onToast: makeToast });
+    // Cast makeToast to the composables' broader (...unknown[]) signature.
+    // makeToast's full typed signature differs from the (...args: unknown[]) =&gt; void
+    // expected by the composable interface (TOAST-SHIM cohort).
+    const toastFn = makeToast as unknown as (...args: unknown[]) => void;
+    const info = useEntityInfo({ onToast: toastFn });
     const search = useEntityAutocomplete({
-      onToast: makeToast,
+      onToast: toastFn,
       getCurrentEntityId: () => info.entity_info.value.entity_id,
     });
-    const mutations = useEntityMutations({ onToast: makeToast, onAnnounce: announce });
+    const mutations = useEntityMutations({ onToast: toastFn, onAnnounce: announce });
     const modals = useEntityModifyModals();
     const statusForm = useStatusForm();
 

--- a/app/src/views/curate/ModifyEntity.vue
+++ b/app/src/views/curate/ModifyEntity.vue
@@ -329,6 +329,13 @@ export default defineComponent({
         status_options.value = Array.isArray(status_data) ? status_data : (status_data as any)?.data || [];
       } catch (e) {
         makeToast(e, 'Error', 'danger');
+        // Set deterministic empty defaults so downstream modals render
+        // their empty-state alerts instead of staying in the null/loading
+        // limbo (StatusModifyModal hides both the select and the empty
+        // alert while statusOptions is null).
+        if (phenotypes_options.value === null) phenotypes_options.value = [];
+        if (variation_ontology_options.value === null) variation_ontology_options.value = [];
+        if (status_options.value === null) status_options.value = [];
       } finally {
         status_options_loading.value = false;
       }
@@ -349,6 +356,10 @@ export default defineComponent({
       replace_check.value = false;
       search.replace_entity_input.value = null;
       search.replace_entity_display.value = '';
+      // Clear stale autocomplete results so the dropdown doesn't open
+      // with leftover suggestions from a previous deactivation attempt.
+      search.replace_entity_search_results.value = [];
+      search.replace_entity_search_loading.value = false;
       modals.openDeactivate();
       modals.setLoading('deactivate', false);
     }

--- a/app/src/views/curate/components/EntityInfoHeader.vue
+++ b/app/src/views/curate/components/EntityInfoHeader.vue
@@ -1,0 +1,140 @@
+<!-- app/src/views/curate/components/EntityInfoHeader.vue -->
+<template>
+  <div v-if="entity?.entity_id" class="entity-info-header">
+    <!-- Entity Preview Card -->
+    <BCard class="my-2" body-class="p-3" header-class="p-2" border-variant="info">
+      <template #header>
+        <h6 class="mb-0 text-start font-weight-bold d-flex align-items-center">
+          <i class="bi bi-info-circle me-2" aria-hidden="true" />
+          Selected Entity
+          <EntityBadge
+            :entity-id="entity.entity_id"
+            variant="primary"
+            size="md"
+            class="ms-2"
+          />
+        </h6>
+      </template>
+
+      <BRow class="g-3">
+        <BCol md="6">
+          <!-- Gene with badge and HGNC link -->
+          <div class="mb-2">
+            <strong class="text-muted small d-block mb-1">Gene:</strong>
+            <GeneBadge
+              :symbol="entity.symbol || 'N/A'"
+              :hgnc-id="entity.hgnc_id"
+              :link-to="
+                entity.hgnc_id
+                  ? `https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/${entity.hgnc_id}`
+                  : null
+              "
+              size="md"
+            />
+          </div>
+
+          <!-- Disease with badge and ontology link -->
+          <div class="mb-2">
+            <strong class="text-muted small d-block mb-1">Disease:</strong>
+            <DiseaseBadge
+              :name="entity.disease_ontology_name || 'N/A'"
+              :ontology-id="entity.disease_ontology_id_version"
+              :link-to="
+                entity.disease_ontology_id_version
+                  ? `/Ontology/${entity.disease_ontology_id_version.replace(/_.+/g, '')}`
+                  : null
+              "
+              size="md"
+              :max-length="40"
+            />
+          </div>
+        </BCol>
+
+        <BCol md="6">
+          <!-- Inheritance with icon -->
+          <div class="mb-2">
+            <strong class="text-muted small d-block mb-1">Inheritance:</strong>
+            <BBadge variant="info" class="d-inline-flex align-items-center">
+              <i class="bi bi-diagram-3 me-1" aria-hidden="true" />
+              {{
+                entity.hpo_mode_of_inheritance_term_name ||
+                entity.hpo_mode_of_inheritance_term ||
+                'N/A'
+              }}
+            </BBadge>
+          </div>
+
+          <!-- Category with stoplight style -->
+          <div class="mb-2">
+            <strong class="text-muted small d-block mb-1">Category:</strong>
+            <BBadge
+              :variant="(stoplightsStyle[entity.category] || 'secondary') as any"
+              class="d-inline-flex align-items-center"
+            >
+              <i class="bi bi-stoplights me-1" aria-hidden="true" />
+              {{ entity.category || 'N/A' }}
+            </BBadge>
+          </div>
+
+          <!-- NDD Status with icon -->
+          <div class="mb-2">
+            <strong class="text-muted small d-block mb-1">NDD Status:</strong>
+            <BBadge
+              :variant="(nddIconStyle[entity.ndd_phenotype_word] || 'secondary') as any"
+              class="d-inline-flex align-items-center"
+            >
+              <i
+                :class="`bi bi-${nddIcon[entity.ndd_phenotype_word] || 'question'} me-1`"
+                aria-hidden="true"
+              />
+              {{ entity.ndd_phenotype_word || 'N/A' }}
+            </BBadge>
+          </div>
+        </BCol>
+      </BRow>
+    </BCard>
+
+    <!-- Icon Legend -->
+    <IconLegend
+      v-if="legendItems && legendItems.length"
+      :legend-items="legendItems"
+      title="Category & NDD Status Icons"
+      class="my-2"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue';
+import GeneBadge from '@/components/ui/GeneBadge.vue';
+import DiseaseBadge from '@/components/ui/DiseaseBadge.vue';
+import EntityBadge from '@/components/ui/EntityBadge.vue';
+import IconLegend from '@/components/accessibility/IconLegend.vue';
+
+export default defineComponent({
+  name: 'EntityInfoHeader',
+  components: { GeneBadge, DiseaseBadge, EntityBadge, IconLegend },
+  props: {
+    entity: {
+      type: Object as PropType<Record<string, any> | null>,
+      default: null,
+    },
+    legendItems: {
+      type: Array as PropType<Array<{ icon: string; color: string; label: string }>>,
+      default: () => [],
+    },
+    stoplightsStyle: {
+      type: Object as PropType<Record<string, string>>,
+      default: () => ({}),
+    },
+    nddIconStyle: {
+      type: Object as PropType<Record<string, string>>,
+      default: () => ({}),
+    },
+    nddIcon: {
+      type: Object as PropType<Record<string, string>>,
+      default: () => ({}),
+    },
+  },
+});
+</script>

--- a/app/src/views/curate/components/EntityInfoHeader.vue
+++ b/app/src/views/curate/components/EntityInfoHeader.vue
@@ -27,7 +27,7 @@
               :link-to="
                 entity.hgnc_id
                   ? `https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/${entity.hgnc_id}`
-                  : null
+                  : undefined
               "
               size="md"
             />
@@ -42,7 +42,7 @@
               :link-to="
                 entity.disease_ontology_id_version
                   ? `/Ontology/${entity.disease_ontology_id_version.replace(/_.+/g, '')}`
-                  : null
+                  : undefined
               "
               size="md"
               :max-length="40"

--- a/app/src/views/curate/components/EntityRenameDeactivateModal.vue
+++ b/app/src/views/curate/components/EntityRenameDeactivateModal.vue
@@ -1,0 +1,192 @@
+<!-- app/src/views/curate/components/EntityRenameDeactivateModal.vue -->
+<template>
+  <BModal
+    :id="mode === 'rename' ? 'renameModal' : 'deactivateModal'"
+    v-model="proxyVisible"
+    size="lg"
+    centered
+    ok-title="Submit"
+    no-close-on-esc
+    no-close-on-backdrop
+    header-bg-variant="dark"
+    header-text-variant="light"
+    header-close-label="Close"
+    @ok.prevent="$emit('submit')"
+    @cancel="$emit('cancel')"
+    @hide="$emit('cancel')"
+  >
+    <template #title>
+      <div class="d-flex flex-column gap-2">
+        <h4 class="mb-0">
+          {{ mode === 'rename' ? 'Rename Entity Disease' : 'Deactivate Entity' }}
+          <EntityBadge
+            v-if="entity?.entity_id"
+            :entity-id="entity.entity_id"
+            variant="primary"
+            size="md"
+            class="ms-2"
+          />
+        </h4>
+        <div class="d-flex flex-wrap gap-2 small">
+          <span class="d-flex align-items-center">
+            <i class="bi bi-file-earmark-medical me-1" />
+            <strong>{{ entity?.symbol || 'N/A' }}</strong>
+          </span>
+          <span class="text-muted">|</span>
+          <span
+            class="d-flex align-items-center text-truncate"
+            style="max-width: 200px"
+            :title="entity?.disease_ontology_name"
+          >
+            <i class="bi bi-clipboard2-pulse me-1" />
+            {{ entity?.disease_ontology_name || 'N/A' }}
+          </span>
+          <span class="text-muted">|</span>
+          <span class="d-flex align-items-center">
+            <i class="bi bi-diagram-3 me-1" />
+            {{
+              entity?.hpo_mode_of_inheritance_term_name ||
+              entity?.hpo_mode_of_inheritance_term ||
+              'N/A'
+            }}
+          </span>
+          <span class="text-muted">|</span>
+          <BBadge
+            :variant="(stoplightsStyle[entity?.category] || 'secondary') as any"
+            class="d-inline-flex align-items-center"
+          >
+            <i class="bi bi-stoplights me-1" />
+            {{ entity?.category || 'N/A' }}
+          </BBadge>
+        </div>
+      </div>
+    </template>
+
+    <!-- Rename mode -->
+    <template v-if="mode === 'rename'">
+      <p class="my-3">Select a new disease name:</p>
+      <AutocompleteInput
+        v-model:display-value="ontologyDisplayProxy"
+        :model-value="(ontologyInput as any)"
+        :results="ontologySearchResults"
+        :loading="ontologySearchLoading"
+        label="Disease"
+        input-id="ontology-select"
+        placeholder="Search by disease name or ontology ID (e.g., OMIM:123456)..."
+        item-key="id"
+        item-label="label"
+        item-secondary="id"
+        @search="(q) => $emit('search-ontology', q)"
+        @update:model-value="(id) => $emit('select-ontology', id)"
+      />
+      <small class="text-muted">Search for diseases by name or ontology identifier</small>
+    </template>
+
+    <!-- Deactivate mode -->
+    <template v-else>
+      <div>
+        <p class="my-2">1. Are you sure that you want to deactivate this entity?</p>
+        <BFormCheckbox
+          id="deactivateSwitch"
+          :model-value="deactivateCheck"
+          switch
+          size="md"
+          @update:model-value="$emit('update:deactivate-check', $event)"
+        >
+          <strong>{{ deactivateCheck ? 'Yes' : 'No' }}</strong>
+        </BFormCheckbox>
+      </div>
+
+      <div v-if="deactivateCheck">
+        <p class="my-2">2. Was this entity replaced by another one?</p>
+        <BFormCheckbox
+          id="replaceSwitch"
+          :model-value="replaceCheck"
+          switch
+          size="md"
+          @update:model-value="$emit('update:replace-check', $event)"
+        >
+          <strong>{{ replaceCheck ? 'Yes' : 'No' }}</strong>
+        </BFormCheckbox>
+      </div>
+
+      <div v-if="replaceCheck">
+        <p class="my-2">3. Select the entity replacing the above one:</p>
+        <AutocompleteInput
+          v-model:display-value="replaceDisplayProxy"
+          :model-value="(replaceEntityInput as any)"
+          :results="replaceSearchResults"
+          :loading="replaceSearchLoading"
+          label="Replacement Entity"
+          input-id="replace-entity-select"
+          placeholder="Search by ID, gene symbol, or disease name..."
+          item-key="entity_id"
+          item-label="symbol"
+          item-secondary="entity_id"
+          item-description="disease_ontology_name"
+          @search="(q) => $emit('search-replacement', q)"
+          @update:model-value="(id) => $emit('select-replacement', id)"
+        />
+        <small class="text-muted">Search for the entity that replaces this one</small>
+      </div>
+    </template>
+  </BModal>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, type PropType } from 'vue';
+import AutocompleteInput from '@/components/forms/AutocompleteInput.vue';
+import EntityBadge from '@/components/ui/EntityBadge.vue';
+
+export default defineComponent({
+  name: 'EntityRenameDeactivateModal',
+  components: { AutocompleteInput, EntityBadge },
+  props: {
+    visible: { type: Boolean, default: false },
+    mode: { type: String as PropType<'rename' | 'deactivate'>, required: true },
+    entity: { type: Object as PropType<Record<string, any> | null>, default: null },
+    submitting: { type: String as PropType<string | null>, default: null },
+    stoplightsStyle: { type: Object as PropType<Record<string, string>>, default: () => ({}) },
+    // rename mode bindings
+    ontologyDisplay: { type: String, default: '' },
+    ontologyInput: { type: [String, null] as PropType<string | null>, default: null },
+    ontologySearchResults: { type: Array as PropType<any[]>, default: () => [] },
+    ontologySearchLoading: { type: Boolean, default: false },
+    // deactivate mode bindings
+    deactivateCheck: { type: Boolean, default: false },
+    replaceCheck: { type: Boolean, default: false },
+    replaceDisplay: { type: String, default: '' },
+    replaceEntityInput: { type: [Number, null] as PropType<number | null>, default: null },
+    replaceSearchResults: { type: Array as PropType<any[]>, default: () => [] },
+    replaceSearchLoading: { type: Boolean, default: false },
+  },
+  emits: [
+    'update:visible',
+    'update:ontology-display',
+    'update:replace-display',
+    'update:deactivate-check',
+    'update:replace-check',
+    'search-ontology',
+    'select-ontology',
+    'search-replacement',
+    'select-replacement',
+    'submit',
+    'cancel',
+  ],
+  setup(props, { emit }) {
+    const proxyVisible = computed({
+      get: () => props.visible,
+      set: (v: boolean) => emit('update:visible', v),
+    });
+    const ontologyDisplayProxy = computed({
+      get: () => props.ontologyDisplay,
+      set: (v: string) => emit('update:ontology-display', v),
+    });
+    const replaceDisplayProxy = computed({
+      get: () => props.replaceDisplay,
+      set: (v: string) => emit('update:replace-display', v),
+    });
+    return { proxyVisible, ontologyDisplayProxy, replaceDisplayProxy };
+  },
+});
+</script>

--- a/app/src/views/curate/components/EntitySearchPanel.vue
+++ b/app/src/views/curate/components/EntitySearchPanel.vue
@@ -1,0 +1,67 @@
+<!-- app/src/views/curate/components/EntitySearchPanel.vue -->
+<template>
+  <BCard class="my-2" body-class="p-2" header-class="p-1" border-variant="dark">
+    <template #header>
+      <h6 class="mb-1 text-start font-weight-bold">1. Select an entity to modify</h6>
+    </template>
+
+    <BRow>
+      <BCol class="my-1">
+        <AutocompleteInput
+          v-model:display-value="displayProxy"
+          :model-value="(modelValue as any)"
+          :results="searchResults"
+          :loading="loading"
+          label="Entity"
+          input-id="entity-select"
+          placeholder="Search by ID, gene symbol, or disease name..."
+          item-key="entity_id"
+          item-label="symbol"
+          item-secondary="entity_id"
+          item-description="disease_ontology_name"
+          @search="(q) => $emit('search', q)"
+          @update:model-value="(id) => $emit('update:model-value', id)"
+        />
+        <small class="text-muted">
+          Search for entities by sysndd ID, gene symbol, or disease name
+        </small>
+      </BCol>
+    </BRow>
+  </BCard>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, type PropType } from 'vue';
+import AutocompleteInput from '@/components/forms/AutocompleteInput.vue';
+
+export default defineComponent({
+  name: 'EntitySearchPanel',
+  components: { AutocompleteInput },
+  props: {
+    modelValue: {
+      type: [Number, null] as PropType<number | null>,
+      default: null,
+    },
+    displayValue: {
+      type: String,
+      default: '',
+    },
+    searchResults: {
+      type: Array as PropType<any[]>,
+      default: () => [],
+    },
+    loading: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ['update:model-value', 'update:display-value', 'search'],
+  setup(props, { emit }) {
+    const displayProxy = computed({
+      get: () => props.displayValue,
+      set: (v: string) => emit('update:display-value', v),
+    });
+    return { displayProxy };
+  },
+});
+</script>

--- a/app/src/views/curate/components/ReviewModifyModal.vue
+++ b/app/src/views/curate/components/ReviewModifyModal.vue
@@ -1,0 +1,273 @@
+<!-- app/src/views/curate/components/ReviewModifyModal.vue -->
+<template>
+  <BModal
+    id="modifyReviewModal"
+    v-model="proxyVisible"
+    size="xl"
+    centered
+    ok-title="Submit"
+    no-close-on-esc
+    no-close-on-backdrop
+    header-bg-variant="dark"
+    header-text-variant="light"
+    header-close-label="Close"
+    :busy="loading || submitting === 'review'"
+    @ok.prevent="$emit('submit')"
+    @hide="onHide"
+  >
+    <template #title>
+      <div class="d-flex flex-column gap-2">
+        <h4 class="mb-0">
+          Modify Review
+          <EntityBadge
+            v-if="entity?.entity_id"
+            :entity-id="entity.entity_id"
+            variant="primary"
+            size="md"
+            class="ms-2"
+          />
+        </h4>
+        <div class="d-flex flex-wrap gap-2 small">
+          <span class="d-flex align-items-center">
+            <i class="bi bi-file-earmark-medical me-1" />
+            <strong>{{ entity?.symbol || 'N/A' }}</strong>
+          </span>
+          <span class="text-muted">|</span>
+          <span
+            class="d-flex align-items-center text-truncate"
+            style="max-width: 200px"
+            :title="entity?.disease_ontology_name"
+          >
+            <i class="bi bi-clipboard2-pulse me-1" />
+            {{ entity?.disease_ontology_name || 'N/A' }}
+          </span>
+          <span class="text-muted">|</span>
+          <span class="d-flex align-items-center">
+            <i class="bi bi-diagram-3 me-1" />
+            {{
+              entity?.hpo_mode_of_inheritance_term_name ||
+              entity?.hpo_mode_of_inheritance_term ||
+              'N/A'
+            }}
+          </span>
+          <span class="text-muted">|</span>
+          <BBadge
+            :variant="(stoplightsStyle[entity?.category] || 'secondary') as any"
+            class="d-inline-flex align-items-center"
+          >
+            <i class="bi bi-stoplights me-1" />
+            {{ entity?.category || 'N/A' }}
+          </BBadge>
+        </div>
+      </div>
+    </template>
+
+    <BOverlay :show="loading" rounded="sm">
+      <BForm @submit.stop.prevent="$emit('submit')">
+        <!-- Synopsis textarea -->
+        <label class="mr-sm-2 font-weight-bold" for="review-textarea-synopsis">Synopsis</label>
+        <BFormTextarea
+          id="review-textarea-synopsis"
+          :model-value="review?.synopsis"
+          rows="3"
+          size="sm"
+          @update:model-value="$emit('update:review', { ...review, synopsis: $event })"
+        />
+
+        <!-- Phenotype select -->
+        <label class="mr-sm-2 font-weight-bold" for="review-phenotype-select">Phenotypes</label>
+        <TreeMultiSelect
+          v-if="phenotypeOptions && phenotypeOptions.length > 0"
+          id="review-phenotype-select"
+          :model-value="selectPhenotype"
+          :options="phenotypeOptions"
+          placeholder="Select phenotypes..."
+          search-placeholder="Search phenotypes (name or HP:ID)..."
+          @update:model-value="$emit('update:select-phenotype', $event)"
+        />
+
+        <!-- Variation ontology select -->
+        <label class="mr-sm-2 font-weight-bold" for="review-variation-select"
+          >Variation ontology</label
+        >
+        <TreeMultiSelect
+          v-if="variationOptions && variationOptions.length > 0"
+          id="review-variation-select"
+          :model-value="selectVariation"
+          :options="variationOptions"
+          placeholder="Select variations..."
+          search-placeholder="Search variation types..."
+          @update:model-value="$emit('update:select-variation', $event)"
+        />
+
+        <!-- Publications tag form with links out -->
+        <label class="mr-sm-2 font-weight-bold" for="review-publications-select"
+          >Publications</label
+        >
+        <BFormTags
+          :model-value="selectAdditionalReferences"
+          input-id="review-literature-select"
+          no-outer-focus
+          class="my-0"
+          separator=",;"
+          :tag-validator="tagValidatorPMID"
+          remove-on-delete
+          @update:model-value="$emit('update:select-additional-references', $event)"
+        >
+          <template #default="{ tags, inputAttrs, inputHandlers, addTag, removeTag }">
+            <BInputGroup class="my-0">
+              <BFormInput
+                v-bind="inputAttrs"
+                placeholder="Enter PMIDs separated by comma or semicolon"
+                class="form-control"
+                size="sm"
+                v-on="inputHandlers"
+              />
+              <BButton variant="secondary" size="sm" @click="addTag()">Add</BButton>
+            </BInputGroup>
+            <div class="d-inline-block">
+              <h6>
+                <BFormTag
+                  v-for="tag in tags"
+                  :key="tag"
+                  :title="tag"
+                  variant="secondary"
+                  @remove="removeTag(tag)"
+                >
+                  <BLink
+                    :href="'https://pubmed.ncbi.nlm.nih.gov/' + tag.replace('PMID:', '')"
+                    target="_blank"
+                    class="text-light"
+                  >
+                    <i class="bi bi-box-arrow-up-right" />
+                    {{ tag }}
+                  </BLink>
+                </BFormTag>
+              </h6>
+            </div>
+          </template>
+        </BFormTags>
+
+        <!-- Genereviews tag form with links out -->
+        <label class="mr-sm-2 font-weight-bold" for="review-genereviews-select"
+          >Genereviews</label
+        >
+        <BFormTags
+          :model-value="selectGeneReviews"
+          input-id="review-genereviews-select"
+          no-outer-focus
+          class="my-0"
+          separator=",;"
+          :tag-validator="tagValidatorPMID"
+          remove-on-delete
+          @update:model-value="$emit('update:select-gene-reviews', $event)"
+        >
+          <template #default="{ tags, inputAttrs, inputHandlers, addTag, removeTag }">
+            <BInputGroup class="my-0">
+              <BFormInput
+                v-bind="inputAttrs"
+                placeholder="Enter PMIDs separated by comma or semicolon"
+                class="form-control"
+                size="sm"
+                v-on="inputHandlers"
+              />
+              <BButton variant="secondary" size="sm" @click="addTag()">Add</BButton>
+            </BInputGroup>
+            <div class="d-inline-block">
+              <h6>
+                <BFormTag
+                  v-for="tag in tags"
+                  :key="tag"
+                  :title="tag"
+                  variant="secondary"
+                  @remove="removeTag(tag)"
+                >
+                  <BLink
+                    :href="'https://pubmed.ncbi.nlm.nih.gov/' + tag.replace('PMID:', '')"
+                    target="_blank"
+                    class="text-light"
+                  >
+                    <i class="bi bi-box-arrow-up-right" />
+                    {{ tag }}
+                  </BLink>
+                </BFormTag>
+              </h6>
+            </div>
+          </template>
+        </BFormTags>
+
+        <!-- Review comment textarea -->
+        <label class="mr-sm-2 font-weight-bold" for="review-textarea-comment">Comment</label>
+        <BFormTextarea
+          id="review-textarea-comment"
+          :model-value="review?.comment"
+          rows="2"
+          size="sm"
+          placeholder="Additional comments to this entity relevant for the curator."
+          @update:model-value="$emit('update:review', { ...review, comment: $event })"
+        />
+      </BForm>
+    </BOverlay>
+  </BModal>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, type PropType } from 'vue';
+import TreeMultiSelect from '@/components/forms/TreeMultiSelect.vue';
+import EntityBadge from '@/components/ui/EntityBadge.vue';
+
+export default defineComponent({
+  name: 'ReviewModifyModal',
+  components: { TreeMultiSelect, EntityBadge },
+  props: {
+    visible: { type: Boolean, default: false },
+    loading: { type: Boolean, default: false },
+    submitting: { type: String as PropType<string | null>, default: null },
+    entity: { type: Object as PropType<Record<string, any> | null>, default: null },
+    review: { type: Object as PropType<any>, default: null },
+    selectPhenotype: { type: Array as PropType<string[]>, default: () => [] },
+    selectVariation: { type: Array as PropType<string[]>, default: () => [] },
+    selectAdditionalReferences: { type: Array as PropType<string[]>, default: () => [] },
+    selectGeneReviews: { type: Array as PropType<string[]>, default: () => [] },
+    phenotypeOptions: { type: Array as PropType<any[]>, default: () => [] },
+    variationOptions: { type: Array as PropType<any[]>, default: () => [] },
+    hasChanges: { type: Boolean, default: false },
+    stoplightsStyle: { type: Object as PropType<Record<string, string>>, default: () => ({}) },
+  },
+  emits: [
+    'update:visible',
+    'update:review',
+    'update:select-phenotype',
+    'update:select-variation',
+    'update:select-additional-references',
+    'update:select-gene-reviews',
+    'submit',
+    'discard-request',
+  ],
+  setup(props, { emit }) {
+    const proxyVisible = computed({
+      get: () => props.visible,
+      set: (v: boolean) => emit('update:visible', v),
+    });
+
+    function tagValidatorPMID(tag: string): boolean {
+      const t = tag.replace(/\s+/g, '');
+      return (
+        !Number.isNaN(Number(t.replaceAll('PMID:', ''))) &&
+        t.includes('PMID:') &&
+        t.replace('PMID:', '').length > 4 &&
+        t.replace('PMID:', '').length < 9
+      );
+    }
+
+    function onHide(event: any): void {
+      if (props.hasChanges && props.submitting !== 'review') {
+        event?.preventDefault?.();
+        emit('discard-request', 'review');
+      }
+    }
+
+    return { proxyVisible, tagValidatorPMID, onHide };
+  },
+});
+</script>

--- a/app/src/views/curate/components/ReviewModifyModal.vue
+++ b/app/src/views/curate/components/ReviewModifyModal.vue
@@ -251,13 +251,10 @@ export default defineComponent({
     });
 
     function tagValidatorPMID(tag: string): boolean {
+      // Tight: PMID: prefix at start, 5–8 digits only (no trailing/leading garbage).
+      // Strips whitespace first to tolerate copy-paste, then enforces shape.
       const t = tag.replace(/\s+/g, '');
-      return (
-        !Number.isNaN(Number(t.replaceAll('PMID:', ''))) &&
-        t.includes('PMID:') &&
-        t.replace('PMID:', '').length > 4 &&
-        t.replace('PMID:', '').length < 9
-      );
+      return /^PMID:\d{5,8}$/.test(t);
     }
 
     function onHide(event: any): void {

--- a/app/src/views/curate/components/StatusModifyModal.vue
+++ b/app/src/views/curate/components/StatusModifyModal.vue
@@ -98,7 +98,7 @@
           :model-value="formData.comment"
           rows="2"
           size="sm"
-          placeholder="Why should this entities status be changed."
+          placeholder="Why should this entity's status be changed."
           @update:model-value="$emit('update:form-data', { ...formData, comment: $event })"
         />
       </BForm>

--- a/app/src/views/curate/components/StatusModifyModal.vue
+++ b/app/src/views/curate/components/StatusModifyModal.vue
@@ -1,0 +1,153 @@
+<!-- app/src/views/curate/components/StatusModifyModal.vue -->
+<template>
+  <BModal
+    id="modifyStatusModal"
+    v-model="proxyVisible"
+    size="lg"
+    centered
+    ok-title="Submit"
+    no-close-on-esc
+    no-close-on-backdrop
+    header-bg-variant="dark"
+    header-text-variant="light"
+    header-close-label="Close"
+    :busy="loading || submitting === 'status'"
+    @ok.prevent="$emit('submit')"
+    @hide="onHide"
+  >
+    <template #title>
+      <div class="d-flex flex-column gap-2">
+        <h4 class="mb-0">
+          Modify Status
+          <EntityBadge
+            v-if="entity?.entity_id"
+            :entity-id="entity.entity_id"
+            variant="primary"
+            size="md"
+            class="ms-2"
+          />
+        </h4>
+        <div class="d-flex flex-wrap gap-2 small">
+          <span class="d-flex align-items-center">
+            <i class="bi bi-file-earmark-medical me-1" />
+            <strong>{{ entity?.symbol || 'N/A' }}</strong>
+          </span>
+          <span class="text-muted">|</span>
+          <span
+            class="d-flex align-items-center text-truncate"
+            style="max-width: 200px"
+            :title="entity?.disease_ontology_name"
+          >
+            <i class="bi bi-clipboard2-pulse me-1" />
+            {{ entity?.disease_ontology_name || 'N/A' }}
+          </span>
+          <span class="text-muted">|</span>
+          <span class="d-flex align-items-center">
+            <i class="bi bi-diagram-3 me-1" />
+            {{
+              entity?.hpo_mode_of_inheritance_term_name ||
+              entity?.hpo_mode_of_inheritance_term ||
+              'N/A'
+            }}
+          </span>
+          <span class="text-muted">|</span>
+          <BBadge
+            :variant="(stoplightsStyle[entity?.category] || 'secondary') as any"
+            class="d-inline-flex align-items-center"
+          >
+            <i class="bi bi-stoplights me-1" />
+            {{ entity?.category || 'N/A' }}
+          </BBadge>
+        </div>
+      </div>
+    </template>
+
+    <BOverlay :show="loading" rounded="sm">
+      <BForm @submit.stop.prevent="$emit('submit')">
+        <!-- Status dropdown with loading state -->
+        <BSpinner v-if="statusOptionsLoading" small label="Loading..." />
+        <BFormSelect
+          v-else-if="statusOptions && statusOptions.length > 0"
+          id="status-select"
+          :model-value="formData.category_id"
+          :options="normalizedStatusOptions"
+          size="sm"
+          @update:model-value="$emit('update:form-data', { ...formData, category_id: $event })"
+        >
+          <template #first>
+            <BFormSelectOption :value="null">Select status...</BFormSelectOption>
+          </template>
+        </BFormSelect>
+        <BAlert v-else-if="statusOptions !== null" variant="warning" class="mb-0">
+          No status options available
+        </BAlert>
+
+        <BFormCheckbox
+          id="removeSwitch"
+          :model-value="formData.problematic"
+          switch
+          size="md"
+          @update:model-value="$emit('update:form-data', { ...formData, problematic: $event })"
+        >
+          Suggest removal
+        </BFormCheckbox>
+
+        <label class="mr-sm-2 font-weight-bold" for="status-textarea-comment">Comment</label>
+        <BFormTextarea
+          id="status-textarea-comment"
+          :model-value="formData.comment"
+          rows="2"
+          size="sm"
+          placeholder="Why should this entities status be changed."
+          @update:model-value="$emit('update:form-data', { ...formData, comment: $event })"
+        />
+      </BForm>
+    </BOverlay>
+  </BModal>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent, type PropType } from 'vue';
+import EntityBadge from '@/components/ui/EntityBadge.vue';
+import type { StatusFormData } from '../composables/useStatusForm';
+
+export default defineComponent({
+  name: 'StatusModifyModal',
+  components: { EntityBadge },
+  props: {
+    visible: { type: Boolean, default: false },
+    loading: { type: Boolean, default: false },
+    submitting: { type: String as PropType<string | null>, default: null },
+    entity: { type: Object as PropType<Record<string, any> | null>, default: null },
+    statusOptions: { type: Array as PropType<any[] | null>, default: null },
+    statusOptionsLoading: { type: Boolean, default: false },
+    formData: {
+      type: Object as PropType<StatusFormData>,
+      required: true,
+    },
+    hasChanges: { type: Boolean, default: false },
+    stoplightsStyle: { type: Object as PropType<Record<string, string>>, default: () => ({}) },
+  },
+  emits: ['update:visible', 'update:form-data', 'submit', 'discard-request'],
+  setup(props, { emit }) {
+    const proxyVisible = computed({
+      get: () => props.visible,
+      set: (v: boolean) => emit('update:visible', v),
+    });
+
+    const normalizedStatusOptions = computed(() => {
+      if (!props.statusOptions || !Array.isArray(props.statusOptions)) return [];
+      return props.statusOptions.map((opt: any) => ({ value: opt.id, text: opt.label }));
+    });
+
+    function onHide(event: any): void {
+      if (props.hasChanges && props.submitting !== 'status') {
+        event?.preventDefault?.();
+        emit('discard-request', 'status');
+      }
+    }
+
+    return { proxyVisible, normalizedStatusOptions, onHide };
+  },
+});
+</script>

--- a/app/src/views/curate/composables/__tests__/useEntityAutocomplete.spec.ts
+++ b/app/src/views/curate/composables/__tests__/useEntityAutocomplete.spec.ts
@@ -1,0 +1,75 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { useEntityAutocomplete } from '../useEntityAutocomplete';
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('useEntityAutocomplete', () => {
+  test('searchEntity skips when query < 2 chars and clears results', async () => {
+    const a = useEntityAutocomplete();
+    a.entity_search_results.value = [{ entity_id: 1 } as any];
+    await a.searchEntity('');
+    expect(a.entity_search_results.value).toEqual([]);
+  });
+
+  test('searchEntity GETs and populates results capped at 10', async () => {
+    server.use(
+      http.get('*/api/entity/*', () =>
+        HttpResponse.json({
+          data: Array.from({ length: 25 }, (_, i) => ({ entity_id: i + 1, symbol: `G${i}` })),
+        }),
+      ),
+    );
+    const a = useEntityAutocomplete();
+    await a.searchEntity('GR');
+    expect(a.entity_search_results.value.length).toBe(10);
+  });
+
+  test('searchOntology populates ontology_search_results capped at 10', async () => {
+    server.use(
+      http.get('*/api/search/ontology*', () =>
+        HttpResponse.json(Array.from({ length: 15 }, (_, i) => ({ id: `HP:${i}`, label: `term ${i}` }))),
+      ),
+    );
+    const a = useEntityAutocomplete();
+    await a.searchOntology('seizure');
+    expect(a.ontology_search_results.value.length).toBe(10);
+  });
+
+  test('searchReplacementEntity excludes the current entity_id', async () => {
+    server.use(
+      http.get('*/api/entity/*', () =>
+        HttpResponse.json({
+          data: [
+            { entity_id: 5, symbol: 'CURRENT' },
+            { entity_id: 6, symbol: 'OTHER' },
+          ],
+        }),
+      ),
+    );
+    const a = useEntityAutocomplete({ getCurrentEntityId: () => 5 });
+    await a.searchReplacementEntity('GR');
+    expect(a.replace_entity_search_results.value.map((e) => e.entity_id)).toEqual([6]);
+  });
+
+  test('clearAll resets every buffer', () => {
+    const a = useEntityAutocomplete();
+    a.entity_search_results.value = [{ entity_id: 1 } as any];
+    a.ontology_search_results.value = [{ id: 'HP:1', label: 'x' } as any];
+    a.replace_entity_search_results.value = [{ entity_id: 2 } as any];
+    a.modify_entity_input.value = 9;
+    a.ontology_input.value = 'HP:2';
+    a.replace_entity_input.value = 3;
+    a.clearAll();
+    expect(a.entity_search_results.value).toEqual([]);
+    expect(a.ontology_search_results.value).toEqual([]);
+    expect(a.replace_entity_search_results.value).toEqual([]);
+    expect(a.modify_entity_input.value).toBeNull();
+    expect(a.ontology_input.value).toBeNull();
+    expect(a.replace_entity_input.value).toBeNull();
+  });
+});

--- a/app/src/views/curate/composables/__tests__/useEntityAutocomplete.spec.ts
+++ b/app/src/views/curate/composables/__tests__/useEntityAutocomplete.spec.ts
@@ -1,12 +1,11 @@
-import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { http, HttpResponse } from 'msw';
-import { setupServer } from 'msw/node';
+import { server } from '@/test-utils/mocks/server';
 import { useEntityAutocomplete } from '../useEntityAutocomplete';
 
-const server = setupServer();
-beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
+// Lifecycle (listen / resetHandlers / close) is provided globally by
+// vitest.setup.ts. This file only adds per-test handler overrides via
+// `server.use(...)`.
 
 describe('useEntityAutocomplete', () => {
   test('searchEntity skips when query < 2 chars and clears results', async () => {

--- a/app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts
+++ b/app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts
@@ -1,0 +1,91 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { useEntityInfo } from '../useEntityInfo';
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('useEntityInfo', () => {
+  test('loadEntity populates entity_info from listEntities response', async () => {
+    server.use(
+      http.get('*/api/entity/*', () =>
+        HttpResponse.json({
+          data: [{ entity_id: 7, symbol: 'GRIN2B', disease_ontology_name: 'NDD' }],
+        }),
+      ),
+    );
+    const e = useEntityInfo();
+    await e.loadEntity(7);
+    expect(e.entity_info.value.entity_id).toBe(7);
+    expect(e.entity_info.value.symbol).toBe('GRIN2B');
+  });
+
+  test('loadEntity surfaces a not-found toast and clears entity_info', async () => {
+    server.use(http.get('*/api/entity/*', () => HttpResponse.json({ data: [] })));
+    const toasts: any[] = [];
+    const e = useEntityInfo({ onToast: (...a) => toasts.push(a) });
+    await e.loadEntity(99);
+    expect(e.entity_info.value).toEqual({});
+    expect(toasts.length).toBe(1);
+  });
+
+  test('loadReview snapshots reviewLoadedData for change detection', async () => {
+    server.use(
+      http.get('*/api/entity/7/review', () =>
+        HttpResponse.json([
+          { synopsis: 'syn', comment: 'cm', review_id: 1, entity_id: 7 },
+        ]),
+      ),
+      http.get('*/api/entity/7/phenotypes', () =>
+        HttpResponse.json([{ phenotype_id: 'HP:1', modifier_id: 'present' }]),
+      ),
+      http.get('*/api/entity/7/variation', () =>
+        HttpResponse.json([{ vario_id: 'VARIO:1', modifier_id: 'present' }]),
+      ),
+      http.get('*/api/entity/7/publications', () =>
+        HttpResponse.json([
+          { publication_id: 'PMID:1', publication_type: 'gene_review' },
+          { publication_id: 'PMID:2', publication_type: 'additional_references' },
+        ]),
+      ),
+    );
+    const e = useEntityInfo();
+    await e.loadReview(7);
+    expect(e.reviewLoadedData.value).not.toBeNull();
+    expect(e.select_phenotype.value).toEqual(['present-HP:1']);
+    expect(e.select_gene_reviews.value).toEqual(['PMID:1']);
+    expect(e.hasReviewChanges.value).toBe(false);
+  });
+
+  test('hasReviewChanges flips when a watched field diverges', async () => {
+    server.use(
+      http.get('*/api/entity/7/review', () =>
+        HttpResponse.json([{ synopsis: 'a', comment: 'b', review_id: 1, entity_id: 7 }]),
+      ),
+      http.get('*/api/entity/7/phenotypes', () => HttpResponse.json([])),
+      http.get('*/api/entity/7/variation', () => HttpResponse.json([])),
+      http.get('*/api/entity/7/publications', () => HttpResponse.json([])),
+    );
+    const e = useEntityInfo();
+    await e.loadReview(7);
+    expect(e.hasReviewChanges.value).toBe(false);
+    e.review_info.value.synopsis = 'CHANGED';
+    expect(e.hasReviewChanges.value).toBe(true);
+  });
+
+  test('loadStatus populates status_info', async () => {
+    server.use(
+      http.get('*/api/entity/7/status', () =>
+        HttpResponse.json([
+          { category_id: 'definitive', comment: 'c', problematic: 0, status_id: 1, entity_id: 7 },
+        ]),
+      ),
+    );
+    const e = useEntityInfo();
+    await e.loadStatus(7);
+    expect(e.status_info.value.category_id).toBe('definitive');
+  });
+});

--- a/app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts
+++ b/app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts
@@ -1,12 +1,11 @@
-import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { http, HttpResponse } from 'msw';
-import { setupServer } from 'msw/node';
+import { server } from '@/test-utils/mocks/server';
 import { useEntityInfo } from '../useEntityInfo';
 
-const server = setupServer();
-beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
+// Lifecycle (listen / resetHandlers / close) is provided globally by
+// vitest.setup.ts. This file only adds per-test handler overrides via
+// `server.use(...)`.
 
 describe('useEntityInfo', () => {
   test('loadEntity populates entity_info from listEntities response', async () => {

--- a/app/src/views/curate/composables/__tests__/useEntityModifyModals.spec.ts
+++ b/app/src/views/curate/composables/__tests__/useEntityModifyModals.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest';
+import { useEntityModifyModals } from '../useEntityModifyModals';
+
+describe('useEntityModifyModals', () => {
+  test('open / close per modal type', () => {
+    const m = useEntityModifyModals();
+    expect(m.isRenameOpen.value).toBe(false);
+    m.openRename();
+    expect(m.isRenameOpen.value).toBe(true);
+    m.close();
+    expect(m.isRenameOpen.value).toBe(false);
+    m.openDeactivate();
+    expect(m.isDeactivateOpen.value).toBe(true);
+    m.close();
+    m.openReview();
+    expect(m.isReviewOpen.value).toBe(true);
+    m.close();
+    m.openStatus();
+    expect(m.isStatusOpen.value).toBe(true);
+  });
+
+  test('switching from review to status auto-closes the previous', () => {
+    const m = useEntityModifyModals();
+    m.openReview();
+    m.openStatus();
+    expect(m.isReviewOpen.value).toBe(false);
+    expect(m.isStatusOpen.value).toBe(true);
+  });
+
+  test('discard-confirm flow: requestDiscard sets pendingDiscardTarget; confirmDiscard closes the target', () => {
+    const m = useEntityModifyModals();
+    m.openReview();
+    expect(m.pendingDiscardTarget.value).toBeNull();
+    m.requestDiscard('review');
+    expect(m.pendingDiscardTarget.value).toBe('review');
+    m.confirmDiscard();
+    expect(m.pendingDiscardTarget.value).toBeNull();
+    expect(m.isReviewOpen.value).toBe(false);
+  });
+
+  test('per-modal loading flags toggle independently', () => {
+    const m = useEntityModifyModals();
+    expect(m.loadingReview.value).toBe(true);
+    m.setLoading('review', false);
+    expect(m.loadingReview.value).toBe(false);
+    expect(m.loadingStatus.value).toBe(true);
+  });
+});

--- a/app/src/views/curate/composables/__tests__/useEntityMutations.spec.ts
+++ b/app/src/views/curate/composables/__tests__/useEntityMutations.spec.ts
@@ -1,12 +1,11 @@
-import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { http, HttpResponse } from 'msw';
-import { setupServer } from 'msw/node';
+import { server } from '@/test-utils/mocks/server';
 import { useEntityMutations } from '../useEntityMutations';
 
-const server = setupServer();
-beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
+// Lifecycle (listen / resetHandlers / close) is provided globally by
+// vitest.setup.ts. This file only adds per-test handler overrides via
+// `server.use(...)`.
 
 const apiBase = import.meta.env.VITE_API_URL ?? '';
 

--- a/app/src/views/curate/composables/__tests__/useEntityMutations.spec.ts
+++ b/app/src/views/curate/composables/__tests__/useEntityMutations.spec.ts
@@ -1,0 +1,83 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { useEntityMutations } from '../useEntityMutations';
+
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const apiBase = import.meta.env.VITE_API_URL ?? '';
+
+describe('useEntityMutations', () => {
+  test('rename POST sends rename_json and toggles submitting', async () => {
+    let received: any = null;
+    server.use(
+      http.post(`${apiBase}/api/entity/rename`, async ({ request }) => {
+        received = await request.json();
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    const m = useEntityMutations();
+    expect(m.submitting.value).toBeNull();
+    const p = m.rename({ entity_info: { entity_id: 1 }, ontology_input: 'MONDO:1' });
+    expect(m.submitting.value).toBe('rename');
+    await p;
+    expect(m.submitting.value).toBeNull();
+    expect(received.rename_json).toBeDefined();
+  });
+
+  test('deactivate POST sends deactivate_json with replace_entity', async () => {
+    let received: any = null;
+    server.use(
+      http.post(`${apiBase}/api/entity/deactivate`, async ({ request }) => {
+        received = await request.json();
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    const m = useEntityMutations();
+    await m.deactivate({
+      entity_info: { entity_id: 1 },
+      deactivate_check: true,
+      replace_entity_input: 5,
+    });
+    expect(received.deactivate_json).toBeDefined();
+  });
+
+  test('submitReview POST sends review_json', async () => {
+    let received: any = null;
+    server.use(
+      http.post(`${apiBase}/api/review/create`, async ({ request }) => {
+        received = await request.json();
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    const m = useEntityMutations();
+    await m.submitReview({
+      review_info: { synopsis: 's', comment: 'c' } as any,
+      select_phenotype: ['present-HP:1'],
+      select_variation: ['present-VARIO:1'],
+      select_additional_references: ['PMID:1'],
+      select_gene_reviews: ['PMID:2'],
+    });
+    expect(received.review_json).toBeDefined();
+    expect(received.review_json.phenotypes.length).toBe(1);
+    expect(received.review_json.variation_ontology.length).toBe(1);
+  });
+
+  test('error path resets submitting and surfaces toast', async () => {
+    server.use(
+      http.post(`${apiBase}/api/entity/rename`, () =>
+        HttpResponse.json({ error: 'boom' }, { status: 500 }),
+      ),
+    );
+    const toasts: any[] = [];
+    const m = useEntityMutations({ onToast: (...a) => toasts.push(a) });
+    await expect(
+      m.rename({ entity_info: { entity_id: 1 }, ontology_input: 'MONDO:1' }),
+    ).rejects.toBeTruthy();
+    expect(m.submitting.value).toBeNull();
+    expect(toasts.length).toBe(1);
+  });
+});

--- a/app/src/views/curate/composables/__tests__/useStatusForm.contract.spec.ts
+++ b/app/src/views/curate/composables/__tests__/useStatusForm.contract.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest';
+import * as mod from '../useStatusForm';
+
+describe('useStatusForm — public API contract (pin)', () => {
+  test('default export or named export exists', () => {
+    const factory = (mod as any).default ?? (mod as any).useStatusForm;
+    expect(typeof factory).toBe('function');
+  });
+
+  test('returned shape has the documented surface', () => {
+    const factory = (mod as any).default ?? (mod as any).useStatusForm;
+    const inst = factory();
+    for (const key of [
+      'formData',
+      'loading',
+      'loadStatusByEntity',
+      'submitForm',
+      'resetForm',
+      'hasChanges',
+    ]) {
+      expect(inst).toHaveProperty(key);
+    }
+  });
+});

--- a/app/src/views/curate/composables/useEntityAutocomplete.ts
+++ b/app/src/views/curate/composables/useEntityAutocomplete.ts
@@ -1,0 +1,169 @@
+// app/src/views/curate/composables/useEntityAutocomplete.ts
+import { ref, type Ref } from 'vue';
+import { listEntities } from '@/api/entity';
+import { searchOntology as searchOntologyApi } from '@/api/search';
+
+export interface UseEntityAutocompleteOptions {
+  onToast?: (...args: unknown[]) => void;
+  getCurrentEntityId?: () => number | null | undefined;
+}
+
+export interface EntitySearchResult {
+  entity_id: number;
+  symbol?: string;
+  disease_ontology_name?: string;
+  disease_ontology_id_version?: string;
+  hpo_mode_of_inheritance_term_name?: string;
+}
+
+export interface OntologySearchResult {
+  id: string;
+  label: string;
+}
+
+export function useEntityAutocomplete(options: UseEntityAutocompleteOptions = {}) {
+  const { onToast, getCurrentEntityId } = options;
+
+  // Inputs (selected ids)
+  const modify_entity_input = ref<number | null>(null);
+  const ontology_input = ref<string | null>(null);
+  const replace_entity_input = ref<number | null>(null);
+
+  // Display strings
+  const entity_display = ref('');
+  const ontology_display = ref('');
+  const replace_entity_display = ref('');
+
+  // Results
+  const entity_search_results = ref<EntitySearchResult[]>([]);
+  const ontology_search_results = ref<OntologySearchResult[]>([]);
+  const replace_entity_search_results = ref<EntitySearchResult[]>([]);
+
+  // Loading flags
+  const entity_search_loading = ref(false);
+  const ontology_search_loading = ref(false);
+  const replace_entity_search_loading = ref(false);
+
+  // Loaded flag
+  const entity_loaded = ref(false);
+
+  async function searchEntity(query: string): Promise<void> {
+    if (!query || query.length < 2) {
+      entity_search_results.value = [];
+      return;
+    }
+    entity_search_loading.value = true;
+    try {
+      const response: any = await listEntities({ filter: `contains(any,${query})` });
+      const data = response?.data || [];
+      entity_search_results.value = Array.isArray(data) ? data.slice(0, 10) : [];
+    } catch (e) {
+      onToast?.(e, 'Error', 'danger');
+      entity_search_results.value = [];
+    } finally {
+      entity_search_loading.value = false;
+    }
+  }
+
+  async function searchOntology(query: string): Promise<void> {
+    if (!query || query.length < 2) {
+      ontology_search_results.value = [];
+      return;
+    }
+    ontology_search_loading.value = true;
+    try {
+      const data: any = await searchOntologyApi(query, { tree: true });
+      ontology_search_results.value = Array.isArray(data) ? data.slice(0, 10) : [];
+    } catch (e) {
+      onToast?.(e, 'Error', 'danger');
+      ontology_search_results.value = [];
+    } finally {
+      ontology_search_loading.value = false;
+    }
+  }
+
+  async function searchReplacementEntity(query: string): Promise<void> {
+    if (!query || query.length < 2) {
+      replace_entity_search_results.value = [];
+      return;
+    }
+    replace_entity_search_loading.value = true;
+    try {
+      const response: any = await listEntities({ filter: `contains(any,${query})` });
+      const data = response?.data || [];
+      const currentId = getCurrentEntityId?.();
+      replace_entity_search_results.value = Array.isArray(data)
+        ? data.filter((e: EntitySearchResult) => e.entity_id !== currentId).slice(0, 10)
+        : [];
+    } catch (e) {
+      onToast?.(e, 'Error', 'danger');
+      replace_entity_search_results.value = [];
+    } finally {
+      replace_entity_search_loading.value = false;
+    }
+  }
+
+  function onEntitySelected(entityId: number | null): void {
+    modify_entity_input.value = entityId;
+    if (!entityId) {
+      entity_loaded.value = false;
+    }
+  }
+
+  function onOntologySelected(ontologyId: string | null): void {
+    ontology_input.value = ontologyId;
+  }
+
+  function onReplacementEntitySelected(entityId: number | null): void {
+    replace_entity_input.value = entityId;
+  }
+
+  function normalizerEntitySearch(node: any) {
+    return {
+      id: node.entity_id,
+      label: `sysndd:${node.entity_id} (${node.symbol} - ${node.disease_ontology_name} - (${node.disease_ontology_id_version}) - ${node.hpo_mode_of_inheritance_term_name})`,
+    };
+  }
+
+  function normalizerOntologySearch(node: any) {
+    return { id: node.id, label: `${node.id} (${node.label})` };
+  }
+
+  function clearAll(): void {
+    modify_entity_input.value = null;
+    ontology_input.value = null;
+    replace_entity_input.value = null;
+    entity_display.value = '';
+    ontology_display.value = '';
+    replace_entity_display.value = '';
+    entity_search_results.value = [];
+    ontology_search_results.value = [];
+    replace_entity_search_results.value = [];
+    entity_loaded.value = false;
+  }
+
+  return {
+    modify_entity_input,
+    ontology_input,
+    replace_entity_input,
+    entity_display,
+    ontology_display,
+    replace_entity_display,
+    entity_search_results,
+    ontology_search_results,
+    replace_entity_search_results,
+    entity_search_loading,
+    ontology_search_loading,
+    replace_entity_search_loading,
+    entity_loaded,
+    searchEntity,
+    searchOntology,
+    searchReplacementEntity,
+    onEntitySelected,
+    onOntologySelected,
+    onReplacementEntitySelected,
+    normalizerEntitySearch,
+    normalizerOntologySearch,
+    clearAll,
+  };
+}

--- a/app/src/views/curate/composables/useEntityAutocomplete.ts
+++ b/app/src/views/curate/composables/useEntityAutocomplete.ts
@@ -1,5 +1,5 @@
 // app/src/views/curate/composables/useEntityAutocomplete.ts
-import { ref, type Ref } from 'vue';
+import { ref } from 'vue';
 import { listEntities } from '@/api/entity';
 import { searchOntology as searchOntologyApi } from '@/api/search';
 

--- a/app/src/views/curate/composables/useEntityInfo.ts
+++ b/app/src/views/curate/composables/useEntityInfo.ts
@@ -1,0 +1,181 @@
+// app/src/views/curate/composables/useEntityInfo.ts
+import { computed, ref } from 'vue';
+import {
+  listEntities,
+  getEntityReview,
+  getEntityPhenotypes,
+  getEntityVariation,
+  getEntityPublications,
+  getEntityStatus,
+} from '@/api/entity';
+
+import Review from '@/assets/js/classes/submission/submissionReview';
+import Status from '@/assets/js/classes/submission/submissionStatus';
+import Phenotype from '@/assets/js/classes/submission/submissionPhenotype';
+import Variation from '@/assets/js/classes/submission/submissionVariation';
+import Literature from '@/assets/js/classes/submission/submissionLiterature';
+
+export interface UseEntityInfoOptions {
+  onToast?: (...args: unknown[]) => void;
+}
+
+interface ReviewSnapshot {
+  synopsis: string;
+  comment: string;
+  phenotypes: string[];
+  variationOntology: string[];
+  publications: string[];
+  genereviews: string[];
+}
+
+const arrEqual = (a: string[], b: string[]) => {
+  if (a.length !== b.length) return false;
+  const sa = [...a].sort();
+  const sb = [...b].sort();
+  return sa.every((v, i) => v === sb[i]);
+};
+
+export function useEntityInfo(options: UseEntityInfoOptions = {}) {
+  const { onToast } = options;
+
+  const entity_info = ref<Record<string, any>>({});
+  const review_info = ref<any>(new Review());
+  const status_info = ref<any>(new Status());
+
+  const select_phenotype = ref<string[]>([]);
+  const select_variation = ref<string[]>([]);
+  const select_additional_references = ref<string[]>([]);
+  const select_gene_reviews = ref<string[]>([]);
+
+  const reviewLoadedData = ref<ReviewSnapshot | null>(null);
+
+  const hasReviewChanges = computed(() => {
+    if (!reviewLoadedData.value) return false;
+    const snap = reviewLoadedData.value;
+    return (
+      (review_info.value.synopsis || '') !== snap.synopsis ||
+      (review_info.value.comment || '') !== snap.comment ||
+      !arrEqual(select_phenotype.value, snap.phenotypes) ||
+      !arrEqual(select_variation.value, snap.variationOntology) ||
+      !arrEqual(select_additional_references.value, snap.publications) ||
+      !arrEqual(select_gene_reviews.value, snap.genereviews)
+    );
+  });
+
+  async function loadEntity(entityId: number): Promise<void> {
+    try {
+      const response: any = await listEntities({ filter: `equals(entity_id,${entityId})` });
+      const data = response?.data;
+      if (!Array.isArray(data) || data.length === 0) {
+        onToast?.(`Entity ${entityId} not found`, 'Error', 'danger');
+        entity_info.value = {};
+        return;
+      }
+      entity_info.value = data[0];
+    } catch (e) {
+      onToast?.(e, 'Error', 'danger');
+      entity_info.value = {};
+    }
+  }
+
+  async function loadReview(entityId: number): Promise<void> {
+    try {
+      const review_data: any = await getEntityReview(entityId);
+      const phenotypes_data: any = await getEntityPhenotypes(entityId);
+      const variation_data: any = await getEntityVariation(entityId);
+      const publications_data: any = await getEntityPublications(entityId);
+
+      const new_phenotype = phenotypes_data.map(
+        (item: any) => new Phenotype(item.phenotype_id, item.modifier_id),
+      );
+      select_phenotype.value = phenotypes_data.map(
+        (item: any) => `${item.modifier_id}-${item.phenotype_id}`,
+      );
+
+      const new_variation = variation_data.map(
+        (item: any) => new Variation(item.vario_id, item.modifier_id),
+      );
+      select_variation.value = variation_data.map(
+        (item: any) => `${item.modifier_id}-${item.vario_id}`,
+      );
+
+      const literature_gene_reviews = publications_data
+        .filter((item: any) => item.publication_type === 'gene_review')
+        .map((item: any) => item.publication_id);
+      const literature_additional_references = publications_data
+        .filter((item: any) => item.publication_type === 'additional_references')
+        .map((item: any) => item.publication_id);
+
+      select_additional_references.value = literature_additional_references;
+      select_gene_reviews.value = literature_gene_reviews;
+
+      const new_literature = new Literature(
+        literature_additional_references,
+        literature_gene_reviews,
+      );
+
+      review_info.value = new Review(
+        review_data[0].synopsis,
+        new_literature,
+        new_phenotype,
+        new_variation,
+        review_data[0].comment,
+      );
+      review_info.value.review_id = review_data[0].review_id;
+      review_info.value.entity_id = review_data[0].entity_id;
+
+      reviewLoadedData.value = {
+        synopsis: review_info.value.synopsis || '',
+        comment: review_info.value.comment || '',
+        phenotypes: [...select_phenotype.value],
+        variationOntology: [...select_variation.value],
+        publications: [...select_additional_references.value],
+        genereviews: [...select_gene_reviews.value],
+      };
+    } catch (e) {
+      onToast?.(e, 'Error', 'danger');
+    }
+  }
+
+  async function loadStatus(entityId: number): Promise<void> {
+    try {
+      const status_data: any = await getEntityStatus(entityId);
+      status_info.value = new Status(
+        status_data[0].category_id,
+        status_data[0].comment,
+        status_data[0].problematic,
+      );
+      status_info.value.status_id = status_data[0].status_id;
+      status_info.value.entity_id = status_data[0].entity_id;
+    } catch (e) {
+      onToast?.(e, 'Error', 'danger');
+    }
+  }
+
+  function reset(): void {
+    entity_info.value = {};
+    review_info.value = new Review();
+    status_info.value = new Status();
+    select_phenotype.value = [];
+    select_variation.value = [];
+    select_additional_references.value = [];
+    select_gene_reviews.value = [];
+    reviewLoadedData.value = null;
+  }
+
+  return {
+    entity_info,
+    review_info,
+    status_info,
+    select_phenotype,
+    select_variation,
+    select_additional_references,
+    select_gene_reviews,
+    reviewLoadedData,
+    hasReviewChanges,
+    loadEntity,
+    loadReview,
+    loadStatus,
+    reset,
+  };
+}

--- a/app/src/views/curate/composables/useEntityModifyModals.ts
+++ b/app/src/views/curate/composables/useEntityModifyModals.ts
@@ -1,0 +1,116 @@
+// app/src/views/curate/composables/useEntityModifyModals.ts
+import { ref } from 'vue';
+
+export type ModalKind = 'rename' | 'deactivate' | 'review' | 'status';
+
+export function useEntityModifyModals() {
+  const isRenameOpen = ref(false);
+  const isDeactivateOpen = ref(false);
+  const isReviewOpen = ref(false);
+  const isStatusOpen = ref(false);
+
+  const loadingRename = ref(true);
+  const loadingDeactivate = ref(true);
+  const loadingReview = ref(true);
+  const loadingStatus = ref(true);
+
+  const pendingDiscardTarget = ref<ModalKind | null>(null);
+
+  function closeAll(): void {
+    isRenameOpen.value = false;
+    isDeactivateOpen.value = false;
+    isReviewOpen.value = false;
+    isStatusOpen.value = false;
+  }
+
+  function openRename(): void {
+    closeAll();
+    isRenameOpen.value = true;
+  }
+
+  function openDeactivate(): void {
+    closeAll();
+    isDeactivateOpen.value = true;
+  }
+
+  function openReview(): void {
+    closeAll();
+    isReviewOpen.value = true;
+  }
+
+  function openStatus(): void {
+    closeAll();
+    isStatusOpen.value = true;
+  }
+
+  function close(): void {
+    closeAll();
+    pendingDiscardTarget.value = null;
+  }
+
+  function setLoading(kind: ModalKind, value: boolean): void {
+    switch (kind) {
+      case 'rename':
+        loadingRename.value = value;
+        break;
+      case 'deactivate':
+        loadingDeactivate.value = value;
+        break;
+      case 'review':
+        loadingReview.value = value;
+        break;
+      case 'status':
+        loadingStatus.value = value;
+        break;
+    }
+  }
+
+  function requestDiscard(target: ModalKind): void {
+    pendingDiscardTarget.value = target;
+  }
+
+  function confirmDiscard(): void {
+    const t = pendingDiscardTarget.value;
+    pendingDiscardTarget.value = null;
+    if (!t) return;
+    switch (t) {
+      case 'rename':
+        isRenameOpen.value = false;
+        break;
+      case 'deactivate':
+        isDeactivateOpen.value = false;
+        break;
+      case 'review':
+        isReviewOpen.value = false;
+        break;
+      case 'status':
+        isStatusOpen.value = false;
+        break;
+    }
+  }
+
+  function cancelDiscard(): void {
+    pendingDiscardTarget.value = null;
+  }
+
+  return {
+    isRenameOpen,
+    isDeactivateOpen,
+    isReviewOpen,
+    isStatusOpen,
+    loadingRename,
+    loadingDeactivate,
+    loadingReview,
+    loadingStatus,
+    pendingDiscardTarget,
+    openRename,
+    openDeactivate,
+    openReview,
+    openStatus,
+    close,
+    setLoading,
+    requestDiscard,
+    confirmDiscard,
+    cancelDiscard,
+  };
+}

--- a/app/src/views/curate/composables/useEntityMutations.ts
+++ b/app/src/views/curate/composables/useEntityMutations.ts
@@ -1,0 +1,131 @@
+// app/src/views/curate/composables/useEntityMutations.ts
+import { ref } from 'vue';
+import { apiClient } from '@/api/client';
+
+import Submission from '@/assets/js/classes/submission/submissionSubmission';
+import Phenotype from '@/assets/js/classes/submission/submissionPhenotype';
+import Variation from '@/assets/js/classes/submission/submissionVariation';
+import Literature from '@/assets/js/classes/submission/submissionLiterature';
+
+const apiBase = import.meta.env.VITE_API_URL ?? '';
+
+export type SubmittingState = 'rename' | 'deactivate' | 'review' | 'status' | null;
+
+export interface UseEntityMutationsOptions {
+  onToast?: (...args: unknown[]) => void;
+  onAnnounce?: (msg: string, politeness?: 'polite' | 'assertive') => void;
+}
+
+export interface RenameArgs {
+  entity_info: any;
+  ontology_input: string | null;
+}
+
+export interface DeactivateArgs {
+  entity_info: any;
+  deactivate_check: boolean;
+  replace_entity_input: number | null;
+}
+
+export interface SubmitReviewArgs {
+  review_info: any;
+  select_phenotype: string[];
+  select_variation: string[];
+  select_additional_references: string[];
+  select_gene_reviews: string[];
+}
+
+export function useEntityMutations(options: UseEntityMutationsOptions = {}) {
+  const { onToast, onAnnounce } = options;
+  const submitting = ref<SubmittingState>(null);
+
+  async function rename(args: RenameArgs): Promise<void> {
+    submitting.value = 'rename';
+    args.entity_info.disease_ontology_id_version = args.ontology_input;
+    const submission = new Submission(args.entity_info);
+    try {
+      const response = await apiClient.raw.post(`${apiBase}/api/entity/rename`, {
+        rename_json: submission,
+      });
+      onToast?.(
+        `The new disease name for this entity has been submitted (status ${response.status} (${response.statusText}).`,
+        'Success',
+        'success',
+      );
+      onAnnounce?.('Disease name updated successfully');
+    } catch (e) {
+      onToast?.(e, 'Error', 'danger');
+      onAnnounce?.('Failed to update disease name', 'assertive');
+      throw e;
+    } finally {
+      submitting.value = null;
+    }
+  }
+
+  async function deactivate(args: DeactivateArgs): Promise<void> {
+    submitting.value = 'deactivate';
+    args.entity_info.is_active = args.deactivate_check ? 0 : 1;
+    args.entity_info.replaced_by =
+      args.replace_entity_input === null ? null : args.replace_entity_input;
+    const submission = new Submission(args.entity_info);
+    try {
+      const response = await apiClient.raw.post(`${apiBase}/api/entity/deactivate`, {
+        deactivate_json: submission,
+      });
+      onToast?.(
+        `The deactivation for this entity has been submitted (status ${response.status} (${response.statusText}).`,
+        'Success',
+        'success',
+      );
+      onAnnounce?.('Entity deactivation submitted successfully');
+    } catch (e) {
+      onToast?.(e, 'Error', 'danger');
+      onAnnounce?.('Failed to deactivate entity', 'assertive');
+      throw e;
+    } finally {
+      submitting.value = null;
+    }
+  }
+
+  async function submitReview(args: SubmitReviewArgs): Promise<void> {
+    submitting.value = 'review';
+    const additional_clean = args.select_additional_references.map((s) => s.replace(/\s+/g, ''));
+    const gene_reviews_clean = args.select_gene_reviews.map((s) => s.replace(/\s+/g, ''));
+    const replace_literature = new Literature(additional_clean, gene_reviews_clean);
+
+    const replace_phenotype = args.select_phenotype.map(
+      (item) => new Phenotype(item.split('-')[1], item.split('-')[0]),
+    );
+    const replace_variation = args.select_variation.map(
+      (item) => new Variation(item.split('-')[1], item.split('-')[0]),
+    );
+
+    args.review_info.literature = replace_literature;
+    args.review_info.phenotypes = replace_phenotype;
+    args.review_info.variation_ontology = replace_variation;
+
+    try {
+      const response = await apiClient.raw.post(`${apiBase}/api/review/create`, {
+        review_json: args.review_info,
+      });
+      onToast?.(
+        `The new review for this entity has been submitted (status ${response.status} (${response.statusText}).`,
+        'Success',
+        'success',
+      );
+      onAnnounce?.('Review submitted successfully');
+    } catch (e) {
+      onToast?.(e, 'Error', 'danger');
+      onAnnounce?.('Failed to submit review', 'assertive');
+      throw e;
+    } finally {
+      submitting.value = null;
+    }
+  }
+
+  function setSubmittingState(state: SubmittingState): void {
+    submitting.value = state;
+  }
+
+  return { submitting, rename, deactivate, submitReview, setSubmittingState };
+}

--- a/app/src/views/curate/composables/useEntityMutations.ts
+++ b/app/src/views/curate/composables/useEntityMutations.ts
@@ -41,14 +41,18 @@ export function useEntityMutations(options: UseEntityMutationsOptions = {}) {
 
   async function rename(args: RenameArgs): Promise<void> {
     submitting.value = 'rename';
-    args.entity_info.disease_ontology_id_version = args.ontology_input;
-    const submission = new Submission(args.entity_info);
+    // Build the wire payload from a clone so a failed request doesn't
+    // leave the caller's reactive entity_info with the new ontology id.
+    const renamed = { ...args.entity_info, disease_ontology_id_version: args.ontology_input };
+    const submission = new Submission(renamed);
     try {
       const response = await apiClient.raw.post(`${apiBase}/api/entity/rename`, {
         rename_json: submission,
       });
+      // Persist successful change back to the caller's entity_info.
+      args.entity_info.disease_ontology_id_version = args.ontology_input;
       onToast?.(
-        `The new disease name for this entity has been submitted (status ${response.status} (${response.statusText}).`,
+        `The new disease name for this entity has been submitted (status ${response.status} (${response.statusText})).`,
         'Success',
         'success',
       );
@@ -64,16 +68,26 @@ export function useEntityMutations(options: UseEntityMutationsOptions = {}) {
 
   async function deactivate(args: DeactivateArgs): Promise<void> {
     submitting.value = 'deactivate';
-    args.entity_info.is_active = args.deactivate_check ? 0 : 1;
-    args.entity_info.replaced_by =
+    const nextActive = args.deactivate_check ? 0 : 1;
+    const nextReplacedBy =
       args.replace_entity_input === null ? null : args.replace_entity_input;
-    const submission = new Submission(args.entity_info);
+    // Build the wire payload from a clone so a failed request doesn't
+    // leave the caller's reactive entity_info with mutated is_active/replaced_by.
+    const deactivated = {
+      ...args.entity_info,
+      is_active: nextActive,
+      replaced_by: nextReplacedBy,
+    };
+    const submission = new Submission(deactivated);
     try {
       const response = await apiClient.raw.post(`${apiBase}/api/entity/deactivate`, {
         deactivate_json: submission,
       });
+      // Persist successful change back to the caller's entity_info.
+      args.entity_info.is_active = nextActive;
+      args.entity_info.replaced_by = nextReplacedBy;
       onToast?.(
-        `The deactivation for this entity has been submitted (status ${response.status} (${response.statusText}).`,
+        `The deactivation for this entity has been submitted (status ${response.status} (${response.statusText})).`,
         'Success',
         'success',
       );
@@ -109,7 +123,7 @@ export function useEntityMutations(options: UseEntityMutationsOptions = {}) {
         review_json: args.review_info,
       });
       onToast?.(
-        `The new review for this entity has been submitted (status ${response.status} (${response.statusText}).`,
+        `The new review for this entity has been submitted (status ${response.status} (${response.statusText})).`,
         'Success',
         'success',
       );


### PR DESCRIPTION
## Summary

- **W1** Decomposed `ManageUser.vue` (1701 → 577 LoC) into 4 composables under `app/src/views/admin/composables/` (`useUserData`, `useUserMutations`, `useBulkUserActions`, `useUserModals`) and 7 sub-components under `app/src/views/admin/components/`.
- **W2** Decomposed `ModifyEntity.vue` (1522 → 537 LoC) into 4 composables under `app/src/views/curate/composables/` (`useEntityAutocomplete`, `useEntityInfo`, `useEntityMutations`, `useEntityModifyModals`) — alongside existing `useStatusForm` (untouched, pinned by a contract spec) — and 5 sub-components under `app/src/views/curate/components/`.
- **W3** Fixed #29 entity-batch grouping with gene-first SELECT + soft-LIMIT in `api/services/re-review-service.R` via a shared `select_matching_entities()` helper consumed by `batch_preview`, `batch_create`, and `batch_recalculate`. `ManageReReview.vue` shows a pre-create warning when criteria would extend the batch beyond `batch_size` to keep a gene atomic.

Closeout: bumps `app/package.json` to **0.13.0**, adds a v11.2 status block to `.planning/reviews/2026-04-23-codebase-review.md` (P2.7 → ✅ DONE; #29 closed), and documents the new soft-LIMIT semantics under AGENTS.md § Stack-Specific Gotchas.

## Acceptance

- [x] `wc -l app/src/views/admin/ManageUser.vue` < 600 (577)
- [x] `ls app/src/views/admin/composables/` lists 4 `use*.ts` files + a `__tests__/` directory
- [x] `ls app/src/views/admin/components/` lists ≥ 3 `*.vue` files (7 new)
- [x] `wc -l app/src/views/curate/ModifyEntity.vue` < 600 (537)
- [x] `ls app/src/views/curate/composables/` lists 5 `use*.ts` files (4 new + existing `useStatusForm`)
- [x] `ls app/src/views/curate/components/` lists ≥ 3 `*.vue` files (5 new)
- [x] `grep -n "boundary_gene" api/services/re-review-service.R` finds matches
- [x] `grep -n "boundary_gene" app/src/views/curate/ManageReReview.vue` finds matches
- [x] `cd app && npm run lint` green (0 errors)
- [x] `cd app && npm run type-check` green
- [x] `cd app && npm run test:unit -- --run` green (~920+ tests across 95 files)
- [x] `make lint-api` green
- [x] R API tests green (gene-atomic re-review tests included)
- [x] `make ci-local` green at every merge step (W3 → W2 → W1 → closeout)

Two-stage review (spec compliance + code quality) was run per workstream against the plan files; all three Ws landed with ✅ approvals after one fix-up commit each (W2 unused `Ref` import, W1 unhandled-rejection `.catch()` + dead `roleOptions` prop + leaky composable returns).

Closes #29

## Plan artifacts

- Spec: `.planning/superpowers/specs/2026-04-25-v11.2-monolith-cleanup-design.md`
- Master plan: `.planning/superpowers/plans/2026-04-26-v11.2-monolith-cleanup-plan.md`
- Workstream plans: `2026-04-26-v11.2-wave-1-w{1,2,3}-*.md`
- Closeout plan: `2026-04-26-v11.2-wave-2-closeout.md`