### PR TITLE
Fix toast notification rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ __pycache__/
 .planning/ui-audit/**/lighthouse-profile/
 .planning/ui-audit/**/lighthouse-summary.json
 .planning/ui-audit/**/playwright-audit*.json
+
+# Generated Playwright design-audit captures
+.planning/screenshots/*-design-audit/

--- a/.planning/superpowers/plans/2026-05-13-curation-admin-design-refactor-plan.md
+++ b/.planning/superpowers/plans/2026-05-13-curation-admin-design-refactor-plan.md
@@ -1,0 +1,204 @@
+# Curation and Admin Design Refactor Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` or `superpowers:executing-plans` to implement this plan task-by-task. Keep PRs small and verify each route locally with Playwright because these authenticated views are local-only visual coverage.
+
+**Goal:** Bring all Curation and Administration views up to the current SysNDD design standard used by `/`, `/Entities?sort=%2Bentity_id&page_size=10`, and the recent table/page shells.
+
+**Architecture:** Reuse the existing `AuthenticatedPageShell.vue` and `TableShell.vue` visual language instead of inventing a second admin system. Convert legacy dark Bootstrap cards and stacked mobile tables into consistent route shells, compact toolbars, purpose-built mobile rows, and footer-safe scroll areas.
+
+**Tech Stack:** Vue 3, TypeScript, Bootstrap Vue Next, existing table/mobile-row patterns, local Playwright visual checks.
+
+---
+
+## Playwright Evidence
+
+Audit run against the active dev app at `http://localhost:5173` after logging in as the deterministic `pw_admin` Playwright fixture user. The fixture user had to be seeded into the current dev DB because the active `make dev` database did not contain the Playwright accounts. The temporary fixture users were removed after the audit.
+
+Artifacts:
+
+- Screenshots and metrics: `.planning/screenshots/2026-05-13-curation-admin-design-audit/`
+- Desktop contact sheet: `.planning/screenshots/2026-05-13-curation-admin-design-audit/contact-desktop-top.png`
+- Mobile contact sheet: `.planning/screenshots/2026-05-13-curation-admin-design-audit/contact-mobile-top.png`
+- Route metrics: `.planning/screenshots/2026-05-13-curation-admin-design-audit/audit-summary.tsv`
+- Scroll/overlap metrics: `.planning/screenshots/2026-05-13-curation-admin-design-audit/scroll-overlap-summary.tsv`
+
+Findings from the audit:
+
+- All target routes returned `200` and had no captured console errors.
+- Top-level horizontal overflow was not detected at 1440x900 or 390x844.
+- Every Curation/Admin target had `shellCount=0`; the reference Entities table had `shellCount=1`.
+- The authenticated views are inside `main.scrollable-content`, so document-level full-page screenshots miss lower content. Several pages have internal scroll heights far beyond the visible area.
+- Mobile stacked tables are the biggest quality gap: `ManageOntology` measured `8257px`, `ManageUser` `6395px`, `ApproveUser` `3553px`, `ApproveReview` `3143px`, and `ViewLogs` `2979px` of internal scroll content.
+- Many routes use dark-bordered Bootstrap cards, nested cards, duplicated headings, or dense controls that do not match the current restrained table/home design.
+
+## Current Standard
+
+A page fits the current standard when it has:
+
+- A single clear page shell with compact title, description, meta, and actions.
+- White surfaces with subtle borders/shadows, about 8px radius, and no card-in-card chrome.
+- Dense but readable operation controls, aligned in predictable toolbar rows.
+- Tables inside `TableShell`, with mobile-specific record rows instead of Bootstrap stacked table output.
+- Footer-safe scrolling so important controls and row actions are not covered by the fixed footer.
+- One real page heading, accessible icon buttons, and labels for filters/help controls.
+
+## Route Ratings
+
+Scale: `5` fits the standard, `4` mostly fits, `3` functional but inconsistent, `2` legacy/high-priority refactor, `1` serious UX blocker.
+
+### Curation
+
+| Route | Score | Evidence | Refactor Direction |
+|---|---:|---|---|
+| `/CreateEntity` | 3 | Modern wizard structure, but no authenticated shell; desktop card is overly centered and mobile stepper/form content falls into the fixed-footer danger zone. | Wrap in `AuthenticatedPageShell`; make wizard content footer-safe; tighten stepper and form spacing. |
+| `/ModifyEntity` | 2 | Nested dark cards, sparse empty state, no page-level hierarchy. | Replace nested search cards with a shell, search/results split, and entity summary panel. |
+| `/ApproveReview` | 2 | Dark bordered card, dense legend, desktop scroll height `1813px`, mobile stacked table `3143px`. | Move to `TableShell`; compact toolbar; purpose-built approval mobile rows. |
+| `/ApproveStatus` | 2 | Same approval-table language as review; mobile stacked table `2371px`. | Share the approval table refactor with status-specific chips and row actions. |
+| `/ApproveUser` | 2 | Desktop is usable, but mobile stacked user rows are long and visually heavy at `3553px`. | Create user-application mobile cards; move actions into stable icon cluster. |
+| `/ManageReReview` | 2 | Four separate cards, mixed create/assign/manage workflows, mobile scroll `2518px`. | Split into shell sections: create batch, assign entities, manage submissions. |
+
+### Administration
+
+| Route | Score | Evidence | Refactor Direction |
+|---|---:|---|---|
+| `/ManageUser` | 2 | Functional table, but legacy dark card and severe mobile stacked table height `6395px`. | Convert to `TableShell`; add compact user mobile rows and bulk toolbar. |
+| `/ManageAnnotations` | 3 | Operation cards are understandable, but the page is a loose card stack without shell rhythm. | Turn into an operations board with status chips, descriptions, and grouped actions. |
+| `/ManageOntology` | 2 | Functional table, but mobile stacked table height `8257px`; old table frame. | Use `TableShell` plus compact variation-term mobile rows. |
+| `/ManageAbout` | 2 | Nine cards with seven nested cards; editing surface feels like a card stack rather than CMS tooling. | Build an editor layout with section list, editor pane, and publish actions. |
+| `/ViewLogs` | 3 | Inherits table behavior and is functional, but still has legacy chrome and mobile stacked height `2979px`. | Move to authenticated table shell; compact log mobile rows. |
+| `/AdminStatistics` | 4 | Closest to current standard; KPI/chart hierarchy works, but filters/header are disconnected and chart content can meet the footer. | Wrap in shell; compress filters; make charts footer-safe. |
+| `/ManageBackups` | 3 | Usable admin table, but backup/restore actions and danger flows are visually crowded. | Use shell plus operations/action panels and safer destructive zones. |
+| `/ManagePubtator` | 2 | Nested cards, heavy bordered form, oversized danger zone. | Rebuild as an operation page with query/status/fetch/cache panels. |
+| `/ManageLLM` | 3 | Dashboard intent is good, but duplicate heading, nested cards, dark border, and oversized tabs feel legacy. | Use shell, KPI grid, segmented tabs, and compact job/cache panels. |
+
+## Small PR Sequence
+
+### PR 1: Shared Authenticated Surface And Scroll Safety
+
+**Files:**
+
+- Modify: `app/src/components/layout/AuthenticatedPageShell.vue`
+- Modify: `app/src/App.vue`
+- Modify: target route wrappers under `app/src/views/admin/` and `app/src/views/curate/`
+- Add: `app/tests/e2e/authenticated-admin-curation-design.spec.ts`
+
+Steps:
+
+- Extend `AuthenticatedPageShell` only if needed for `meta`, `actions`, and full-width content variants.
+- Ensure `main.scrollable-content` and shell content reserve footer-safe bottom space. The fixed footer must not cover form controls, table actions, or chart legends.
+- Add a local-only Playwright design spec that logs in as admin and asserts:
+  - route loads with no hard console errors,
+  - no horizontal overflow at 1440 and 390,
+  - exactly one visible route heading,
+  - target routes use an authenticated shell,
+  - visible content does not sit under the fixed footer.
+- Apply the shell wrapper to routes without changing API calls or data timing.
+
+### PR 2: Approval And User Management Tables
+
+**Files:**
+
+- Modify: `app/src/views/curate/ApproveReview.vue`
+- Modify: `app/src/views/curate/ApproveStatus.vue`
+- Modify: `app/src/views/curate/ApproveUser.vue`
+- Modify: `app/src/components/ApprovalTableView.vue`
+- Modify: `app/src/views/admin/ManageUser.vue`
+- Add: `app/src/views/curate/components/ApprovalMobileRows.vue`
+- Add: `app/src/views/curate/components/UserApplicationMobileRows.vue`
+- Add: `app/src/views/admin/components/UserAdminMobileRows.vue`
+
+Steps:
+
+- Replace dark `BCard` table frames with `TableShell`.
+- Keep desktop columns and existing approve/dismiss/edit behavior.
+- Replace `stacked="md"` output with compact mobile rows:
+  - primary line: entity/user identifier,
+  - secondary line: disease/email/status,
+  - chip row: category, role, user, date,
+  - action cluster: details/edit/approve/dismiss.
+- Keep legends but move them into a compact help/disclosure row.
+- Add Vitest coverage for mobile row rendering and emitted actions.
+
+### PR 3: Admin Table Surfaces
+
+**Files:**
+
+- Modify: `app/src/views/admin/ManageOntology.vue`
+- Modify: `app/src/views/admin/ViewLogs.vue`
+- Modify: `app/src/views/admin/ManageBackups.vue`
+- Add: `app/src/views/admin/components/OntologyMobileRows.vue`
+- Add: `app/src/views/admin/components/LogMobileRows.vue`
+- Add: `app/src/views/admin/components/BackupMobileRows.vue`
+
+Steps:
+
+- Put each table in `TableShell` with consistent toolbar placement.
+- Replace mobile stacked tables with compact rows.
+- Keep export, copy-link, filter presets, pagination, and destructive actions.
+- Move backup restore/delete confirmations into clearer danger panels/modals with stable footer-safe actions.
+
+### PR 4: Curation Workflow Forms
+
+**Files:**
+
+- Modify: `app/src/views/curate/CreateEntity.vue`
+- Modify: `app/src/views/curate/ModifyEntity.vue`
+- Modify: `app/src/views/curate/ManageReReview.vue`
+- Modify: `app/src/views/curate/components/EntitySearchPanel.vue`
+- Modify: `app/src/views/curate/components/EntityInfoHeader.vue`
+
+Steps:
+
+- Keep existing composables and submission behavior unchanged.
+- `CreateEntity`: keep the five-step wizard, but place it in the authenticated shell and make the stepper responsive.
+- `ModifyEntity`: replace nested dark search cards with a two-zone layout: search/results first, selected entity summary and edit actions second.
+- `ManageReReview`: separate create-batch, assignment, and submissions management into clear sections with compact headers and status chips.
+- Add empty, loading, and selected states that do not rely on large bordered cards.
+
+### PR 5: Admin Operation Pages And Dashboards
+
+**Files:**
+
+- Modify: `app/src/views/admin/ManageAnnotations.vue`
+- Modify: `app/src/views/admin/ManageAbout.vue`
+- Modify: `app/src/views/admin/AdminStatistics.vue`
+- Modify: `app/src/views/admin/ManagePubtator.vue`
+- Modify: `app/src/views/admin/ManageLLM.vue`
+
+Steps:
+
+- `ManageAnnotations`: convert the cards into grouped operation panels with status chips and primary/secondary action hierarchy.
+- `ManageAbout`: move to a CMS-style layout: section navigation on the left, editor/preview on the right, publish actions in the shell action area.
+- `AdminStatistics`: keep the KPI/dashboard direction; move filters into shell actions and keep charts within footer-safe panels.
+- `ManagePubtator`: split search/status, fetch job, and clear-cache danger zone into separate operation panels.
+- `ManageLLM`: remove duplicate heading and nested cards; use KPI grid, segmented tabs, and compact job/cache controls.
+
+## Verification Gates
+
+Run after each PR:
+
+```bash
+make lint-app
+cd app && npm run type-check
+cd app && npm run type-check:strict
+cd app && npm run test:unit
+```
+
+Run local Playwright after each visual PR:
+
+```bash
+cd app && npx playwright test tests/e2e/authenticated-admin-curation-design.spec.ts
+```
+
+Manual evidence to update per PR:
+
+- Capture desktop `1440x900` and mobile `390x844` screenshots for each changed route.
+- Update `.planning/screenshots/<date>-curation-admin-design-audit/` or a new dated folder.
+- Confirm no page regresses from the ratings above.
+
+## Non-Goals
+
+- No API endpoint, data contract, request timing, auth guard, or database behavior changes.
+- No replacement of Bootstrap Vue Next.
+- No destructive admin action should be exercised by the design audit.
+- No global marketing-style redesign; these are operational tools and should stay dense, calm, and scannable.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysndd",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysndd",
-      "version": "0.17.2",
+      "version": "0.17.3",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@unhead/vue": "^3.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -120,6 +120,12 @@ export default {
 <style lang="scss">
 @use '@/assets/scss/custom.scss' as custom;
 
+:root {
+  --app-navbar-height: 60px;
+  --app-footer-height: 48px;
+  --app-toast-offset: 0.75rem;
+}
+
 #app {
   font-family: Avenir, Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -130,35 +136,157 @@ export default {
 }
 
 body {
-  padding-top: 60px;
-  padding-bottom: 48px;
+  padding-top: var(--app-navbar-height);
+  padding-bottom: var(--app-footer-height);
   overflow: hidden;
 }
 
+.orchestrator-container {
+  position: relative;
+  z-index: 1045;
+}
+
+.toast-container.position-fixed {
+  z-index: 1045;
+  max-height: calc(
+    100vh - var(--app-navbar-height) - var(--app-footer-height) -
+      (var(--app-toast-offset) * 2) - env(safe-area-inset-top) - env(safe-area-inset-bottom)
+  );
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 0 !important;
+  pointer-events: none;
+  scrollbar-gutter: stable;
+}
+
 .toast-container.top-0 {
-  top: 64px !important;
+  top: calc(
+    var(--app-navbar-height) + var(--app-toast-offset) + env(safe-area-inset-top)
+  ) !important;
+}
+
+.toast-container.bottom-0 {
+  bottom: calc(
+    var(--app-footer-height) + var(--app-toast-offset) + env(safe-area-inset-bottom)
+  ) !important;
+}
+
+.toast-container.end-0 {
+  right: max(1rem, env(safe-area-inset-right)) !important;
+}
+
+.toast-container.start-0 {
+  left: max(1rem, env(safe-area-inset-left)) !important;
+}
+
+.toast-container .app-toast {
+  width: min(var(--bs-toast-max-width, 360px), calc(100vw - 2rem));
+  max-width: 100%;
+  margin-bottom: 0.75rem;
+  overflow: hidden;
+  color: #1f2933 !important;
+  text-align: left;
+  background: rgba(255, 255, 255, 0.98) !important;
+  border: 1px solid #d8e0ea;
+  border-left: 4px solid #607d8b;
+  border-radius: 8px;
+  box-shadow:
+    0 16px 40px rgba(15, 23, 42, 0.16),
+    0 2px 8px rgba(15, 23, 42, 0.08);
+  pointer-events: auto;
+  backdrop-filter: blur(12px);
+}
+
+.toast-container .app-toast--success {
+  border-left-color: #2e7d32;
+}
+
+.toast-container .app-toast--danger {
+  border-left-color: #c62828;
+}
+
+.toast-container .app-toast--warning {
+  border-left-color: #b7791f;
+}
+
+.toast-container .app-toast--info,
+.toast-container .app-toast--primary {
+  border-left-color: #0d47a1;
+}
+
+.toast-container .app-toast--secondary {
+  border-left-color: #5f6b7a;
+}
+
+.toast-container .app-toast__header {
+  gap: 0.5rem;
+  padding: 0.75rem 0.85rem 0.2rem;
+  color: #1f2933;
+  font-size: 0.86rem;
+  font-weight: 800;
+  line-height: 1.2;
+  background: transparent;
+  border-bottom: 0;
+}
+
+.toast-container .app-toast__body {
+  min-width: 0;
+  padding: 0.35rem 0.85rem 0.85rem;
+  color: #344054;
+  font-size: 0.875rem;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.toast-container .app-toast .btn-close {
+  flex: 0 0 auto;
+  margin-left: 0.75rem;
+  opacity: 0.58;
+}
+
+.toast-container .app-toast .btn-close:hover,
+.toast-container .app-toast .btn-close:focus-visible {
+  opacity: 0.86;
+}
+
+.toast-container .app-toast .progress {
+  height: 3px !important;
+  border-radius: 0;
+  opacity: 0.4;
 }
 
 @media (max-width: 575.98px) {
-  .toast-container.top-0 {
-    right: 0 !important;
-    left: 0 !important;
-    width: min(100vw - 1.5rem, 24rem);
-    margin-right: auto;
-    margin-left: auto;
-    padding-right: 0 !important;
-    padding-left: 0 !important;
+  .toast-container.position-fixed {
+    max-height: min(
+      45vh,
+      calc(
+        100vh - var(--app-navbar-height) - var(--app-footer-height) -
+          1rem - env(safe-area-inset-top) - env(safe-area-inset-bottom)
+      )
+    );
   }
 
-  .toast-container.top-0 .toast {
+  .toast-container.top-0 {
+    top: calc(var(--app-navbar-height) + 0.5rem + env(safe-area-inset-top)) !important;
+  }
+
+  .toast-container.top-0,
+  .toast-container.bottom-0 {
+    right: max(0.75rem, env(safe-area-inset-right)) !important;
+    left: max(0.75rem, env(safe-area-inset-left)) !important;
+    width: auto !important;
+    transform: none !important;
+  }
+
+  .toast-container .app-toast {
     width: 100%;
-    max-width: 100%;
+    margin-bottom: 0.5rem;
   }
 }
 
 // Native scrollbar styling
 .scrollable-content {
-  height: calc(100vh - 108px);
+  height: calc(100vh - var(--app-navbar-height) - var(--app-footer-height));
   overflow-y: auto;
   overflow-x: hidden;
 }

--- a/app/src/api/auth.ts
+++ b/app/src/api/auth.ts
@@ -73,11 +73,19 @@ export interface SignupRequest {
  * Returns the bare JWT string (plumber serialises it as `[token]`, which
  * `unwrapScalar` collapses before handing it back).
  */
