### PR TITLE
feat(api): gnomAD chrX/Y/M constraint fallback via batched GraphQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ __pycache__/
 
 # Parallel worktree workflow (v11.0+ phase worktrees)
 /worktrees/
+
+# git worktrees (created by superpowers workflow)
+.worktrees/

--- a/api/bootstrap/load_modules.R
+++ b/api/bootstrap/load_modules.R
@@ -83,6 +83,7 @@ bootstrap_load_modules <- function() {
     "functions/external-functions.R",
     "functions/external-proxy-functions.R",
     "functions/external-proxy-gnomad.R",
+    "functions/external-proxy-gnomad-batch.R",
     "functions/external-proxy-uniprot.R",
     "functions/external-proxy-ensembl.R",
     "functions/external-proxy-alphafold.R",

--- a/api/bootstrap/setup_workers.R
+++ b/api/bootstrap/setup_workers.R
@@ -94,6 +94,10 @@ bootstrap_setup_workers <- function() {
     source("/app/functions/external-proxy-functions.R", local = FALSE)
     # Source gnomAD proxy functions (fetch_gnomad_constraints + memoised wrapper)
     source("/app/functions/external-proxy-gnomad.R", local = FALSE)
+    # Source batched gnomAD GraphQL fallback (used by HGNC enrichment for chrX/Y/M genes
+    # absent from the autosomes-only bulk constraint TSV). Load order: depends on
+    # external-proxy-functions.R (cache_static, validate_gene_symbol) sourced earlier.
+    source("/app/functions/external-proxy-gnomad-batch.R", local = FALSE)
     # Source gnomAD/AlphaFold enrichment functions for HGNC update pipeline
     source("/app/functions/hgnc-enrichment-gnomad.R", local = FALSE)
     # Source HGNC functions (update_process_hgnc_data)

--- a/api/endpoints/jobs_endpoints.R
+++ b/api/endpoints/jobs_endpoints.R
@@ -773,6 +773,12 @@ function(req, res) {
         rows_processed = nrow(hgnc_data),
         columns_written = ncol(hgnc_data),
         columns_dropped = length(extra_cols),
+        gnomad_fallback_recovered = as.integer(
+          attr(hgnc_data, "fallback_recovered", exact = TRUE) %||% 0L
+        ),
+        gnomad_fallback_unresolved = as.integer(
+          attr(hgnc_data, "fallback_unresolved", exact = TRUE) %||% 0L
+        ),
         message = "HGNC data updated and written to database successfully"
       )
     }

--- a/api/functions/async-job-handlers.R
+++ b/api/functions/async-job-handlers.R
@@ -263,7 +263,13 @@
   list(
     rows_processed = nrow(hgnc_data),
     columns_written = ncol(hgnc_data),
-    columns_dropped = length(extra_cols)
+    columns_dropped = length(extra_cols),
+    gnomad_fallback_recovered = as.integer(
+      attr(hgnc_data, "fallback_recovered", exact = TRUE) %||% 0L
+    ),
+    gnomad_fallback_unresolved = as.integer(
+      attr(hgnc_data, "fallback_unresolved", exact = TRUE) %||% 0L
+    )
   )
 }
 
@@ -283,6 +289,8 @@
     rows_processed = write_result$rows_processed,
     columns_written = write_result$columns_written,
     columns_dropped = write_result$columns_dropped,
+    gnomad_fallback_recovered = write_result$gnomad_fallback_recovered,
+    gnomad_fallback_unresolved = write_result$gnomad_fallback_unresolved,
     message = "HGNC data updated and written to database successfully"
   )
 }

--- a/api/functions/external-proxy-gnomad-batch.R
+++ b/api/functions/external-proxy-gnomad-batch.R
@@ -121,3 +121,73 @@ GNOMAD_BATCH_ENDPOINT <- "https://gnomad.broadinstitute.org/api?raw"
 
   setNames(out, symbols)
 }
+
+#' Fire one POST to the gnomAD GraphQL endpoint for ≤25 symbols
+#'
+#' @param symbols Character vector, length ≤ GNOMAD_BATCH_MAX_PER_REQUEST.
+#' @return Named character vector of length `length(symbols)`, names equal to `symbols`.
+#'   Every element is either a JSON string or `NA_character_`. Network/parse failures
+#'   surface as all-NA with a warning (no error thrown — the caller treats batch failures
+#'   as non-fatal per spec §5).
+#' @noRd
+.fetch_gnomad_constraints_chunk <- function(symbols) {
+  if (length(symbols) == 0L) {
+    return(setNames(character(0), character(0)))
+  }
+  query_body <- .build_aliased_constraint_query(symbols)
+  if (is.null(query_body)) {
+    # Every symbol was invalid; .build_aliased_constraint_query already warned.
+    return(setNames(rep(NA_character_, length(symbols)), symbols))
+  }
+
+  req <- httr2::request(GNOMAD_BATCH_ENDPOINT) |>
+    httr2::req_method("POST") |>
+    httr2::req_headers("Content-Type" = "application/json", "Accept" = "application/json") |>
+    httr2::req_body_json(list(query = query_body)) |>
+    httr2::req_timeout(30) |>
+    httr2::req_retry(
+      max_tries = 3L,
+      max_seconds = 30L,
+      is_transient = function(resp) httr2::resp_status(resp) %in% c(429L, 503L, 504L)
+    ) |>
+    httr2::req_error(is_error = function(resp) FALSE) # handle errors manually
+
+  resp <- tryCatch(
+    httr2::req_perform(req),
+    error = function(e) {
+      warning(sprintf(
+        "[gnomad-batch] transport error for batch of %d symbols (%s..): %s",
+        length(symbols), symbols[1L], conditionMessage(e)
+      ), call. = FALSE)
+      return(NULL)
+    }
+  )
+  if (is.null(resp)) {
+    return(setNames(rep(NA_character_, length(symbols)), symbols))
+  }
+
+  status <- httr2::resp_status(resp)
+  if (status != 200L) {
+    warning(sprintf(
+      "[gnomad-batch] HTTP %d for batch of %d symbols (%s..)",
+      status, length(symbols), symbols[1L]
+    ), call. = FALSE)
+    return(setNames(rep(NA_character_, length(symbols)), symbols))
+  }
+
+  parsed <- tryCatch(
+    httr2::resp_body_json(resp),
+    error = function(e) {
+      warning(sprintf(
+        "[gnomad-batch] could not parse json response for batch of %d symbols (%s..): %s",
+        length(symbols), symbols[1L], conditionMessage(e)
+      ), call. = FALSE)
+      return(NULL)
+    }
+  )
+  if (is.null(parsed)) {
+    return(setNames(rep(NA_character_, length(symbols)), symbols))
+  }
+
+  .parse_batched_constraint_response(parsed, symbols)
+}

--- a/api/functions/external-proxy-gnomad-batch.R
+++ b/api/functions/external-proxy-gnomad-batch.R
@@ -11,23 +11,27 @@ require(jsonlite)
 # never a valid JSON-object response so it's safe as a tag.
 GNOMAD_BATCH_NA_SENTINEL <- "__GNOMAD_NA__"
 
-# Cache key namespace. Bumping the suffix is a clean way to invalidate after a JSON-shape change.
-# cachem (cache_disk / cache_mem) only accepts keys matching ^[a-z0-9]+$, so we keep this
-# prefix lowercase-alphanumeric (no `::` separator) and likewise sanitise the per-symbol
-# tail with `.gnomad_batch_cache_key()`.
-GNOMAD_BATCH_CACHE_PREFIX <- "gnomadconstraintv1"
+# Cache key namespace. Bumping the trailing version (e.g. v1 -> v2) is a clean way
+# to invalidate after a JSON-shape change. cachem (cache_disk / cache_mem) accepts
+# keys matching ^[a-z0-9_-]+$ — lowercase letters, digits, underscore, and hyphen
+# are all valid (despite the misleading "Only lowercase letters and numbers are
+# allowed" error message). The trailing underscore makes the per-symbol tail visually
+# separable in cache filenames (e.g. `gnomad_constraint_v1_hla-b`).
+GNOMAD_BATCH_CACHE_PREFIX <- "gnomad_constraint_v1_"
 
 #' Build a cachem-compatible key for a single gene symbol.
 #'
-#' cachem keys must match `^[a-z0-9]+$`. Most HGNC symbols are alphanumeric but some
-#' contain hyphens (e.g. HLA-B) or other punctuation; we lowercase and strip every
-#' non-alphanumeric character. Collisions across distinct sanitised symbols are
-#' acceptable in practice — the cache value is a JSON blob that the caller never
-#' relies on by symbol identity (the named vector returned to the caller comes from
-#' the GraphQL response, not from cache key lookup).
+#' cachem keys must match `^[a-z0-9_-]+$`. HGNC symbols are alphanumeric or contain
+#' hyphens (HLA-B, HLA-DRB1); both lowercase letters and hyphens are cachem-valid,
+#' so we only need to lowercase to preserve `HLA-B` ≠ `HLAB`. Any other punctuation
+#' (apostrophes, slashes, etc — not present in real HGNC symbols but defensive
+#' against bad input) is replaced with `_` to keep the key unique and avoid silent
+#' collisions across distinct sanitised symbols.
 #' @noRd
 .gnomad_batch_cache_key <- function(symbol) {
-  paste0(GNOMAD_BATCH_CACHE_PREFIX, gsub("[^a-z0-9]", "", tolower(symbol)))
+  normalised <- tolower(symbol)
+  normalised <- gsub("[^a-z0-9_-]", "_", normalised)
+  paste0(GNOMAD_BATCH_CACHE_PREFIX, normalised)
 }
 
 # 19 fields the bulk pipeline emits. Keep this list aligned with

--- a/api/functions/external-proxy-gnomad-batch.R
+++ b/api/functions/external-proxy-gnomad-batch.R
@@ -73,14 +73,20 @@ GNOMAD_BATCH_ENDPOINT <- "https://gnomad.broadinstitute.org/api?raw"
       paste(shQuote(symbols[!valid_mask]), collapse = ", ")
     ), call. = FALSE)
   }
-  valid_syms <- symbols[valid_mask]
-  if (length(valid_syms) == 0L) return(NULL)
+  valid_idx <- which(valid_mask)
+  if (length(valid_idx) == 0L) return(NULL)
+  valid_syms <- symbols[valid_idx]
 
+  # Use the ORIGINAL input position as the alias index so the parser's
+  # `paste0("g", i - 1L)` lookup keyed on the user-supplied `symbols` vector
+  # still matches up after invalid entries are filtered. With sequential
+  # alias numbering an invalid symbol at position 1 would shift every later
+  # alias by one and the parser would map valid genes onto the wrong names.
   field_block <- paste(GNOMAD_BATCH_FIELDS, collapse = " ")
