### PR TITLE
[codex] fix ontology async progress reporting

### DIFF
--- a/api/functions/ontology-functions.R
+++ b/api/functions/ontology-functions.R
@@ -224,7 +224,8 @@ identify_critical_ontology_changes <- function(disease_ontology_set_update, dise
 #'
 #' @param hgnc_list A tibble containing non-alternative loci gene data (columns: hgnc_id, symbol).
 #' @param mode_of_inheritance_list A tibble containing mode of inheritance data.
-#' @param max_file_age Integer, maximum age of the file in months before regeneration.
+#' @param max_file_age Numeric, maximum age in months for OMIM mim2gene
+#'   deprecation cache reuse. Use 0 to force a fresh mim2gene download.
 #' @param output_path String, the path where the output CSV file will be stored.
 #' @param progress_callback Optional function for async progress reporting.
 #'   Called with (step, message, current, total) parameters.
@@ -240,7 +241,7 @@ identify_critical_ontology_changes <- function(disease_ontology_set_update, dise
 #'   combined_ontology_data <- process_combine_ontology(
 #'     non_alt_loci_set, moi_list, 3, "data/",
 #'     progress_callback = function(step, message, current, total) {
-#'       message(sprintf("%s: %d/%d", message, current, total))
+#'       base::message(sprintf("%s: %d/%d", message, current, total))
 #'     }
 #'   )
 #' }
@@ -426,7 +427,8 @@ process_mondo_ontology <- function(mondo_file = "data/mondo_terms/mondo_terms.tx
 #'
 #' @param hgnc_list A tibble of HGNC gene symbols and corresponding identifiers (columns: hgnc_id, symbol).
 #' @param moi_list A tibble of mode of inheritance terms for HPO mapping.
-#' @param max_file_age Integer, maximum age in days for the mim2gene deprecation cache (default: 3).
+#' @param max_file_age Numeric, maximum age in months for the mim2gene
+#'   deprecation cache (default: 3). Use 0 to force a fresh mim2gene download.
 #' @param progress_callback Optional function for async progress reporting.
 #'   Called with (step, message, current, total) parameters.
 #' @return A tibble containing processed data from the OMIM ontology.
@@ -448,7 +450,7 @@ process_mondo_ontology <- function(mondo_file = "data/mondo_terms/mondo_terms.tx
 #'   processed_omim_data <- process_omim_ontology(
 #'     hgnc_list, moi_list, 3,
 #'     progress_callback = function(step, message, current, total) {
-#'       message(sprintf("%s: %d/%d", message, current, total))
+#'       base::message(sprintf("%s: %d/%d", message, current, total))
 #'     }
 #'   )
 #' }
@@ -499,7 +501,8 @@ process_omim_ontology <- function(hgnc_list, moi_list, max_file_age = 3, progres
     )
   }
   tryCatch({
-    mim2gene_file <- download_mim2gene("data/", force = FALSE, max_age_days = max_file_age)
+    mim2gene_max_age_days <- max(0, ceiling(max_file_age * 30))
+    mim2gene_file <- download_mim2gene("data/", force = FALSE, max_age_days = mim2gene_max_age_days)
     mim2gene_data <- parse_mim2gene(mim2gene_file)
     deprecated_mims <- get_deprecated_mim_numbers(mim2gene_data)
     if (length(deprecated_mims) > 0) {

--- a/api/functions/ontology-functions.R
+++ b/api/functions/ontology-functions.R
@@ -227,7 +227,7 @@ identify_critical_ontology_changes <- function(disease_ontology_set_update, dise
 #' @param max_file_age Integer, maximum age of the file in months before regeneration.
 #' @param output_path String, the path where the output CSV file will be stored.
 #' @param progress_callback Optional function for async progress reporting.
-#'   Called with (step, current, total) parameters.
+#'   Called with (step, message, current, total) parameters.
 #' @return A tibble containing the combined ontology dataset.
 #'
 #' @examples
@@ -239,8 +239,8 @@ identify_critical_ontology_changes <- function(disease_ontology_set_update, dise
 #'   # With progress callback (for async jobs)
 #'   combined_ontology_data <- process_combine_ontology(
 #'     non_alt_loci_set, moi_list, 3, "data/",
-#'     progress_callback = function(step, current, total) {
-#'       message(sprintf("%s: %d/%d", step, current, total))
+#'     progress_callback = function(step, message, current, total) {
+#'       message(sprintf("%s: %d/%d", message, current, total))
 #'     }
 #'   )
 #' }
@@ -299,7 +299,12 @@ process_combine_ontology <- function(hgnc_list, mode_of_inheritance_list, max_fi
     # Download and apply MONDO SSSOM mappings for OMIM-to-MONDO equivalence
     # This enriches the MONDO column for mim2gene entries via vectorized join
     if (!is.null(progress_callback)) {
-      progress_callback(step = "Applying MONDO SSSOM mappings", current = 4, total = 4)
+      progress_callback(
+        step = "Applying MONDO SSSOM mappings",
+        message = "Applying MONDO SSSOM mappings",
+        current = 4,
+        total = 4
+      )
     }
     mondo_sssom_file <- download_mondo_sssom(paste0(output_path, "mondo_mappings/"))
     mondo_sssom <- parse_mondo_sssom(mondo_sssom_file)
@@ -421,9 +426,9 @@ process_mondo_ontology <- function(mondo_file = "data/mondo_terms/mondo_terms.tx
 #'
 #' @param hgnc_list A tibble of HGNC gene symbols and corresponding identifiers (columns: hgnc_id, symbol).
 #' @param moi_list A tibble of mode of inheritance terms for HPO mapping.
-#' @param max_file_age Integer, maximum age of the file in months before re-downloading (default: 3).
+#' @param max_file_age Integer, maximum age in days for the mim2gene deprecation cache (default: 3).
 #' @param progress_callback Optional function for async progress reporting.
-#'   Called with (step, current, total) parameters.
+#'   Called with (step, message, current, total) parameters.
 #' @return A tibble containing processed data from the OMIM ontology.
 #'
 #' @details
@@ -442,8 +447,8 @@ process_mondo_ontology <- function(mondo_file = "data/mondo_terms/mondo_terms.tx
 #'   # With progress callback (for async jobs)
 #'   processed_omim_data <- process_omim_ontology(
 #'     hgnc_list, moi_list, 3,
-#'     progress_callback = function(step, current, total) {
-#'       message(sprintf("%s: %d/%d", step, current, total))
+#'     progress_callback = function(step, message, current, total) {
+#'       message(sprintf("%s: %d/%d", message, current, total))
 #'     }
 #'   )
 #' }
@@ -452,19 +457,34 @@ process_mondo_ontology <- function(mondo_file = "data/mondo_terms/mondo_terms.tx
 process_omim_ontology <- function(hgnc_list, moi_list, max_file_age = 3, progress_callback = NULL) {
   # Step 1: Download genemap2.txt (Phase 76 shared infrastructure)
   if (!is.null(progress_callback)) {
-    progress_callback(step = "Downloading genemap2.txt", current = 1, total = 4)
+    progress_callback(
+      step = "Downloading genemap2.txt",
+      message = "Downloading genemap2.txt",
+      current = 1,
+      total = 4
+    )
   }
   genemap2_file <- download_genemap2("data/", force = FALSE)
 
   # Step 2: Parse genemap2 (Phase 76 shared function)
   if (!is.null(progress_callback)) {
-    progress_callback(step = "Parsing genemap2.txt", current = 2, total = 4)
+    progress_callback(
+      step = "Parsing genemap2.txt",
+      message = "Parsing genemap2.txt",
+      current = 2,
+      total = 4
+    )
   }
   genemap2_parsed <- parse_genemap2(genemap2_file)
 
   # Step 3: Build ontology set with inheritance mapping
   if (!is.null(progress_callback)) {
-    progress_callback(step = "Building OMIM ontology set from genemap2", current = 3, total = 4)
+    progress_callback(
+      step = "Building OMIM ontology set from genemap2",
+      message = "Building OMIM ontology set from genemap2",
+      current = 3,
+      total = 4
+    )
   }
   omim_terms <- build_omim_from_genemap2(genemap2_parsed, hgnc_list, moi_list)
 
@@ -473,12 +493,13 @@ process_omim_ontology <- function(hgnc_list, moi_list, max_file_age = 3, progres
   if (!is.null(progress_callback)) {
     progress_callback(
       step = "Downloading mim2gene.txt for deprecation tracking",
+      message = "Downloading mim2gene.txt for deprecation tracking",
       current = 4,
       total = 4
     )
   }
   tryCatch({
-    mim2gene_file <- download_mim2gene("data/", force = FALSE, max_age_months = max_file_age)
+    mim2gene_file <- download_mim2gene("data/", force = FALSE, max_age_days = max_file_age)
     mim2gene_data <- parse_mim2gene(mim2gene_file)
     deprecated_mims <- get_deprecated_mim_numbers(mim2gene_data)
     if (length(deprecated_mims) > 0) {

--- a/api/tests/testthat/test-unit-ontology-functions.R
+++ b/api/tests/testthat/test-unit-ontology-functions.R
@@ -264,6 +264,210 @@ test_that("ontology ID format validation", {
 })
 
 # =============================================================================
+# process_omim_ontology() progress/deprecation plumbing
+# =============================================================================
+
+load_ontology_runtime <- function() {
+  runtime <- new.env(parent = globalenv())
+  suppressWarnings(
+    sys.source(file.path(api_dir, "functions", "file-functions.R"), envir = runtime)
+  )
+  suppressWarnings(
+    sys.source(file.path(api_dir, "functions", "ontology-functions.R"), envir = runtime)
+  )
+  runtime
+}
+
+stub_omim_runtime <- function(runtime, mim2gene_args = new.env(parent = emptyenv())) {
+  runtime$download_genemap2 <- function(output_path = "data/", force = FALSE, max_age_days = 1) {
+    "data/genemap2.test.txt"
+  }
+  runtime$parse_genemap2 <- function(genemap2_path) {
+    tibble(
+      Approved_Symbol = "GENE1",
+      disease_ontology_name = "Test disease",
+      disease_ontology_id = "OMIM:123456",
+      Mapping_key = "3",
+      hpo_mode_of_inheritance_term_name = "Autosomal dominant inheritance"
+    )
+  }
+  runtime$build_omim_from_genemap2 <- function(genemap2_parsed, hgnc_list, moi_list) {
+    tibble(
+      disease_ontology_id_version = "OMIM:123456",
+      disease_ontology_id = "OMIM:123456",
+      disease_ontology_name = "Test disease",
+      disease_ontology_source = "mim2gene",
+      disease_ontology_date = "2026-05-13",
+      disease_ontology_is_specific = TRUE,
+      hgnc_id = "HGNC:1",
+      hpo_mode_of_inheritance_term = "HP:0000006"
+    )
+  }
+  runtime$download_mim2gene <- function(output_path = "data/", force = FALSE, max_age_days = 1) {
+    mim2gene_args$output_path <- output_path
+    mim2gene_args$force <- force
+    mim2gene_args$max_age_days <- max_age_days
+    "data/mim2gene.test.txt"
+  }
+  runtime$parse_mim2gene <- function(file_path) {
+    tibble(
+      mim_number = character(),
+      mim_entry_type = character(),
+      gene_symbol = character(),
+      is_deprecated = logical()
+    )
+  }
+  runtime$get_deprecated_mim_numbers <- function(mim2gene_data) character()
+  runtime$write_csv <- function(x, file, na = "NA") invisible(NULL)
+
+  mim2gene_args
+}
+
+test_that("process_omim_ontology sends async progress messages", {
+  withr::local_dir(withr::local_tempdir())
+  runtime <- load_ontology_runtime()
+  stub_omim_runtime(runtime)
+
+  progress_calls <- list()
+  progress <- function(step, message, current = NULL, total = NULL) {
+    progress_calls[[length(progress_calls) + 1L]] <<- list(
+      step = step,
+      message = message,
+      current = current,
+      total = total
+    )
+  }
+
+  expect_no_error(
+    runtime$process_omim_ontology(
+      hgnc_list = tibble(symbol = "GENE1", hgnc_id = "HGNC:1"),
+      moi_list = tibble(
+        hpo_mode_of_inheritance_term_name = "Autosomal dominant inheritance",
+        hpo_mode_of_inheritance_term = "HP:0000006"
+      ),
+      max_file_age = 7,
+      progress_callback = progress
+    )
+  )
+
+  expect_equal(length(progress_calls), 4L)
+  expect_true(all(nzchar(vapply(progress_calls, `[[`, character(1), "message"))))
+  expect_equal(vapply(progress_calls, `[[`, numeric(1), "total"), rep(4, 4))
+})
+
+test_that("process_omim_ontology forwards mim2gene cache age in days", {
+  withr::local_dir(withr::local_tempdir())
+  runtime <- load_ontology_runtime()
+  mim2gene_args <- stub_omim_runtime(runtime)
+
+  suppressWarnings(runtime$process_omim_ontology(
+    hgnc_list = tibble(symbol = "GENE1", hgnc_id = "HGNC:1"),
+    moi_list = tibble(
+      hpo_mode_of_inheritance_term_name = "Autosomal dominant inheritance",
+      hpo_mode_of_inheritance_term = "HP:0000006"
+    ),
+    max_file_age = 7,
+    progress_callback = NULL
+  ))
+
+  expect_equal(mim2gene_args$max_age_days, 7)
+})
+
+test_that("process_combine_ontology sends a message for MONDO SSSOM progress", {
+  withr::local_dir(withr::local_tempdir())
+  skip_if_not_installed("tidyr")
+  runtime <- load_ontology_runtime()
+  runtime$separate_rows <- tidyr::separate_rows
+  runtime$check_file_age <- function(file_basename, folder, months) FALSE
+  runtime$process_mondo_ontology <- function() {
+    tibble(
+      disease_ontology_id_version = "MONDO:0000001",
+      disease_ontology_id = "MONDO:0000001",
+      disease_ontology_name = "MONDO disease",
+      disease_ontology_source = "mondo",
+      disease_ontology_date = "2026-05-13",
+      disease_ontology_is_specific = FALSE,
+      hgnc_id = NA_character_,
+      hpo_mode_of_inheritance_term = NA_character_
+    )
+  }
+  runtime$process_omim_ontology <- function(
+    hgnc_list,
+    moi_list,
+    max_file_age,
+    progress_callback
+  ) {
+    tibble(
+      disease_ontology_id_version = "OMIM:123456",
+      disease_ontology_id = "OMIM:123456",
+      disease_ontology_name = "OMIM disease",
+      disease_ontology_source = "mim2gene",
+      disease_ontology_date = "2026-05-13",
+      disease_ontology_is_specific = TRUE,
+      hgnc_id = "HGNC:1",
+      hpo_mode_of_inheritance_term = "HP:0000006"
+    )
+  }
+  runtime$get_ontology_object <- function(
+    ontology_type,
+    config_vars,
+    tags = "everything",
+    max_age = 1
+  ) {
+    list()
+  }
+  runtime$get_mondo_mappings <- function(
+    mondo_ontology,
+    max_age = 1,
+    output_path = "data/",
+    columns_to_return = NULL
+  ) {
+    tibble(
+      OMIM = "OMIM:123456",
+      MONDO = "MONDO:0000001",
+      DOID = NA_character_,
+      Orphanet = NA_character_,
+      EFO = NA_character_
+    )
+  }
+  runtime$download_mondo_sssom <- function(output_path) {
+    "data/mondo-omim.test.sssom.tsv"
+  }
+  runtime$parse_mondo_sssom <- function(file_path) {
+    tibble(omim_id = "OMIM:123456", mondo_id = "MONDO:0000001")
+  }
+  runtime$add_mondo_mappings_to_ontology <- function(disease_ontology_set, mondo_mappings) {
+    disease_ontology_set
+  }
+  runtime$write_csv <- function(x, file, na = "NA") invisible(NULL)
+
+  progress_calls <- list()
+  progress <- function(step, message, current = NULL, total = NULL) {
+    progress_calls[[length(progress_calls) + 1L]] <<- list(
+      step = step,
+      message = message,
+      current = current,
+      total = total
+    )
+  }
+
+  result <- runtime$process_combine_ontology(
+    hgnc_list = tibble(symbol = "GENE1", hgnc_id = "HGNC:1"),
+    mode_of_inheritance_list = tibble(
+      hpo_mode_of_inheritance_term_name = "Autosomal dominant inheritance",
+      hpo_mode_of_inheritance_term = "HP:0000006"
+    ),
+    max_file_age = 3,
+    output_path = "data/",
+    progress_callback = progress
+  )
+
+  expect_equal(nrow(result), 2L)
+  expect_true(any(vapply(progress_calls, `[[`, character(1), "message") ==
+    "Applying MONDO SSSOM mappings"))
+})
+
+# =============================================================================
 # Mode of inheritance term mapping tests
 # =============================================================================
 

--- a/api/tests/testthat/test-unit-ontology-functions.R
+++ b/api/tests/testthat/test-unit-ontology-functions.R
@@ -355,7 +355,7 @@ test_that("process_omim_ontology sends async progress messages", {
   expect_equal(vapply(progress_calls, `[[`, numeric(1), "total"), rep(4, 4))
 })
 
-test_that("process_omim_ontology forwards mim2gene cache age in days", {
+test_that("process_omim_ontology converts mim2gene cache age from months to days", {
   withr::local_dir(withr::local_tempdir())
   runtime <- load_ontology_runtime()
   mim2gene_args <- stub_omim_runtime(runtime)
@@ -370,7 +370,7 @@ test_that("process_omim_ontology forwards mim2gene cache age in days", {
     progress_callback = NULL
   ))
 
-  expect_equal(mim2gene_args$max_age_days, 7)
+  expect_equal(mim2gene_args$max_age_days, 210)
 })
 
 test_that("process_combine_ontology sends a message for MONDO SSSOM progress", {

--- a/api/version_spec.json
+++ b/api/version_spec.json
@@ -1,7 +1,7 @@
 {
   "title": "SysNDD API",
   "description": "This is the API powering the SysNDD website, allowing programmatic access to the database contents.",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "contact": {
     "name": "API Support",
     "url": "https://berntpopp.github.io/sysndd/api.html",


### PR DESCRIPTION
## Summary

Fixes the async ontology update failure shown as `argument "message" is missing, with no default`.

The durable async job progress reporter requires callbacks shaped as `function(step, message, current, total)`, but `process_omim_ontology()` and `process_combine_ontology()` were reporting progress without `message`. The worker therefore failed before the ontology update could proceed.

Also fixes the OMIM mim2gene cache-age plumbing: `download_mim2gene()` expects `max_age_days`, but the ontology path was passing `max_age_months`, which was caught and downgraded to a warning in the deprecation-tracking `tryCatch`.

## Changes

- Add explicit progress `message` values for OMIM and combined ontology progress callbacks.
- Pass `max_age_days` into `download_mim2gene()`.
- Add regression coverage for async progress callback calls and mim2gene cache-age forwarding.

## Validation

- `cd api && Rscript --no-init-file -e "testthat::test_file('tests/testthat/test-unit-ontology-functions.R')"`
- `cd api && Rscript --no-init-file -e "testthat::test_file('tests/testthat/test-unit-async-job-worker.R')"`
- `make test-api-fast` (`FAIL 0 | WARN 66 | SKIP 197 | PASS 2405`)
- `make lint-api`
- `make ci-local` (`FAIL 0 | WARN 67 | SKIP 315 | PASS 2574`)
- Docker API-container regression check against the same callback path passed in a temporary isolated compose stack.

## Playwright note

The standard `make playwright-stack` could not start locally because an existing dev stack already owned fixed container names (`sysndd_traefik`, `sysndd_mysql`). I attempted an isolated temporary compose override on port `18080`; the Docker API-container regression passed there, but Playwright `/ManageAnnotations` smoke could not complete because `/api/auth/authenticate` timed out in that temporary stack. A direct `curl` to the same auth endpoint also timed out, so I did not claim a passing Playwright run.
