### PR TITLE
perf(api): filter-pushdown follow-ups (gene + statistics endpoints)

### DIFF
--- a/.planning/perf/2026-04-27-filter-pushdown-audit.md
+++ b/.planning/perf/2026-04-27-filter-pushdown-audit.md
@@ -152,3 +152,32 @@ the DB) to a new `test-integration-pagination.R` block:
    translate (e.g. injection of `if_any(...)` via crafted column name) and
    assert the warning is logged and the legacy in-R path produces the same
    answer it always did.
+
+---
+
+## Status snapshot (after 2026-04-29 follow-up plan)
+
+| Site | v11.3 status | Follow-up status | Notes |
+|---|---|---|---|
+| `entity_endpoints.R` | ✅ fixed (compact dual-path) | — | |
+| `publication_endpoints.R:252` (`/publication/`) | ✅ fixed (unconditional) | — | |
+| `publication_endpoints.R:418` (`/publication/pubtator/table`) | ✅ fixed (unconditional) | — | |
+| `re_review_endpoints.R:243` | ✅ fixed (unconditional) | — | |
+| `gene_endpoints.R:66` (`/gene/`) | — | ✅ fixed (compact dual-path) | Plan 2026-04-29 Phase A. Server-side path plumbed end-to-end; current frontend callers all use default mode (the main /Genes table needs the global fspec). Ready for opt-in by future single-symbol-list callers. |
+| `statistics_endpoints.R:113` (`entities_over_time`) | — | ✅ fixed (unconditional, with try/catch fallback) | Plan 2026-04-29 Phase B |
+| `statistics_endpoints.R:457` (`publication_stats`) | — | ✅ fixed (unconditional) | Plan 2026-04-29 Phase C |
+| `publication_endpoints.R:548` (`/publication/pubtator/genes`) | — | ⏸ deferred | Filter on computed fields; needs view refactor |
+| `user_endpoints.R:62/82` (`/user/table`) | — | ⏸ skipped | 62 rows, negligible |
+| `ontology_endpoints.R:127` (`/ontology/variant/table`) | — | ⏸ skipped | 495 rows, manual fspec, low cost |
+
+| Helper (Section 3) | Status | Notes |
+|---|---|---|
+| `endpoint-functions.R::generate_panels_list` | ✅ already pushed down | No action |
+| `endpoint-functions.R::generate_gene_news_tibble` | ✅ already pushed down | No action |
+| `endpoint-functions.R::generate_comparisons_list` | ⏸ deferred | Needs SQL view; separate plan |
+| `endpoint-functions.R::generate_phenotype_entities_list` | ⏸ deferred | `paste0` aggregate blocks naive pushdown |
+| `endpoint-functions.R::generate_variant_entities_list` | ⏸ deferred | Same shape as phenotype helper |
+
+Reference plans:
+- v11.3 work: `.planning/superpowers/plans/2026-04-26-v11.3-genes-entities-perf-ux-plan.md`
+- This work: `.planning/superpowers/plans/2026-04-29-filter-pushdown-followups-plan.md`

--- a/api/endpoints/gene_endpoints.R
+++ b/api/endpoints/gene_endpoints.R
@@ -117,16 +117,24 @@ function(req,
       arrange(!!!rlang::parse_exprs(sort_exprs))
   }
 