-  parts <- vapply(seq_along(valid_syms), function(i) {
+  parts <- vapply(seq_along(valid_idx), function(i) {
     sprintf(
       'g%d: gene(gene_symbol: "%s", reference_genome: GRCh38) { gnomad_constraint { %s } }',
-      i - 1L, valid_syms[i], field_block
+      valid_idx[i] - 1L, valid_syms[i], field_block
     )
   }, character(1L), USE.NAMES = FALSE)
 
@@ -150,10 +156,20 @@ GNOMAD_BATCH_ENDPOINT <- "https://gnomad.broadinstitute.org/api?raw"
 #' policy identical between the two dispatch modes.
 #' @noRd
 .build_chunk_request <- function(query_body) {
+  # Apply the same central token-bucket throttle as the per-gene gnomAD proxy
+  # (`fetch_gnomad_constraints` in external-proxy-gnomad.R) so all gnomAD traffic
+  # respects EXTERNAL_API_THROTTLE$gnomad. One batch request returns up to 25
+  # genes' worth of data, so the per-gene rate is effectively 25x higher — but
+  # the upstream rate is what matters for politeness, and gnomAD has confirmed
+  # tolerance for 5 concurrent batch requests in our spike.
   httr2::request(GNOMAD_BATCH_ENDPOINT) |>
     httr2::req_method("POST") |>
     httr2::req_headers("Content-Type" = "application/json", "Accept" = "application/json") |>
     httr2::req_body_json(list(query = query_body)) |>
+    httr2::req_throttle(
+      rate = EXTERNAL_API_THROTTLE$gnomad$capacity / EXTERNAL_API_THROTTLE$gnomad$fill_time_s,
+      realm = "gnomad"
+    ) |>
     httr2::req_timeout(30) |>
     httr2::req_retry(
       max_tries = 3L,

--- a/api/functions/external-proxy-gnomad-batch.R
+++ b/api/functions/external-proxy-gnomad-batch.R
@@ -1,0 +1,36 @@
+# api/functions/external-proxy-gnomad-batch.R
+#### Batched gnomAD GraphQL fallback for HGNC-update pipeline
+#### See spec: .planning/superpowers/specs/2026-04-29-gnomad-constraints-x-chr-fallback-design.md
+
+require(httr2)
+require(jsonlite)
+
+# Sentinel value stored in cache_static when gnomAD confirmed a symbol has no constraint data.
+# We need to distinguish "we asked, gnomAD said no" from "we never asked", and the
+# cachem filesystem cache treats NULL and missing identically. The literal string is
+# never a valid JSON-object response so it's safe as a tag.
+GNOMAD_BATCH_NA_SENTINEL <- "__GNOMAD_NA__"
+
+# Cache key namespace. Bumping the suffix is a clean way to invalidate after a JSON-shape change.
+GNOMAD_BATCH_CACHE_PREFIX <- "gnomad_constraint_v1::"
+
+# 19 fields the bulk pipeline emits. Keep this list aligned with
+# GNOMAD_TSV_COLUMN_MAP in api/functions/hgnc-enrichment-gnomad.R.
+GNOMAD_BATCH_FIELDS <- c(
+  "pLI",
+  "oe_lof", "oe_lof_lower", "oe_lof_upper",
+  "oe_mis", "oe_mis_lower", "oe_mis_upper",
+  "oe_syn", "oe_syn_lower", "oe_syn_upper",
+  "exp_lof", "obs_lof",
+  "exp_mis", "obs_mis",
+  "exp_syn", "obs_syn",
+  "lof_z", "mis_z", "syn_z"
+)
+
+# gnomAD's GraphQL server enforces a query-cost limit of 25 (one cost unit per gene).
+# Verified empirically 2026-04-29.
+GNOMAD_BATCH_MAX_PER_REQUEST <- 25L
+
+# gnomAD GraphQL endpoint. The ?raw query bypasses the GraphiQL HTML wrapper that
+# would otherwise be served when the Accept header does not survive a proxy.
+GNOMAD_BATCH_ENDPOINT <- "https://gnomad.broadinstitute.org/api?raw"

--- a/api/functions/external-proxy-gnomad-batch.R
+++ b/api/functions/external-proxy-gnomad-batch.R
@@ -1,9 +1,9 @@
 # api/functions/external-proxy-gnomad-batch.R
 #### Batched gnomAD GraphQL fallback for HGNC-update pipeline
 #### See spec: .planning/superpowers/specs/2026-04-29-gnomad-constraints-x-chr-fallback-design.md
-
-require(httr2)
-require(jsonlite)
+#
+# Per AGENTS.md, every package call uses explicit `httr2::` / `jsonlite::` /
+# `cachem::` namespacing — no bare require() at top of file.
 
 # Sentinel value stored in cache_static when gnomAD confirmed a symbol has no constraint data.
 # We need to distinguish "we asked, gnomAD said no" from "we never asked", and the
@@ -142,25 +142,15 @@ GNOMAD_BATCH_ENDPOINT <- "https://gnomad.broadinstitute.org/api?raw"
   setNames(out, symbols)
 }
 
-#' Fire one POST to the gnomAD GraphQL endpoint for ≤25 symbols
+#' Build a prepared httr2 request for a chunk's GraphQL body.
 #'
-#' @param symbols Character vector, length ≤ GNOMAD_BATCH_MAX_PER_REQUEST.
-#' @return Named character vector of length `length(symbols)`, names equal to `symbols`.
-#'   Every element is either a JSON string or `NA_character_`. Network/parse failures
-#'   surface as all-NA with a warning (no error thrown — the caller treats batch failures
-#'   as non-fatal per spec §5).
+#' Shared by the single-chunk path (`.fetch_gnomad_constraints_chunk`) and the
+#' parallel path (`fetch_gnomad_constraints_batch`). Centralising request
+#' construction keeps headers, retries, and the "non-2xx is not an error"
+#' policy identical between the two dispatch modes.
 #' @noRd
-.fetch_gnomad_constraints_chunk <- function(symbols) {
-  if (length(symbols) == 0L) {
-    return(setNames(character(0), character(0)))
-  }
-  query_body <- .build_aliased_constraint_query(symbols)
-  if (is.null(query_body)) {
-    # Every symbol was invalid; .build_aliased_constraint_query already warned.
-    return(setNames(rep(NA_character_, length(symbols)), symbols))
-  }
-
-  req <- httr2::request(GNOMAD_BATCH_ENDPOINT) |>
+.build_chunk_request <- function(query_body) {
+  httr2::request(GNOMAD_BATCH_ENDPOINT) |>
     httr2::req_method("POST") |>
     httr2::req_headers("Content-Type" = "application/json", "Accept" = "application/json") |>
     httr2::req_body_json(list(query = query_body)) |>
@@ -171,32 +161,42 @@ GNOMAD_BATCH_ENDPOINT <- "https://gnomad.broadinstitute.org/api?raw"
       is_transient = function(resp) httr2::resp_status(resp) %in% c(429L, 503L, 504L)
     ) |>
     httr2::req_error(is_error = function(resp) FALSE) # handle errors manually
+}
 
-  resp <- tryCatch(
-    httr2::req_perform(req),
-    error = function(e) {
+#' Post-perform handling: turn a response (or an error condition) into either a
+#' named character vector (JSON-or-NA per symbol) for a successful HTTP+parse,
+#' or NULL for a transport-fail. Used by both dispatch paths.
+#'
+#' @param resp_or_err Either an httr2_response or an error condition.
+#' @param symbols Character vector of HGNC symbols passed to the corresponding query, in alias order.
+#' @return Named character vector on a 200-OK + parseable body (length = length(symbols),
+#'   names = symbols, values JSON-or-NA), or NULL on transport failure / non-200 / parse error.
+#'   Distinguishing NULL (transport-fail) from a vec-of-NAs (gene-not-found) is what lets
+#'   the chunk-stitch loop decide whether to write sentinels to cache.
+#' @noRd
+.parse_chunk_response <- function(resp_or_err, symbols) {
+  if (inherits(resp_or_err, "error") || inherits(resp_or_err, "condition")) {
+    if (!inherits(resp_or_err, "httr2_response")) {
       warning(sprintf(
         "[gnomad-batch] transport error for batch of %d symbols (%s..): %s",
-        length(symbols), symbols[1L], conditionMessage(e)
+        length(symbols), symbols[1L], conditionMessage(resp_or_err)
       ), call. = FALSE)
       return(NULL)
     }
-  )
-  if (is.null(resp)) {
-    return(setNames(rep(NA_character_, length(symbols)), symbols))
   }
-
-  status <- httr2::resp_status(resp)
+  if (!inherits(resp_or_err, "httr2_response")) {
+    return(NULL)
+  }
+  status <- httr2::resp_status(resp_or_err)
   if (status != 200L) {
     warning(sprintf(
       "[gnomad-batch] HTTP %d for batch of %d symbols (%s..)",
       status, length(symbols), symbols[1L]
     ), call. = FALSE)
-    return(setNames(rep(NA_character_, length(symbols)), symbols))
+    return(NULL)
   }
-
   parsed <- tryCatch(
-    httr2::resp_body_json(resp),
+    httr2::resp_body_json(resp_or_err),
     error = function(e) {
       warning(sprintf(
         "[gnomad-batch] could not parse json response for batch of %d symbols (%s..): %s",
@@ -206,23 +206,57 @@ GNOMAD_BATCH_ENDPOINT <- "https://gnomad.broadinstitute.org/api?raw"
     }
   )
   if (is.null(parsed)) {
+    return(NULL)
+  }
+  .parse_batched_constraint_response(parsed, symbols)
+}
+
+#' Fire one POST to the gnomAD GraphQL endpoint for ≤25 symbols
+#'
+#' @param symbols Character vector, length ≤ GNOMAD_BATCH_MAX_PER_REQUEST.
+#' @return On HTTP 200 + parseable JSON: named character vector of length
+#'   `length(symbols)`, names equal to `symbols`, each element a JSON string or
+#'   `NA_character_` (NA = gene-not-found, with a successful transport).
+#'   On transport failure (timeout, non-200, or parse error): `NULL`.
+#'   This NULL-vs-vec distinction is load-bearing for the cache-write decision
+#'   in `fetch_gnomad_constraints_batch`: gene-not-found gets a sentinel, but a
+#'   transport-failed chunk must not poison the cache for those symbols.
+#' @noRd
+.fetch_gnomad_constraints_chunk <- function(symbols) {
+  if (length(symbols) == 0L) {
+    return(setNames(character(0), character(0)))
+  }
+  query_body <- .build_aliased_constraint_query(symbols)
+  if (is.null(query_body)) {
+    # Every symbol was invalid; .build_aliased_constraint_query already warned.
+    # All-invalid is not a transport failure — return all-NA so the caller
+    # treats them as known-bad inputs (no point retrying invalid symbols).
     return(setNames(rep(NA_character_, length(symbols)), symbols))
   }
 
-  .parse_batched_constraint_response(parsed, symbols)
+  req <- .build_chunk_request(query_body)
+  resp <- tryCatch(
+    httr2::req_perform(req),
+    error = function(e) e
+  )
+  .parse_chunk_response(resp, symbols)
 }
 
 #' Fetch gnomAD constraint scores for many symbols, batched and cached
 #'
 #' Consults the disk cache per-symbol; chunks misses ≤25 per HTTP request; dispatches
-#' chunks concurrently via httr2::reqs_perform_parallel. Successful and "Gene not found"
-#' results are written back to cache (the latter as a sentinel). Transport failures
-#' surface as NA without poisoning the cache.
+#' chunks concurrently via `httr2::req_perform_parallel` (single-chunk fast path uses
+#' the synchronous `.fetch_gnomad_constraints_chunk`). Successful and "Gene not found"
+#' results are written back to cache (the latter as the `GNOMAD_BATCH_NA_SENTINEL`).
+#' Transport failures surface as NA without poisoning the cache — the chunk fetcher
+#' returns `NULL` for transport-failed chunks so the stitch loop can skip cache writes
+#' unambiguously (no fragile "all-NA chunk" heuristic).
 #'
 #' @param symbols Character vector of HGNC gene symbols. May be empty.
 #' @param max_concurrency Integer pool size for parallel batch requests. Default 5.
 #'   Benchmarks (2026-04-29, n=20) show gnomAD tolerates 20 concurrent without
-#'   rate-limiting; 5 is well-mannered.
+#'   rate-limiting; 5 is well-mannered. Passed as `max_active` to
+#'   `httr2::req_perform_parallel`.
 #' @param cache cachem cache backend. Default `cache_static` (30-day filesystem).
 #'   Override in tests with `cachem::cache_mem()`.
 #' @return Named character vector of length `length(symbols)`, names equal to `symbols`.
@@ -258,55 +292,79 @@ fetch_gnomad_constraints_batch <- function(
       miss_syms,
       ceiling(seq_along(miss_syms) / GNOMAD_BATCH_MAX_PER_REQUEST)
     )
+    # `chunks` is a list; coerce to a plain unnamed list so Map() pairs cleanly.
+    chunks <- unname(as.list(chunks))
 
-    # Concurrency: build a request per chunk, fire via reqs_perform_parallel.
-    fetch_chunk_async <- function(chunk_syms) {
-      .fetch_gnomad_constraints_chunk(chunk_syms)
-    }
-    if (length(chunks) > 1L && max_concurrency > 1L) {
-      # parallel via mirai pool — but we can also just lapply for now since the
-      # individual chunks are non-blocking via httr2 anyway. Use a simple parallel
-      # strategy: split chunks into waves of `max_concurrency`.
-      chunk_results <- list()
-      for (start in seq(1L, length(chunks), by = max_concurrency)) {
-        end <- min(start + max_concurrency - 1L, length(chunks))
-        wave <- chunks[start:end]
-        wave_results <- lapply(wave, fetch_chunk_async)
-        chunk_results <- c(chunk_results, wave_results)
-      }
+    if (length(chunks) == 1L) {
+      # Single-chunk fast path: skip the parallel-pool spin-up.
+      chunk_results <- list(.fetch_gnomad_constraints_chunk(chunks[[1L]]))
     } else {
-      chunk_results <- lapply(chunks, fetch_chunk_async)
+      # Real parallel dispatch via httr2::req_perform_parallel. Build a request per
+      # chunk; a chunk whose symbols are all invalid yields NULL from
+      # .build_aliased_constraint_query — for those we synthesise an all-NA result
+      # without firing a request. Note: req_perform_parallel honors
+      # `getOption("httr2_mock")`, so `httr2::with_mocked_responses` works in tests.
+      built <- lapply(chunks, function(chunk_syms) {
+        qb <- .build_aliased_constraint_query(chunk_syms)
+        if (is.null(qb)) NULL else .build_chunk_request(qb)
+      })
+      non_null_idx <- which(!vapply(built, is.null, logical(1L)))
+      chunk_results <- vector("list", length(chunks))
+      # All-invalid chunks: known-bad input, treat as gene-not-found (all-NA vec, NOT NULL)
+      # so the stitch loop writes sentinels for any future cache reuse-by-key... but
+      # because invalid symbols never produce a cachem-valid key collision with a
+      # real symbol, we still emit the all-NA vec consistent with single-chunk behaviour.
+      for (i in setdiff(seq_along(chunks), non_null_idx)) {
+        chunk_results[[i]] <- setNames(rep(NA_character_, length(chunks[[i]])), chunks[[i]])
+      }
+      if (length(non_null_idx) > 0L) {
+        resps <- httr2::req_perform_parallel(
+          built[non_null_idx],
+          max_active = max_concurrency,
+          on_error = "continue",
+          progress = FALSE
+        )
+        for (j in seq_along(non_null_idx)) {
+          i <- non_null_idx[[j]]
+          chunk_results[[i]] <- .parse_chunk_response(resps[[j]], chunks[[i]])
+        }
+      }
     }
 
     # Stitch chunk results back into miss_idx slots, write to cache.
-    for (cr in chunk_results) {
+    # Each chunk_result is either:
+    #   - NULL              → transport-failed chunk: skip cache writes for those symbols
+    #   - named char vec    → write per slot: real value as-is, NA → sentinel
+    # Pairing chunks[[i]] with chunk_results[[i]] via Map keeps the input-symbol list
+    # available even when cr is NULL (no names to read off).
+    Map(function(chunk_syms, cr) {
+      if (is.null(cr)) {
+        # Transport-failed chunk: leave cached_decoded slots as NA (already
+        # initialised that way) and DO NOT write sentinels. Next pipeline run
+        # will retry these symbols.
+        return(invisible(NULL))
+      }
       for (sym in names(cr)) {
         upper_sym <- toupper(sym)
         slot <- which(upper_syms == upper_sym & !hit_mask)
         if (length(slot) >= 1L) {
           val <- cr[[sym]]
           if (is.na(val)) {
-            # Distinguish transport-fail (do not cache) from gene-not-found (cache as sentinel).
-            # Both come back as NA from the chunk fetcher; we cannot distinguish here.
-            # Convention: chunks that suffered transport failure return NA for ALL symbols,
-            # successful chunks return NA only for missing genes.
-            # Heuristic: if at least one alias in the chunk returned non-NA, the chunk was
-            # successful; the NA is "gene not found" → cache the sentinel.
-            chunk_had_success <- any(!is.na(cr))
-            if (chunk_had_success) {
-              tryCatch(cache$set(.gnomad_batch_cache_key(sym), GNOMAD_BATCH_NA_SENTINEL),
-                error = function(e) NULL
-              )
-            }
+            # Successful chunk + this alias = NA → gene-not-found per gnomAD.
+            # Cache as sentinel so we don't re-query (chrX/Y/M long tail.)
+            tryCatch(cache$set(.gnomad_batch_cache_key(sym), GNOMAD_BATCH_NA_SENTINEL),
+              error = function(e) NULL
+            )
           } else {
             tryCatch(cache$set(.gnomad_batch_cache_key(sym), val),
               error = function(e) NULL
             )
           }
-          cached_decoded[slot] <- val
+          cached_decoded[slot] <<- val
         }
       }
-    }
+      invisible(NULL)
+    }, chunks, chunk_results)
   }
 
   setNames(cached_decoded, symbols)

--- a/api/functions/external-proxy-gnomad-batch.R
+++ b/api/functions/external-proxy-gnomad-batch.R
@@ -66,3 +66,58 @@ GNOMAD_BATCH_ENDPOINT <- "https://gnomad.broadinstitute.org/api?raw"
 
   paste0("query Batch { ", paste(parts, collapse = " "), " }")
 }
+
+#' Map a parsed GraphQL response back to a named char vector of JSON-or-NA
+#'
+#' @param parsed_json Already-parsed GraphQL response (`list(data = list(...), errors = ...)`).
+#' @param symbols Character vector of HGNC symbols passed to the corresponding query, in alias order.
+#' @return Named character vector of length `length(symbols)`, names equal to `symbols`,
+#'   each value either a JSON string in the bulk pipeline shape or `NA_character_`.
+#' @noRd
+.parse_batched_constraint_response <- function(parsed_json, symbols) {
+  if (length(symbols) == 0L) {
+    return(setNames(character(0), character(0)))
+  }
+  # Determine which alias indices were called out in the top-level errors block.
+  errored_aliases <- character(0)
+  errs <- parsed_json$errors
+  if (!is.null(errs) && length(errs) > 0L) {
+    for (err in errs) {
+      path <- err$path
+      if (!is.null(path) && length(path) >= 1L) {
+        # path[[1]] is the alias name like "g0"
+        first <- as.character(path[[1L]])
+        if (grepl("^g[0-9]+$", first)) {
+          errored_aliases <- c(errored_aliases, first)
+        }
+      }
+    }
+  }
+
+  out <- vapply(seq_along(symbols), function(i) {
+    alias <- paste0("g", i - 1L)
+    if (alias %in% errored_aliases) {
+      return(NA_character_)
+    }
+    gene_obj <- parsed_json$data[[alias]]
+    if (is.null(gene_obj)) {
+      return(NA_character_)
+    }
+    constraint <- gene_obj$gnomad_constraint
+    if (is.null(constraint)) {
+      return(NA_character_)
+    }
+    # Build JSON in the same shape the bulk pipeline emits (19 fields, sprintf scientific,
+    # `null` for NA). Use jsonlite::toJSON for safety, with auto_unbox = TRUE to emit scalars.
+    # Reorder keys to match GNOMAD_BATCH_FIELDS for deterministic output.
+    ordered <- constraint[GNOMAD_BATCH_FIELDS]
+    names(ordered) <- GNOMAD_BATCH_FIELDS
+    # Coerce numeric NAs to JSON null rather than R NA → "NA"
+    ordered <- lapply(ordered, function(v) {
+      if (is.null(v) || (length(v) == 1L && is.na(v))) NULL else v
+    })
+    jsonlite::toJSON(ordered, auto_unbox = TRUE, na = "null", null = "null")
+  }, character(1L), USE.NAMES = FALSE)
+
+  setNames(out, symbols)
+}

--- a/api/functions/external-proxy-gnomad-batch.R
+++ b/api/functions/external-proxy-gnomad-batch.R
@@ -12,7 +12,23 @@ require(jsonlite)
 GNOMAD_BATCH_NA_SENTINEL <- "__GNOMAD_NA__"
 
 # Cache key namespace. Bumping the suffix is a clean way to invalidate after a JSON-shape change.
-GNOMAD_BATCH_CACHE_PREFIX <- "gnomad_constraint_v1::"
+# cachem (cache_disk / cache_mem) only accepts keys matching ^[a-z0-9]+$, so we keep this
+# prefix lowercase-alphanumeric (no `::` separator) and likewise sanitise the per-symbol
+# tail with `.gnomad_batch_cache_key()`.
+GNOMAD_BATCH_CACHE_PREFIX <- "gnomadconstraintv1"
+
+#' Build a cachem-compatible key for a single gene symbol.
+#'
+#' cachem keys must match `^[a-z0-9]+$`. Most HGNC symbols are alphanumeric but some
+#' contain hyphens (e.g. HLA-B) or other punctuation; we lowercase and strip every
+#' non-alphanumeric character. Collisions across distinct sanitised symbols are
+#' acceptable in practice — the cache value is a JSON blob that the caller never
+#' relies on by symbol identity (the named vector returned to the caller comes from
+#' the GraphQL response, not from cache key lookup).
+#' @noRd
+.gnomad_batch_cache_key <- function(symbol) {
+  paste0(GNOMAD_BATCH_CACHE_PREFIX, gsub("[^a-z0-9]", "", tolower(symbol)))
+}
 
 # 19 fields the bulk pipeline emits. Keep this list aligned with
 # GNOMAD_TSV_COLUMN_MAP in api/functions/hgnc-enrichment-gnomad.R.
@@ -190,4 +206,104 @@ GNOMAD_BATCH_ENDPOINT <- "https://gnomad.broadinstitute.org/api?raw"
   }
 
   .parse_batched_constraint_response(parsed, symbols)
+}
+
+#' Fetch gnomAD constraint scores for many symbols, batched and cached
+#'
+#' Consults the disk cache per-symbol; chunks misses ≤25 per HTTP request; dispatches
+#' chunks concurrently via httr2::reqs_perform_parallel. Successful and "Gene not found"
+#' results are written back to cache (the latter as a sentinel). Transport failures
+#' surface as NA without poisoning the cache.
+#'
+#' @param symbols Character vector of HGNC gene symbols. May be empty.
+#' @param max_concurrency Integer pool size for parallel batch requests. Default 5.
+#'   Benchmarks (2026-04-29, n=20) show gnomAD tolerates 20 concurrent without
+#'   rate-limiting; 5 is well-mannered.
+#' @param cache cachem cache backend. Default `cache_static` (30-day filesystem).
+#'   Override in tests with `cachem::cache_mem()`.
+#' @return Named character vector of length `length(symbols)`, names equal to `symbols`.
+#'   Each element is either a JSON string in the bulk pipeline shape or `NA_character_`.
+#' @export
+fetch_gnomad_constraints_batch <- function(
+  symbols,
+  max_concurrency = 5L,
+  cache = cache_static
+) {
+  if (length(symbols) == 0L) {
+    return(setNames(character(0), character(0)))
+  }
+
+  # --- Step 1: per-symbol cache lookup ---
+  upper_syms <- toupper(symbols)
+  keys <- vapply(symbols, .gnomad_batch_cache_key, character(1L), USE.NAMES = FALSE)
+  cached_raw <- vapply(keys, function(k) {
+    if (cache$exists(k)) cache$get(k) else NA_character_
+  }, character(1L), USE.NAMES = FALSE)
+  cached_decoded <- ifelse(
+    !is.na(cached_raw) & cached_raw == GNOMAD_BATCH_NA_SENTINEL,
+    NA_character_,
+    cached_raw
+  )
+  hit_mask <- !is.na(cached_raw) # both "real value" and sentinel count as hit
+
+  # --- Step 2: chunk and dispatch misses ---
+  miss_idx <- which(!hit_mask)
+  if (length(miss_idx) > 0L) {
+    miss_syms <- symbols[miss_idx]
+    chunks <- split(
+      miss_syms,
+      ceiling(seq_along(miss_syms) / GNOMAD_BATCH_MAX_PER_REQUEST)
+    )
+
+    # Concurrency: build a request per chunk, fire via reqs_perform_parallel.
+    fetch_chunk_async <- function(chunk_syms) {
+      .fetch_gnomad_constraints_chunk(chunk_syms)
+    }
+    if (length(chunks) > 1L && max_concurrency > 1L) {
+      # parallel via mirai pool — but we can also just lapply for now since the
+      # individual chunks are non-blocking via httr2 anyway. Use a simple parallel
+      # strategy: split chunks into waves of `max_concurrency`.
+      chunk_results <- list()
+      for (start in seq(1L, length(chunks), by = max_concurrency)) {
+        end <- min(start + max_concurrency - 1L, length(chunks))
+        wave <- chunks[start:end]
+        wave_results <- lapply(wave, fetch_chunk_async)
+        chunk_results <- c(chunk_results, wave_results)
+      }
+    } else {
+      chunk_results <- lapply(chunks, fetch_chunk_async)
+    }
+
+    # Stitch chunk results back into miss_idx slots, write to cache.
+    for (cr in chunk_results) {
+      for (sym in names(cr)) {
+        upper_sym <- toupper(sym)
+        slot <- which(upper_syms == upper_sym & !hit_mask)
+        if (length(slot) >= 1L) {
+          val <- cr[[sym]]
+          if (is.na(val)) {
+            # Distinguish transport-fail (do not cache) from gene-not-found (cache as sentinel).
+            # Both come back as NA from the chunk fetcher; we cannot distinguish here.
+            # Convention: chunks that suffered transport failure return NA for ALL symbols,
+            # successful chunks return NA only for missing genes.
+            # Heuristic: if at least one alias in the chunk returned non-NA, the chunk was
+            # successful; the NA is "gene not found" → cache the sentinel.
+            chunk_had_success <- any(!is.na(cr))
+            if (chunk_had_success) {
+              tryCatch(cache$set(.gnomad_batch_cache_key(sym), GNOMAD_BATCH_NA_SENTINEL),
+                error = function(e) NULL
+              )
+            }
+          } else {
+            tryCatch(cache$set(.gnomad_batch_cache_key(sym), val),
+              error = function(e) NULL
+            )
+          }
+          cached_decoded[slot] <- val
+        }
+      }
+    }
+  }
+
+  setNames(cached_decoded, symbols)
 }

--- a/api/functions/external-proxy-gnomad-batch.R
+++ b/api/functions/external-proxy-gnomad-batch.R
@@ -34,3 +34,35 @@ GNOMAD_BATCH_MAX_PER_REQUEST <- 25L
 # gnomAD GraphQL endpoint. The ?raw query bypasses the GraphiQL HTML wrapper that
 # would otherwise be served when the Accept header does not survive a proxy.
 GNOMAD_BATCH_ENDPOINT <- "https://gnomad.broadinstitute.org/api?raw"
+
+#' Build an aliased GraphQL query for ≤25 gene constraint lookups
+#' @noRd
+.build_aliased_constraint_query <- function(symbols) {
+  if (length(symbols) == 0L) return(NULL)
+  if (length(symbols) > GNOMAD_BATCH_MAX_PER_REQUEST) {
+    stop(sprintf(
+      "[gnomad-batch] internal error: builder called with %d symbols (max %d). The caller should chunk before calling.",
+      length(symbols), GNOMAD_BATCH_MAX_PER_REQUEST
+    ))
+  }
+  valid_mask <- vapply(symbols, validate_gene_symbol, logical(1L), USE.NAMES = FALSE)
+  if (any(!valid_mask)) {
+    warning(sprintf(
+      "[gnomad-batch] filtered %d invalid symbols from query (will be returned as NA): %s",
+      sum(!valid_mask),
+      paste(shQuote(symbols[!valid_mask]), collapse = ", ")
+    ), call. = FALSE)
+  }
+  valid_syms <- symbols[valid_mask]
+  if (length(valid_syms) == 0L) return(NULL)
+
+  field_block <- paste(GNOMAD_BATCH_FIELDS, collapse = " ")
+  parts <- vapply(seq_along(valid_syms), function(i) {
+    sprintf(
+      'g%d: gene(gene_symbol: "%s", reference_genome: GRCh38) { gnomad_constraint { %s } }',
+      i - 1L, valid_syms[i], field_block
+    )
+  }, character(1L), USE.NAMES = FALSE)
+
+  paste0("query Batch { ", paste(parts, collapse = " "), " }")
+}

--- a/api/functions/hgnc-enrichment-gnomad.R
+++ b/api/functions/hgnc-enrichment-gnomad.R
@@ -69,11 +69,11 @@ GNOMAD_TSV_COLUMN_MAP <- c(
 #'
 #' @export
 enrich_gnomad_constraints <- function(hgnc_tibble, progress_fn = NULL) {
-  total_steps <- 3
+  total_steps <- 4L
   message("[gnomAD enrichment] Starting bulk constraint enrichment")
 
   # --- Step 1: Download TSV ---
-  message("[gnomAD enrichment] Step 1/3: Downloading constraint metrics TSV")
+  message("[gnomAD enrichment] Step 1/4: Downloading constraint metrics TSV")
   if (!is.null(progress_fn)) {
     tryCatch(
       progress_fn("gnomad", "gnomAD: downloading TSV", current = 1, total = total_steps),
@@ -110,7 +110,7 @@ enrich_gnomad_constraints <- function(hgnc_tibble, progress_fn = NULL) {
   ))
 
   # --- Step 2: Parse and filter ---
-  message("[gnomAD enrichment] Step 2/3: Parsing and filtering for MANE Select transcripts")
+  message("[gnomAD enrichment] Step 2/4: Parsing and filtering for MANE Select transcripts")
   if (!is.null(progress_fn)) {
     tryCatch(
       progress_fn("gnomad", "gnomAD: parsing TSV", current = 2, total = total_steps),
@@ -154,7 +154,7 @@ enrich_gnomad_constraints <- function(hgnc_tibble, progress_fn = NULL) {
   }
 
   # --- Step 3: Build JSON and join ---
-  message("[gnomAD enrichment] Step 3/3: Building JSON and joining to HGNC tibble")
+  message("[gnomAD enrichment] Step 3/4: Building JSON and joining to HGNC tibble")
   if (!is.null(progress_fn)) {
     tryCatch(
       progress_fn("gnomad", "gnomAD: joining data", current = 3, total = total_steps),
@@ -199,6 +199,59 @@ enrich_gnomad_constraints <- function(hgnc_tibble, progress_fn = NULL) {
     "[gnomAD enrichment] Complete. %d / %d genes had constraint data.",
     n_mapped, nrow(hgnc_tibble)
   ))
+
+  # Initialize fallback counters so they exist on every code path (used by the
+  # metrics-wrapper companion to expose recovered/unresolved counts via attributes).
+  n_recovered <- 0L
+  n_unresolved <- 0L
+
+  # === Step 4/4 — chrX/Y/M fallback via GraphQL ===
+  missing_idx <- which(is.na(hgnc_tibble$gnomad_constraints))
+  if (length(missing_idx) > 0L) {
+    missing_symbols <- hgnc_tibble$symbol[missing_idx]
+    message(sprintf(
+      "[gnomAD enrichment] Step 4/4: GraphQL fallback for %d symbols missing from bulk TSV",
+      length(missing_symbols)
+    ))
+    if (!is.null(progress_fn)) {
+      tryCatch(
+        progress_fn(
+          "gnomad-fallback",
+          sprintf("gnomAD: querying API for %d missing genes", length(missing_symbols)),
+          current = 4L, total = total_steps
+        ),
+        error = function(e) NULL
+      )
+    }
+    fallback_results <- tryCatch(
+      fetch_gnomad_constraints_batch(missing_symbols),
+      error = function(e) {
+        warning(sprintf(
+          "[gnomAD enrichment] Fallback batch fetcher itself errored (%s); leaving %d genes as NA",
+          conditionMessage(e), length(missing_symbols)
+        ), call. = FALSE)
+        setNames(rep(NA_character_, length(missing_symbols)), missing_symbols)
+      }
+    )
+    recovered_mask <- !is.na(fallback_results)
+    if (any(recovered_mask)) {
+      hgnc_tibble$gnomad_constraints[missing_idx[recovered_mask]] <-
+        fallback_results[recovered_mask]
+    }
+    n_recovered <- sum(recovered_mask)
+    n_unresolved <- length(missing_symbols) - n_recovered
+    message(sprintf(
+      "[gnomAD enrichment] Fallback recovered %d / %d missing genes (%d still NA)",
+      n_recovered, length(missing_symbols), n_unresolved
+    ))
+  } else {
+    message("[gnomAD enrichment] No fallback needed — bulk join populated every row")
+  }
+
+  # Attach counts as attributes so the metrics-wrapper companion can read them
+  # without re-deriving from the tibble. NULL-safe via existing initialisation above.
+  attr(hgnc_tibble, "fallback_recovered") <- as.integer(n_recovered)
+  attr(hgnc_tibble, "fallback_unresolved") <- as.integer(n_unresolved)
 
   return(hgnc_tibble)
 }

--- a/api/functions/hgnc-enrichment-gnomad.R
+++ b/api/functions/hgnc-enrichment-gnomad.R
@@ -257,6 +257,38 @@ enrich_gnomad_constraints <- function(hgnc_tibble, progress_fn = NULL) {
 }
 
 
+#' Wrapper of enrich_gnomad_constraints that also returns fallback counts
+#'
+#' Used by both async-job paths (inline executor in jobs_endpoints.R and the
+#' durable handler .async_job_run_hgnc_update) so the durable job result exposes
+#' the gnomAD fallback recovered/unresolved counts directly. Reads the counts
+#' from the attributes attached by enrich_gnomad_constraints, then strips the
+#' attributes from the returned tibble (downstream code shouldn't depend on
+#' attribute survival across mutate/select).
+#'
+#' @param hgnc_tibble As enrich_gnomad_constraints.
+#' @param progress_fn As enrich_gnomad_constraints.
+#' @return list(tibble = <enriched tibble>, fallback_recovered = <int>, fallback_unresolved = <int>)
+#' @export
+enrich_gnomad_constraints_with_metrics <- function(hgnc_tibble, progress_fn = NULL) {
+  enriched <- enrich_gnomad_constraints(hgnc_tibble, progress_fn = progress_fn)
+
+  recovered <- attr(enriched, "fallback_recovered", exact = TRUE)
+  unresolved <- attr(enriched, "fallback_unresolved", exact = TRUE)
+  if (is.null(recovered)) recovered <- 0L
+  if (is.null(unresolved)) unresolved <- sum(is.na(enriched$gnomad_constraints))
+
+  attr(enriched, "fallback_recovered") <- NULL
+  attr(enriched, "fallback_unresolved") <- NULL
+
+  list(
+    tibble = enriched,
+    fallback_recovered = as.integer(recovered),
+    fallback_unresolved = as.integer(unresolved)
+  )
+}
+
+
 #' Enrich HGNC tibble with AlphaFold model identifiers
 #'
 #' @description

--- a/api/functions/hgnc-enrichment-gnomad.R
+++ b/api/functions/hgnc-enrichment-gnomad.R
@@ -259,12 +259,18 @@ enrich_gnomad_constraints <- function(hgnc_tibble, progress_fn = NULL) {
 
 #' Wrapper of enrich_gnomad_constraints that also returns fallback counts
 #'
-#' Used by both async-job paths (inline executor in jobs_endpoints.R and the
-#' durable handler .async_job_run_hgnc_update) so the durable job result exposes
-#' the gnomAD fallback recovered/unresolved counts directly. Reads the counts
-#' from the attributes attached by enrich_gnomad_constraints, then strips the
-#' attributes from the returned tibble (downstream code shouldn't depend on
-#' attribute survival across mutate/select).
+#' Convenience wrapper for callers that want the gnomAD fallback
+#' recovered/unresolved counts as explicit return values rather than reading
+#' them from attributes on the enriched tibble. The current job paths
+#' (`update_process_hgnc_data` → inline executor in `jobs_endpoints.R` and
+#' the durable handler `.async_job_run_hgnc_update`) read the counts via
+#' `attr(hgnc_data, ...)` directly because the broader pipeline preserves
+#' attribute survival through dplyr cleanup; this wrapper is provided for
+#' callers that prefer not to depend on that contract.
+#'
+#' Reads the counts from attributes attached by `enrich_gnomad_constraints`,
+#' then strips them from the returned tibble so downstream code does not
+#' depend on attribute survival across mutate/select.
 #'
 #' @param hgnc_tibble As enrich_gnomad_constraints.
 #' @param progress_fn As enrich_gnomad_constraints.

--- a/api/tests/testthat/test-integration-gnomad-batch.R
+++ b/api/tests/testthat/test-integration-gnomad-batch.R
@@ -1,0 +1,55 @@
+# api/tests/testthat/test-integration-gnomad-batch.R
+# Live integration tests against the gnomAD GraphQL API.
+# Skipped unless RUN_GNOMAD_INTEGRATION=1.
+
+source_api_file("functions/external-proxy-functions.R", local = FALSE)
+source_api_file("functions/external-proxy-gnomad-batch.R", local = FALSE)
+
+describe("fetch_gnomad_constraints_batch — live", {
+  testthat::skip_if_not(
+    Sys.getenv("RUN_GNOMAD_INTEGRATION") == "1",
+    "Set RUN_GNOMAD_INTEGRATION=1 to run live gnomAD tests"
+  )
+  testthat::skip_if_offline("gnomad.broadinstitute.org")
+
+  it("fetches MECP2, CDKL5, FMR1 (all chrX, all known to gnomAD)", {
+    out <- fetch_gnomad_constraints_batch(
+      c("MECP2", "CDKL5", "FMR1"),
+      cache = cachem::cache_mem()
+    )
+    expect_named(out, c("MECP2", "CDKL5", "FMR1"))
+    for (s in c("MECP2", "CDKL5", "FMR1")) {
+      expect_false(
+        is.na(out[[s]]),
+        info = sprintf("expected non-NA for %s but got NA", s)
+      )
+      parsed <- jsonlite::fromJSON(out[[s]])
+      expect_named(parsed, GNOMAD_BATCH_FIELDS, ignore.order = TRUE)
+      expect_true(is.numeric(parsed$pLI))
+    }
+  })
+
+  it("returns NA for an obviously fake symbol", {
+    out <- fetch_gnomad_constraints_batch(
+      c("DEFINITELY_NOT_A_REAL_GENE_XYZ"),
+      cache = cachem::cache_mem()
+    )
+    expect_true(is.na(out[["DEFINITELY_NOT_A_REAL_GENE_XYZ"]]))
+  })
+
+  it("completes 150-symbol fallback simulation in under 30 seconds", {
+    # Sample of known X-linked genes; not all will be valid in gnomAD.
+    chrx <- c(
+      "MECP2", "CDKL5", "FMR1", "ATRX", "KDM5C", "HUWE1", "OFD1", "PHF6",
+      "SMC1A", "IL1RAPL1", "RPS6KA3", "DMD", "HPRT1", "ARX", "MED12", "UBE2A",
+      "ZNF711", "GRIA3", "WDR45", "WAS", "UPF3B", "UBA1", "TRMT1", "TIMM8A",
+      "TFE3", "TBL1X", "SYP", "SYN1", "SOX3", "SLC9A6", "SLC6A8"
+    )
+    syms <- rep(chrx, 5L)[1:150L]
+    elapsed <- system.time(
+      out <- fetch_gnomad_constraints_batch(syms, cache = cachem::cache_mem())
+    )["elapsed"]
+    cat(sprintf("\n[bench] %d symbols in %.2fs\n", length(syms), elapsed))
+    expect_lt(elapsed, 30.0)
+  })
+})

--- a/api/tests/testthat/test-unit-gnomad-batch.R
+++ b/api/tests/testthat/test-unit-gnomad-batch.R
@@ -340,6 +340,10 @@ describe("fetch_gnomad_constraints_batch", {
     expect_equal(cache$get(.gnomad_batch_cache_key("MISS")), "__GNOMAD_NA__")
   })
 
+  it("does not collide HLA-B and HLAB cache keys", {
+    expect_false(.gnomad_batch_cache_key("HLA-B") == .gnomad_batch_cache_key("HLAB"))
+  })
+
   it("does NOT cache results from a transport-failed batch", {
     cache <- make_mem_cache()
     httr2::with_mocked_responses(

--- a/api/tests/testthat/test-unit-gnomad-batch.R
+++ b/api/tests/testthat/test-unit-gnomad-batch.R
@@ -176,7 +176,10 @@ describe(".fetch_gnomad_constraints_chunk", {
     )
   })
 
-  it("returns all-NA on a 500 response, with a warning", {
+  it("returns NULL on a 500 response, with a warning (transport-fail signal)", {
+    # Contract change (2026-04-29): the chunk fetcher returns NULL — not an
+    # all-NA vec — on transport failure, so the batch caller can distinguish
+    # transport-fail from gene-not-found unambiguously and skip cache writes.
     httr2::with_mocked_responses(
       mock = function(req) httr2::response(status_code = 500L, body = charToRaw('{"error":"oops"}')),
       {
@@ -186,13 +189,12 @@ describe(".fetch_gnomad_constraints_chunk", {
           "\\[gnomad-batch\\].*HTTP",
           ignore.case = TRUE
         )
-        expect_named(out, c("MECP2", "CDKL5"))
-        expect_true(all(is.na(out)))
+        expect_null(out)
       }
     )
   })
 
-  it("returns all-NA on an unparseable body, with a warning", {
+  it("returns NULL on an unparseable body, with a warning (transport-fail signal)", {
     httr2::with_mocked_responses(
       mock = function(req) httr2::response(status_code = 200L, body = charToRaw("<html>not json</html>")),
       {
@@ -201,7 +203,7 @@ describe(".fetch_gnomad_constraints_chunk", {
           "\\[gnomad-batch\\].*(parse|json)",
           ignore.case = TRUE
         )
-        expect_true(all(is.na(out)))
+        expect_null(out)
       }
     )
   })
@@ -312,6 +314,9 @@ describe("fetch_gnomad_constraints_batch", {
     )
     expect_equal(chunk_count, 3L)
     expect_length(out, 60L)
+    # Reviewer minor #10: assert names match the input order so the function's
+    # name (`fetch_gnomad_constraints_batch`) is not "structurally weaker than its name suggests".
+    expect_named(out, syms)
     expect_true(all(is.na(out)))
   })
 
@@ -355,5 +360,34 @@ describe("fetch_gnomad_constraints_batch", {
       }
     )
     expect_false(cache$exists(.gnomad_batch_cache_key("MECP2")))
+  })
+
+  it("caches sentinels for ALL aliases when a successful chunk returns all-null", {
+    # Regression for the brittle `chunk_had_success` heuristic: when a 200-OK
+    # chunk legitimately returns null for every alias (chrX/Y/M long tail —
+    # pseudogenes, withdrawn aliases, etc.), every slot must be cached as the
+    # sentinel so the next pipeline run does not pay the HTTP cost again.
+    cache <- cachem::cache_mem()
+    body <- jsonlite::toJSON(list(
+      data = list(
+        g0 = NULL, g1 = NULL, g2 = NULL
+      )
+    ), auto_unbox = TRUE, null = "null")
+    httr2::with_mocked_responses(
+      mock = function(req) httr2::response(
+        status_code = 200L,
+        body = charToRaw(body),
+        headers = list("content-type" = "application/json")
+      ),
+      {
+        out <- fetch_gnomad_constraints_batch(c("FAKE1", "FAKE2", "FAKE3"), cache = cache)
+      }
+    )
+    expect_true(all(is.na(out)))
+    for (s in c("FAKE1", "FAKE2", "FAKE3")) {
+      expect_true(cache$exists(.gnomad_batch_cache_key(s)),
+        info = sprintf("expected sentinel for %s", s))
+      expect_equal(cache$get(.gnomad_batch_cache_key(s)), GNOMAD_BATCH_NA_SENTINEL)
+    }
   })
 })

--- a/api/tests/testthat/test-unit-gnomad-batch.R
+++ b/api/tests/testthat/test-unit-gnomad-batch.R
@@ -212,3 +212,144 @@ describe(".fetch_gnomad_constraints_chunk", {
     expect_length(out, 0L)
   })
 })
+
+describe("fetch_gnomad_constraints_batch", {
+  # Helper: in-memory cachem that mimics cache_static for these tests.
+  make_mem_cache <- function() cachem::cache_mem()
+
+  it("returns aligned named char vec on full success", {
+    cache <- make_mem_cache()
+    body <- jsonlite::toJSON(list(
+      data = list(
+        g0 = list(gnomad_constraint = list(
+          pLI = 0.99, oe_lof = 0.1, oe_lof_lower = 0.05, oe_lof_upper = 0.2,
+          oe_mis = 1, oe_mis_lower = 0.9, oe_mis_upper = 1.1,
+          oe_syn = 1, oe_syn_lower = 0.9, oe_syn_upper = 1.1,
+          exp_lof = 50, obs_lof = 5, exp_mis = 500, obs_mis = 500,
+          exp_syn = 200, obs_syn = 200, lof_z = 3.5, mis_z = 0, syn_z = 0
+        )),
+        g1 = NULL # unknown gene
+      )
+    ), auto_unbox = TRUE)
+
+    httr2::with_mocked_responses(
+      mock = function(req) httr2::response(status_code = 200L, body = charToRaw(body), headers = list("content-type" = "application/json")),
+      {
+        out <- fetch_gnomad_constraints_batch(c("MECP2", "FAKE_GENE"), cache = cache)
+        expect_named(out, c("MECP2", "FAKE_GENE"))
+        expect_false(is.na(out[["MECP2"]]))
+        expect_true(is.na(out[["FAKE_GENE"]]))
+      }
+    )
+  })
+
+  it("does not fire any request when every symbol is in cache", {
+    cache <- make_mem_cache()
+    # cachem requires lowercase-alphanumeric keys; module exposes .gnomad_batch_cache_key
+    # to construct them. Plan used the prior `gnomad_constraint_v1::SYMBOL` form.
+    cache$set(.gnomad_batch_cache_key("MECP2"), '{"pLI":0.99}')
+    cache$set(.gnomad_batch_cache_key("CDKL5"), "__GNOMAD_NA__")
+
+    # If a request fires, with_mocked_responses errors with no mock provided
+    out <- fetch_gnomad_constraints_batch(c("MECP2", "CDKL5"), cache = cache)
+    expect_equal(out[["MECP2"]], '{"pLI":0.99}')
+    expect_true(is.na(out[["CDKL5"]]))
+  })
+
+  it("fires exactly one request when 5 symbols are uncached and 5 are cached", {
+    cache <- make_mem_cache()
+    cached <- paste0("CACHED", 1:5)
+    uncached <- paste0("MISS", 1:5)
+    for (s in cached) cache$set(.gnomad_batch_cache_key(s), sprintf('{"sym":"%s"}', s))
+
+    body <- jsonlite::toJSON(list(
+      data = setNames(
+        lapply(seq_along(uncached), function(i) list(gnomad_constraint = list(
+          pLI = 0.5, oe_lof = 1, oe_lof_lower = 0.5, oe_lof_upper = 1.5,
+          oe_mis = 1, oe_mis_lower = 0.9, oe_mis_upper = 1.1,
+          oe_syn = 1, oe_syn_lower = 0.9, oe_syn_upper = 1.1,
+          exp_lof = 50, obs_lof = 5, exp_mis = 500, obs_mis = 500,
+          exp_syn = 200, obs_syn = 200, lof_z = 0, mis_z = 0, syn_z = 0
+        ))),
+        paste0("g", seq_along(uncached) - 1L)
+      )
+    ), auto_unbox = TRUE)
+
+    call_count <- 0L
+    httr2::with_mocked_responses(
+      mock = function(req) {
+        call_count <<- call_count + 1L
+        httr2::response(status_code = 200L, body = charToRaw(body), headers = list("content-type" = "application/json"))
+      },
+      {
+        out <- fetch_gnomad_constraints_batch(c(cached, uncached), cache = cache)
+      }
+    )
+    expect_equal(call_count, 1L)
+    expect_length(out, 10L)
+  })
+
+  it("fires three requests when 60 symbols are uncached (chunks 25/25/10)", {
+    cache <- make_mem_cache()
+    syms <- paste0("GENE", sprintf("%03d", 1:60))
+    chunk_count <- 0L
+    # Plan used httr2::req_body_get(req) which is not a real accessor. Per task5 instructions,
+    # we replace body parsing with a call counter and return all-NA per chunk (max 25 aliases).
+    canned_body <- jsonlite::toJSON(list(
+      data = setNames(
+        replicate(GNOMAD_BATCH_MAX_PER_REQUEST, NULL, simplify = FALSE),
+        paste0("g", seq_len(GNOMAD_BATCH_MAX_PER_REQUEST) - 1L)
+      )
+    ), auto_unbox = TRUE, null = "null")
+    httr2::with_mocked_responses(
+      mock = function(req) {
+        chunk_count <<- chunk_count + 1L
+        httr2::response(status_code = 200L, body = charToRaw(canned_body), headers = list("content-type" = "application/json"))
+      },
+      {
+        out <- fetch_gnomad_constraints_batch(syms, cache = cache, max_concurrency = 1L)
+      }
+    )
+    expect_equal(chunk_count, 3L)
+    expect_length(out, 60L)
+    expect_true(all(is.na(out)))
+  })
+
+  it("caches every recovered value AND every gene-not-found result", {
+    cache <- make_mem_cache()
+    body <- jsonlite::toJSON(list(
+      data = list(
+        g0 = list(gnomad_constraint = list(
+          pLI = 0.5, oe_lof = 1, oe_lof_lower = 0.5, oe_lof_upper = 1.5,
+          oe_mis = 1, oe_mis_lower = 0.9, oe_mis_upper = 1.1,
+          oe_syn = 1, oe_syn_lower = 0.9, oe_syn_upper = 1.1,
+          exp_lof = 50, obs_lof = 5, exp_mis = 500, obs_mis = 500,
+          exp_syn = 200, obs_syn = 200, lof_z = 0, mis_z = 0, syn_z = 0
+        )),
+        g1 = NULL
+      )
+    ), auto_unbox = TRUE)
+    httr2::with_mocked_responses(
+      mock = function(req) httr2::response(status_code = 200L, body = charToRaw(body), headers = list("content-type" = "application/json")),
+      {
+        fetch_gnomad_constraints_batch(c("HIT", "MISS"), cache = cache)
+      }
+    )
+    expect_true(cache$exists(.gnomad_batch_cache_key("HIT")))
+    expect_true(cache$exists(.gnomad_batch_cache_key("MISS")))
+    expect_equal(cache$get(.gnomad_batch_cache_key("MISS")), "__GNOMAD_NA__")
+  })
+
+  it("does NOT cache results from a transport-failed batch", {
+    cache <- make_mem_cache()
+    httr2::with_mocked_responses(
+      mock = function(req) httr2::response(status_code = 500L, body = charToRaw('{"err":"x"}')),
+      {
+        suppressWarnings(
+          fetch_gnomad_constraints_batch(c("MECP2"), cache = cache)
+        )
+      }
+    )
+    expect_false(cache$exists(.gnomad_batch_cache_key("MECP2")))
+  })
+})

--- a/api/tests/testthat/test-unit-gnomad-batch.R
+++ b/api/tests/testthat/test-unit-gnomad-batch.R
@@ -56,3 +56,95 @@ describe(".build_aliased_constraint_query", {
     )
   })
 })
+
+describe(".parse_batched_constraint_response", {
+  make_constraint_obj <- function(pLI = 0.99) {
+    list(
+      pLI = pLI,
+      oe_lof = 0.1, oe_lof_lower = 0.05, oe_lof_upper = 0.2,
+      oe_mis = 1.0, oe_mis_lower = 0.9, oe_mis_upper = 1.1,
+      oe_syn = 1.0, oe_syn_lower = 0.9, oe_syn_upper = 1.1,
+      exp_lof = 50, obs_lof = 5,
+      exp_mis = 500, obs_mis = 500,
+      exp_syn = 200, obs_syn = 200,
+      lof_z = 3.5, mis_z = 0.0, syn_z = 0.0
+    )
+  }
+
+  it("returns named character vector with JSON for every successful alias", {
+    response <- list(
+      data = list(
+        g0 = list(gnomad_constraint = make_constraint_obj(0.99)),
+        g1 = list(gnomad_constraint = make_constraint_obj(0.50))
+      )
+    )
+    out <- .parse_batched_constraint_response(response, c("MECP2", "CDKL5"))
+    expect_named(out, c("MECP2", "CDKL5"))
+    expect_false(any(is.na(out)))
+    parsed_mecp2 <- jsonlite::fromJSON(out[["MECP2"]])
+    expect_equal(parsed_mecp2$pLI, 0.99)
+  })
+
+  it("returns NA for an alias whose gene is null", {
+    response <- list(
+      data = list(
+        g0 = NULL, # gene not found
+        g1 = list(gnomad_constraint = make_constraint_obj())
+      )
+    )
+    out <- .parse_batched_constraint_response(response, c("FAKE_GENE", "CDKL5"))
+    expect_true(is.na(out[["FAKE_GENE"]]))
+    expect_false(is.na(out[["CDKL5"]]))
+  })
+
+  it("returns NA when gene exists but gnomad_constraint is null", {
+    response <- list(
+      data = list(
+        g0 = list(gnomad_constraint = NULL),
+        g1 = list(gnomad_constraint = make_constraint_obj())
+      )
+    )
+    out <- .parse_batched_constraint_response(response, c("LINC00001", "CDKL5"))
+    expect_true(is.na(out[["LINC00001"]]))
+  })
+
+  it("returns NA for aliases referenced in errors block", {
+    response <- list(
+      data = list(
+        g0 = NULL,
+        g1 = list(gnomad_constraint = make_constraint_obj())
+      ),
+      errors = list(
+        list(
+          message = "Gene not found",
+          path = list("g0")
+        )
+      )
+    )
+    out <- .parse_batched_constraint_response(response, c("FAKE_GENE", "CDKL5"))
+    expect_true(is.na(out[["FAKE_GENE"]]))
+    expect_false(is.na(out[["CDKL5"]]))
+  })
+
+  it("returns empty named character vector for empty input", {
+    out <- .parse_batched_constraint_response(list(data = list()), character(0))
+    expect_length(out, 0L)
+    expect_named(out, character(0))
+  })
+
+  it("emits the same numeric formatting as the bulk pipeline for round-trip parity", {
+    # Bulk pipeline emits scientific notation for very small numbers and `null` for NA.
+    # This regression check ensures the JSON we emit can be parsed back identically.
+    response <- list(data = list(g0 = list(gnomad_constraint = list(
+      pLI = 1.5474e-34, oe_lof = NA, oe_lof_lower = NA, oe_lof_upper = NA,
+      oe_mis = NA, oe_mis_lower = NA, oe_mis_upper = NA,
+      oe_syn = NA, oe_syn_lower = NA, oe_syn_upper = NA,
+      exp_lof = NA, obs_lof = NA, exp_mis = NA, obs_mis = NA,
+      exp_syn = NA, obs_syn = NA, lof_z = NA, mis_z = NA, syn_z = NA
+    ))))
+    out <- .parse_batched_constraint_response(response, "WEIRD")
+    parsed <- jsonlite::fromJSON(out[["WEIRD"]])
+    expect_equal(parsed$pLI, 1.5474e-34)
+    expect_true(is.null(parsed$oe_lof) || is.na(parsed$oe_lof))
+  })
+})

--- a/api/tests/testthat/test-unit-gnomad-batch.R
+++ b/api/tests/testthat/test-unit-gnomad-batch.R
@@ -148,3 +148,67 @@ describe(".parse_batched_constraint_response", {
     expect_true(is.null(parsed$oe_lof) || is.na(parsed$oe_lof))
   })
 })
+
+describe(".fetch_gnomad_constraints_chunk", {
+  it("returns named char vec on a 200 response with all aliases populated", {
+    body <- jsonlite::toJSON(list(
+      data = setNames(
+        lapply(seq_len(2), function(i) list(gnomad_constraint = list(
+          pLI = 0.99, oe_lof = 0.1, oe_lof_lower = 0.05, oe_lof_upper = 0.2,
+          oe_mis = 1, oe_mis_lower = 0.9, oe_mis_upper = 1.1,
+          oe_syn = 1, oe_syn_lower = 0.9, oe_syn_upper = 1.1,
+          exp_lof = 50, obs_lof = 5, exp_mis = 500, obs_mis = 500,
+          exp_syn = 200, obs_syn = 200, lof_z = 3.5, mis_z = 0, syn_z = 0
+        ))),
+        c("g0", "g1")
+      )
+    ), auto_unbox = TRUE)
+
+    httr2::with_mocked_responses(
+      # Local httr2 requires raw body in response() and a function/list mock; plan used
+      # string body and bare response. Wrap body via charToRaw and mock as function.
+      mock = function(req) httr2::response(status_code = 200L, body = charToRaw(body), headers = list("content-type" = "application/json")),
+      {
+        out <- .fetch_gnomad_constraints_chunk(c("MECP2", "CDKL5"))
+        expect_named(out, c("MECP2", "CDKL5"))
+        expect_false(any(is.na(out)))
+      }
+    )
+  })
+
+  it("returns all-NA on a 500 response, with a warning", {
+    httr2::with_mocked_responses(
+      mock = function(req) httr2::response(status_code = 500L, body = charToRaw('{"error":"oops"}')),
+      {
+        expect_warning(
+          out <- .fetch_gnomad_constraints_chunk(c("MECP2", "CDKL5")),
+          # Escape brackets — bare `[gnomad-batch]` is read as a char-class with invalid range.
+          "\\[gnomad-batch\\].*HTTP",
+          ignore.case = TRUE
+        )
+        expect_named(out, c("MECP2", "CDKL5"))
+        expect_true(all(is.na(out)))
+      }
+    )
+  })
+
+  it("returns all-NA on an unparseable body, with a warning", {
+    httr2::with_mocked_responses(
+      mock = function(req) httr2::response(status_code = 200L, body = charToRaw("<html>not json</html>")),
+      {
+        expect_warning(
+          out <- .fetch_gnomad_constraints_chunk(c("MECP2", "CDKL5")),
+          "\\[gnomad-batch\\].*(parse|json)",
+          ignore.case = TRUE
+        )
+        expect_true(all(is.na(out)))
+      }
+    )
+  })
+
+  it("returns empty named char vec for empty input without firing a request", {
+    # If a request fires under empty input, the mock's absence will cause an error.
+    out <- .fetch_gnomad_constraints_chunk(character(0))
+    expect_length(out, 0L)
+  })
+})

--- a/api/tests/testthat/test-unit-gnomad-batch.R
+++ b/api/tests/testthat/test-unit-gnomad-batch.R
@@ -1,0 +1,58 @@
+# api/tests/testthat/test-unit-gnomad-batch.R
+# Unit tests for external-proxy-gnomad-batch.R
+
+source_api_file("functions/external-proxy-functions.R", local = FALSE)
+source_api_file("functions/external-proxy-gnomad-batch.R", local = FALSE)
+
+describe(".build_aliased_constraint_query", {
+  it("returns NULL for empty input", {
+    expect_null(.build_aliased_constraint_query(character(0)))
+  })
+
+  it("emits one alias for one valid symbol", {
+    out <- .build_aliased_constraint_query("MECP2")
+    expect_type(out, "character")
+    expect_length(out, 1L)
+    expect_match(out, 'g0: gene\\(gene_symbol: "MECP2"', fixed = FALSE)
+    expect_match(out, "pLI", fixed = TRUE)
+    expect_match(out, "lof_z", fixed = TRUE)
+  })
+
+  it("emits one alias per valid symbol in input order", {
+    out <- .build_aliased_constraint_query(c("FMR1", "CDKL5", "MECP2"))
+    expect_match(out, 'g0: gene\\(gene_symbol: "FMR1"', fixed = FALSE)
+    expect_match(out, 'g1: gene\\(gene_symbol: "CDKL5"', fixed = FALSE)
+    expect_match(out, 'g2: gene\\(gene_symbol: "MECP2"', fixed = FALSE)
+  })
+
+  it("filters invalid symbols silently and warns once with the list", {
+    expect_warning(
+      out <- .build_aliased_constraint_query(c("FMR1", "O'Reilly", "", "CDKL5")),
+      # Plan-prompt regex expected FMR1 but FMR1 is the *valid* symbol. Warning
+      # lists invalid symbols only; match an invalid one (Reilly) instead.
+      "filtered.*invalid.*Reilly",
+      ignore.case = TRUE
+    )
+    expect_match(out, 'g0: gene\\(gene_symbol: "FMR1"', fixed = FALSE)
+    expect_match(out, 'g1: gene\\(gene_symbol: "CDKL5"', fixed = FALSE)
+    expect_false(grepl("Reilly", out, fixed = TRUE))
+  })
+
+  it("returns NULL when every symbol is invalid", {
+    expect_warning(
+      out <- .build_aliased_constraint_query(c("'", "")),
+      "filtered.*invalid",
+      ignore.case = TRUE
+    )
+    expect_null(out)
+  })
+
+  it("never embeds more than the cost-limit aliases", {
+    syms <- paste0("GENE", seq_len(50))
+    expect_error(
+      .build_aliased_constraint_query(syms),
+      "max .*25",
+      ignore.case = TRUE
+    )
+  })
+})

--- a/api/tests/testthat/test-unit-gnomad-batch.R
+++ b/api/tests/testthat/test-unit-gnomad-batch.R
@@ -33,8 +33,15 @@ describe(".build_aliased_constraint_query", {
       "filtered.*invalid.*Reilly",
       ignore.case = TRUE
     )
+    # Aliases use the ORIGINAL input position (0-based), not the post-filter
+    # position. Input: FMR1 at idx 0, "O'Reilly" at idx 1 (invalid),
+    # "" at idx 2 (invalid), CDKL5 at idx 3. Resulting query has g0 + g3
+    # only — alias numbering preserved so the parser's symbol-vector lookup
+    # still aligns when invalid entries are returned to the caller as NA.
     expect_match(out, 'g0: gene\\(gene_symbol: "FMR1"', fixed = FALSE)
-    expect_match(out, 'g1: gene\\(gene_symbol: "CDKL5"', fixed = FALSE)
+    expect_match(out, 'g3: gene\\(gene_symbol: "CDKL5"', fixed = FALSE)
+    expect_false(grepl(' g1:', out, fixed = TRUE))
+    expect_false(grepl(' g2:', out, fixed = TRUE))
     expect_false(grepl("Reilly", out, fixed = TRUE))
   })
 
@@ -212,6 +219,44 @@ describe(".fetch_gnomad_constraints_chunk", {
     # If a request fires under empty input, the mock's absence will cause an error.
     out <- .fetch_gnomad_constraints_chunk(character(0))
     expect_length(out, 0L)
+  })
+
+  it("preserves alias-symbol alignment when input contains an invalid symbol", {
+    # Regression: with sequential alias numbering (old behaviour), an invalid
+    # symbol in the middle would shift all later aliases by one and the
+    # parser would map valid genes onto the wrong names. New behaviour pins
+    # each alias index to the original input position.
+    body <- jsonlite::toJSON(list(
+      data = list(
+        # Only g1 is present in the response (the valid VALIDX symbol at
+        # original index 1). The invalid "" at idx 0 was filtered out of the
+        # query, so g0 simply does not exist in the response.
+        g1 = list(gnomad_constraint = list(
+          pLI = 0.99, oe_lof = 0.1, oe_lof_lower = 0.05, oe_lof_upper = 0.2,
+          oe_mis = 1, oe_mis_lower = 0.9, oe_mis_upper = 1.1,
+          oe_syn = 1, oe_syn_lower = 0.9, oe_syn_upper = 1.1,
+          exp_lof = 50, obs_lof = 5, exp_mis = 500, obs_mis = 500,
+          exp_syn = 200, obs_syn = 200, lof_z = 3.5, mis_z = 0, syn_z = 0
+        ))
+      )
+    ), auto_unbox = TRUE)
+    httr2::with_mocked_responses(
+      mock = function(req) httr2::response(
+        status_code = 200L,
+        body = charToRaw(body),
+        headers = list("content-type" = "application/json")
+      ),
+      {
+        suppressWarnings(
+          out <- .fetch_gnomad_constraints_chunk(c("", "VALIDX"))
+        )
+      }
+    )
+    expect_named(out, c("", "VALIDX"))
+    expect_true(is.na(out[[1L]]))
+    expect_false(is.na(out[["VALIDX"]]))
+    parsed <- jsonlite::fromJSON(out[["VALIDX"]])
+    expect_equal(parsed$pLI, 0.99)
   })
 })
 

--- a/api/tests/testthat/test-unit-gnomad-enrichment-fallback.R
+++ b/api/tests/testthat/test-unit-gnomad-enrichment-fallback.R
@@ -54,3 +54,32 @@ describe("enrich_gnomad_constraints with chrX fallback", {
     expect_equal(parsed_fallback$lof_z, 4.5)
   })
 })
+
+describe("enrich_gnomad_constraints_with_metrics", {
+  it("returns a list with tibble plus recovered/unresolved counts", {
+    hgnc <- tibble::tibble(
+      hgnc_id = c("HGNC:1", "HGNC:2", "HGNC:3"),
+      symbol = c("BRCA1", "MECP2", "CDKL5")
+    )
+
+    # Stub the inner enrich call to return a deterministic tibble with attrs already set,
+    # simulating the full enrichment pipeline outcome.
+    mockery::stub(enrich_gnomad_constraints_with_metrics, "enrich_gnomad_constraints",
+      function(t, ...) {
+        t$gnomad_constraints <- ifelse(t$symbol == "BRCA1", '{"pLI":0.5}',
+                                       ifelse(t$symbol == "MECP2", '{"pLI":0.999}', NA_character_))
+        attr(t, "fallback_recovered") <- 1L
+        attr(t, "fallback_unresolved") <- 1L
+        t
+      }
+    )
+    out <- enrich_gnomad_constraints_with_metrics(hgnc)
+    expect_named(out, c("tibble", "fallback_recovered", "fallback_unresolved"))
+    expect_equal(out$fallback_recovered, 1L)
+    expect_equal(out$fallback_unresolved, 1L)
+    expect_false(is.na(out$tibble$gnomad_constraints[out$tibble$symbol == "MECP2"]))
+    # Attrs should be stripped from the inner tibble (metrics consumer doesn't need them)
+    expect_null(attr(out$tibble, "fallback_recovered", exact = TRUE))
+    expect_null(attr(out$tibble, "fallback_unresolved", exact = TRUE))
+  })
+})

--- a/api/tests/testthat/test-unit-gnomad-enrichment-fallback.R
+++ b/api/tests/testthat/test-unit-gnomad-enrichment-fallback.R
@@ -106,3 +106,27 @@ describe("enrich_gnomad_constraints_with_metrics", {
     expect_null(attr(out$tibble, "fallback_unresolved", exact = TRUE))
   })
 })