-export async function authenticate(user_name: string, password: string): Promise<string> {
-  const body = await apiClient.post<[string]>('/api/auth/authenticate', {
-    user_name,
-    password,
-  });
+export async function authenticate(
+  user_name: string,
+  password: string,
+  config?: AxiosRequestConfig
+): Promise<string> {
+  const body = await apiClient.post<[string]>(
+    '/api/auth/authenticate',
+    {
+      user_name,
+      password,
+    },
+    config
+  );
   return unwrapScalar(body);
 }
 

--- a/app/src/api/client.spec.ts
+++ b/app/src/api/client.spec.ts
@@ -117,6 +117,28 @@ describe('api/client — typed wrapper smoke tests', () => {
       expect(isApiError(caught)).toBe(false);
     });
 
+    it('preserves the original AxiosError when auth redirect handling is skipped', async () => {
+      let caught: unknown;
+      try {
+        await apiClient.post(
+          '/api/auth/authenticate',
+          {
+            user_name: ERROR_SENTINELS.WRONG_USER,
+            password: 'hunter2!',
+          },
+          { skipAuthRedirect: true }
+        );
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeDefined();
+      expect(isApiError(caught)).toBe(true);
+      if (isApiError(caught)) {
+        expect(caught.response?.status).toBe(401);
+      }
+    });
+
     it('recognises an AxiosError thrown from a 400 body-validation response', async () => {
       let caught: unknown;
       try {

--- a/app/src/composables/useToast.spec.ts
+++ b/app/src/composables/useToast.spec.ts
@@ -52,7 +52,7 @@ describe('useToast', () => {
           body: 'Test message',
           title: 'Test Title',
           variant: 'success',
-          pos: 'top-end',
+          position: 'top-end',
         })
       );
 
@@ -110,7 +110,7 @@ describe('useToast', () => {
 
       expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
-          pos: 'top-end',
+          position: 'top-end',
         })
       );
 
@@ -124,11 +124,12 @@ describe('useToast', () => {
 
       result.makeToast('Critical error', 'Error', 'danger');
 
-      // modelValue: -1 means no auto-hide (negative value disables auto-hide)
+      // modelValue: true keeps the toast visible without starting a countdown.
       expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
           variant: 'danger',
-          modelValue: -1, // No auto-hide for danger
+          modelValue: true,
+          isStatus: false,
         })
       );
 
@@ -144,7 +145,7 @@ describe('useToast', () => {
       expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
           variant: 'danger',
-          modelValue: -1, // Forced to -1 regardless of parameters
+          modelValue: true,
         })
       );
 
@@ -161,6 +162,7 @@ describe('useToast', () => {
         expect.objectContaining({
           variant: 'success',
           modelValue: 3000, // Auto-hide after 3s
+          isStatus: true,
         })
       );
 
@@ -191,6 +193,7 @@ describe('useToast', () => {
         expect.objectContaining({
           variant: 'info',
           modelValue: 3000,
+          isStatus: true,
         })
       );
 
@@ -218,7 +221,25 @@ describe('useToast', () => {
 
       expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
-          modelValue: -1, // Negative value disables auto-hide
+          modelValue: true,
+        })
+      );
+
+      app.unmount();
+    });
+
+    it('adds the app toast classes used by the global layout styling', () => {
+      const [result, app] = withSetup(() => useToast());
+
+      result.makeToast('Styled warning', 'Warning', 'warning');
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toastClass: 'app-toast app-toast--warning',
+          bodyClass: 'app-toast__body',
+          headerClass: 'app-toast__header',
+          appendToast: true,
+          noProgress: false,
         })
       );
 