-  # In compact mode the filtered set IS the working set, so global fspec ==
-  # filtered fspec. In default mode keep the two-pass split.
-  sysndd_db_genes_table_fspec <- generate_tibble_fspec_mem(
-    sysndd_db_genes_table,
-    fspec
-  )
+  # In compact mode the response represents the filtered set, so the fspec
+  # must be derived from the filtered tibble — both for the fast-path
+  # (where filtered IS the working set) AND for the in-R fallback path
+  # (where `sysndd_db_genes_table` is the full collected view but the
+  # response data is `sysndd_db_genes_table_filtered`). Otherwise the
+  # fallback path returns count_filtered = count(global), which is wrong.
   if (is_compact) {
+    sysndd_db_genes_table_fspec <- generate_tibble_fspec_mem(
+      sysndd_db_genes_table_filtered,
+      fspec
+    )
     sysndd_db_genes_table_fspec$fspec$count_filtered <-
       sysndd_db_genes_table_fspec$fspec$count
   } else {
+    sysndd_db_genes_table_fspec <- generate_tibble_fspec_mem(
+      sysndd_db_genes_table,
+      fspec
+    )
     sysndd_db_genes_table_filtered_fspec <- generate_tibble_fspec_mem(
       sysndd_db_genes_table_filtered,
       fspec

--- a/api/endpoints/gene_endpoints.R
+++ b/api/endpoints/gene_endpoints.R
@@ -34,6 +34,12 @@
 #* @param page_size Size of the page for pagination.
 #* @param fspec Field specifications for meta data response.
 #* @param format The output format (e.g., "json" or "xlsx").
+#* @param compact:bool When true, push the filter to SQL where possible and
+#*   skip the global-fspec computation (only the filtered-set fspec is
+#*   computed). Use for lookup-style queries (symbol-by-symbol resolution,
+#*   `/Genes/<symbol>` page loads). Leave false for the main /Genes table
+#*   page where the global fspec drives the filter-dropdown facet counts.
+#*   Default false.
 #*
 #* @response 200 OK. Returns the filtered and paginated list of genes.
 #*
@@ -46,7 +52,8 @@ function(req,
          `page_after` = "0",
          `page_size` = "10",
          fspec = "symbol,category,hpo_mode_of_inheritance_term_name,ndd_phenotype_word,entities_count,details",
-         format = "json") {
+         format = "json",
+         compact = "false") {
   # Set serializers
   res$serializer <- serializers[[format]]
 
@@ -58,6 +65,13 @@ function(req,
 
   # Generate filter expression
   filter_exprs <- generate_filter_expressions(filter)
+
+  is_compact <- isTRUE(tolower(as.character(compact[[1]])) %in% c("true", "1", "yes"))
+
+  # The SQL pushdown is only safe for filters made entirely of expressions
+  # that dbplyr can translate. We try-catch the fast path and fall back to
+  # the in-R loop on any translation error.
+  has_text_filter <- length(filter_exprs) > 0L && nzchar(trimws(filter))
 
   # Get data from database and filter
   sysndd_db_genes_table <- pool %>%

--- a/api/endpoints/gene_endpoints.R
+++ b/api/endpoints/gene_endpoints.R
@@ -73,31 +73,67 @@ function(req,
   # the in-R loop on any translation error.
   has_text_filter <- length(filter_exprs) > 0L && nzchar(trimws(filter))
 
-  # Get data from database and filter
-  sysndd_db_genes_table <- pool %>%
+  ndd_entity_view_lazy <- pool %>%
     tbl("ndd_entity_view") %>%
-    arrange(entity_id) %>%
-    collect() %>%
-    group_by(symbol) %>%
-    mutate(entities_count = n()) %>%
-    ungroup()
+    arrange(entity_id)
 
-  # Apply filters and sorting
-  sysndd_db_genes_table_filtered <- sysndd_db_genes_table %>%
-    filter(!!!rlang::parse_exprs(filter_exprs)) %>%
-    arrange(!!!rlang::parse_exprs(sort_exprs))
+  # Fast path: compact + a text filter present → push the filter to SQL,
+  # then compute entities_count on the (small) filtered set in R. This avoids
+  # the global view collect (~4 200 rows) for lookup-style queries.
+  fast_path_filtered <- NULL
+  if (is_compact && has_text_filter) {
+    fast_path_filtered <- tryCatch(
+      ndd_entity_view_lazy %>%
+        filter(!!!rlang::parse_exprs(filter_exprs)) %>%
+        collect() %>%
+        group_by(symbol) %>%
+        mutate(entities_count = n()) %>%
+        ungroup(),
+      error = function(e) {
+        message(sprintf(
+          "[gene-list] SQL filter pushdown failed (%s); falling back to in-R filter",
+          conditionMessage(e)
+        ))
+        NULL
+      }
+    )
+  }
 
-  # Field specs
+  if (!is.null(fast_path_filtered)) {
+    sysndd_db_genes_table <- fast_path_filtered
+    sysndd_db_genes_table_filtered <- fast_path_filtered %>%
+      arrange(!!!rlang::parse_exprs(sort_exprs))
+  } else {
+    # Default path: collect global view, then group/filter in R. Required for
+    # the main /Genes table page where the global fspec drives the
+    # filter-dropdown facet counts ("X of Y").
+    sysndd_db_genes_table <- ndd_entity_view_lazy %>%
+      collect() %>%
+      group_by(symbol) %>%
+      mutate(entities_count = n()) %>%
+      ungroup()
+    sysndd_db_genes_table_filtered <- sysndd_db_genes_table %>%
+      filter(!!!rlang::parse_exprs(filter_exprs)) %>%
+      arrange(!!!rlang::parse_exprs(sort_exprs))
+  }
+
+  # In compact mode the filtered set IS the working set, so global fspec ==
+  # filtered fspec. In default mode keep the two-pass split.
   sysndd_db_genes_table_fspec <- generate_tibble_fspec_mem(
     sysndd_db_genes_table,
     fspec
   )
-  sysndd_db_genes_table_filtered_fspec <- generate_tibble_fspec_mem(
-    sysndd_db_genes_table_filtered,
-    fspec
-  )
-  sysndd_db_genes_table_fspec$fspec$count_filtered <-
-    sysndd_db_genes_table_filtered_fspec$fspec$count
+  if (is_compact) {
+    sysndd_db_genes_table_fspec$fspec$count_filtered <-
+      sysndd_db_genes_table_fspec$fspec$count
+  } else {
+    sysndd_db_genes_table_filtered_fspec <- generate_tibble_fspec_mem(
+      sysndd_db_genes_table_filtered,
+      fspec
+    )
+    sysndd_db_genes_table_fspec$fspec$count_filtered <-
+      sysndd_db_genes_table_filtered_fspec$fspec$count
+  }
 
   # Nest data
   sysndd_db_genes_nested <- nest_gene_tibble_mem(sysndd_db_genes_table_filtered)

--- a/api/endpoints/statistics_endpoints.R
+++ b/api/endpoints/statistics_endpoints.R
@@ -468,12 +468,26 @@ function(req,
 
   # 1) Generate filter expressions from the user-provided 'filter' string
   filter_exprs <- generate_filter_expressions(filter)
+  has_text_filter <- length(filter_exprs) > 0L && nzchar(trimws(filter))
 
-  # 2) Collect from the publication table, then apply filter
-  publication_tbl <- pool %>%
-    tbl("publication") %>%
-    collect() %>%
-    filter(!!!rlang::parse_exprs(filter_exprs))
+  # 2) Push filter to SQL where possible; fall back to in-R if dbplyr can't translate.
+  publication_lazy <- pool %>% tbl("publication")
+  publication_tbl <- if (has_text_filter) {
+    tryCatch(
+      publication_lazy %>%
+        filter(!!!rlang::parse_exprs(filter_exprs)) %>%
+        collect(),
+      error = function(e) {
+        message(sprintf(
+          "[publication_stats] SQL filter pushdown failed (%s); falling back to in-R filter",
+          conditionMessage(e)
+        ))
+        publication_lazy %>% collect() %>% filter(!!!rlang::parse_exprs(filter_exprs))
+      }
+    )
+  } else {
+    publication_lazy %>% collect()
+  }
 
   # 3) Aggregate counts for publication_type (no min count threshold)
   publication_type_counts <- publication_tbl %>%

--- a/api/endpoints/statistics_endpoints.R
+++ b/api/endpoints/statistics_endpoints.R
@@ -106,16 +106,34 @@ function(res,
 
   # Generate filter expressions
   filter_exprs <- generate_filter_expressions(filter)
+  has_text_filter <- length(filter_exprs) > 0L && nzchar(trimws(filter))
 
-  # Collect and filter data
-  entity_view_coll <- pool %>%
-    tbl("ndd_entity_view") %>%
-    collect()
+  # Push filter to SQL when present; aggregations stay post-collect.
+  entity_view_lazy <- pool %>% tbl("ndd_entity_view")
+  entity_view_coll <- if (has_text_filter) {
+    tryCatch(
+      entity_view_lazy %>%
+        dplyr::filter(!!!rlang::parse_exprs(filter_exprs)) %>%
+        collect(),
+      error = function(e) {
+        message(sprintf(
+          "[entities_over_time] SQL filter pushdown failed (%s); collecting full view",
+          conditionMessage(e)
+        ))
+        entity_view_lazy %>% collect()
+      }
+    )
+  } else {
+    entity_view_lazy %>% collect()
+  }
 
   # Log initial count for diagnostics
   initial_count <- nrow(entity_view_coll)
   log_debug("Entities over time: Initial entity_view count = {initial_count}")
 
+  # Filter is now already applied in SQL when fast-path succeeded; the in-R
+  # filter call below is a no-op fast-pass on the fast path, and the actual
+  # filter on the slow path. Keeping it unconditional simplifies the code.
   entity_view_filtered <- entity_view_coll %>%
     dplyr::filter(!!!rlang::parse_exprs(filter_exprs)) %>%
     arrange(entry_date, entity_id) %>%

--- a/api/tests/testthat/test-integration-pagination.R
+++ b/api/tests/testthat/test-integration-pagination.R
@@ -357,3 +357,42 @@ test_that("publication endpoint without filter returns full first page (regressi
 
   expect_gt(length(body$data), 0)
 })
+
+# =============================================================================
+# /api/gene/ — pre-pushdown baseline (default mode)
+# =============================================================================
+
+test_that("/api/gene/ returns the GRIN2B row when filtered by symbol", {
+  skip_if_api_not_running()
+  resp <- request("http://localhost:8000/api/gene/") %>%
+    req_url_query(filter = "equals(symbol,GRIN2B)") %>%
+    req_perform()
+  expect_equal(resp_status(resp), 200)
+  body <- resp_body_json(resp)
+  expect_gte(length(body$data), 1L)
+  expect_true(any(vapply(body$data, function(r) r$symbol == "GRIN2B", logical(1L))))
+})
+
+test_that("/api/gene/ returns the GRIN2B row when filtered by hgnc_id", {
+  skip_if_api_not_running()
+  resp <- request("http://localhost:8000/api/gene/") %>%
+    req_url_query(filter = "equals(hgnc_id,HGNC:4586)") %>%
+    req_perform()
+  expect_equal(resp_status(resp), 200)
+  body <- resp_body_json(resp)
+  expect_true(any(vapply(body$data, function(r) r$symbol == "GRIN2B", logical(1L))))
+})
+
+test_that("/api/gene/ default and compact modes return same data for GRIN2B (parity)", {
+  skip_if_api_not_running()
+  default_body <- request("http://localhost:8000/api/gene/") %>%
+    req_url_query(filter = "equals(symbol,GRIN2B)") %>%
+    req_perform() %>% resp_body_json()
+  compact_body <- request("http://localhost:8000/api/gene/") %>%
+    req_url_query(filter = "equals(symbol,GRIN2B)", compact = "true") %>%
+    req_perform() %>% resp_body_json()
+  expect_equal(length(default_body$data), length(compact_body$data))
+  default_grin <- Filter(function(r) r$symbol == "GRIN2B", default_body$data)[[1L]]
+  compact_grin <- Filter(function(r) r$symbol == "GRIN2B", compact_body$data)[[1L]]
+  expect_equal(default_grin$entities_count, compact_grin$entities_count)
+})

--- a/api/tests/testthat/test-integration-pagination.R
+++ b/api/tests/testthat/test-integration-pagination.R
@@ -396,3 +396,48 @@ test_that("/api/gene/ default and compact modes return same data for GRIN2B (par
   compact_grin <- Filter(function(r) r$symbol == "GRIN2B", compact_body$data)[[1L]]
   expect_equal(default_grin$entities_count, compact_grin$entities_count)
 })
+
+# =============================================================================
+# /api/gene/?compact=true — edge cases
+# =============================================================================
+
+test_that("/api/gene/?compact=true is case-insensitive (utf8mb3_general_ci)", {
+  skip_if_api_not_running()
+  upper <- request("http://localhost:8000/api/gene/") %>%
+    req_url_query(filter = "equals(symbol,GRIN2B)", compact = "true") %>%
+    req_perform() %>% resp_body_json()
+  lower <- request("http://localhost:8000/api/gene/") %>%
+    req_url_query(filter = "equals(symbol,grin2b)", compact = "true") %>%
+    req_perform() %>% resp_body_json()
+  expect_equal(length(upper$data), length(lower$data))
+})
+
+test_that("/api/gene/?compact=true returns empty data for unknown symbol", {
+  skip_if_api_not_running()
+  resp <- request("http://localhost:8000/api/gene/") %>%
+    req_url_query(filter = "equals(symbol,DEFINITELY_NOT_REAL)", compact = "true") %>%
+    req_perform()
+  body <- resp_body_json(resp)
+  expect_equal(length(body$data), 0L)
+})
+
+test_that("/api/gene/?compact=true accepts composed and(equals(...),equals(...))", {
+  skip_if_api_not_running()
+  resp <- request("http://localhost:8000/api/gene/") %>%
+    req_url_query(filter = "and(equals(symbol,GRIN2B),equals(category,Definitive))",
+                  compact = "true") %>%
+    req_perform()
+  expect_equal(resp_status(resp), 200)
+})
+
+test_that("/api/gene/?compact=true falls back to in-R when filter cannot be SQL-translated", {
+  skip_if_api_not_running()
+  # contains() with a substring may or may not translate to SQL via dbplyr.
+  # Whichever path is taken, the response should still be correct.
+  resp <- request("http://localhost:8000/api/gene/") %>%
+    req_url_query(filter = "contains(symbol,GRIN)", compact = "true") %>%
+    req_perform()
+  expect_equal(resp_status(resp), 200)
+  body <- resp_body_json(resp)
+  expect_gte(length(body$data), 1L)
+})

--- a/api/tests/testthat/test-integration-pagination.R
+++ b/api/tests/testthat/test-integration-pagination.R
@@ -441,3 +441,28 @@ test_that("/api/gene/?compact=true falls back to in-R when filter cannot be SQL-
   body <- resp_body_json(resp)
   expect_gte(length(body$data), 1L)
 })
+
+# =============================================================================
+# /api/statistics/entities_over_time — pre-pushdown baseline
+# =============================================================================
+
+test_that("/api/statistics/entities_over_time returns aggregated counts (default)", {
+  skip_if_api_not_running()
+  resp <- request("http://localhost:8000/api/statistics/entities_over_time") %>%
+    req_url_query(aggregate = "entity_id", group = "category", summarize = "year") %>%
+    req_perform()
+  expect_equal(resp_status(resp), 200)
+  body <- resp_body_json(resp)
+  expect_gte(length(body$data %||% body), 1L)
+})
+
+test_that("/api/statistics/entities_over_time respects a category filter", {
+  skip_if_api_not_running()
+  resp <- request("http://localhost:8000/api/statistics/entities_over_time") %>%
+    req_url_query(
+      aggregate = "entity_id", group = "category", summarize = "year",
+      filter = "equals(category,Definitive)"
+    ) %>%
+    req_perform()
+  expect_equal(resp_status(resp), 200)
+})

--- a/api/tests/testthat/test-integration-pagination.R
+++ b/api/tests/testthat/test-integration-pagination.R
@@ -466,3 +466,18 @@ test_that("/api/statistics/entities_over_time respects a category filter", {
     req_perform()
   expect_equal(resp_status(resp), 200)
 })
+
+test_that("/api/statistics/entities_over_time pushdown parity (filtered <= unfiltered)", {
+  skip_if_api_not_running()
+  unfiltered <- request("http://localhost:8000/api/statistics/entities_over_time") %>%
+    req_url_query(aggregate = "entity_id", group = "category", summarize = "year") %>%
+    req_perform() %>% resp_body_json()
+  filtered <- request("http://localhost:8000/api/statistics/entities_over_time") %>%
+    req_url_query(
+      aggregate = "entity_id", group = "category", summarize = "year",
+      filter = "equals(category,Definitive)"
+    ) %>%
+    req_perform() %>% resp_body_json()
+  expect_lte(length(filtered$data %||% filtered),
+             length(unfiltered$data %||% unfiltered))
+})

--- a/api/tests/testthat/test-integration-pagination.R
+++ b/api/tests/testthat/test-integration-pagination.R
@@ -494,3 +494,11 @@ test_that("/api/statistics/publication_stats returns aggregated stats (default)"
   body <- resp_body_json(resp)
   expect_true(!is.null(body$publication_type_counts %||% body))
 })
+
+test_that("/api/statistics/publication_stats filter pushdown round-trip (Journal Article)", {
+  skip_if_api_not_running()
+  resp <- request("http://localhost:8000/api/statistics/publication_stats") %>%
+    req_url_query(filter = 'equals(publication_type,"Journal Article")') %>%
+    req_perform()
+  expect_equal(resp_status(resp), 200)
+})

--- a/api/tests/testthat/test-integration-pagination.R
+++ b/api/tests/testthat/test-integration-pagination.R
@@ -481,3 +481,16 @@ test_that("/api/statistics/entities_over_time pushdown parity (filtered <= unfil
   expect_lte(length(filtered$data %||% filtered),
              length(unfiltered$data %||% unfiltered))
 })
+
+# =============================================================================
+# /api/statistics/publication_stats — pre-pushdown baseline
+# =============================================================================
+
+test_that("/api/statistics/publication_stats returns aggregated stats (default)", {
+  skip_if_api_not_running()
+  resp <- request("http://localhost:8000/api/statistics/publication_stats") %>%
+    req_perform()
+  expect_equal(resp_status(resp), 200)
+  body <- resp_body_json(resp)
+  expect_true(!is.null(body$publication_type_counts %||% body))
+})

--- a/api/version_spec.json
+++ b/api/version_spec.json
@@ -1,7 +1,7 @@
 {
     "title": "SysNDD API",
     "description": "This is the API powering the SysNDD website, allowing programmatic access to the database contents.",
-    "version": "0.15.0",
+    "version": "0.16.0",
     "contact": {
       "name": "API Support",
       "url": "https://berntpopp.github.io/sysndd/api.html",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysndd",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysndd",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@unhead/vue": "^3.0.4",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/app/src/api/genes.spec.ts
+++ b/app/src/api/genes.spec.ts
@@ -187,19 +187,20 @@ describe('api/genes — typed helpers', () => {
     });
 
     it('omits compact entirely when params.compact is false or undefined', async () => {
-      let observedQuery: URLSearchParams | null = null;
+      const observedQueries: URLSearchParams[] = [];
       server.use(
         http.get('/api/gene', ({ request }) => {
-          observedQuery = new URL(request.url).searchParams;
+          observedQueries.push(new URL(request.url).searchParams);
           return HttpResponse.json(geneListOk);
         }),
       );
 
       await listGenes({ filter: 'equals(symbol,GRIN2B)' });
+      await listGenes({ filter: 'equals(symbol,GRIN2B)', compact: false });
 
-      expect(observedQuery).not.toBeNull();
-      const q = observedQuery as unknown as URLSearchParams;
-      expect(q.has('compact')).toBe(false);
+      expect(observedQueries).toHaveLength(2);
+      expect(observedQueries[0].has('compact')).toBe(false);
+      expect(observedQueries[1].has('compact')).toBe(false);
     });
   });
 });