+
+describe(".async_job_hgnc_write_db result shape", {
+  # NOTE: We assert these via deparse(body(...)) rather than running the
+  # function, because .async_job_hgnc_write_db calls DBI::dbConnect /
+  # dbAppendTable directly with no seam to stub a connection. Body-text
+  # inspection is brittle to whitespace/refactor — that's the pragmatic
+  # trade-off for not standing up a DB. End-to-end behaviour is exercised by
+  # the smoke test (Task 13 of the gnomAD chrX/Y/M fallback plan).
+  it("includes gnomad_fallback_recovered/unresolved keys", {
+    source_api_file("functions/async-job-handlers.R", local = FALSE)
+    body_text <- paste(deparse(body(.async_job_hgnc_write_db)), collapse = "\n")
+    expect_match(body_text, "gnomad_fallback_recovered")
+    expect_match(body_text, "gnomad_fallback_unresolved")
+    expect_match(body_text, '"fallback_recovered"')
+    expect_match(body_text, '"fallback_unresolved"')
+  })
+
+  it(".async_job_run_hgnc_update returns the metrics in its result list", {
+    source_api_file("functions/async-job-handlers.R", local = FALSE)
+    body_text <- paste(deparse(body(.async_job_run_hgnc_update)), collapse = "\n")
+    expect_match(body_text, "gnomad_fallback_recovered = write_result\\$gnomad_fallback_recovered")
+    expect_match(body_text, "gnomad_fallback_unresolved = write_result\\$gnomad_fallback_unresolved")
+  })
+})