--- a/app/src/composables/useToast.ts
+++ b/app/src/composables/useToast.ts
@@ -78,16 +78,27 @@ export default function useToast(): ToastMethods {
       body = String(message);
     }
 
-    // For error toasts (danger variant), disable auto-hide per medical app requirements
-    // This ensures users don't miss important error messages
-    const shouldAutoHide = variant === 'danger' ? false : autoHide;
+    // For error toasts (danger variant), disable auto-hide per medical app requirements.
+    // BootstrapVueNext shows persistent toasts with boolean true; negative numeric
+    // countdown values no longer render.
+    const isErrorToast = variant === 'danger';
+    const shouldAutoHide = isErrorToast ? false : autoHide;
+    const toastClass = ['app-toast', variant ? `app-toast--${variant}` : '']
+      .filter(Boolean)
+      .join(' ');
 
     toast.create({
       title,
       body,
       variant,
-      pos: 'top-end',
-      modelValue: shouldAutoHide ? autoHideDelay : -1, // Negative value disables auto-hide
+      position: 'top-end',
+      appendToast: true,
+      toastClass,
+      headerClass: 'app-toast__header',
+      bodyClass: 'app-toast__body',
+      isStatus: !isErrorToast,
+      noProgress: !shouldAutoHide,
+      modelValue: shouldAutoHide ? autoHideDelay : true,
     });
   };
 