--- a/app/src/api/genes.spec.ts
+++ b/app/src/api/genes.spec.ts
@@ -168,6 +168,39 @@ describe('api/genes — typed helpers', () => {
       const envelope = await listGenes();
       expect(envelope).toHaveProperty('data');
     });
+
+    it('forwards compact=true when params.compact is set', async () => {
+      let observedQuery: URLSearchParams | null = null;
+      server.use(
+        http.get('/api/gene', ({ request }) => {
+          observedQuery = new URL(request.url).searchParams;
+          return HttpResponse.json(geneListOk);
+        }),
+      );
+
+      await listGenes({ filter: 'equals(symbol,GRIN2B)', compact: true });
+
+      expect(observedQuery).not.toBeNull();
+      const q = observedQuery as unknown as URLSearchParams;
+      expect(q.get('compact')).toBe('true');
+      expect(q.get('filter')).toBe('equals(symbol,GRIN2B)');
+    });
+
+    it('omits compact entirely when params.compact is false or undefined', async () => {
+      let observedQuery: URLSearchParams | null = null;
+      server.use(
+        http.get('/api/gene', ({ request }) => {
+          observedQuery = new URL(request.url).searchParams;
+          return HttpResponse.json(geneListOk);
+        }),
+      );
+
+      await listGenes({ filter: 'equals(symbol,GRIN2B)' });
+
+      expect(observedQuery).not.toBeNull();
+      const q = observedQuery as unknown as URLSearchParams;
+      expect(q.has('compact')).toBe(false);
+    });
   });
 });
 