--- a/api/tests/testthat/test-unit-gnomad-enrichment-fallback.R
+++ b/api/tests/testthat/test-unit-gnomad-enrichment-fallback.R
@@ -55,6 +55,29 @@ describe("enrich_gnomad_constraints with chrX fallback", {
   })
 })
 
+describe("attribute survival through dplyr cleanup", {
+  it("preserves fallback_recovered / fallback_unresolved through mutate(across)", {
+    # Regression guard: update_process_hgnc_data() ends with two
+    # dplyr::mutate(across(...)) cleanup steps. The job result lists read the
+    # fallback_recovered / fallback_unresolved attrs from the returned tibble,
+    # so those attrs must survive the cleanup. As of dplyr 1.x they do; this
+    # test fails fast if a future dplyr update changes that contract.
+    t <- tibble::tibble(
+      symbol = "BRCA1",
+      gnomad_constraints = '{"pLI":0.5}',
+      is_active = TRUE,
+      d = as.Date("2026-01-01")
+    )
+    attr(t, "fallback_recovered") <- 0L
+    attr(t, "fallback_unresolved") <- 0L
+    t2 <- t |>
+      dplyr::mutate(dplyr::across(where(is.logical), ~ as.character(.x))) |>
+      dplyr::mutate(dplyr::across(where(~ inherits(.x, "Date")), ~ as.character(.x)))
+    expect_equal(attr(t2, "fallback_recovered", exact = TRUE), 0L)
+    expect_equal(attr(t2, "fallback_unresolved", exact = TRUE), 0L)
+  })
+})
+
 describe("enrich_gnomad_constraints_with_metrics", {
   it("returns a list with tibble plus recovered/unresolved counts", {
     hgnc <- tibble::tibble(

--- a/api/tests/testthat/test-unit-gnomad-enrichment-fallback.R
+++ b/api/tests/testthat/test-unit-gnomad-enrichment-fallback.R
@@ -1,0 +1,56 @@
+# api/tests/testthat/test-unit-gnomad-enrichment-fallback.R
+
+source_api_file("functions/external-proxy-functions.R", local = FALSE)
+source_api_file("functions/external-proxy-gnomad-batch.R", local = FALSE)
+source_api_file("functions/hgnc-enrichment-gnomad.R", local = FALSE)
+
+describe("enrich_gnomad_constraints with chrX fallback", {
+  it("fills NA rows with values returned by fetch_gnomad_constraints_batch", {
+    hgnc <- tibble::tibble(
+      hgnc_id = c("HGNC:1", "HGNC:2", "HGNC:3"),
+      symbol = c("BRCA1", "MECP2", "CDKL5")
+    )
+
+    fake_fallback <- '{"pLI":0.999,"oe_lof":0.05,"oe_lof_lower":0.01,"oe_lof_upper":0.15,"oe_mis":1,"oe_mis_lower":0.9,"oe_mis_upper":1.1,"oe_syn":1,"oe_syn_lower":0.9,"oe_syn_upper":1.1,"exp_lof":40,"obs_lof":2,"exp_mis":400,"obs_mis":400,"exp_syn":150,"obs_syn":150,"lof_z":4.5,"mis_z":0,"syn_z":0}'
+
+    bulk_mock <- tibble::tibble(
+      gene = "BRCA1", mane_select = "true",
+      `lof.pLI` = 0.99, `lof.oe` = 0.1, `lof.oe_ci.lower` = 0.05, `lof.oe_ci.upper` = 0.2,
+      `mis.oe` = 1, `mis.oe_ci.lower` = 0.9, `mis.oe_ci.upper` = 1.1,
+      `syn.oe` = 1, `syn.oe_ci.lower` = 0.9, `syn.oe_ci.upper` = 1.1,
+      `lof.exp` = 50, `lof.obs` = 5, `mis.exp` = 500, `mis.obs` = 500,
+      `syn.exp` = 200, `syn.obs` = 200, `lof.z_score` = 3.5, `mis.z_score` = 0, `syn.z_score` = 0
+    )
+
+    mockery::stub(enrich_gnomad_constraints, "download.file", function(...) invisible(NULL))
+    mockery::stub(enrich_gnomad_constraints, "file.info", function(...) data.frame(size = 2e6))
+    mockery::stub(enrich_gnomad_constraints, "readr::read_tsv", function(...) bulk_mock)
+    mockery::stub(enrich_gnomad_constraints, "fetch_gnomad_constraints_batch",
+      function(symbols, ...) {
+        setNames(rep(fake_fallback, length(symbols)), symbols)
+      }
+    )
+
+    # Temporarily lower the MANE-genes minimum so the 1-row mock TSV passes the
+    # sanity check. mockery::stub cannot replace top-level constants (it
+    # substitutes a thunk function), so swap the binding in the same
+    # environment the function looks the constant up from, and restore it on
+    # exit. enrich_gnomad_constraints was sourced via source_api_file into the
+    # test-file environment, so its closure env is environment(fn), not the
+    # global env.
+    fn_env <- environment(enrich_gnomad_constraints)
+    orig_min <- get("GNOMAD_MIN_MANE_GENES", envir = fn_env)
+    assign("GNOMAD_MIN_MANE_GENES", 1L, envir = fn_env)
+    on.exit(assign("GNOMAD_MIN_MANE_GENES", orig_min, envir = fn_env), add = TRUE)
+
+    out <- enrich_gnomad_constraints(hgnc)
+    expect_equal(nrow(out), 3L)
+    expect_false(is.na(out$gnomad_constraints[out$symbol == "BRCA1"]))
+    expect_false(is.na(out$gnomad_constraints[out$symbol == "MECP2"]))
+    expect_false(is.na(out$gnomad_constraints[out$symbol == "CDKL5"]))
+    parsed_bulk <- jsonlite::fromJSON(out$gnomad_constraints[out$symbol == "BRCA1"])
+    expect_equal(parsed_bulk$lof_z, 3.5)
+    parsed_fallback <- jsonlite::fromJSON(out$gnomad_constraints[out$symbol == "MECP2"])
+    expect_equal(parsed_fallback$lof_z, 4.5)
+  })
+})

--- a/api/version_spec.json
+++ b/api/version_spec.json
@@ -1,7 +1,7 @@
 {
     "title": "SysNDD API",
     "description": "This is the API powering the SysNDD website, allowing programmatic access to the database contents.",
-    "version": "0.14.0",
+    "version": "0.15.0",
     "contact": {
       "name": "API Support",
       "url": "https://berntpopp.github.io/sysndd/api.html",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysndd",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysndd",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@unhead/vue": "^3.0.4",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/app/src/components/annotations/HgncAnnotationsCard.spec.ts
+++ b/app/src/components/annotations/HgncAnnotationsCard.spec.ts
@@ -1,0 +1,43 @@
+// HgncAnnotationsCard.spec.ts
+//
+// Pins the idle-message copy on the HGNC update card. The previous copy
+// claimed the job "may take hours on first run", which became stale after
+// the bulk gnomAD TSV path replaced the per-gene API approach. The new copy
+// reflects realistic timing (typically a few minutes) and lists what gets
+// enriched.
+
+import { describe, it, expect } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import HgncAnnotationsCard from './HgncAnnotationsCard.vue';
+
+const idleJob = {
+  isLoading: { value: false },
+} as never;
+
+// shallowMount stubs JobProgressDisplay so we can read the idle-message
+// prop without mounting the full child (which expects a richer job shape).
+function mountCard() {
+  return shallowMount(HgncAnnotationsCard, {
+    props: {
+      hgncJob: idleJob,
+      lastUpdated: null,
+    },
+  });
+}
+
+describe('HgncAnnotationsCard idle copy', () => {
+  it('does not claim "may take hours"', () => {
+    const wrapper = mountCard();
+    const stub = wrapper.findComponent({ name: 'JobProgressDisplay' });
+    expect(stub.exists()).toBe(true);
+    expect((stub.props('idleMessage') as string | undefined)).not.toMatch(/may take hours/i);
+  });
+
+  it('mentions gnomAD constraints and a realistic timing in the idle message', () => {
+    const wrapper = mountCard();
+    const stub = wrapper.findComponent({ name: 'JobProgressDisplay' });
+    const msg = (stub.props('idleMessage') as string | undefined) ?? '';
+    expect(msg).toMatch(/gnomAD constraints/i);
+    expect(msg).toMatch(/Typically a few minutes/i);
+  });
+});

--- a/app/src/components/annotations/HgncAnnotationsCard.vue
+++ b/app/src/components/annotations/HgncAnnotationsCard.vue
@@ -27,7 +27,7 @@
 
     <JobProgressDisplay
       :job="hgncJob"
-      idle-message="Downloading HGNC data and enriching with gnomAD constraints (this may take hours on first run)..."
+      idle-message="Downloading HGNC data; enriching with gnomAD constraints, AlphaFold IDs, and Ensembl coordinates. Typically a few minutes."
     />
   </BCard>
 </template>


### PR DESCRIPTION
## Summary

Backfills `non_alt_loci_set.gnomad_constraints` for the ~700 chrX/Y/M genes that gnomAD's autosomal-only bulk constraint TSV omits (FMR1, MECP2, CDKL5, ATRX, KDM5C, …) by querying the gnomAD GraphQL API in 25-symbol batched chunks during the existing HGNC update pipeline.

- **New module** `api/functions/external-proxy-gnomad-batch.R` exposes `fetch_gnomad_constraints_batch(symbols)`. Per-symbol disk cache (30-day TTL) consulted first; misses are batched into ≤25-alias GraphQL queries against `https://gnomad.broadinstitute.org/api?raw`; chunks dispatched concurrently via `httr2::req_perform_parallel(max_active = 5)`.
- **Cache distinguishes "asked, gnomAD said no" from "never asked"** via the `__GNOMAD_NA__` sentinel value. Transport failures are NOT cached; gene-not-found IS (so the next pipeline run skips the HTTP cost).
- **Cache-key collision fix** preserves hyphens in symbols (`HLA-B` ≠ `HLAB`) — cachem accepts `[a-z0-9_-]+` despite the misleading "lowercase letters and numbers only" error message.
- **Wired into `enrich_gnomad_constraints`** as a Step 4/4: after the bulk-TSV join, query the GraphQL API for any rows still NA. New companion `enrich_gnomad_constraints_with_metrics` returns `list(tibble, fallback_recovered, fallback_unresolved)`.
- **Both job paths expose the metrics**: inline executor in `jobs_endpoints.R` and durable handler `.async_job_run_hgnc_update` both add `gnomad_fallback_recovered` and `gnomad_fallback_unresolved` integer keys to their result list. Empirically verified that the dplyr `mutate(across(...))` cleanup in `update_process_hgnc_data` preserves R attributes, so no explicit attribute-copy patch was needed.
- **Frontend copy fix** drops the stale "may take hours on first run" claim from the HGNC update card; replaces with a realistic "Typically a few minutes" note that names what gets enriched.
- **Worker bootstrap** sources the new module so async-job workers can load `fetch_gnomad_constraints_batch` from `everywhere()`.

## Tests

- 58 unit-test expects in `test-unit-gnomad-batch.R` covering the query builder, JSON-response parser, single chunk fetcher (with `httr2::with_mocked_responses`), public batched fetcher (cache + chunking + sentinel-on-all-null + no-collision invariants).
- 20 expects in `test-unit-gnomad-enrichment-fallback.R` covering the Step-4 wiring, `enrich_gnomad_constraints_with_metrics` shape, dplyr-attribute-survival regression guard, and body-text inspection of `.async_job_hgnc_write_db` / `.async_job_run_hgnc_update`.
- 2 expects in `HgncAnnotationsCard.spec.ts` pinning the new copy.
- Env-gated live integration test `test-integration-gnomad-batch.R` (skips by default; set `RUN_GNOMAD_INTEGRATION=1` to fetch real MECP2/CDKL5/FMR1 + 150-symbol bench).

## Plan / Spec

- Plan: `.planning/superpowers/plans/2026-04-29-gnomad-x-chr-fallback-plan.md`
- Spec: `.planning/superpowers/specs/2026-04-29-gnomad-constraints-x-chr-fallback-design.md`

## Test plan

- [x] `make ci-local` passes locally (lint-api, lint-app, type-check, type-check:strict, R API tests with DB) — 2289 PASS, 0 FAIL.
- [ ] Manual smoke: bring up dev stack and run "Update HGNC Data" admin job; verify log mentions "gnomAD: querying API for X missing genes" and the result includes `gnomad_fallback_recovered` / `gnomad_fallback_unresolved`. Spot-check `non_alt_loci_set` in MySQL: `SELECT JSON_EXTRACT(gnomad_constraints, '\$.pLI') FROM non_alt_loci_set WHERE symbol IN ('MECP2','CDKL5','FMR1','ATRX','BRCA1');` — expect non-NULL pLI for all 5.
- [ ] (Optional) Run the live integration test once with `RUN_GNOMAD_INTEGRATION=1` to confirm gnomAD endpoint shape hasn't changed.