--- a/app/src/composables/useToastNotifications.ts
+++ b/app/src/composables/useToastNotifications.ts
@@ -1,5 +1,5 @@
-import { useToast } from 'bootstrap-vue-next';
-import type { ToastNotifications, ToastVariant } from '@/types/components';
+import type { ToastNotifications } from '@/types/components';
+import useToast from './useToast';
 
 /**
  * Composable for toast notifications using Bootstrap-Vue-Next
@@ -7,34 +7,5 @@ import type { ToastNotifications, ToastVariant } from '@/types/components';
  * @returns {ToastNotifications} Toast notification methods
  */
 export default function useToastNotifications(): ToastNotifications {
-  const toast = useToast();
-
-  /**
-   * Show a toast notification
-   * @param {string|object} message - Message to display (or object with message property)
-   * @param {string} title - Toast title
-   * @param {string} variant - Bootstrap variant (success, danger, warning, info)
-   * @param {boolean} autoHide - Whether to auto-dismiss (default: true)
-   * @param {number} autoHideDelay - Delay in ms before auto-hide (default: 3000)
-   */
-  const makeToast = (
-    message: string | { message: string },
-    title: string | null = null,
-    variant: ToastVariant | null = null,
-    autoHide: boolean = true,
-    autoHideDelay: number = 3000
-  ): void => {
-    const body: string =
-      typeof message === 'object' && message.message ? message.message : (message as string);
-
-    toast.create({
-      title,
-      body,
-      variant,
-      pos: 'top-end',
-      modelValue: autoHide ? autoHideDelay : -1, // Negative value disables auto-hide
-    });
-  };
-
-  return { makeToast };
+  return useToast();
 }