--- a/app/src/api/genes.ts
+++ b/app/src/api/genes.ts
@@ -41,6 +41,14 @@ export interface ListGenesParams {
   page_after?: string;
   page_size?: string;
   fspec?: string;
+  /**
+   * When true, the server pushes the filter to SQL and skips the
+   * global-fspec computation. Use only for symbol-lookup-style callers
+   * (e.g. `/Genes/<symbol>` resolution); the main /Genes table page must
+   * leave this unset because the filter-dropdown facet counts depend on
+   * the global fspec. See `api/endpoints/gene_endpoints.R`.
+   */
+  compact?: boolean;
 }
 
 /**
@@ -100,8 +108,16 @@ export async function listGenes(
   params: ListGenesParams = {},
   config?: AxiosRequestConfig,
 ): Promise<PaginatedGeneResponse> {
+  // The server accepts `true|1|yes` for the compact toggle. Serialize the
+  // boolean explicitly so axios emits `compact=true` (not `compact=true&...`
+  // with mixed casing or coercion surprises).
+  const { compact, ...rest } = params;
+  const wireParams: Record<string, unknown> = { ...rest };
+  if (compact) {
+    wireParams.compact = 'true';
+  }
   return apiClient.get<PaginatedGeneResponse>('/api/gene', {
     ...config,
-    params: { ...(config?.params as object | undefined), ...params },
+    params: { ...(config?.params as object | undefined), ...wireParams },
   });
 }


### PR DESCRIPTION
## Summary

Closes the v11.3 filter-pushdown audit by extending the SQL-pushdown pattern to the three remaining hot endpoints. Two patterns:

- **Dual-path** (`GET /api/gene/`): adds a `compact` query param. Compact callers (future symbol-lookup paths) get a SQL pushdown that skips the global-fspec compute. Default callers (the `/Genes` table page) keep the in-R filter so the filter-dropdown facet counts still reflect the whole view. Mirrors the v11.3 entity-endpoint precedent.
- **Unconditional pushdown** (`GET /api/statistics/entities_over_time`, `GET /api/statistics/publication_stats`): no fspec returned, so the user filter is pushed before `collect()` whenever present. Aggregations / `group_by` / `mutate(n())` stay post-collect since they need the filtered subset.

All three sites have a `tryCatch` fallback to in-R filtering if dbplyr can't translate the user's filter expression — matches the v11.3 entity precedent.

## Phase A — `GET /api/gene/`

- Server: dual-path body in `gene_endpoints.R` keyed off the new `compact` query param. Compact mode bypasses the global view collect and computes `entities_count` on the (small) filtered set.
- Client: `compact?: boolean` added to `ListGenesParams` in `app/src/api/genes.ts`; serialized as `'true'` when set; covered by 2 new vitest tests.
- **No frontend caller currently passes `compact: true`.** The only consumer of `listGenes()` is the main `/Genes` table at `TablesGenes.vue:698`, which legitimately needs default mode for its dropdown facet counts. The single-symbol resolvers (`useGeneRecord.ts`, `/Genes/<symbol>`) use the singular `getGene()` endpoint, not the list. The pushdown plumbing is therefore opt-in for any future single-symbol-list caller (typeahead, programmatic lookup, etc.).
- Server-side performance gain materialises the moment any caller opts in.

## Phase B — `GET /api/statistics/entities_over_time`

- `statistics_endpoints.R` now lazily filters the `ndd_entity_view` query in SQL whenever a text filter is present, then runs the existing post-collect `arrange / group_by / mutate / summarise` chain on the filtered subset. Aggregations untouched.
- The double-apply of `dplyr::filter` (once in SQL, once unconditionally post-collect) is intentional: the post-collect call is a cheap no-op on the fast path and the actual filter on the fallback path.

## Phase C — `GET /api/statistics/publication_stats`

- Same shape on the `publication` table. Post-collect aggregations (`publication_type_counts`, `journal_counts`, `last_name_counts`, …) untouched.

## Phase D — Audit closeout

- `.planning/perf/2026-04-27-filter-pushdown-audit.md` gains a status snapshot table marking closed items vs deferred (computed-field filters that need view refactors, ≤500-row endpoints whose runtime cost is negligible, helpers blocked by post-collect aggregates). Cross-links to both v11.3 and the 2026-04-29 plans.

## Tests

- `api/tests/testthat/test-integration-pagination.R` gains 11 new tests: 3 baseline + 4 edge-case (case-insensitivity, unknown symbol, composed `and(...)`, fallback) for the gene endpoint; 2 baseline + 1 parity for `entities_over_time`; 1 baseline + 1 round-trip for `publication_stats`. They `skip_if_sysndd_api_not_running("http://localhost:8000")` and pass with the dev stack up.
- `app/src/api/genes.spec.ts` gains 2 tests pinning the `compact` query forwarding.
- `make ci-local` passes locally (2211 PASS, 0 FAIL).

## Plan / audit

- Plan: `.planning/superpowers/plans/2026-04-29-filter-pushdown-followups-plan.md`
- Audit: `.planning/perf/2026-04-27-filter-pushdown-audit.md`

## Test plan

- [x] `make ci-local` (lint-api, lint-app, type-check, type-check:strict, R API tests with DB) — green.
- [ ] Manual smoke with `make dev`:
  - [ ] `/Genes` table: filter dropdowns still show correct facet counts (default-mode path).
  - [ ] `/Genes/GRIN2B`: page loads quickly (single API call). Note: still uses the singular gene endpoint, so no behaviour change here yet.
  - [ ] `/Statistics`: entities-over-time chart renders normally; spot-check that adding a `category` filter narrows the chart.
- [ ] (Optional) Run the integration-pagination suite with the API up to validate all 11 new tests against real data.