### PR TITLE
[codex] Fix design refactor follow-ups

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysndd",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysndd",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@unhead/vue": "^3.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/app/src/components/AppNavbar.spec.ts
+++ b/app/src/components/AppNavbar.spec.ts
@@ -9,13 +9,16 @@ vi.mock('@/api/auth', () => ({
   signin: vi.fn(),
 }));
 
-const mountNavbar = async () => {
+const mountNavbar = async (initialPath = '/') => {
   const router = createRouter({
     history: createWebHistory(),
-    routes: [{ path: '/', name: 'Home', component: { template: '<div />' } }],
+    routes: [
+      { path: '/', name: 'Home', component: { template: '<div />' } },
+      { path: '/Genes/:symbol', name: 'GenesDetail', component: { template: '<div />' } },
+    ],
   });
 
-  await router.push('/');
+  await router.push(initialPath);
   await router.isReady();
 
   return mount(AppNavbar, {
@@ -88,6 +91,13 @@ describe('AppNavbar', () => {
     const toggle = wrapper.get('.navbar-toggler-stub');
     expect(toggle.attributes('aria-label')).toBe('Open navigation menu');
     expect(toggle.attributes('aria-expanded')).toBe('false');
+  });
+
+  it('shows navbar search on direct non-home route loads', async () => {
+    const wrapper = await mountNavbar('/Genes/ARID1B');
+
+    expect(wrapper.find('.app-navbar__search .search-combobox-stub').exists()).toBe(true);
+    expect(wrapper.find('.app-navbar__mobile-search .search-combobox-stub').exists()).toBe(true);
   });
 
   it('shows admin menus from the persisted auth payload while JWT validation is still pending', async () => {

--- a/app/src/components/AppNavbar.vue
+++ b/app/src/components/AppNavbar.vue
@@ -146,16 +146,22 @@ export default {
         // Close mobile navbar on route change (fixes #94)
         this.navbarCollapsed = false;
       }
-      // Vue Router 4: onReady replaced with isReady()
-      this.$router.isReady().then(() => {
-        this.show_search = this.$route.name !== 'Home';
-      });
+      this.updateSearchVisibility();
     },
   },
   mounted() {
     this.isUserLoggedIn();
+    this.updateSearchVisibility();
   },
   methods: {
+    updateSearchVisibility() {
+      // Vue Router 4: onReady replaced with isReady(). Run this on mount too
+      // so direct non-home loads show the navbar search before any route change.
+      this.show_search = this.$route.name !== 'Home';
+      this.$router.isReady().then(() => {
+        this.show_search = this.$route.name !== 'Home';
+      });
+    },
     isUserLoggedIn() {
       // Phase E.E7: `isAuthenticated` covers both "token present" and
       // "user payload parsed cleanly" — the composable already refused a

--- a/app/src/components/ReloadPrompt.spec.ts
+++ b/app/src/components/ReloadPrompt.spec.ts
@@ -1,4 +1,6 @@
 import { mount } from '@vue/test-utils';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { ref } from 'vue';
 import { createRouter, createWebHistory } from 'vue-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -94,5 +96,14 @@ describe('ReloadPrompt', () => {
 
     expect(wrapper.get('[role="status"]').text()).toContain('New SysNDD version available');
     expect(wrapper.get('button.btn-primary').text()).toBe('Update');
+  });
+
+  it('offsets the fixed prompt above the fixed footer', () => {
+    const source = readFileSync(fileURLToPath(import.meta.url).replace(/\.spec\.ts$/, '.vue'), {
+      encoding: 'utf8',
+    });
+
+    expect(source).toContain('--app-footer-height');
+    expect(source).toMatch(/bottom:\s*calc\(var\(--app-footer-height,\s*48px\)\s*\+\s*1rem/);
   });
 });

--- a/app/src/components/ReloadPrompt.vue
+++ b/app/src/components/ReloadPrompt.vue
@@ -52,7 +52,7 @@ function close() {
 .reload-prompt {
   position: fixed;
   right: 1rem;
-  bottom: calc(1rem + env(safe-area-inset-bottom));
+  bottom: calc(var(--app-footer-height, 48px) + 1rem + env(safe-area-inset-bottom));
   z-index: 1060;
   background: #fff;
   border: 1px solid rgba(33, 37, 41, 0.12);
@@ -115,7 +115,7 @@ function close() {
 @media (max-width: 575.98px) {
   .reload-prompt {
     right: 0.75rem;
-    bottom: calc(0.75rem + env(safe-area-inset-bottom));
+    bottom: calc(var(--app-footer-height, 48px) + 0.75rem + env(safe-area-inset-bottom));
     align-items: flex-start;
   }
 

--- a/app/src/views/tables/PanelsMobileRows.spec.ts
+++ b/app/src/views/tables/PanelsMobileRows.spec.ts
@@ -37,7 +37,12 @@ describe('PanelsMobileRows', () => {
 
     await wrapper.get('button[aria-expanded="false"]').trigger('click');
 
-    expect(wrapper.get('button').attributes('aria-expanded')).toBe('true');
+    const detailsButton = wrapper.get('button');
+    const detailsId = detailsButton.attributes('aria-controls');
+
+    expect(detailsButton.attributes('aria-expanded')).toBe('true');
+    expect(detailsId).toBeTruthy();
+    expect(wrapper.find(`#${detailsId}`).exists()).toBe(true);
     expect(wrapper.text()).toContain('HGNC:18040');
     expect(wrapper.text()).toContain('57492');
   });

--- a/app/src/views/tables/PanelsMobileRows.vue
+++ b/app/src/views/tables/PanelsMobileRows.vue
@@ -1,6 +1,6 @@
 <template>
   <MobileTableList :items="items" label="Panel gene records" :item-key="rowKey">
-    <template #default="{ item }">
+    <template #default="{ item, index }">
       <article class="mobile-record-row" role="listitem">
         <div class="mobile-record-row__topline">
           <GeneBadge
@@ -17,6 +17,7 @@
             class="btn btn-sm btn-outline-secondary mobile-record-row__toggle"
             type="button"
             :aria-expanded="expandedKey === rowKey(item) ? 'true' : 'false'"
+            :aria-controls="detailsId(index)"
             @click="toggleDetails(item)"
           >
             {{ expandedKey === rowKey(item) ? 'Hide' : 'Details' }}
@@ -35,7 +36,11 @@
           </span>
         </div>
 
-        <dl v-if="expandedKey === rowKey(item)" class="mobile-record-row__details">
+        <dl
+          v-if="expandedKey === rowKey(item)"
+          :id="detailsId(index)"
+          class="mobile-record-row__details"
+        >
           <template v-for="fieldKey in selectedFieldKeys" :key="fieldKey">
             <dt>{{ fieldLabel(fieldKey) }}</dt>
             <dd>{{ getText(item, fieldKey) || '-' }}</dd>
@@ -76,6 +81,10 @@ function toggleDetails(item: PanelRow) {
 
 function rowKey(item: PanelRow): string {
   return getText(item, 'hgnc_id') || getText(item, 'symbol');
+}
+
+function detailsId(index: number): string {
+  return `panels-mobile-row-details-${index}`;
 }
 
 function geneLink(item: PanelRow): string | undefined {

--- a/app/src/views/tables/PanelsTable.spec.ts
+++ b/app/src/views/tables/PanelsTable.spec.ts
@@ -1,0 +1,99 @@
+import { shallowMount } from '@vue/test-utils';
+import { createPinia } from 'pinia';
+import { describe, expect, it, vi } from 'vitest';
+import { browsePanels } from '@/api/panels';
+import PanelsTable from './PanelsTable.vue';
+
+vi.mock('@unhead/vue', () => ({
+  useHead: vi.fn(),
+}));
+
+vi.mock('@/composables', () => ({
+  useToast: () => ({
+    makeToast: vi.fn(),
+  }),
+}));
+
+vi.mock('@/api/panels', () => ({
+  getPanelOptions: vi.fn(() => new Promise(() => {})),
+  browsePanels: vi.fn(),
+  browsePanelsXlsx: vi.fn(),
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function responseFor(symbol: string) {
+  return {
+    data: [{ symbol }],
+    fields: [{ key: 'symbol', label: 'Symbol' }],
+    meta: [
+      {
+        totalItems: 1,
+        currentPage: 1,
+        totalPages: 1,
+        prevItemID: null,
+        currentItemID: 0,
+        nextItemID: null,
+        lastItemID: null,
+        executionTime: '10 ms',
+      },
+    ],
+  };
+}
+
+function mountPanelsTable() {
+  return shallowMount(PanelsTable, {
+    global: {
+      plugins: [createPinia()],
+      directives: {
+        bTooltip: {},
+      },
+      mocks: {
+        $route: {
+          params: {
+            category_input: 'All',
+            inheritance_input: 'All',
+          },
+        },
+      },
+    },
+  });
+}
+
+describe('PanelsTable', () => {
+  it('ignores stale browse responses when panel controls change quickly', async () => {
+    const first = deferred<ReturnType<typeof responseFor>>();
+    const second = deferred<ReturnType<typeof responseFor>>();
+    vi.mocked(browsePanels).mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+
+    const wrapper = mountPanelsTable();
+    Object.assign(wrapper.vm, {
+      selected_category: 'All',
+      selected_inheritance: 'All',
+      selected_columns: ['symbol'],
+      perPage: 10,
+      currentItemID: 0,
+    });
+
+    const firstRequest = wrapper.vm.requestSelected();
+    const secondRequest = wrapper.vm.requestSelected();
+
+    second.resolve(responseFor('SECOND'));
+    await secondRequest;
+
+    expect(wrapper.vm.items).toEqual([{ symbol: 'SECOND' }]);
+
+    first.resolve(responseFor('FIRST'));
+    await firstRequest;
+
+    expect(wrapper.vm.items).toEqual([{ symbol: 'SECOND' }]);
+  });
+});

--- a/app/src/views/tables/PanelsTable.vue
+++ b/app/src/views/tables/PanelsTable.vue
@@ -245,6 +245,7 @@ export default {
       isBusy: true,
       downloading: false,
       show_table: false,
+      panelRequestSerial: 0,
     };
   },
   watch: {
@@ -359,6 +360,8 @@ export default {
       }
     },
     async requestSelected() {
+      const requestSerial = this.panelRequestSerial + 1;
+      this.panelRequestSerial = requestSerial;
       this.isBusy = true;
 
       // Extract sort column and order from array-based sortBy (Bootstrap-Vue-Next format)
@@ -373,6 +376,10 @@ export default {
           page_after: this.currentItemID,
           page_size: String(this.perPage),
         });
+
+        if (!this.isCurrentPanelRequest(requestSerial)) {
+          return;
+        }
 
         this.items = data.data;
         this.fields = data.fields;
@@ -389,17 +396,22 @@ export default {
         this.nextItemID = data.meta[0].nextItemID;
         this.lastItemID = data.meta[0].lastItemID;
         this.executionTime = data.meta[0].executionTime;
-
-        this.isBusy = false;
       } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
-        this.isBusy = false;
+        if (this.isCurrentPanelRequest(requestSerial)) {
+          this.makeToast(e, 'Error', 'danger');
+        }
+      } finally {
+        if (this.isCurrentPanelRequest(requestSerial)) {
+          const uiStore = useUiStore();
+          uiStore.requestScrollbarUpdate();
+
+          this.isBusy = false;
+          this.loading = false;
+        }
       }
-
-      const uiStore = useUiStore();
-      uiStore.requestScrollbarUpdate();
-
-      this.loading = false;
+    },
+    isCurrentPanelRequest(requestSerial) {
+      return requestSerial === this.panelRequestSerial;
     },
     async requestExcel() {
       this.downloading = true;


### PR DESCRIPTION
## Summary

This small follow-up PR addresses the design-refactor risks found during review:

- Initialize navbar search visibility on mount so direct non-home route loads show search immediately.
- Offset the fixed PWA reload prompt above the fixed footer.
- Add `aria-controls` linkage to panel mobile-row detail toggles.
- Guard `PanelsTable` browse responses with a request serial so stale rapid-control responses cannot overwrite newer data.

## Root Cause

The refactor introduced several mostly presentation-level behaviors that depended on route changes, fixed-position assumptions, or request resolution order. The panel table in particular had no stale-response guard, so older browse requests could win after a newer filter/sort/page request.

## Validation

- `cd app && npx vitest run src/components/AppNavbar.spec.ts src/components/ReloadPrompt.spec.ts src/views/tables/PanelsMobileRows.spec.ts src/views/tables/PanelsTable.spec.ts`
- `cd app && npx prettier --check src/components/AppNavbar.vue src/components/AppNavbar.spec.ts src/components/ReloadPrompt.vue src/components/ReloadPrompt.spec.ts src/views/tables/PanelsMobileRows.vue src/views/tables/PanelsMobileRows.spec.ts src/views/tables/PanelsTable.vue src/views/tables/PanelsTable.spec.ts`
- `cd app && npm run type-check`
- `cd app && npm run type-check:strict`
- `make lint-app`
- `cd app && npm run test:unit`
- `make dev`
- `cd app && npx playwright test tests/e2e/tables-responsive.spec.ts`
- `make ci-local`

Notes: Playwright global setup reported that seeding test users could not find service `mysql`, then continued without reseed; the responsive spec itself passed all 15 tests. Existing lint warnings and R test warnings/skips remain, but the commands above completed successfully.