--- a/app/src/plugins/axios.ts
+++ b/app/src/plugins/axios.ts
@@ -1,5 +1,11 @@
 import axios from 'axios';
 
+declare module 'axios' {
+  interface AxiosRequestConfig {
+    skipAuthRedirect?: boolean;
+  }
+}
+
 // Configure axios defaults
 axios.defaults.baseURL = import.meta.env.VITE_BASE_URL || '';
 
@@ -25,6 +31,11 @@ let isLoggingOut = false;
 axios.interceptors.response.use(
   (response) => response,
   async (error) => {
+    const skipAuthRedirect = error.config?.skipAuthRedirect === true;
+    if (error.response?.status === 401 && skipAuthRedirect) {
+      return Promise.reject(error);
+    }
+
     if (error.response?.status === 401 && !isLoggingOut) {
       isLoggingOut = true;
 

--- a/app/src/views/LoginView.spec.ts
+++ b/app/src/views/LoginView.spec.ts
@@ -415,10 +415,9 @@ describe('LoginView — fix #2 readable error toast', () => {
   });
 
   it('401 from /api/auth/authenticate: toasts a readable string (not the raw AxiosError object)', async () => {
-    // The shared axios 401 interceptor swallows the original AxiosError and
-    // re-rejects with `new Error('Redirecting to login')`. LoginView's catch
-    // must still surface a string — the regression mode is `[object Object]`
-    // when the catch passes the bare Error reference instead of `.message`.
+    // LoginView opts the bootstrap credential check out of the global
+    // session-expired 401 redirect so invalid credentials can surface the
+    // API's actual message instead of the generic redirect placeholder.
     server.use(
       http.post('/api/auth/authenticate', () =>
         HttpResponse.text('User or password wrong.', { status: 401 })
@@ -443,9 +442,7 @@ describe('LoginView — fix #2 readable error toast', () => {
     // criterion is "string, not [object Object]".
     expect(typeof firstArg).toBe('string');
     expect(firstArg).not.toMatch(/\[object Object\]/);
-    // The handled-401 message is what the user actually sees on a wrong
-    // credentials submit (plus the LoginView redirect).
-    expect(firstArg).toBe('Redirecting to login');
+    expect(firstArg).toBe('User or password wrong.');
   });
 
   it("non-401 with literal API string body: toasts the API's exact text", async () => {

--- a/app/src/views/LoginView.vue
+++ b/app/src/views/LoginView.vue
@@ -236,7 +236,9 @@ export default {
       // The typed `authenticate()` helper unwraps the Plumber scalar-array
       // envelope before returning the bare token string.
       try {
-        const token = await authenticate(this.user_name, this.password);
+        const token = await authenticate(this.user_name, this.password, {
+          skipAuthRedirect: true,
+        });
         if (typeof token !== 'string' || !token) {
           this.makeToast(
             'Authentication failed: invalid token shape from server',
@@ -263,6 +265,7 @@ export default {
       // half-logged-in state other tabs/components could observe.
       try {
         const userPayload = await signin({
+          skipAuthRedirect: true,
           headers: {
             Authorization: `Bearer ${token}`, // closeout-exception-E1: bootstrap two-step handshake; useAuth.login() requires both token+user atomically (§3.4)
           },

--- a/app/tests/e2e/toast.spec.ts
+++ b/app/tests/e2e/toast.spec.ts
@@ -1,0 +1,59 @@
+// app/tests/e2e/toast.spec.ts
+import { test, expect } from './fixtures/auth';
+import type { Locator, Page } from '@playwright/test';
+
+type ViewportCase = {
+  name: string;
+  width: number;
+  height: number;
+};
+
+const viewports: ViewportCase[] = [
+  { name: 'desktop', width: 1440, height: 900 },
+  { name: 'mobile', width: 390, height: 740 },
+];
+
+async function triggerBadLoginToast(page: Page) {
+  await page.goto('/Login');
+  await page.getByPlaceholder('User').fill('nopelogin');
+  await page.getByPlaceholder('Password').fill('also-nope-pw');
+  await page.getByRole('button', { name: /^Login$/ }).click();
+}
+
+async function visibleBox(locator: Locator) {
+  await expect(locator).toBeVisible();
+  const box = await locator.boundingBox();
+  expect(box).not.toBeNull();
+  if (!box) {
+    throw new Error('Expected visible element to have a bounding box');
+  }
+  return box;
+}
+
+test.describe('toast notifications', () => {
+  for (const viewport of viewports) {
+    test(`bad login renders a visible, chrome-aware toast on ${viewport.name}`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: viewport.width, height: viewport.height });
+      await triggerBadLoginToast(page);
+
+      const toast = page
+        .locator('.toast')
+        .filter({ hasText: /User or password wrong\.|Authentication failed\./ })
+        .first();
+
+      await expect(toast).toHaveClass(/show/);
+      const toastBox = await visibleBox(toast);
+      await expect(toast).toHaveAttribute('role', 'alert');
+
+      const navbarBox = await visibleBox(page.locator('.app-navbar__bar').first());
+      const footerBox = await visibleBox(page.locator('.app-footer__bar').first());
+
+      expect(toastBox.y).toBeGreaterThanOrEqual(navbarBox.y + navbarBox.height + 4);
+      expect(toastBox.y + toastBox.height).toBeLessThanOrEqual(footerBox.y - 4);
+      expect(toastBox.x).toBeGreaterThanOrEqual(8);
+      expect(toastBox.x + toastBox.width).toBeLessThanOrEqual(viewport.width - 8);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Fix persistent danger toasts by using BootstrapVueNext's supported persistent model value.
- Let login credential failures bypass the global 401 redirect handler so users see the API error toast.
- Add chrome-aware toast styling, a local Playwright toast regression, and the Curation/Admin design refactor plan.
- Bump app patch version to 0.17.3.

## Verification
- make lint-app
- cd app && npm run type-check
- cd app && npm run type-check:strict
- cd app && npm run test:unit
- cd app && npx playwright test tests/e2e/toast.spec.ts