### PR TITLE
[codex] Align admin operation surfaces with visual guide

### DIFF
--- a/.agents/skills/sysndd-visual-design/SKILL.md
+++ b/.agents/skills/sysndd-visual-design/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: sysndd-visual-design
+description: Use when changing SysNDD UI, UX, visual design, page layouts, tables, mobile rows, design tokens, authenticated admin/curation surfaces, or public data views
+---
+
+# SysNDD Visual Design
+
+Use this skill before editing any SysNDD frontend surface that changes how the app looks or feels.
+
+## Required Reference
+
+Read `documentation/10-visual-design-guide.md` before making UI edits. Treat it as the source of truth for visual positioning, tokens, layout patterns, component rules, and route-specific debt.
+
+## Operating Rules
+
+- Keep SysNDD compact, clinical, table-first, and quiet.
+- Prefer existing `AuthenticatedPageShell`, `TableShell`, mobile-row, chip, token, and form patterns.
+- Do not introduce marketing-style hero layouts, decorative gradients, nested card stacks, or new one-off palettes.
+- Use purpose-built mobile record rows for complex tables instead of stacked Bootstrap table output.
+- Keep cards at 8px radius or less unless an existing component contract requires otherwise.
+- Use existing design tokens for color, spacing, typography, and radius.
+- Preserve footer-safe scrolling and avoid horizontal overflow.
+
+## Verification
+
+For authenticated admin/curation visual changes, run:
+
+```bash
+cd app && PLAYWRIGHT_BASE_URL=http://localhost:5173 npx playwright test tests/e2e/authenticated-admin-curation-design.spec.ts --project=chromium-desktop
+```
+
+Before handoff, choose the repo verification lane appropriate to the change from `AGENTS.md`.

--- a/.cursor/rules/sysndd-visual-design.mdc
+++ b/.cursor/rules/sysndd-visual-design.mdc
@@ -1,0 +1,22 @@
+---
+description: SysNDD UI/UX visual standards for frontend design changes
+globs:
+  - "app/src/**/*.vue"
+  - "app/src/**/*.ts"
+  - "app/src/**/*.scss"
+  - "app/tests/e2e/**/*.ts"
+  - "documentation/10-visual-design-guide.md"
+alwaysApply: false
+---
+
+# SysNDD Visual Design
+
+Before changing SysNDD UI/UX, page layouts, tables, mobile rows, authenticated admin/curation surfaces, public data views, or design tokens, read `documentation/10-visual-design-guide.md`.
+
+Preserve the established visual direction: compact, clinical, table-first, quiet, token-based, shell-based, footer-safe, and mobile-row aware. Prefer existing `AuthenticatedPageShell`, `TableShell`, chip, form, and mobile-row patterns. Avoid nested card stacks, decorative gradients, marketing-style layouts, and one-off palette values.
+
+For authenticated admin/curation visual changes, run:
+
+```bash
+cd app && PLAYWRIGHT_BASE_URL=http://localhost:5173 npx playwright test tests/e2e/authenticated-admin-curation-design.spec.ts --project=chromium-desktop
+```

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ __pycache__/
 
 # Generated Playwright design-audit captures
 .planning/screenshots/*-design-audit/
+.planning/screenshots/**/*.png

--- a/.windsurf/rules/sysndd-visual-design.md
+++ b/.windsurf/rules/sysndd-visual-design.md
@@ -1,0 +1,20 @@
+# SysNDD Visual Design
+
+Use this rule when changing SysNDD UI/UX, page layouts, tables, mobile rows, authenticated admin/curation surfaces, public data views, or design tokens.
+
+Read `documentation/10-visual-design-guide.md` before editing. It is the canonical visual guide.
+
+Preserve the established direction:
+
+- Compact, clinical, table-first, and quiet.
+- Existing shells and table patterns before new layout systems.
+- Existing design tokens before one-off colors, spacing, typography, or radius.
+- Purpose-built mobile record rows for complex tables.
+- No nested card stacks, decorative gradients, or marketing-style operational pages.
+- No horizontal overflow; keep important controls footer-safe.
+
+For authenticated admin/curation visual changes, run:
+
+```bash
+cd app && PLAYWRIGHT_BASE_URL=http://localhost:5173 npx playwright test tests/e2e/authenticated-admin-curation-design.spec.ts --project=chromium-desktop
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,5 +100,7 @@ When repository behavior changes, update the durable docs in the same change:
 
 - Start with `documentation/08-development.qmd` for human developer onboarding.
 - Use `documentation/09-deployment.qmd` for deployment and production operations.
+- Use `documentation/10-visual-design-guide.md` for SysNDD UI/UX visual standards before changing public tables, authenticated admin/curation pages, mobile table rows, or design tokens.
+- Cross-LLM visual-design enforcement lives in `.agents/skills/sysndd-visual-design/SKILL.md`, `.cursor/rules/sysndd-visual-design.mdc`, `.windsurf/rules/sysndd-visual-design.md`, and `GEMINI.md`; keep those pointers aligned with the visual guide.
 - See `db/migrations/README.md` for migration-specific details.
 - Planning, specs, reviews, and LLM workflow docs live under `.planning/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@ Service functions must keep their `svc_` or `service_` prefixes. If a service fu
 
 Async jobs are durable and MySQL-backed. The web API submits jobs and serves status/history; the separate worker service claims and executes them. Worker-executed code is sourced once when the worker starts. If you change worker-executed code, restart the worker container before assuming the change is live.
 
+The worker must have outbound network egress for external providers used inside jobs, including Gemini, PubMed, and PubTator. Keep it attached to both the internal `backend` network for database access and the egress-capable `proxy` network; attaching it only to `backend` breaks DNS/API calls because `backend` is `internal: true`.
+
 ### Migrations
 
 `db/migrations/*.sql` are applied at API startup by the migration runner using MySQL advisory locks. Migration failures are supposed to crash startup. Do not work around a failing migration by weakening startup checks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 _Nothing yet._
 
+## [0.19.0] — 2026-05-14
+
+Minor bump for PR #338's admin visual-design pass, log-table performance work, LLM regeneration feedback fixes, and worker egress correction.
+
+### Added
+
+- **Canonical SysNDD visual guide.** Added `documentation/10-visual-design-guide.md`, admin visual ratings, and cross-agent/editor pointers for future UI work.
+- **Shared admin operation surface.** Added `AdminOperationPanel` and migrated multiple admin/annotation views away from dark Bootstrap card chrome.
+
+### Changed
+
+- **Admin operation pages are more consistent.** Refined ManageLLM, ManagePubtator, ManageBackups, AdminStatistics, ViewLogs, and Entities table layouts toward the compact table-first visual guide.
+- **Worker egress is explicit.** The async worker remains on the internal backend network and is also attached to the egress-capable proxy network for Gemini, PubMed, PubTator, and similar provider calls.
+
+### Fixed
+
+- **Logs first page loads faster without breaking cursor semantics.** The first-page SQL fast path preserves `page_size=all`, returns a last-page cursor, and uses stable `id` tie-breaking for non-unique sort columns.
+- **LLM regeneration tracking is visible and durable across page navigation.** ManageLLM now tracks child jobs per cluster type and restores active browser-session job cards after returning to the page.
+- **Character phenotype cluster IDs no longer break LLM progress messages.** Cluster progress formatting now accepts descriptive cluster labels.
+
 ## [0.16.5] — 2026-05-09
 
 Fix bump for entity detail clipboard resiliency after PR #328 feedback.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,8 @@
+# GEMINI.md
+
+@AGENTS.md
+
+## Gemini-specific notes
+
+- `AGENTS.md` is the shared source of truth for repository instructions.
+- For UI/UX or visual design changes, read `documentation/10-visual-design-guide.md` before editing.

--- a/api/endpoints/logging_endpoints.R
+++ b/api/endpoints/logging_endpoints.R
@@ -94,27 +94,42 @@ function(req,
       # Parse filter string to filter list for repository
       filter_list <- parse_logging_filter(filter)
 
-      # Use repository for database-side filtering (fixes #152 - no collect())
-      logs_raw <- get_logs_filtered(
-        filters = filter_list,
-        sort_column = sort_column,
-        sort_direction = sort_direction
-      )
+      page_after_int <- suppressWarnings(as.integer(page_after))
+      use_first_page_fast_path <- format != "xlsx" && !is.na(page_after_int) && page_after_int == 0L
+
+      if (use_first_page_fast_path) {
+        log_pagination_info <- get_logs_first_page(
+          filters = filter_list,
+          sort_column = sort_column,
+          sort_direction = sort_direction,
+          page_size = page_size
+        )
+        logs_raw <- log_pagination_info$data
+      } else {
+        # Use repository for database-side filtering (fixes #152 - no collect())
+        logs_raw <- get_logs_filtered(
+          filters = filter_list,
+          sort_column = sort_column,
+          sort_direction = sort_direction
+        )
+
+        # Pagination
+        log_pagination_info <- generate_cursor_pag_inf(
+          logs_raw,
+          page_size,
+          page_after,
+          "id"
+        )
+      }
 
       # Select fields if specified
       if (fields != "") {
         selected_fields <- unlist(strsplit(fields, ","))
         logs_raw <- logs_raw %>%
           dplyr::select(all_of(selected_fields))
+        log_pagination_info$data <- log_pagination_info$data %>%
+          dplyr::select(all_of(selected_fields))
       }
-
-      # Pagination
-      log_pagination_info <- generate_cursor_pag_inf(
-        logs_raw,
-        page_size,
-        page_after,
-        "id"
-      )
 
       # Field specs
       logs_raw_fspec <- NULL

--- a/api/functions/llm-batch-generator.R
+++ b/api/functions/llm-batch-generator.R
@@ -49,6 +49,15 @@ if (!exists("generate_and_validate_with_judge", mode = "function")) {
   }
 }
 
+llm_cluster_progress_message <- function(cluster_num, current, total) {
+  sprintf(
+    "Cluster %s (%d/%d)",
+    as.character(cluster_num[[1]]),
+    as.integer(current),
+    as.integer(total)
+  )
+}
+
 
 #' Trigger LLM batch generation after clustering completion
 #'
@@ -331,7 +340,7 @@ llm_batch_executor <- function(params) {
     # Update progress
     reporter(
       step = "generation",
-      message = sprintf("Cluster %d (%d/%d)", cluster_num, i, total),
+      message = llm_cluster_progress_message(cluster_num, i, total),
       current = i,
       total = total
     )

--- a/api/functions/logging-repository.R
+++ b/api/functions/logging-repository.R
@@ -387,7 +387,11 @@ build_logging_order_clause <- function(
   # Validate direction
   direction <- validate_sort_direction(sort_direction)
 
-  paste("ORDER BY", sort_column, direction)
+  if (sort_column == "id") {
+    paste("ORDER BY id", direction)
+  } else {
+    paste0("ORDER BY ", sort_column, " ", direction, ", id ", direction)
+  }
 }
 
 #------------------------------------------------------------------------------
@@ -459,8 +463,9 @@ get_logs_filtered <- function(
   where_clause <- where_result$clause
   params <- where_result$params
 
-  # Build ORDER BY clause
-  order_clause <- paste("ORDER BY", sort_column, sort_direction)
+  # Build ORDER BY clause. Non-unique sort columns need id as a stable
+  # tiebreaker so cursor IDs point to the same row across page requests.
+  order_clause <- build_logging_order_clause(sort_column, sort_direction)
 
   # Execute query with LIMIT for safety (LOG-01)
   # The LIMIT prevents memory issues even with very broad filters
@@ -502,20 +507,13 @@ get_logs_first_page <- function(
 
   validate_logging_column(sort_column, LOGGING_ALLOWED_SORT_COLUMNS, "sort")
   sort_direction <- validate_sort_direction(sort_direction)
-  page_size <- suppressWarnings(as.integer(page_size))
-  if (is.na(page_size) || page_size < 1L) {
-    page_size <- 10L
-  }
-  page_size <- min(page_size, 500L)
+  page_size_all <- identical(tolower(as.character(page_size)), "all")
+  requested_page_size <- suppressWarnings(as.integer(page_size))
 
   where_result <- build_logging_where_clause(filters)
   where_clause <- where_result$clause
   params <- where_result$params
-  order_clause <- if (sort_column == "id") {
-    paste("ORDER BY id", sort_direction)
-  } else {
-    paste("ORDER BY", sort_column, sort_direction, ", id", sort_direction)
-  }
+  order_clause <- build_logging_order_clause(sort_column, sort_direction)
 
   count_sql <- paste(
     "SELECT COUNT(*) AS total",
@@ -523,6 +521,13 @@ get_logs_first_page <- function(
   )
   count_result <- db_execute_query(count_sql, params)
   total_items <- as.integer(count_result$total[[1]] %||% 0L)
+  page_size <- if (page_size_all) {
+    total_items
+  } else if (is.na(requested_page_size) || requested_page_size < 1L) {
+    10L
+  } else {
+    min(requested_page_size, 500L)
+  }
   total_pages <- if (total_items == 0L) 0L else ceiling(total_items / page_size)
 
   data_sql <- paste(
@@ -532,15 +537,33 @@ get_logs_first_page <- function(
     order_clause,
     "LIMIT ?"
   )
-  lookahead_limit <- page_size + 1L
+  lookahead_limit <- if (page_size_all) page_size else page_size + 1L
   data_result <- tibble::as_tibble(db_execute_query(data_sql, append(params, list(lookahead_limit))))
-  has_next <- nrow(data_result) > page_size
+  has_next <- !page_size_all && nrow(data_result) > page_size
   page_data <- utils::head(data_result, page_size)
 
   current_page_last_id <- if (nrow(page_data) > 0L) {
     page_data$id[[nrow(page_data)]]
   } else {
     "null"
+  }
+
+  last_cursor_id <- "null"
+  if (!page_size_all && total_pages > 1L) {
+    last_cursor_offset <- as.integer(page_size * (total_pages - 1L) - 1L)
+    last_cursor_sql <- paste(
+      "SELECT id",
+      "FROM logging WHERE", where_clause,
+      order_clause,
+      "LIMIT 1 OFFSET ?"
+    )
+    last_cursor_result <- db_execute_query(
+      last_cursor_sql,
+      append(params, list(last_cursor_offset))
+    )
+    if (nrow(last_cursor_result) > 0L) {
+      last_cursor_id <- last_cursor_result$id[[1]]
+    }
   }
 
   links <- tibble::as_tibble(list(
@@ -551,7 +574,11 @@ get_logs_first_page <- function(
     } else {
       "null"
     },
-    "last" = "null"
+    "last" = if (identical(last_cursor_id, "null")) {
+      "null"
+    } else {
+      paste0("&page_after=", last_cursor_id, "&page_size=", page_size)
+    }
   ))
 
   meta <- tibble::as_tibble(list(
@@ -561,7 +588,7 @@ get_logs_first_page <- function(
     "prevItemID" = "null",
     "currentItemID" = 0L,
     "nextItemID" = if (has_next) current_page_last_id else "null",
-    "lastItemID" = "null",
+    "lastItemID" = last_cursor_id,
     "totalItems" = total_items
   ))
 

--- a/api/functions/logging-repository.R
+++ b/api/functions/logging-repository.R
@@ -480,6 +480,94 @@ get_logs_filtered <- function(
   tibble::as_tibble(data_result)
 }
 
+#' Get the first logs page using SQL count and limit
+#'
+#' Fetches only the requested first page plus one lookahead row. This avoids
+#' loading the repository safety cap into R before pagination.
+#'
+#' @param filters Named list of filter criteria
+#' @param sort_column Character, column to sort by. Default: "id"
+#' @param sort_direction Character, ASC or DESC. Default: "DESC"
+#' @param page_size Integer, number of rows to return
+#'
+#' @return Cursor pagination list with links, meta, and data
+#' @export
+get_logs_first_page <- function(
+  filters = list(),
+  sort_column = "id",
+  sort_direction = "DESC",
+  page_size = 10L
+) {
+  log_info("Fetching first logs page: sort={sort_column} {sort_direction}, page_size={page_size}")
+
+  validate_logging_column(sort_column, LOGGING_ALLOWED_SORT_COLUMNS, "sort")
+  sort_direction <- validate_sort_direction(sort_direction)
+  page_size <- suppressWarnings(as.integer(page_size))
+  if (is.na(page_size) || page_size < 1L) {
+    page_size <- 10L
+  }
+  page_size <- min(page_size, 500L)
+
+  where_result <- build_logging_where_clause(filters)
+  where_clause <- where_result$clause
+  params <- where_result$params
+  order_clause <- if (sort_column == "id") {
+    paste("ORDER BY id", sort_direction)
+  } else {
+    paste("ORDER BY", sort_column, sort_direction, ", id", sort_direction)
+  }
+
+  count_sql <- paste(
+    "SELECT COUNT(*) AS total",
+    "FROM logging WHERE", where_clause
+  )
+  count_result <- db_execute_query(count_sql, params)
+  total_items <- as.integer(count_result$total[[1]] %||% 0L)
+  total_pages <- if (total_items == 0L) 0L else ceiling(total_items / page_size)
+
+  data_sql <- paste(
+    "SELECT id, timestamp, address, agent, host, request_method, path,",
+    "query, post, status, duration, file, modified",
+    "FROM logging WHERE", where_clause,
+    order_clause,
+    "LIMIT ?"
+  )
+  lookahead_limit <- page_size + 1L
+  data_result <- tibble::as_tibble(db_execute_query(data_sql, append(params, list(lookahead_limit))))
+  has_next <- nrow(data_result) > page_size
+  page_data <- utils::head(data_result, page_size)
+
+  current_page_last_id <- if (nrow(page_data) > 0L) {
+    page_data$id[[nrow(page_data)]]
+  } else {
+    "null"
+  }
+
+  links <- tibble::as_tibble(list(
+    "prev" = "null",
+    "self" = paste0("&page_after=0&page_size=", page_size),
+    "next" = if (has_next) {
+      paste0("&page_after=", current_page_last_id, "&page_size=", page_size)
+    } else {
+      "null"
+    },
+    "last" = "null"
+  ))
+
+  meta <- tibble::as_tibble(list(
+    "perPage" = page_size,
+    "currentPage" = 1L,
+    "totalPages" = total_pages,
+    "prevItemID" = "null",
+    "currentItemID" = 0L,
+    "nextItemID" = if (has_next) current_page_last_id else "null",
+    "lastItemID" = "null",
+    "totalItems" = total_items
+  ))
+
+  list(links = links, meta = meta, data = page_data)
+}
+
 #' Parse filter string to filter list
 #'
 #' Converts the filter string from the endpoint into a list

--- a/api/tests/testthat/test-unit-compose-network.R
+++ b/api/tests/testthat/test-unit-compose-network.R
@@ -1,0 +1,29 @@
+library(testthat)
+
+find_repo_root <- function(start = getwd()) {
+  current <- normalizePath(start, mustWork = TRUE)
+  repeat {
+    candidate <- file.path(current, "docker-compose.yml")
+    if (file.exists(candidate)) {
+      return(current)
+    }
+    parent <- dirname(current)
+    if (identical(parent, current)) {
+      stop("docker-compose.yml not found from ", start, call. = FALSE)
+    }
+    current <- parent
+  }
+}
+
+repo_root <- find_repo_root()
+compose_path <- file.path(repo_root, "docker-compose.yml")
+
+test_that("async worker has outbound egress for external provider calls", {
+  skip_if_not_installed("yaml")
+
+  compose <- yaml::read_yaml(compose_path)
+
+  expect_true(isTRUE(compose$networks$backend$internal))
+  expect_true("backend" %in% compose$services$worker$networks)
+  expect_true("proxy" %in% compose$services$worker$networks)
+})

--- a/api/tests/testthat/test-unit-llm-batch-progress.R
+++ b/api/tests/testthat/test-unit-llm-batch-progress.R
@@ -1,0 +1,24 @@
+library(testthat)
+
+source_llm_batch_for_progress_tests <- function() {
+  env <- new.env(parent = globalenv())
+  env$generate_cluster_summary <- function(...) NULL
+  env$get_cached_summary <- function(...) NULL
+  env$create_progress_reporter <- function(...) function(...) invisible(NULL)
+  env$generate_and_validate_with_judge <- function(...) NULL
+  source_api_file("functions/llm-batch-generator.R", local = FALSE, envir = env)
+  env
+}
+
+test_that("LLM cluster progress message accepts character phenotype cluster IDs", {
+  env <- source_llm_batch_for_progress_tests()
+
+  expect_equal(
+    env$llm_cluster_progress_message("8", 1L, 5L),
+    "Cluster 8 (1/5)"
+  )
+  expect_equal(
+    env$llm_cluster_progress_message("functional cluster 8", 1L, 5L),
+    "Cluster functional cluster 8 (1/5)"
+  )
+})

--- a/api/tests/testthat/test-unit-logging-repository.R
+++ b/api/tests/testthat/test-unit-logging-repository.R
@@ -641,3 +641,60 @@ describe("parse_logging_filter", {
     expect_equal(result$path_contains, "/api/")
   })
 })
+
+describe("get_logs_first_page", {
+  it("uses SQL COUNT and page-size LIMIT instead of fetching the safety cap", {
+    calls <- list()
+    original_db_execute_query <- if (exists("db_execute_query", envir = .GlobalEnv)) {
+      get("db_execute_query", envir = .GlobalEnv)
+    } else {
+      NULL
+    }
+
+    assign("db_execute_query", function(sql, params = list(), conn = NULL) {
+      calls[[length(calls) + 1]] <<- list(sql = sql, params = params)
+      if (grepl("COUNT\\(\\*\\)", sql)) {
+        return(data.frame(total = 123L))
+      }
+      data.frame(
+        id = c(123L, 122L, 121L),
+        timestamp = as.POSIXct(c("2026-05-14 10:00:00", "2026-05-14 09:00:00", "2026-05-14 08:00:00")),
+        address = "127.0.0.1",
+        agent = "agent",
+        host = "localhost",
+        request_method = "GET",
+        path = "/api/logs/",
+        query = "",
+        post = "",
+        status = 200L,
+        duration = 1,
+        file = "",
+        modified = as.POSIXct(c("2026-05-14 10:00:00", "2026-05-14 09:00:00", "2026-05-14 08:00:00"))
+      )
+    }, envir = .GlobalEnv)
+
+    on.exit({
+      if (is.null(original_db_execute_query)) {
+        rm("db_execute_query", envir = .GlobalEnv)
+      } else {
+        assign("db_execute_query", original_db_execute_query, envir = .GlobalEnv)
+      }
+    }, add = TRUE)
+
+    result <- get_logs_first_page(
+      filters = list(),
+      sort_column = "id",
+      sort_direction = "DESC",
+      page_size = 2
+    )
+
+    expect_equal(length(calls), 2)
+    expect_match(calls[[1]]$sql, "SELECT COUNT\\(\\*\\) AS total")
+    expect_match(calls[[2]]$sql, "LIMIT \\?")
+    expect_equal(calls[[2]]$params[[1]], 3L)
+    expect_equal(nrow(result$data), 2)
+    expect_equal(result$meta$totalItems[[1]], 123L)
+    expect_equal(result$meta$nextItemID[[1]], 122L)
+    expect_false(any(vapply(calls[[2]]$params, identical, logical(1), 100000L)))
+  })
+})

--- a/api/tests/testthat/test-unit-logging-repository.R
+++ b/api/tests/testthat/test-unit-logging-repository.R
@@ -438,7 +438,7 @@ describe("build_logging_order_clause", {
 
   it("accepts valid sort column", {
     result <- build_logging_order_clause(sort_column = "timestamp")
-    expect_equal(result, "ORDER BY timestamp DESC")
+    expect_equal(result, "ORDER BY timestamp DESC, id DESC")
   })
 
   it("accepts valid sort direction", {
@@ -451,7 +451,7 @@ describe("build_logging_order_clause", {
       sort_column = "status",
       sort_direction = "ASC"
     )
-    expect_equal(result, "ORDER BY status ASC")
+    expect_equal(result, "ORDER BY status ASC, id ASC")
   })
 
   it("normalizes direction to uppercase", {
@@ -465,7 +465,12 @@ describe("build_logging_order_clause", {
   it("accepts all valid sort columns", {
     for (col in LOGGING_ALLOWED_SORT_COLUMNS) {
       result <- build_logging_order_clause(sort_column = col)
-      expect_equal(result, paste("ORDER BY", col, "DESC"))
+      expected <- if (col == "id") {
+        "ORDER BY id DESC"
+      } else {
+        paste("ORDER BY", col, "DESC, id DESC")
+      }
+      expect_equal(result, expected)
     }
   })
 
@@ -656,6 +661,9 @@ describe("get_logs_first_page", {
       if (grepl("COUNT\\(\\*\\)", sql)) {
         return(data.frame(total = 123L))
       }
+      if (grepl("OFFSET", sql)) {
+        return(data.frame(id = 2L))
+      }
       data.frame(
         id = c(123L, 122L, 121L),
         timestamp = as.POSIXct(c("2026-05-14 10:00:00", "2026-05-14 09:00:00", "2026-05-14 08:00:00")),
@@ -688,13 +696,70 @@ describe("get_logs_first_page", {
       page_size = 2
     )
 
-    expect_equal(length(calls), 2)
+    expect_equal(length(calls), 3)
     expect_match(calls[[1]]$sql, "SELECT COUNT\\(\\*\\) AS total")
     expect_match(calls[[2]]$sql, "LIMIT \\?")
     expect_equal(calls[[2]]$params[[1]], 3L)
+    expect_match(calls[[3]]$sql, "LIMIT 1 OFFSET \\?")
+    expect_equal(calls[[3]]$params[[1]], 121L)
     expect_equal(nrow(result$data), 2)
     expect_equal(result$meta$totalItems[[1]], 123L)
     expect_equal(result$meta$nextItemID[[1]], 122L)
+    expect_equal(result$meta$lastItemID[[1]], 2L)
     expect_false(any(vapply(calls[[2]]$params, identical, logical(1), 100000L)))
+  })
+
+  it("preserves page_size all semantics in the first-page path", {
+    calls <- list()
+    original_db_execute_query <- if (exists("db_execute_query", envir = .GlobalEnv)) {
+      get("db_execute_query", envir = .GlobalEnv)
+    } else {
+      NULL
+    }
+
+    assign("db_execute_query", function(sql, params = list(), conn = NULL) {
+      calls[[length(calls) + 1]] <<- list(sql = sql, params = params)
+      if (grepl("COUNT\\(\\*\\)", sql)) {
+        return(data.frame(total = 3L))
+      }
+      data.frame(
+        id = c(3L, 2L, 1L),
+        timestamp = as.POSIXct(c("2026-05-14 10:00:00", "2026-05-14 09:00:00", "2026-05-14 08:00:00")),
+        address = "127.0.0.1",
+        agent = "agent",
+        host = "localhost",
+        request_method = "GET",
+        path = "/api/logs/",
+        query = "",
+        post = "",
+        status = 200L,
+        duration = 1,
+        file = "",
+        modified = as.POSIXct(c("2026-05-14 10:00:00", "2026-05-14 09:00:00", "2026-05-14 08:00:00"))
+      )
+    }, envir = .GlobalEnv)
+
+    on.exit({
+      if (is.null(original_db_execute_query)) {
+        rm("db_execute_query", envir = .GlobalEnv)
+      } else {
+        assign("db_execute_query", original_db_execute_query, envir = .GlobalEnv)
+      }
+    }, add = TRUE)
+
+    result <- get_logs_first_page(
+      filters = list(),
+      sort_column = "id",
+      sort_direction = "DESC",
+      page_size = "all"
+    )
+
+    expect_equal(length(calls), 2)
+    expect_equal(calls[[2]]$params[[1]], 3L)
+    expect_equal(nrow(result$data), 3)
+    expect_equal(result$meta$perPage[[1]], 3L)
+    expect_equal(result$meta$totalPages[[1]], 1L)
+    expect_equal(result$meta$nextItemID[[1]], "null")
+    expect_equal(result$meta$lastItemID[[1]], "null")
   })
 })

--- a/api/version_spec.json
+++ b/api/version_spec.json
@@ -1,7 +1,7 @@
 {
   "title": "SysNDD API",
   "description": "This is the API powering the SysNDD website, allowing programmatic access to the database contents.",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "contact": {
     "name": "API Support",
     "url": "https://berntpopp.github.io/sysndd/api.html",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysndd",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysndd",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@unhead/vue": "^3.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/app/src/components/admin/AdminOperationPanel.spec.ts
+++ b/app/src/components/admin/AdminOperationPanel.spec.ts
@@ -1,0 +1,46 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import AdminOperationPanel from './AdminOperationPanel.vue';
+
+describe('AdminOperationPanel', () => {
+  it('renders a compact operation surface with title, meta, description, actions, and body', () => {
+    const wrapper = mount(AdminOperationPanel, {
+      props: {
+        title: 'Publication Metadata Refresh',
+        description: 'Refresh PubMed metadata without changing curated entities.',
+        meta: ['4,689 publications', '4,515 outdated'],
+      },
+      slots: {
+        actions: '<button type="button">Refresh Stats</button>',
+        default: '<button type="button">Refresh Publications</button>',
+      },
+    });
+
+    expect(wrapper.get('[data-testid="admin-operation-panel"]').classes()).toContain(
+      'admin-operation-panel'
+    );
+    expect(wrapper.get('h2').text()).toBe('Publication Metadata Refresh');
+    expect(wrapper.text()).toContain('Refresh PubMed metadata without changing curated entities.');
+    expect(wrapper.text()).toContain('4,689 publications');
+    expect(wrapper.text()).toContain('4,515 outdated');
+    expect(wrapper.findAll('button').map((button) => button.text())).toEqual([
+      'Refresh Stats',
+      'Refresh Publications',
+    ]);
+  });
+
+  it('marks danger panels without using dark card chrome', () => {
+    const wrapper = mount(AdminOperationPanel, {
+      props: {
+        title: 'Clear Cache',
+        tone: 'danger',
+      },
+      slots: {
+        default: '<button type="button">Clear</button>',
+      },
+    });
+
+    expect(wrapper.classes()).toContain('admin-operation-panel--danger');
+    expect(wrapper.classes()).not.toContain('border-dark');
+  });
+});

--- a/app/src/components/admin/AdminOperationPanel.vue
+++ b/app/src/components/admin/AdminOperationPanel.vue
@@ -1,0 +1,193 @@
+<template>
+  <section
+    class="admin-operation-panel"
+    :class="toneClass"
+    data-testid="admin-operation-panel"
+  >
+    <header class="admin-operation-panel__header">
+      <div class="admin-operation-panel__heading">
+        <div class="admin-operation-panel__title-line">
+          <component :is="headingTag" class="admin-operation-panel__title">
+            <i v-if="icon" :class="['bi', icon, 'admin-operation-panel__icon']" aria-hidden="true" />
+            {{ title }}
+          </component>
+          <span
+            v-for="item in normalizedMeta"
+            :key="item"
+            class="admin-operation-panel__meta"
+          >
+            {{ item }}
+          </span>
+        </div>
+        <p v-if="description" class="admin-operation-panel__description">
+          {{ description }}
+        </p>
+      </div>
+      <div v-if="$slots.actions" class="admin-operation-panel__actions">
+        <slot name="actions" />
+      </div>
+    </header>
+
+    <div class="admin-operation-panel__body">
+      <slot />
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = withDefaults(
+  defineProps<{
+    title: string;
+    description?: string;
+    meta?: string | string[] | null;
+    icon?: string;
+    headingTag?: 'h2' | 'h3' | 'h4';
+    tone?: 'default' | 'danger' | 'success' | 'warning';
+  }>(),
+  {
+    description: undefined,
+    meta: null,
+    icon: undefined,
+    headingTag: 'h2',
+    tone: 'default',
+  }
+);
+
+const normalizedMeta = computed(() => {
+  if (!props.meta) return [];
+  return Array.isArray(props.meta) ? props.meta.filter(Boolean) : [props.meta];
+});
+
+const toneClass = computed(() =>
+  props.tone === 'default' ? undefined : `admin-operation-panel--${props.tone}`
+);
+</script>
+
+<style scoped>
+.admin-operation-panel {
+  overflow: hidden;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  border-radius: var(--radius-lg, 0.5rem);
+  background: #fff;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
+  text-align: left;
+}
+
+.admin-operation-panel + .admin-operation-panel {
+  margin-top: 1rem;
+}
+
+.admin-operation-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.admin-operation-panel__heading {
+  min-width: 0;
+}
+
+.admin-operation-panel__title-line {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.admin-operation-panel__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin: 0;
+  color: var(--neutral-900, #212121);
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.admin-operation-panel__icon {
+  color: var(--medical-blue-700, #0d47a1);
+  font-size: 0.95rem;
+}
+
+.admin-operation-panel__meta {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.5rem;
+  padding: 0.125rem 0.5rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: var(--radius-full, 9999px);
+  background: #f8fafc;
+  color: #475569;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.admin-operation-panel__description {
+  margin: 0.25rem 0 0;
+  color: #64748b;
+  font-size: 0.875rem;
+  line-height: 1.45;
+}
+
+.admin-operation-panel__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.admin-operation-panel__body {
+  padding: 1rem 1.25rem 1.25rem;
+  text-align: left;
+}
+
+.admin-operation-panel--danger {
+  border-color: rgba(198, 40, 40, 0.28);
+}
+
+.admin-operation-panel--danger .admin-operation-panel__icon,
+.admin-operation-panel--danger .admin-operation-panel__title {
+  color: var(--status-danger, #c62828);
+}
+
+.admin-operation-panel--success {
+  border-color: rgba(46, 125, 50, 0.28);
+}
+
+.admin-operation-panel--success .admin-operation-panel__icon {
+  color: var(--status-success, #2e7d32);
+}
+
+.admin-operation-panel--warning {
+  border-color: rgba(245, 124, 0, 0.32);
+}
+
+.admin-operation-panel--warning .admin-operation-panel__icon {
+  color: var(--status-warning, #f57c00);
+}
+
+@media (max-width: 767.98px) {
+  .admin-operation-panel__header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+    padding: 0.875rem 1rem;
+  }
+
+  .admin-operation-panel__actions {
+    justify-content: flex-start;
+  }
+
+  .admin-operation-panel__body {
+    padding: 0.875rem 1rem 1rem;
+  }
+}
+</style>

--- a/app/src/components/annotations/ComparisonsRefreshCard.vue
+++ b/app/src/components/annotations/ComparisonsRefreshCard.vue
@@ -1,27 +1,11 @@
 <!-- components/annotations/ComparisonsRefreshCard.vue -->
 <template>
-  <BCard
-    header-tag="header"
-    body-class="p-2"
-    header-class="p-1"
-    border-variant="dark"
-    class="mb-3 text-start"
+  <AdminOperationPanel
+    title="Comparisons Data Refresh"
+    :meta="metaItems"
+    icon="bi-arrow-repeat"
+    heading-tag="h2"
   >
-    <template #header>
-      <h5 class="mb-0 text-start font-weight-bold d-flex align-items-center">
-        Comparisons Data Refresh
-        <span v-if="metadata.last_full_refresh" class="badge bg-secondary ms-2 fw-normal">
-          Last: {{ formatDate(metadata.last_full_refresh) }}
-        </span>
-        <span v-if="metadata.sources_count > 0" class="badge bg-info ms-2 fw-normal">
-          {{ metadata.sources_count }} sources
-        </span>
-        <span v-if="metadata.rows_imported > 0" class="badge bg-info ms-2 fw-normal">
-          {{ metadata.rows_imported.toLocaleString() }} rows
-        </span>
-      </h5>
-    </template>
-
     <div class="mb-3">
       <p class="text-muted small mb-2">
         Refresh comparisons data from 7 external NDD databases: Radboudumc, Gene2Phenotype,
@@ -58,12 +42,14 @@
     <BAlert v-if="job.status.value === 'failed'" variant="danger" show class="mt-2 mb-0">
       {{ job.error.value || 'Comparisons refresh failed. Check job history for details.' }}
     </BAlert>
-  </BCard>
+  </AdminOperationPanel>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue';
 import type { UseAsyncJobReturn } from '@/composables/useAsyncJob';
 import { formatDate } from '@/composables/annotations/useAnnotationFormatters';
+import AdminOperationPanel from '@/components/admin/AdminOperationPanel.vue';
 import JobProgressDisplay from './JobProgressDisplay.vue';
 
 export interface ComparisonsMetadata {
@@ -74,7 +60,7 @@ export interface ComparisonsMetadata {
   rows_imported: number;
 }
 
-defineProps<{
+const props = defineProps<{
   job: UseAsyncJobReturn;
   metadata: ComparisonsMetadata;
   loadingMetadata: boolean;
@@ -84,4 +70,14 @@ defineEmits<{
   (e: 'refresh-metadata'): void;
   (e: 'start-refresh'): void;
 }>();
+
+const metaItems = computed(() =>
+  [
+    props.metadata.last_full_refresh ? `Last: ${formatDate(props.metadata.last_full_refresh)}` : null,
+    props.metadata.sources_count > 0 ? `${props.metadata.sources_count} sources` : null,
+    props.metadata.rows_imported > 0
+      ? `${props.metadata.rows_imported.toLocaleString()} rows`
+      : null,
+  ].filter((item): item is string => Boolean(item))
+);
 </script>

--- a/app/src/components/annotations/DeprecatedEntitiesCard.vue
+++ b/app/src/components/annotations/DeprecatedEntitiesCard.vue
@@ -1,33 +1,12 @@
 <!-- components/annotations/DeprecatedEntitiesCard.vue -->
 <template>
-  <BCard
-    header-tag="header"
-    body-class="p-2"
-    header-class="p-1"
-    border-variant="dark"
-    class="mb-3 text-start"
+  <AdminOperationPanel
+    title="Deprecated OMIM Entities"
+    :meta="metaItems"
+    icon="bi-exclamation-triangle"
+    heading-tag="h2"
+    :tone="data.affected_entity_count > 0 ? 'warning' : 'default'"
   >
-    <template #header>
-      <h5 class="mb-0 text-start font-weight-bold d-flex align-items-center">
-        Deprecated OMIM Entities
-        <span v-if="data.mim2gene_date" class="badge bg-secondary ms-2 fw-normal">
-          mim2gene: {{ data.mim2gene_date }}
-        </span>
-        <span
-          v-if="data.affected_entity_count > 0"
-          class="badge bg-warning text-dark ms-2 fw-normal"
-        >
-          {{ data.affected_entity_count }} entities need review
-        </span>
-        <span
-          v-else-if="!loading && data.deprecated_count !== null"
-          class="badge bg-success ms-2 fw-normal"
-        >
-          No affected entities
-        </span>
-      </h5>
-    </template>
-
     <div class="mb-3">
       <BButton variant="outline-secondary" size="sm" :disabled="loading" @click="$emit('check')">
         <BSpinner v-if="loading" small type="grow" class="me-1" />
@@ -138,10 +117,12 @@
         </template>
       </BTable>
     </div>
-  </BCard>
+  </AdminOperationPanel>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue';
+import AdminOperationPanel from '@/components/admin/AdminOperationPanel.vue';
 import {
   truncateText,
   categoryBadgeClass,
@@ -155,7 +136,7 @@ export interface DeprecatedData {
   message: string | null;
 }
 
-defineProps<{
+const props = defineProps<{
   data: DeprecatedData;
   loading: boolean;
 }>();
@@ -172,6 +153,18 @@ const tableFields = [
   { key: 'deprecation_reason', label: 'Reason', sortable: false },
   { key: 'category', label: 'Category', sortable: true },
 ];
+
+const metaItems = computed(() =>
+  [
+    props.data.mim2gene_date ? `mim2gene: ${props.data.mim2gene_date}` : null,
+    props.data.affected_entity_count > 0
+      ? `${props.data.affected_entity_count} entities need review`
+      : null,
+    !props.loading && props.data.deprecated_count !== null && props.data.affected_entity_count === 0
+      ? 'No affected entities'
+      : null,
+  ].filter((item): item is string => Boolean(item))
+);
 </script>
 
 <style scoped>

--- a/app/src/components/annotations/HgncAnnotationsCard.spec.ts
+++ b/app/src/components/annotations/HgncAnnotationsCard.spec.ts
@@ -22,6 +22,13 @@ function mountCard() {
       hgncJob: idleJob,
       lastUpdated: null,
     },
+    global: {
+      stubs: {
+        AdminOperationPanel: {
+          template: '<section><slot /><slot name="actions" /></section>',
+        },
+      },
+    },
   });
 }
 

--- a/app/src/components/annotations/HgncAnnotationsCard.vue
+++ b/app/src/components/annotations/HgncAnnotationsCard.vue
@@ -1,21 +1,11 @@
 <!-- components/annotations/HgncAnnotationsCard.vue -->
 <template>
-  <BCard
-    header-tag="header"
-    body-class="p-1"
-    header-class="p-1"
-    border-variant="dark"
-    class="mb-3 text-start"
+  <AdminOperationPanel
+    title="Updating HGNC Data"
+    :meta="lastUpdated ? `Last: ${formatDate(lastUpdated)}` : null"
+    icon="bi-database"
+    heading-tag="h2"
   >
-    <template #header>
-      <h5 class="mb-0 text-start font-weight-bold">
-        Updating HGNC Data
-        <span v-if="lastUpdated" class="badge bg-secondary ms-2 fw-normal">
-          Last: {{ formatDate(lastUpdated) }}
-        </span>
-      </h5>
-    </template>
-
     <BButton variant="primary" :disabled="hgncJob.isLoading.value" @click="$emit('start-hgnc')">
       <BSpinner v-if="hgncJob.isLoading.value" small type="grow" class="me-2" />
       {{ hgncJob.isLoading.value ? 'Updating...' : 'Update HGNC Data' }}
@@ -25,12 +15,13 @@
       :job="hgncJob"
       idle-message="Downloading HGNC data; enriching with gnomAD constraints, AlphaFold IDs, and Ensembl coordinates. Typically a few minutes."
     />
-  </BCard>
+  </AdminOperationPanel>
 </template>
 
 <script setup lang="ts">
 import type { UseAsyncJobReturn } from '@/composables/useAsyncJob';
 import { formatDate } from '@/composables/annotations/useAnnotationFormatters';
+import AdminOperationPanel from '@/components/admin/AdminOperationPanel.vue';
 import JobProgressDisplay from './JobProgressDisplay.vue';
 
 defineProps<{

--- a/app/src/components/annotations/OntologyAnnotationsCard.vue
+++ b/app/src/components/annotations/OntologyAnnotationsCard.vue
@@ -1,21 +1,11 @@
 <!-- components/annotations/OntologyAnnotationsCard.vue -->
 <template>
-  <BCard
-    header-tag="header"
-    body-class="p-1"
-    header-class="p-1"
-    border-variant="dark"
-    class="mb-3 text-start"
+  <AdminOperationPanel
+    title="Updating Ontology Annotations"
+    :meta="lastUpdated ? `Last: ${formatDate(lastUpdated)}` : null"
+    icon="bi-diagram-3"
+    heading-tag="h2"
   >
-    <template #header>
-      <h5 class="mb-0 text-start font-weight-bold">
-        Updating Ontology Annotations
-        <span v-if="lastUpdated" class="badge bg-secondary ms-2 fw-normal">
-          Last: {{ formatDate(lastUpdated) }}
-        </span>
-      </h5>
-    </template>
-
     <BButton
       variant="primary"
       :disabled="ontologyJob.isLoading.value"
@@ -123,13 +113,14 @@
         </BProgress>
       </div>
     </BAlert>
-  </BCard>
+  </AdminOperationPanel>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue';
 import type { UseAsyncJobReturn } from '@/composables/useAsyncJob';
 import { formatDate } from '@/composables/annotations/useAnnotationFormatters';
+import AdminOperationPanel from '@/components/admin/AdminOperationPanel.vue';
 import JobProgressDisplay from './JobProgressDisplay.vue';
 
 export interface OntologyBlockedState {

--- a/app/src/components/annotations/PublicationRefreshCard.vue
+++ b/app/src/components/annotations/PublicationRefreshCard.vue
@@ -1,30 +1,11 @@
 <!-- components/annotations/PublicationRefreshCard.vue -->
 <template>
-  <BCard
-    header-tag="header"
-    body-class="p-2"
-    header-class="p-1"
-    border-variant="dark"
-    class="mb-3 text-start"
+  <AdminOperationPanel
+    title="Publication Metadata Refresh"
+    :meta="metaItems"
+    icon="bi-file-earmark-medical"
+    heading-tag="h2"
   >
-    <template #header>
-      <h5 class="mb-0 text-start font-weight-bold d-flex align-items-center">
-        Publication Metadata Refresh
-        <span v-if="stats.total !== null" class="badge bg-info ms-2 fw-normal">
-          {{ stats.total?.toLocaleString() }} publications
-        </span>
-        <span v-if="stats.oldest_update" class="badge bg-warning text-dark ms-2 fw-normal">
-          Oldest: {{ formatDate(stats.oldest_update) }}
-        </span>
-        <span
-          v-if="stats.outdated_count && stats.outdated_count > 0"
-          class="badge bg-danger ms-2 fw-normal"
-        >
-          {{ stats.outdated_count.toLocaleString() }} outdated
-        </span>
-      </h5>
-    </template>
-
     <div class="mb-3">
       <p class="text-muted small mb-2">
         Refresh publication metadata from PubMed. Publications are updated in place (no deletions).
@@ -160,12 +141,14 @@
         {{ job.error.value || 'Refresh failed. Check job history for details.' }}
       </BAlert>
     </div>
-  </BCard>
+  </AdminOperationPanel>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue';
 import type { UseAsyncJobReturn } from '@/composables/useAsyncJob';
 import { formatDate } from '@/composables/annotations/useAnnotationFormatters';
+import AdminOperationPanel from '@/components/admin/AdminOperationPanel.vue';
 
 export type FilterPreset = 'all' | '1year' | '6months' | '3months' | 'custom';
 
@@ -175,7 +158,7 @@ export interface PublicationStats {
   outdated_count: number | null;
 }
 
-defineProps<{
+const props = defineProps<{
   job: UseAsyncJobReturn;
   stats: PublicationStats;
   loadingStats: boolean;
@@ -198,4 +181,14 @@ function onCustomDateInput(event: Event): void {
   const target = event.target as HTMLInputElement;
   emit('update:customDate', target.value);
 }
+
+const metaItems = computed(() =>
+  [
+    props.stats.total !== null ? `${props.stats.total.toLocaleString()} publications` : null,
+    props.stats.oldest_update ? `Oldest: ${formatDate(props.stats.oldest_update)}` : null,
+    props.stats.outdated_count && props.stats.outdated_count > 0
+      ? `${props.stats.outdated_count.toLocaleString()} outdated`
+      : null,
+  ].filter((item): item is string => Boolean(item))
+);
 </script>

--- a/app/src/components/annotations/PubtatorStatsCard.vue
+++ b/app/src/components/annotations/PubtatorStatsCard.vue
@@ -1,30 +1,11 @@
 <!-- components/annotations/PubtatorStatsCard.vue -->
 <template>
-  <BCard
-    header-tag="header"
-    body-class="p-1"
-    header-class="p-1"
-    border-variant="dark"
-    class="mb-3 text-start"
+  <AdminOperationPanel
+    title="PubTator Cache Management"
+    :meta="metaItems"
+    icon="bi-journal-medical"
+    heading-tag="h2"
   >
-    <template #header>
-      <h5 class="mb-0 text-start font-weight-bold">
-        Pubtator Cache Management
-        <span v-if="stats.publication_count !== null" class="badge bg-info ms-2 fw-normal">
-          {{ stats.publication_count?.toLocaleString() }} publications
-        </span>
-        <span v-if="stats.gene_count !== null" class="badge bg-info ms-2 fw-normal">
-          {{ stats.gene_count?.toLocaleString() }} genes
-        </span>
-        <span
-          v-if="stats.novel_count !== null && stats.novel_count > 0"
-          class="badge bg-info ms-2 fw-normal"
-        >
-          {{ stats.novel_count?.toLocaleString() }} literature only
-        </span>
-      </h5>
-    </template>
-
     <div class="mb-2">
       <BButton variant="outline-secondary" size="sm" :disabled="loading" @click="$emit('refresh')">
         <BSpinner v-if="loading" small type="grow" class="me-1" />
@@ -59,17 +40,20 @@
       <router-link :to="{ name: 'ManagePubtator' }">Manage Cache</router-link>
       to fetch publications.
     </BAlert>
-  </BCard>
+  </AdminOperationPanel>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue';
+import AdminOperationPanel from '@/components/admin/AdminOperationPanel.vue';
+
 export interface PubtatorStats {
   publication_count: number | null;
   gene_count: number | null;
   novel_count: number | null;
 }
 
-defineProps<{
+const props = defineProps<{
   stats: PubtatorStats;
   loading: boolean;
 }>();
@@ -77,4 +61,16 @@ defineProps<{
 defineEmits<{
   (e: 'refresh'): void;
 }>();
+
+const metaItems = computed(() =>
+  [
+    props.stats.publication_count !== null
+      ? `${props.stats.publication_count.toLocaleString()} publications`
+      : null,
+    props.stats.gene_count !== null ? `${props.stats.gene_count.toLocaleString()} genes` : null,
+    props.stats.novel_count !== null && props.stats.novel_count > 0
+      ? `${props.stats.novel_count.toLocaleString()} literature only`
+      : null,
+  ].filter((item): item is string => Boolean(item))
+);
 </script>

--- a/app/src/components/small/GenericTable.spec.ts
+++ b/app/src/components/small/GenericTable.spec.ts
@@ -7,8 +7,9 @@ const items = [{ symbol: 'ARID1B' }];
 
 const bTableStub = {
   name: 'BTable',
-  props: ['stacked'],
-  template: '<div data-testid="b-table" :data-stacked="String(stacked)"><slot /></div>',
+  props: ['stacked', 'fixed'],
+  template:
+    '<div data-testid="b-table" :data-stacked="String(stacked)" :data-fixed="String(fixed)"><slot /></div>',
 };
 
 describe('GenericTable responsive mode', () => {
@@ -35,5 +36,21 @@ describe('GenericTable responsive mode', () => {
     });
 
     expect(wrapper.find('[data-testid="b-table"]').attributes('data-stacked')).toBe('false');
+  });
+
+  it('can opt out of fixed table layout for content-heavy public tables', () => {
+    const wrapper = mount(GenericTable, {
+      props: {
+        items,
+        fields,
+        sortBy: 'symbol',
+        sortDesc: false,
+        isBusy: false,
+        fixedLayout: false,
+      },
+      global: { stubs: { BTable: bTableStub } },
+    });
+
+    expect(wrapper.find('[data-testid="b-table"]').attributes('data-fixed')).toBe('false');
   });
 });

--- a/app/src/components/small/GenericTable.vue
+++ b/app/src/components/small/GenericTable.vue
@@ -6,9 +6,9 @@
     :busy="isBusy"
     :sort-by="localSortBy"
     :stacked="stackedMode"
+    :fixed="fixedLayout"
     head-variant="light"
     show-empty
-    fixed
     hover
     sort-icon-left
     no-local-sorting
@@ -483,6 +483,10 @@ export default {
       type: [String, Boolean],
       default: 'md',
     },
+    fixedLayout: {
+      type: Boolean,
+      default: true,
+    },
   },
   emits: ['update-sort', 'update:sort-by', 'head-clicked', 'sorted'],
   computed: {
@@ -623,7 +627,7 @@ export default {
   font-weight: 600;
   font-size: 0.8125rem;
   text-transform: uppercase;
-  letter-spacing: 0.025em;
+  letter-spacing: 0;
   color: #495057;
   background-color: #f8f9fa;
   border-bottom: 2px solid #dee2e6;

--- a/app/src/components/tables/TablesEntities.vue
+++ b/app/src/components/tables/TablesEntities.vue
@@ -25,33 +25,33 @@
 
             <template v-if="!loading" #toolbar>
               <!-- User Interface controls -->
-              <BRow v-if="showSearchInput || totalRows > perPage || showPaginationControls">
-                <BCol v-if="showSearchInput" class="my-1" sm="8">
+              <div
+                v-if="showSearchInput || totalRows > perPage || showPaginationControls"
+                class="entities-toolbar"
+              >
+                <div v-if="showSearchInput" class="entities-toolbar__search">
                   <TableSearchInput
                     v-model="filter['any'].content"
                     :placeholder="'Search any field by typing here'"
                     :debounce-time="500"
                     @update:model-value="filtered"
                   />
-                </BCol>
+                </div>
 
-                <BCol
+                <div
                   v-if="totalRows > perPage || showPaginationControls"
-                  class="my-1"
-                  :sm="showSearchInput ? 4 : 12"
+                  class="entities-toolbar__pagination"
                 >
-                  <BContainer>
-                    <TablePaginationControls
-                      :total-rows="totalRows"
-                      :initial-per-page="perPage"
-                      :page-options="pageOptions"
-                      :current-page="currentPage"
-                      @page-change="handlePageChange"
-                      @per-page-change="handlePerPageChange"
-                    />
-                  </BContainer>
-                </BCol>
-              </BRow>
+                  <TablePaginationControls
+                    :total-rows="totalRows"
+                    :initial-per-page="perPage"
+                    :page-options="pageOptions"
+                    :current-page="currentPage"
+                    @page-change="handlePageChange"
+                    @per-page-change="handlePerPageChange"
+                  />
+                </div>
+              </div>
               <!-- User Interface controls -->
             </template>
 
@@ -66,6 +66,7 @@
                 :fields="fields"
                 :field-details="fields_details"
                 :sort-by="sortBy"
+                :fixed-layout="false"
                 :stacked-mode="false"
                 @update-sort="handleSortUpdate"
               >
@@ -764,6 +765,75 @@ export default {
   line-height: 0.5;
   border-radius: 0.2rem;
 }
+
+.entities-toolbar {
+  display: grid;
+  grid-template-columns: minmax(18rem, 1fr) minmax(17rem, 24rem);
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.entities-toolbar__search,
+.entities-toolbar__pagination {
+  min-width: 0;
+}
+
+.entities-toolbar__pagination {
+  justify-self: end;
+  width: 100%;
+}
+
+.entities-toolbar__pagination :deep(.input-group) {
+  max-width: 10rem;
+  margin-left: auto;
+}
+
+.entities-toolbar__pagination :deep(.pagination) {
+  justify-content: flex-end;
+}
+
+:deep(.search-input) {
+  margin-bottom: 0 !important;
+  border-color: rgba(15, 23, 42, 0.18) !important;
+}
+
+:deep(.entities-table) {
+  table-layout: auto;
+}
+
+:deep(.entities-table th),
+:deep(.entities-table td) {
+  white-space: normal;
+}
+
+:deep(.entities-table th:nth-child(1)),
+:deep(.entities-table td:nth-child(1)),
+:deep(.entities-table th:nth-child(2)),
+:deep(.entities-table td:nth-child(2)),
+:deep(.entities-table th:nth-child(5)),
+:deep(.entities-table td:nth-child(5)),
+:deep(.entities-table th:nth-child(6)),
+:deep(.entities-table td:nth-child(6)),
+:deep(.entities-table th:nth-child(7)),
+:deep(.entities-table td:nth-child(7)) {
+  width: 1%;
+  white-space: nowrap;
+}
+
+:deep(.entities-table th:nth-child(3)),
+:deep(.entities-table td:nth-child(3)) {
+  min-width: 18rem;
+}
+
+:deep(.entities-table th:nth-child(4)),
+:deep(.entities-table td:nth-child(4)) {
+  min-width: 14rem;
+}
+
+:deep(.entities-table thead th) {
+  letter-spacing: 0;
+}
+
 .input-group > .input-group-prepend {
   flex: 0 0 35%;
 }
@@ -832,6 +902,25 @@ export default {
 @media (prefers-reduced-motion: reduce) {
   .entities-skeleton-line {
     animation: none;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .entities-toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .entities-toolbar__pagination {
+    justify-self: stretch;
+  }
+
+  .entities-toolbar__pagination :deep(.input-group) {
+    max-width: none;
+    margin-left: 0;
+  }
+
+  .entities-toolbar__pagination :deep(.pagination) {
+    justify-content: stretch;
   }
 }
 </style>

--- a/app/src/components/tables/TablesLogs.spec.ts
+++ b/app/src/components/tables/TablesLogs.spec.ts
@@ -73,6 +73,7 @@ interface LogsVm {
   deleteMode: string;
   totalRows: number;
   user_options: unknown[];
+  isBusy: boolean;
 }
 
 function makeRouter() {
@@ -180,6 +181,23 @@ describe('TablesLogs — v11.0 closeout F2b apiClient migration', () => {
     const wrapper = await mountTable();
     await (wrapper.vm as unknown as LogsVm).doLoadData();
     await flushPromises();
+  });
+
+  it('shows an inline loading state while logs are loading', async () => {
+    primeAuth('logs-loading-token');
+
+    server.use(
+      http.get('/api/user/list', () => HttpResponse.json([])),
+      http.get('/api/logs/', () =>
+        HttpResponse.json({ data: [], meta: [{ totalItems: 0, currentPage: 1, totalPages: 1 }] })
+      )
+    );
+
+    const wrapper = await mountTable();
+    (wrapper.vm as unknown as LogsVm).isBusy = true;
+    await flushPromises();
+
+    expect(wrapper.get('[data-testid="logs-loading-state"]').text()).toContain('Loading logs');
   });
 
   it('requestExcel issues GET /api/logs/?format=xlsx with the Bearer header', async () => {

--- a/app/src/components/tables/TablesLogs.vue
+++ b/app/src/components/tables/TablesLogs.vue
@@ -1,8 +1,7 @@
 <!-- src/components/tables/TablesLogs.vue -->
 <template>
-  <div class="container-fluid">
-    <BSpinner v-if="loading" label="Loading..." class="float-center m-5" />
-    <BContainer v-else fluid>
+  <div class="container-fluid logs-table">
+    <BContainer fluid>
       <BRow class="justify-content-md-center py-2">
         <BCol col md="12">
           <!-- User Interface controls -->
@@ -234,8 +233,13 @@
             </template>
             <!-- User Interface controls -->
 
+            <div v-if="isBusy" data-testid="logs-loading-state" class="logs-loading-state">
+              <BSpinner small class="me-2" />
+              Loading logs...
+            </div>
+
             <!-- Empty state when no logs match filters -->
-            <div v-if="!isBusy && items.length === 0" class="text-center py-4">
+            <div v-else-if="items.length === 0" class="text-center py-4">
               <i class="bi bi-journal-x fs-1 text-muted" />
               <p class="text-muted mt-2">No logs match your filters</p>
               <BButton v-if="hasActiveFilters" variant="link" @click="removeFilters">
@@ -245,7 +249,7 @@
 
             <!-- Main table element -->
             <GenericTable
-              v-else
+              v-else-if="items.length > 0"
               class="d-none d-md-table"
               :items="items"
               :fields="fields"
@@ -390,10 +394,6 @@
                 </BButton>
               </template>
             </GenericTable>
-            <div v-if="isBusy" class="d-md-none text-center text-muted py-3">
-              <BSpinner small class="me-2" />
-              Loading logs...
-            </div>
             <LogMobileRows
               v-if="!isBusy && items.length > 0"
               class="d-md-none"
@@ -417,6 +417,7 @@
 
       <!-- Delete Logs Confirmation Modal -->
       <BModal
+        v-if="showDeleteModal"
         v-model="showDeleteModal"
         title="Delete Logs"
         header-bg-variant="danger"
@@ -824,9 +825,7 @@ export default {
       });
     });
 
-    setTimeout(() => {
-      this.loading = false;
-    }, 500);
+    this.loading = false;
   },
   methods: {
     // Handle row click to open detail drawer
@@ -1230,6 +1229,10 @@ export default {
   margin-top: 0.5rem;
 }
 
+.logs-table {
+  padding-bottom: max(1rem, var(--app-footer-height, 48px));
+}
+
 .log-mobile-filters summary {
   display: inline-flex;
   align-items: center;
@@ -1246,6 +1249,19 @@ export default {
   grid-template-columns: 1fr;
   gap: 0.5rem;
   margin-top: 0.5rem;
+}
+
+.log-mobile-filters:not([open]) .log-mobile-filters__grid {
+  display: none;
+}
+
+.logs-loading-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 14rem;
+  color: #526070;
+  font-size: 0.875rem;
 }
 
 /* Input group styles */

--- a/app/src/types/llm.ts
+++ b/app/src/types/llm.ts
@@ -136,8 +136,18 @@ export interface RegenerationJobResponse {
   job_id: string;
   status: string;
   cluster_type: ClusterType | 'all';
+  cluster_types?: ClusterType[];
   force: boolean;
   status_url: string;
+  results?: Partial<Record<ClusterType, RegenerationChildJobResult>>;
+}
+
+export interface RegenerationChildJobResult {
+  job_id?: string;
+  status?: string;
+  status_url?: string;
+  skipped?: boolean;
+  reason?: string;
 }
 
 /**

--- a/app/src/views/admin/AdminStatistics.spec.ts
+++ b/app/src/views/admin/AdminStatistics.spec.ts
@@ -41,6 +41,39 @@ afterEach(() => {
 });
 
 describe('AdminStatistics — F2a Bearer-via-interceptor', () => {
+  function mountView() {
+    return mount(AdminStatistics, {
+      global: {
+        provide: {
+          axios,
+        },
+        stubs: {
+          BContainer: { template: '<div><slot /></div>' },
+          BRow: { template: '<div><slot /></div>' },
+          BCol: { template: '<div><slot /></div>' },
+          BCard: { template: '<div><slot name="header" /><slot /></div>' },
+          BButton: { template: '<button><slot /></button>' },
+          BForm: { template: '<form><slot /></form>' },
+          BFormGroup: {
+            props: ['label'],
+            template: '<label><span>{{ label }}</span><slot /></label>',
+          },
+          BFormInput: {
+            props: ['type', 'modelValue'],
+            template: '<input :type="type" :value="modelValue" />',
+          },
+          BFormRadioGroup: { template: '<div />' },
+          BFormCheckboxGroup: { template: '<div />' },
+          EntityTrendChart: { template: '<div />' },
+          ContributorBarChart: { template: '<div />' },
+          ReReviewBarChart: { template: '<div />' },
+          StatCard: { template: '<div />' },
+          'router-link': true,
+        },
+      },
+    });
+  }
+
   it('sends Bearer on GET /api/statistics/entities_over_time', async () => {
     const { token } = primeAuth();
     let sawRequest = false;
@@ -62,35 +95,21 @@ describe('AdminStatistics — F2a Bearer-via-interceptor', () => {
       http.get('*/api/statistics/updated_statuses', () => HttpResponse.json({}))
     );
 
-    mount(AdminStatistics, {
-      global: {
-        provide: {
-          axios,
-        },
-        stubs: {
-          BContainer: { template: '<div><slot /></div>' },
-          BRow: { template: '<div><slot /></div>' },
-          BCol: { template: '<div><slot /></div>' },
-          BCard: { template: '<div><slot name="header" /><slot /></div>' },
-          BButton: { template: '<button><slot /></button>' },
-          BForm: { template: '<form><slot /></form>' },
-          BFormGroup: { template: '<div><slot /></div>' },
-          BFormInput: { template: '<input />' },
-          BFormRadioGroup: { template: '<div />' },
-          BFormCheckboxGroup: { template: '<div />' },
-          EntityTrendChart: { template: '<div />' },
-          ContributorBarChart: { template: '<div />' },
-          ReReviewBarChart: { template: '<div />' },
-          StatCard: { template: '<div />' },
-          'router-link': true,
-        },
-      },
-    });
+    mountView();
 
     // Allow the mount → fetchStatistics → axios → MSW path to complete.
     await new Promise((r) => setTimeout(r, 0));
     await new Promise((r) => setTimeout(r, 0));
 
     expect(sawRequest).toBe(true);
+  });
+
+  it('renders a compact date range control panel', () => {
+    const wrapper = mountView();
+
+    const controlPanel = wrapper.get('[data-testid="admin-statistics-controls"]');
+    expect(controlPanel.text()).toContain('Reporting window');
+    expect(controlPanel.findAll('input[type="date"]')).toHaveLength(2);
+    expect(controlPanel.find('button').text()).toContain('Apply');
   });
 });

--- a/app/src/views/admin/AdminStatistics.spec.ts
+++ b/app/src/views/admin/AdminStatistics.spec.ts
@@ -41,6 +41,18 @@ afterEach(() => {
 });
 
 describe('AdminStatistics — F2a Bearer-via-interceptor', () => {
+  function stubStatisticsEndpoints() {
+    server.use(
+      http.get('*/api/statistics/entities_over_time', () => HttpResponse.json({ data: [] })),
+      http.get('*/api/statistics/leaderboard', () => HttpResponse.json({ data: [] })),
+      http.get('*/api/statistics/rereview_leaderboard', () => HttpResponse.json({ data: [] })),
+      http.get('*/api/statistics/updates', () => HttpResponse.json({})),
+      http.get('*/api/statistics/rereview', () => HttpResponse.json({})),
+      http.get('*/api/statistics/updated_reviews', () => HttpResponse.json({})),
+      http.get('*/api/statistics/updated_statuses', () => HttpResponse.json({}))
+    );
+  }
+
   function mountView() {
     return mount(AdminStatistics, {
       global: {
@@ -105,6 +117,8 @@ describe('AdminStatistics — F2a Bearer-via-interceptor', () => {
   });
 
   it('renders a compact date range control panel', () => {
+    stubStatisticsEndpoints();
+
     const wrapper = mountView();
 
     const controlPanel = wrapper.get('[data-testid="admin-statistics-controls"]');

--- a/app/src/views/admin/AdminStatistics.vue
+++ b/app/src/views/admin/AdminStatistics.vue
@@ -158,13 +158,12 @@
       <!-- Existing text stats (kept for reference) -->
       <BRow v-if="statistics" class="mb-3">
         <BCol md="6" class="mb-3">
-          <BCard header-tag="header" body-class="p-3" header-class="p-2" border-variant="dark">
-            <template #header>
-              <h5 class="mb-0 text-start">
-                Updates Statistics
-                <small class="text-muted">({{ startDate }} to {{ endDate }})</small>
-              </h5>
-            </template>
+          <AdminOperationPanel
+            title="Updates Statistics"
+            :meta="`${startDate} to ${endDate}`"
+            icon="bi-activity"
+            heading-tag="h3"
+          >
             <p class="mb-1">
               Total new entities:
               <span class="stats-number">{{ statistics.total_new_entities }}</span>
@@ -176,16 +175,15 @@
               Average per day:
               <span class="stats-number">{{ formatDecimal(statistics.average_per_day) }}</span>
             </p>
-          </BCard>
+          </AdminOperationPanel>
         </BCol>
         <BCol v-if="reReviewStatistics" md="6" class="mb-3">
-          <BCard header-tag="header" body-class="p-3" header-class="p-2" border-variant="dark">
-            <template #header>
-              <h5 class="mb-0 text-start">
-                Re-review Statistics
-                <small class="text-muted">({{ startDate }} to {{ endDate }})</small>
-              </h5>
-            </template>
+          <AdminOperationPanel
+            title="Re-review Statistics"
+            :meta="`${startDate} to ${endDate}`"
+            icon="bi-clipboard-check"
+            heading-tag="h3"
+          >
             <p class="mb-1">
               Total re-reviews:
               <span class="stats-number">{{ reReviewStatistics.total_rereviews }}</span>
@@ -202,39 +200,37 @@
                 formatDecimal(reReviewStatistics.average_per_day)
               }}</span>
             </p>
-          </BCard>
+          </AdminOperationPanel>
         </BCol>
       </BRow>
       <BRow v-if="updatedReviewsStatistics || updatedStatusesStatistics" class="mb-3">
         <BCol v-if="updatedReviewsStatistics" md="6" class="mb-3">
-          <BCard header-tag="header" body-class="p-3" header-class="p-2" border-variant="dark">
-            <template #header>
-              <h5 class="mb-0 text-start">
-                Updated Reviews Statistics
-                <small class="text-muted">({{ startDate }} to {{ endDate }})</small>
-              </h5>
-            </template>
+          <AdminOperationPanel
+            title="Updated Reviews Statistics"
+            :meta="`${startDate} to ${endDate}`"
+            icon="bi-card-checklist"
+            heading-tag="h3"
+          >
             <p class="mb-0">
               Total updated reviews:
               <span class="stats-number">{{ updatedReviewsStatistics.total_updated_reviews }}</span>
             </p>
-          </BCard>
+          </AdminOperationPanel>
         </BCol>
         <BCol v-if="updatedStatusesStatistics" md="6" class="mb-3">
-          <BCard header-tag="header" body-class="p-3" header-class="p-2" border-variant="dark">
-            <template #header>
-              <h5 class="mb-0 text-start">
-                Updated Statuses Statistics
-                <small class="text-muted">({{ startDate }} to {{ endDate }})</small>
-              </h5>
-            </template>
+          <AdminOperationPanel
+            title="Updated Statuses Statistics"
+            :meta="`${startDate} to ${endDate}`"
+            icon="bi-list-check"
+            heading-tag="h3"
+          >
             <p class="mb-0">
               Total updated statuses:
               <span class="stats-number">{{
                 updatedStatusesStatistics.total_updated_statuses
               }}</span>
             </p>
-          </BCard>
+          </AdminOperationPanel>
         </BCol>
       </BRow>
     </BContainer>
@@ -243,6 +239,7 @@
 
 <script setup lang="ts">
 import AuthenticatedPageShell from '@/components/layout/AuthenticatedPageShell.vue';
+import AdminOperationPanel from '@/components/admin/AdminOperationPanel.vue';
 import { ref, computed, onMounted, inject } from 'vue';
 import type { AxiosInstance } from 'axios';
 import {

--- a/app/src/views/admin/AdminStatistics.vue
+++ b/app/src/views/admin/AdminStatistics.vue
@@ -5,28 +5,49 @@
     full-width
   >
     <BContainer fluid class="py-3">
-      <!-- Header with date controls -->
-      <BRow class="mb-3 align-items-center">
-        <BCol md="6">
-          <small v-if="lastUpdated" class="text-muted">
+      <section class="admin-statistics-controls" data-testid="admin-statistics-controls">
+        <div class="admin-statistics-controls__status">
+          <span class="admin-statistics-controls__eyebrow">Reporting window</span>
+          <span v-if="lastUpdated" class="admin-statistics-controls__updated">
             Data as of {{ formatDateTime(lastUpdated) }}
-            <BButton size="sm" variant="link" class="p-0 ms-1" @click="refreshAll">
-              <i class="bi bi-arrow-clockwise"></i> Refresh
+          </span>
+        </div>
+        <BForm class="admin-statistics-controls__form" @submit.prevent="fetchStatistics">
+          <BFormGroup
+            label="From"
+            label-for="admin-statistics-start-date"
+            label-class="admin-statistics-controls__label"
+            class="admin-statistics-controls__field"
+          >
+            <BFormInput
+              id="admin-statistics-start-date"
+              v-model="startDate"
+              type="date"
+              size="sm"
+            />
+          </BFormGroup>
+          <BFormGroup
+            label="To"
+            label-for="admin-statistics-end-date"
+            label-class="admin-statistics-controls__label"
+            class="admin-statistics-controls__field"
+          >
+            <BFormInput id="admin-statistics-end-date" v-model="endDate" type="date" size="sm" />
+          </BFormGroup>
+          <div class="admin-statistics-controls__actions">
+            <BButton type="submit" variant="primary" size="sm">Apply</BButton>
+            <BButton
+              variant="outline-secondary"
+              size="sm"
+              :disabled="loading.trend || loading.leaderboard || loading.reReviewLeaderboard"
+              @click="refreshAll"
+            >
+              <i class="bi bi-arrow-clockwise" aria-hidden="true"></i>
+              Refresh
             </BButton>
-          </small>
-        </BCol>
-        <BCol md="6">
-          <BForm inline class="justify-content-md-end" @submit.prevent="fetchStatistics">
-            <BFormGroup label="From" label-class="small" class="mb-0 me-2">
-              <BFormInput v-model="startDate" type="date" size="sm" />
-            </BFormGroup>
-            <BFormGroup label="To" label-class="small" class="mb-0 me-2">
-              <BFormInput v-model="endDate" type="date" size="sm" />
-            </BFormGroup>
-            <BButton type="submit" variant="primary" size="sm" class="mt-3"> Apply </BButton>
-          </BForm>
-        </BCol>
-      </BRow>
+          </div>
+        </BForm>
+      </section>
 
       <!-- KPI Cards Row -->
       <BRow class="mb-4">
@@ -45,18 +66,24 @@
         <BCol>
           <BCard>
             <template #header>
-              <div class="d-flex justify-content-between align-items-center">
-                <h5 class="mb-0">Entity Submissions Over Time</h5>
+              <div class="admin-chart-header">
+                <div>
+                  <h2 class="admin-chart-title">Entity Submissions Over Time</h2>
+                  <p class="admin-chart-description">
+                    {{ trendDescription }}
+                  </p>
+                </div>
                 <BFormRadioGroup
                   v-model="granularity"
                   :options="granularityOptions"
                   button-variant="outline-primary"
+                  class="admin-chart-control"
                   size="sm"
                   buttons
                 />
               </div>
-              <div class="d-flex justify-content-between align-items-center mt-2">
-                <div class="d-flex align-items-center gap-2">
+              <div class="admin-chart-toolbar">
+                <div class="admin-chart-toolbar__group">
                   <BFormRadioGroup
                     v-model="nddFilter"
                     :options="nddFilterOptions"
@@ -75,15 +102,13 @@
                 <BFormCheckboxGroup
                   v-model="selectedCategories"
                   :options="categoryFilterOptions"
+                  class="admin-chart-toolbar__categories"
                   size="sm"
                   buttons
                   button-variant="outline-secondary"
                 />
               </div>
             </template>
-            <p class="text-muted small mb-2">
-              {{ trendDescription }}
-            </p>
             <EntityTrendChart
               :entity-data="trendData"
               :category-data="categoryDisplay === 'by_category' ? trendCategoryData : undefined"
@@ -435,7 +460,136 @@ onMounted(() => {
 </script>
 
 <style scoped>
+.admin-statistics-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
+  align-items: end;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  padding: 0.875rem 1rem;
+  border: 1px solid #d7dee8;
+  border-radius: 8px;
+  background: #f8fafc;
+}
+
+.admin-statistics-controls__status {
+  display: flex;
+  min-width: 13rem;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.admin-statistics-controls__eyebrow {
+  color: #24364b;
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+.admin-statistics-controls__updated {
+  color: #5c6f82;
+  font-size: 0.8125rem;
+}
+
+.admin-statistics-controls__form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.625rem;
+  align-items: end;
+  justify-content: flex-end;
+}
+
+.admin-statistics-controls__field {
+  margin-bottom: 0;
+}
+
+.admin-statistics-controls__field :deep(input) {
+  min-width: 9.5rem;
+}
+
+.admin-statistics-controls__label {
+  margin-bottom: 0.25rem;
+  color: #41576f;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.admin-statistics-controls__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.admin-chart-header {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.admin-chart-title {
+  margin: 0;
+  color: #24364b;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.admin-chart-description {
+  max-width: 52rem;
+  margin: 0.25rem 0 0;
+  color: #5c6f82;
+  font-size: 0.8125rem;
+}
+
+.admin-chart-control {
+  flex-shrink: 0;
+}
+
+.admin-chart-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.625rem 1rem;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 0.875rem;
+}
+
+.admin-chart-toolbar__group,
+.admin-chart-toolbar__categories {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
 .stats-number {
   font-weight: bold;
+}
+
+@media (max-width: 767.98px) {
+  .admin-statistics-controls,
+  .admin-statistics-controls__form,
+  .admin-statistics-controls__actions,
+  .admin-chart-header,
+  .admin-chart-toolbar {
+    align-items: stretch;
+  }
+
+  .admin-statistics-controls,
+  .admin-statistics-controls__form,
+  .admin-chart-header {
+    flex-direction: column;
+  }
+
+  .admin-statistics-controls__form,
+  .admin-statistics-controls__field,
+  .admin-statistics-controls__actions,
+  .admin-statistics-controls__actions :deep(.btn),
+  .admin-chart-control {
+    width: 100%;
+  }
+
+  .admin-statistics-controls__field :deep(input) {
+    width: 100%;
+  }
 }
 </style>

--- a/app/src/views/admin/ManageAbout.vue
+++ b/app/src/views/admin/ManageAbout.vue
@@ -9,62 +9,46 @@
       <BContainer fluid>
         <BRow class="justify-content-md-center py-2">
           <BCol md="12" lg="11">
-            <BCard header-tag="header" body-class="p-3" header-class="p-2" border-variant="dark">
-              <template #header>
-                <BRow>
-                  <BCol>
-                    <div class="mb-1 text-start fw-semibold">
-                      <span>Publication status</span>
-                      <BBadge :variant="isDraft ? 'warning' : 'success'" class="ms-2">
-                        {{ isDraft ? 'Draft' : 'Published' }}
-                      </BBadge>
-                      <BBadge v-if="currentVersion" variant="secondary" class="ms-2">
-                        v{{ currentVersion }}
-                      </BBadge>
-                      <BBadge variant="info" class="ms-2">
-                        {{ sections.length }} section{{ sections.length !== 1 ? 's' : '' }}
-                      </BBadge>
-                    </div>
-                  </BCol>
-                  <BCol class="text-end">
-                    <BButton
-                      v-b-tooltip.hover
-                      size="sm"
-                      variant="outline-secondary"
-                      class="me-1"
-                      title="Save as draft"
-                      :disabled="isSaving || isPublishing || sections.length === 0"
-                      @click="handleSaveDraft"
-                    >
-                      <BSpinner v-if="isSaving" small />
-                      <i v-else class="bi bi-save" />
-                      Save Draft
-                    </BButton>
-                    <BButton
-                      v-b-tooltip.hover
-                      size="sm"
-                      variant="success"
-                      class="me-1"
-                      title="Publish content"
-                      :disabled="isSaving || isPublishing || sections.length === 0"
-                      @click="handlePublish"
-                    >
-                      <BSpinner v-if="isPublishing" small />
-                      <i v-else class="bi bi-globe" />
-                      Publish
-                    </BButton>
-                    <BButton
-                      v-b-tooltip.hover
-                      size="sm"
-                      variant="outline-primary"
-                      title="View live About page"
-                      :href="'/About'"
-                      target="_blank"
-                    >
-                      <i class="bi bi-eye" />
-                    </BButton>
-                  </BCol>
-                </BRow>
+            <AdminOperationPanel
+              title="Publication Status"
+              :meta="statusMeta"
+              icon="bi-file-earmark-richtext"
+            >
+              <template #actions>
+                <BButton
+                  v-b-tooltip.hover
+                  size="sm"
+                  variant="outline-secondary"
+                  title="Save as draft"
+                  :disabled="isSaving || isPublishing || sections.length === 0"
+                  @click="handleSaveDraft"
+                >
+                  <BSpinner v-if="isSaving" small />
+                  <i v-else class="bi bi-save" />
+                  Save Draft
+                </BButton>
+                <BButton
+                  v-b-tooltip.hover
+                  size="sm"
+                  variant="success"
+                  title="Publish content"
+                  :disabled="isSaving || isPublishing || sections.length === 0"
+                  @click="handlePublish"
+                >
+                  <BSpinner v-if="isPublishing" small />
+                  <i v-else class="bi bi-globe" />
+                  Publish
+                </BButton>
+                <BButton
+                  v-b-tooltip.hover
+                  size="sm"
+                  variant="outline-primary"
+                  title="View live About page"
+                  :href="'/About'"
+                  target="_blank"
+                >
+                  <i class="bi bi-eye" />
+                </BButton>
               </template>
 
               <!-- Status Messages -->
@@ -132,18 +116,18 @@
                   </BButton>
                 </div>
               </template>
-            </BCard>
+            </AdminOperationPanel>
 
             <!-- Help Card -->
-            <BCard class="mt-3" body-class="p-2" border-variant="light">
-              <div class="d-flex align-items-center">
+            <aside class="cms-editor-tip mt-3">
+              <div class="d-flex align-items-center gap-2">
                 <i class="bi bi-lightbulb text-warning me-2" />
                 <span class="text-muted small">
                   <strong>Tips:</strong> Use markdown for formatting. Drag sections to reorder.
                   Changes auto-save as drafts.
                 </span>
               </div>
-            </BCard>
+            </aside>
           </BCol>
         </BRow>
 
@@ -169,7 +153,8 @@
 
 <script setup lang="ts">
 import AuthenticatedPageShell from '@/components/layout/AuthenticatedPageShell.vue';
-import { ref, onMounted, onBeforeUnmount } from 'vue';
+import AdminOperationPanel from '@/components/admin/AdminOperationPanel.vue';
+import { computed, ref, onMounted, onBeforeUnmount } from 'vue';
 import { useCmsContent } from '@/composables';
 import type { AboutSection } from '@/types';
 import SectionList from '@/components/cms/SectionList.vue';
@@ -193,6 +178,13 @@ const {
 
 const showPublishModal = ref(false);
 const successMessage = ref<string | null>(null);
+const statusMeta = computed(() =>
+  [
+    isDraft.value ? 'Draft' : 'Published',
+    currentVersion.value ? `v${currentVersion.value}` : null,
+    `${sections.value.length} section${sections.value.length !== 1 ? 's' : ''}`,
+  ].filter((item): item is string => Boolean(item))
+);
 
 // Default sections matching the current About page content
 const defaultSections: AboutSection[] = [
@@ -375,5 +367,10 @@ function addInitialSection() {
 </script>
 
 <style scoped>
-/* Match other admin views styling */
+.cms-editor-tip {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: var(--radius-lg, 0.5rem);
+  background: #fff;
+  padding: 0.75rem 1rem;
+}
 </style>

--- a/app/src/views/admin/ManageBackups.spec.ts
+++ b/app/src/views/admin/ManageBackups.spec.ts
@@ -208,4 +208,18 @@ describe('ManageBackups — v11.0 closeout F2b apiClient migration', () => {
     await (wrapper.vm as unknown as BackupsVm).triggerBackup();
     await flushPromises();
   });
+
+  it('keeps the manual backup operation inside the inventory table shell', () => {
+    primeAuth('layout-token');
+
+    server.use(
+      http.get('/api/backup/list', () =>
+        HttpResponse.json({ data: [], meta: { total_count: 0, total_size_bytes: 0 } })
+      )
+    );
+
+    const wrapper = mountView();
+
+    expect(wrapper.find('[data-testid="backup-manual-operation"]').exists()).toBe(true);
+  });
 });

--- a/app/src/views/admin/ManageBackups.vue
+++ b/app/src/views/admin/ManageBackups.vue
@@ -12,8 +12,21 @@
             <TableShell
               title="Backup inventory"
               :meta="`${meta.total_count} backups · ${formatFileSize(meta.total_size_bytes)} total`"
+              description="Download, restore, delete, or create database backups from one inventory surface."
             >
               <template #actions>
+                <BButton
+                  v-b-tooltip.hover
+                  variant="primary"
+                  size="sm"
+                  data-testid="backup-manual-operation"
+                  :disabled="backupJob.isLoading.value"
+                  title="Create an on-demand database backup"
+                  @click="triggerBackup"
+                >
+                  <BSpinner v-if="backupJob.isLoading.value" small type="grow" class="me-1" />
+                  {{ backupJob.isLoading.value ? 'Backing up...' : 'Backup now' }}
+                </BButton>
                 <BButton
                   v-b-tooltip.hover
                   size="sm"
@@ -40,17 +53,16 @@
               </template>
 
               <template #toolbar>
-                <!-- Quick filters row -->
-                <BRow class="g-2">
-                  <BCol>
-                    <div class="d-flex gap-2 align-items-center flex-wrap">
-                      <span class="text-muted small">Quick filters:</span>
+                <div class="backup-toolbar">
+                  <div class="backup-toolbar__filters" aria-label="Backup type quick filters">
+                    <span class="backup-toolbar__label">Type</span>
+                    <div class="backup-toolbar__chips">
                       <BButton
                         v-for="preset in quickFilters"
                         :key="preset.value"
                         size="sm"
                         :variant="typeFilter === preset.value ? 'primary' : 'outline-secondary'"
-                        class="py-0"
+                        class="backup-filter-chip"
                         @click="setTypeFilter(preset.value)"
                       >
                         {{ preset.label }}
@@ -59,99 +71,67 @@
                         </BBadge>
                       </BButton>
                     </div>
-                  </BCol>
-                </BRow>
+                  </div>
 
-                <!-- Search + Pagination row -->
-                <BRow class="g-2 mt-1">
-                  <BCol sm="6">
-                    <BInputGroup>
-                      <template #prepend>
-                        <BInputGroupText>
-                          <i class="bi bi-search" aria-hidden="true" />
-                        </BInputGroupText>
-                      </template>
+                  <div class="backup-toolbar__controls">
+                    <div class="backup-search">
+                      <i class="bi bi-search backup-search__icon" aria-hidden="true" />
                       <BFormInput
                         v-model="searchQuery"
                         placeholder="Search by filename..."
+                        class="backup-search__input"
                         debounce="300"
                         type="search"
                       />
-                    </BInputGroup>
-                  </BCol>
-                  <BCol sm="6">
-                    <div class="d-flex justify-content-end align-items-center gap-2">
-                      <BFormGroup label="Per page" label-class="small text-muted me-2" class="mb-0">
-                        <BFormSelect
-                          v-model="perPage"
-                          :options="pageOptions"
-                          size="sm"
-                          style="width: 80px"
-                        />
-                      </BFormGroup>
-                      <BPagination
-                        v-if="filteredBackups.length > perPage"
-                        v-model="currentPage"
-                        :total-rows="filteredBackups.length"
-                        :per-page="perPage"
-                        size="sm"
-                        class="mb-0"
-                        first-text="«"
-                        prev-text="‹"
-                        next-text="›"
-                        last-text="»"
-                      />
                     </div>
-                  </BCol>
-                </BRow>
 
-                <!-- Filters + count row -->
-                <BRow class="g-2 mt-1">
-                  <BCol sm="4">
-                    <BFormSelect v-model="typeFilter" size="sm">
-                      <BFormSelectOption :value="null">All Types</BFormSelectOption>
-                      <BFormSelectOption value="manual">Manual</BFormSelectOption>
-                      <BFormSelectOption value="auto">Automatic</BFormSelectOption>
-                      <BFormSelectOption value="pre-restore">Pre-Restore</BFormSelectOption>
-                    </BFormSelect>
-                  </BCol>
-                  <BCol sm="4">
-                    <BFormSelect v-model="compressionFilter" size="sm">
-                      <BFormSelectOption :value="null">All Formats</BFormSelectOption>
-                      <BFormSelectOption value="compressed">Compressed (.gz)</BFormSelectOption>
-                      <BFormSelectOption value="uncompressed"
-                        >Uncompressed (.sql)</BFormSelectOption
-                      >
-                    </BFormSelect>
-                  </BCol>
-                  <BCol sm="4" class="text-end">
-                    <span class="text-muted small">
+                    <label class="backup-select-label">
+                      <span>Format</span>
+                      <BFormSelect v-model="compressionFilter" size="sm">
+                        <BFormSelectOption :value="null">All</BFormSelectOption>
+                        <BFormSelectOption value="compressed">.gz</BFormSelectOption>
+                        <BFormSelectOption value="uncompressed">.sql</BFormSelectOption>
+                      </BFormSelect>
+                    </label>
+
+                    <label class="backup-select-label">
+                      <span>Per page</span>
+                      <BFormSelect v-model="perPage" :options="pageOptions" size="sm" />
+                    </label>
+                  </div>
+
+                  <div class="backup-toolbar__footer">
+                    <span class="backup-count">
                       Showing {{ paginationStart }}-{{ paginationEnd }} of
                       {{ filteredBackups.length }}
                     </span>
-                  </BCol>
-                </BRow>
+                    <BPagination
+                      v-if="filteredBackups.length > perPage"
+                      v-model="currentPage"
+                      :total-rows="filteredBackups.length"
+                      :per-page="perPage"
+                      size="sm"
+                      class="mb-0"
+                      first-text="«"
+                      prev-text="‹"
+                      next-text="›"
+                      last-text="»"
+                    />
+                  </div>
 
-                <BRow class="g-2 mt-1 d-md-none">
-                  <BCol>
-                    <BInputGroup prepend="Sort" size="sm">
-                      <BFormSelect
-                        v-model="mobileSortValue"
-                        :options="mobileSortOptions"
-                        size="sm"
-                      />
-                    </BInputGroup>
-                  </BCol>
-                </BRow>
+                  <label class="backup-select-label backup-select-label--mobile-sort d-md-none">
+                    <span>Sort</span>
+                    <BFormSelect v-model="mobileSortValue" :options="mobileSortOptions" size="sm" />
+                  </label>
+                </div>
               </template>
 
               <!-- Backup Table -->
               <BTable
-                class="d-none d-md-table"
+                class="backup-table d-none d-md-table"
                 :items="paginatedBackups"
                 :fields="backupFields"
                 :busy="loading"
-                striped
                 hover
                 small
                 responsive
@@ -244,124 +224,92 @@
                 class="text-center text-muted py-3"
               >
                 <template v-if="backups.length === 0">
-                  No backups available. Use "Backup Now" to create one.
+                  No backups available. Use "Backup now" to create one.
                 </template>
                 <template v-else>
                   No backups match the current filters.
                   <BButton size="sm" variant="link" @click="clearFilters">Clear filters</BButton>
                 </template>
               </div>
+
+              <div class="backup-job-stack">
+                <section
+                  v-if="backupJob.isLoading.value || backupJob.status.value !== 'idle'"
+                  class="backup-job-row"
+                  aria-label="Backup progress"
+                >
+                  <div class="backup-job-row__header">
+                    <strong>Backup progress</strong>
+                    <span class="badge" :class="backupJob.statusBadgeClass.value">
+                      {{ backupJob.status.value }}
+                    </span>
+                  </div>
+                  <p class="backup-job-row__step">{{ backupJob.step.value }}</p>
+
+                  <BProgress
+                    v-if="backupJob.isLoading.value"
+                    :value="
+                      backupJob.hasRealProgress.value
+                        ? (backupJob.progressPercent.value ?? 0)
+                        : 100
+                    "
+                    :max="100"
+                    :animated="!backupJob.hasRealProgress.value"
+                    :striped="!backupJob.hasRealProgress.value"
+                    :variant="backupJob.progressVariant.value"
+                    height="0.875rem"
+                  >
+                    <template #default>
+                      <span v-if="backupJob.hasRealProgress.value">
+                        {{ backupJob.progress.value.current }}/{{
+                          backupJob.progress.value.total
+                        }}
+                        ({{ backupJob.progressPercent.value }}%)
+                      </span>
+                      <span v-else>Backing up... ({{ backupJob.elapsedTimeDisplay.value }})</span>
+                    </template>
+                  </BProgress>
+                </section>
+
+                <section
+                  v-if="restoreJob.isLoading.value || restoreJob.status.value !== 'idle'"
+                  class="backup-job-row"
+                  aria-label="Restore progress"
+                >
+                  <div class="backup-job-row__header">
+                    <strong>Restore progress</strong>
+                    <span class="badge" :class="restoreJob.statusBadgeClass.value">
+                      {{ restoreJob.status.value }}
+                    </span>
+                  </div>
+                  <p class="backup-job-row__step">{{ restoreJob.step.value }}</p>
+
+                  <BProgress
+                    v-if="restoreJob.isLoading.value"
+                    :value="
+                      restoreJob.hasRealProgress.value
+                        ? (restoreJob.progressPercent.value ?? 0)
+                        : 100
+                    "
+                    :max="100"
+                    :animated="!restoreJob.hasRealProgress.value"
+                    :striped="!restoreJob.hasRealProgress.value"
+                    :variant="restoreJob.progressVariant.value"
+                    height="0.875rem"
+                  >
+                    <template #default>
+                      <span v-if="restoreJob.hasRealProgress.value">
+                        {{ restoreJob.progress.value.current }}/{{
+                          restoreJob.progress.value.total
+                        }}
+                        ({{ restoreJob.progressPercent.value }}%)
+                      </span>
+                      <span v-else>Restoring... ({{ restoreJob.elapsedTimeDisplay.value }})</span>
+                    </template>
+                  </BProgress>
+                </section>
+              </div>
             </TableShell>
-
-            <!-- Backup Now Card -->
-            <BCard
-              header-tag="header"
-              body-class="p-2"
-              header-class="p-1"
-              border-variant="dark"
-              class="mt-3 text-start"
-            >
-              <template #header>
-                <h5 class="mb-0 text-start font-weight-bold">Create Manual Backup</h5>
-              </template>
-
-              <BButton
-                variant="primary"
-                :disabled="backupJob.isLoading.value"
-                @click="triggerBackup"
-              >
-                <BSpinner v-if="backupJob.isLoading.value" small type="grow" class="me-2" />
-                {{ backupJob.isLoading.value ? 'Backing up...' : 'Backup Now' }}
-              </BButton>
-
-              <!-- Backup Progress display -->
-              <div
-                v-if="backupJob.isLoading.value || backupJob.status.value !== 'idle'"
-                class="mt-3"
-              >
-                <div class="d-flex align-items-center mb-2">
-                  <span class="badge me-2" :class="backupJob.statusBadgeClass.value">
-                    {{ backupJob.status.value }}
-                  </span>
-                  <span class="text-muted">{{ backupJob.step.value }}</span>
-                </div>
-
-                <BProgress
-                  v-if="backupJob.isLoading.value"
-                  :value="
-                    backupJob.hasRealProgress.value ? (backupJob.progressPercent.value ?? 0) : 100
-                  "
-                  :max="100"
-                  :animated="!backupJob.hasRealProgress.value"
-                  :striped="!backupJob.hasRealProgress.value"
-                  :variant="backupJob.progressVariant.value"
-                  height="1.5rem"
-                >
-                  <template #default>
-                    <span v-if="backupJob.hasRealProgress.value">
-                      {{ backupJob.progress.value.current }}/{{
-                        backupJob.progress.value.total
-                      }}
-                      ({{ backupJob.progressPercent.value }}%)
-                    </span>
-                    <span v-else>Backing up... ({{ backupJob.elapsedTimeDisplay.value }})</span>
-                  </template>
-                </BProgress>
-
-                <div v-if="backupJob.isLoading.value" class="small text-muted mt-1">
-                  Elapsed: {{ backupJob.elapsedTimeDisplay.value }}
-                </div>
-              </div>
-            </BCard>
-
-            <!-- Restore Progress Card (shown when restoring) -->
-            <BCard
-              v-if="restoreJob.isLoading.value || restoreJob.status.value !== 'idle'"
-              header-tag="header"
-              body-class="p-2"
-              header-class="p-1"
-              border-variant="dark"
-              class="mt-3 text-start"
-            >
-              <template #header>
-                <h5 class="mb-0 text-start font-weight-bold">Restore Progress</h5>
-              </template>
-
-              <div class="mt-1">
-                <div class="d-flex align-items-center mb-2">
-                  <span class="badge me-2" :class="restoreJob.statusBadgeClass.value">
-                    {{ restoreJob.status.value }}
-                  </span>
-                  <span class="text-muted">{{ restoreJob.step.value }}</span>
-                </div>
-
-                <BProgress
-                  v-if="restoreJob.isLoading.value"
-                  :value="
-                    restoreJob.hasRealProgress.value ? (restoreJob.progressPercent.value ?? 0) : 100
-                  "
-                  :max="100"
-                  :animated="!restoreJob.hasRealProgress.value"
-                  :striped="!restoreJob.hasRealProgress.value"
-                  :variant="restoreJob.progressVariant.value"
-                  height="1.5rem"
-                >
-                  <template #default>
-                    <span v-if="restoreJob.hasRealProgress.value">
-                      {{ restoreJob.progress.value.current }}/{{
-                        restoreJob.progress.value.total
-                      }}
-                      ({{ restoreJob.progressPercent.value }}%)
-                    </span>
-                    <span v-else>Restoring... ({{ restoreJob.elapsedTimeDisplay.value }})</span>
-                  </template>
-                </BProgress>
-
-                <div v-if="restoreJob.isLoading.value" class="small text-muted mt-1">
-                  Elapsed: {{ restoreJob.elapsedTimeDisplay.value }}
-                </div>
-              </div>
-            </BCard>
           </BCol>
         </BRow>
 
@@ -966,6 +914,126 @@ onMounted(() => {
     'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
 }
 
+.backup-toolbar {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.backup-toolbar__filters,
+.backup-toolbar__controls,
+.backup-toolbar__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.backup-toolbar__controls {
+  display: grid;
+  grid-template-columns: minmax(18rem, 1fr) minmax(7rem, 9rem) minmax(7rem, 8rem);
+}
+
+.backup-toolbar__footer {
+  justify-content: space-between;
+}
+
+.backup-toolbar__footer :deep(.pagination) {
+  flex-wrap: nowrap;
+}
+
+.backup-toolbar__footer :deep(.page-link) {
+  min-width: 2rem;
+  padding: 0.25rem 0.45rem;
+}
+
+.backup-toolbar__label,
+.backup-select-label span,
+.backup-count {
+  color: var(--neutral-600, #757575);
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+.backup-toolbar__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.backup-filter-chip {
+  min-height: 1.75rem;
+  padding-top: 0.125rem;
+  padding-bottom: 0.125rem;
+  border-radius: 999px;
+}
+
+.backup-search {
+  position: relative;
+  min-width: 0;
+}
+
+.backup-search__icon {
+  position: absolute;
+  top: 50%;
+  left: 0.65rem;
+  z-index: 2;
+  color: var(--neutral-600, #757575);
+  transform: translateY(-50%);
+}
+
+.backup-search__input {
+  padding-left: 2rem;
+}
+
+.backup-select-label {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.backup-table {
+  margin-bottom: 0;
+}
+
+.backup-table :deep(thead th) {
+  color: #475569;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.backup-table :deep(td),
+.backup-table :deep(th) {
+  vertical-align: middle;
+}
+
+.backup-job-row__step {
+  margin: 0.2rem 0 0;
+  color: var(--neutral-600, #757575);
+  font-size: 0.875rem;
+}
+
+.backup-job-stack {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.backup-job-row {
+  padding: 0.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 0.5rem;
+  background: #f8fafc;
+}
+
+.backup-job-row__header {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
 .backup-danger-panel {
   display: grid;
   grid-template-columns: auto 1fr;
@@ -1029,5 +1097,21 @@ onMounted(() => {
   justify-content: flex-end;
   gap: 0.5rem;
   width: 100%;
+}
+
+@media (max-width: 767.98px) {
+  .backup-toolbar__controls {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .backup-search {
+    grid-column: 1 / -1;
+  }
+
+  .backup-toolbar__footer {
+    display: flex;
+    align-items: center;
+  }
 }
 </style>

--- a/app/src/views/admin/ManageLLM.spec.ts
+++ b/app/src/views/admin/ManageLLM.spec.ts
@@ -15,7 +15,8 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { http, HttpResponse } from 'msw';
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
+import type { RouteLocationRaw } from 'vue-router';
 
 import { server } from '@/test-utils/mocks/server';
 import { primeAuth } from '@/test-utils/primeAuth';
@@ -36,6 +37,50 @@ afterEach(() => {
 });
 
 describe('ManageLLM — F2a Bearer-via-interceptor', () => {
+  const routerLinkStub = {
+    props: ['to'],
+    template: '<a :href="href"><slot /></a>',
+    computed: {
+      href(this: { to: RouteLocationRaw }): string {
+        const to = this.to as RouteLocationRaw;
+        if (typeof to === 'string') {
+          return to;
+        }
+        return `${to.path ?? ''}${to.hash ?? ''}`;
+      },
+    },
+  };
+
+  const mountManageLLM = () =>
+    mount(ManageLLM, {
+      global: {
+        stubs: {
+          BContainer: { template: '<div><slot /></div>' },
+          BRow: { template: '<div><slot /></div>' },
+          BCol: { template: '<div><slot /></div>' },
+          BCard: { template: '<div><slot name="header" /><slot /></div>' },
+          BButton: { template: '<button><slot /></button>' },
+          BBadge: { template: '<span><slot /></span>' },
+          BSpinner: { template: '<div role="status" />' },
+          BAlert: { template: '<div><slot /></div>' },
+          BTabs: { template: '<div><slot /></div>' },
+          BTab: { template: '<div><slot /></div>' },
+          BProgress: { template: '<div />' },
+          BProgressBar: { template: '<div><slot /></div>' },
+          BModal: { template: '<div />' },
+          BFormGroup: { template: '<div><slot /></div>' },
+          BFormRadioGroup: { template: '<div />' },
+          BNav: { template: '<nav><slot /></nav>' },
+          BNavItem: { template: '<span><slot /></span>' },
+          LlmConfigPanel: { template: '<div />' },
+          LlmPromptEditor: { template: '<div />' },
+          LlmCacheManager: { template: '<div />' },
+          LlmLogViewer: { template: '<div />' },
+          RouterLink: routerLinkStub,
+        },
+      },
+    });
+
   it('sends Bearer on every GET fired by refreshAll()', async () => {
     const { token } = primeAuth();
     const hits = { config: false, prompts: false, stats: false };
@@ -69,30 +114,7 @@ describe('ManageLLM — F2a Bearer-via-interceptor', () => {
       })
     );
 
-    mount(ManageLLM, {
-      global: {
-        stubs: {
-          BContainer: { template: '<div><slot /></div>' },
-          BRow: { template: '<div><slot /></div>' },
-          BCol: { template: '<div><slot /></div>' },
-          BCard: { template: '<div><slot name="header" /><slot /></div>' },
-          BButton: { template: '<button><slot /></button>' },
-          BBadge: { template: '<span><slot /></span>' },
-          BSpinner: { template: '<div role="status" />' },
-          BTabs: { template: '<div><slot /></div>' },
-          BTab: { template: '<div><slot /></div>' },
-          BProgress: { template: '<div />' },
-          BModal: { template: '<div />' },
-          BFormGroup: { template: '<div><slot /></div>' },
-          BFormRadioGroup: { template: '<div />' },
-          LlmConfigPanel: { template: '<div />' },
-          LlmPromptEditor: { template: '<div />' },
-          LlmCacheManager: { template: '<div />' },
-          LlmLogViewer: { template: '<div />' },
-          'router-link': true,
-        },
-      },
-    });
+    mountManageLLM();
 
     // Allow the onMounted → Promise.all(3) → MSW path to resolve.
     await new Promise((r) => setTimeout(r, 0));
@@ -101,5 +123,111 @@ describe('ManageLLM — F2a Bearer-via-interceptor', () => {
     expect(hits.config).toBe(true);
     expect(hits.prompts).toBe(true);
     expect(hits.stats).toBe(true);
+  });
+
+  it('renders direct URLs for every management section', async () => {
+    primeAuth();
+
+    server.use(
+      http.get('*/api/llm/config', () =>
+        HttpResponse.json({
+          gemini_configured: [true],
+          current_model: ['gemini-1.5-flash'],
+        })
+      ),
+      http.get('*/api/llm/prompts', () =>
+        HttpResponse.json({
+          functional: { template: '', version: '1', description: '' },
+          phenotype: { template: '', version: '1', description: '' },
+        })
+      ),
+      http.get('*/api/llm/cache/stats', () =>
+        HttpResponse.json({
+          total_entries: 0,
+          by_type: {},
+          by_status: {},
+          estimated_cost_usd: 0,
+        })
+      )
+    );
+
+    const wrapper = mountManageLLM();
+
+    expect(wrapper.get('a[href="/ManageLLM#overview"]').text()).toBe('Overview');
+    expect(wrapper.get('a[href="/ManageLLM#configuration"]').text()).toBe('Configuration');
+    expect(wrapper.get('a[href="/ManageLLM#prompts"]').text()).toBe('Prompts');
+    expect(wrapper.get('a[href="/ManageLLM#cache"]').text()).toBe('Cache');
+    expect(wrapper.get('a[href="/ManageLLM#logs"]').text()).toBe('Logs');
+  });
+
+  it('tracks the real child job returned by functional regeneration', async () => {
+    const { token } = primeAuth();
+    let polledChildJob = false;
+
+    server.use(
+      http.get('*/api/llm/config', () =>
+        HttpResponse.json({
+          gemini_configured: [true],
+          current_model: ['gemini-1.5-flash'],
+        })
+      ),
+      http.get('*/api/llm/prompts', () =>
+        HttpResponse.json({
+          functional: { template: '', version: '1', description: '' },
+          phenotype: { template: '', version: '1', description: '' },
+        })
+      ),
+      http.get('*/api/llm/cache/stats', () =>
+        HttpResponse.json({
+          total_entries: 0,
+          by_type: {},
+          by_status: {},
+          estimated_cost_usd: 0,
+        })
+      ),
+      http.post('*/api/llm/regenerate', ({ request }) => {
+        expectBearerHeader(request, token);
+        return HttpResponse.json(
+          {
+            job_id: 'parent-job',
+            status: 'accepted',
+            status_url: '/api/jobs/parent-job',
+            cluster_types: ['functional'],
+            results: {
+              functional: {
+                job_id: 'functional-child-job',
+                status: 'accepted',
+                status_url: '/api/jobs/functional-child-job/status',
+              },
+            },
+          },
+          { status: 202 }
+        );
+      }),
+      http.get('*/api/jobs/functional-child-job/status', () => {
+        polledChildJob = true;
+        return HttpResponse.json({
+          status: ['running'],
+          step: ['Generating functional cluster summaries'],
+          progress: { current: [1], total: [8] },
+        });
+      }),
+      http.get('*/api/jobs/parent-job/status', () => {
+        throw new Error('ManageLLM should not poll the synthetic parent job');
+      })
+    );
+
+    vi.useFakeTimers();
+    const wrapper = mountManageLLM();
+    await vi.runOnlyPendingTimersAsync();
+    await wrapper.get('button[data-testid="llm-regenerate-functional"]').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('Functional');
+    expect(wrapper.text()).toContain('functional-child-job');
+
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(polledChildJob).toBe(true);
+    vi.useRealTimers();
   });
 });

--- a/app/src/views/admin/ManageLLM.spec.ts
+++ b/app/src/views/admin/ManageLLM.spec.ts
@@ -34,6 +34,8 @@ import ManageLLM from './ManageLLM.vue';
 
 afterEach(() => {
   useAuth().logout();
+  window.sessionStorage.clear();
+  vi.useRealTimers();
 });
 
 describe('ManageLLM — F2a Bearer-via-interceptor', () => {
@@ -219,15 +221,74 @@ describe('ManageLLM — F2a Bearer-via-interceptor', () => {
 
     vi.useFakeTimers();
     const wrapper = mountManageLLM();
-    await vi.runOnlyPendingTimersAsync();
-    await wrapper.get('button[data-testid="llm-regenerate-functional"]').trigger('click');
-    await flushPromises();
+    try {
+      await vi.runOnlyPendingTimersAsync();
+      await wrapper.get('button[data-testid="llm-regenerate-functional"]').trigger('click');
+      await flushPromises();
 
-    expect(wrapper.text()).toContain('Functional');
-    expect(wrapper.text()).toContain('functional-child-job');
+      expect(wrapper.text()).toContain('Functional');
+      expect(wrapper.text()).toContain('functional-child-job');
 
-    await vi.advanceTimersByTimeAsync(3000);
-    expect(polledChildJob).toBe(true);
-    vi.useRealTimers();
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(polledChildJob).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('resumes a visible regeneration job after returning to the view', async () => {
+    primeAuth();
+    let polledChildJob = false;
+
+    window.sessionStorage.setItem(
+      'sysndd.llm.activeRegenerationJobs.v1',
+      JSON.stringify({ functional: 'functional-child-job' })
+    );
+
+    server.use(
+      http.get('*/api/llm/config', () =>
+        HttpResponse.json({
+          gemini_configured: [true],
+          current_model: ['gemini-1.5-flash'],
+        })
+      ),
+      http.get('*/api/llm/prompts', () =>
+        HttpResponse.json({
+          functional: { template: '', version: '1', description: '' },
+          phenotype: { template: '', version: '1', description: '' },
+        })
+      ),
+      http.get('*/api/llm/cache/stats', () =>
+        HttpResponse.json({
+          total_entries: 0,
+          by_type: {},
+          by_status: {},
+          estimated_cost_usd: 0,
+        })
+      ),
+      http.get('*/api/jobs/functional-child-job/status', () => {
+        polledChildJob = true;
+        return HttpResponse.json({
+          status: ['running'],
+          step: ['Generating functional cluster summaries'],
+          progress: { current: [2], total: [8] },
+        });
+      })
+    );
+
+    vi.useFakeTimers();
+    const wrapper = mountManageLLM();
+    try {
+      await flushPromises();
+
+      expect(wrapper.get('[data-testid="llm-regeneration-job-functional"]').text()).toContain(
+        'functional-child-job'
+      );
+
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(polledChildJob).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/app/src/views/admin/ManageLLM.vue
+++ b/app/src/views/admin/ManageLLM.vue
@@ -9,46 +9,20 @@
       <BContainer fluid>
         <BRow class="justify-content-md-center py-2">
           <BCol col md="12">
-            <BCard
-              header-tag="header"
-              body-class="p-0"
-              header-class="p-2"
-              border-variant="dark"
-              class="mb-3 text-start"
+            <AdminOperationPanel
+              title="LLM Configuration"
+              :meta="config ? (config.gemini_configured ? config.current_model : 'Not configured') : null"
+              icon="bi-cpu"
             >
-              <template #header>
-                <BRow class="align-items-center">
-                  <BCol>
-                    <h5 class="mb-0 text-start fw-bold">
-                      LLM configuration
-                      <BBadge
-                        v-if="config && !config.gemini_configured"
-                        variant="warning"
-                        class="ms-2"
-                      >
-                        Not Configured
-                      </BBadge>
-                      <BBadge v-else-if="config" variant="success" class="ms-2">
-                        {{ config.current_model }}
-                      </BBadge>
-                    </h5>
-                  </BCol>
-                  <BCol class="text-end">
-                    <BButton
-                      variant="outline-primary"
-                      size="sm"
-                      :disabled="loading"
-                      @click="refreshAll"
-                    >
-                      <BSpinner v-if="loading" small class="me-1" />
-                      Refresh
-                    </BButton>
-                  </BCol>
-                </BRow>
+              <template #actions>
+                <BButton variant="outline-primary" size="sm" :disabled="loading" @click="refreshAll">
+                  <BSpinner v-if="loading" small class="me-1" />
+                  Refresh
+                </BButton>
               </template>
 
               <!-- Tab Navigation -->
-              <BTabs pills card nav-class="px-3 pt-2">
+              <BTabs pills nav-class="admin-tabs">
                 <!-- Overview Tab -->
                 <BTab title="Overview">
                   <BRow class="g-3 mb-4">
@@ -85,10 +59,7 @@
                   </BRow>
 
                   <!-- Quick Actions -->
-                  <BCard class="mb-4">
-                    <template #header>
-                      <h6 class="mb-0">Quick Actions</h6>
-                    </template>
+                  <AdminOperationPanel title="Quick Actions" heading-tag="h3" icon="bi-lightning">
                     <BRow class="g-2">
                       <BCol md="4">
                         <BButton
@@ -121,7 +92,7 @@
                         </BButton>
                       </BCol>
                     </BRow>
-                  </BCard>
+                  </AdminOperationPanel>
 
                   <!-- Active Job Progress -->
                   <BCard v-if="regenerationJob.isLoading.value" class="mb-4">
@@ -174,7 +145,7 @@
                   <LlmLogViewer />
                 </BTab>
               </BTabs>
-            </BCard>
+            </AdminOperationPanel>
           </BCol>
         </BRow>
 
@@ -205,6 +176,7 @@
 
 <script setup lang="ts">
 import AuthenticatedPageShell from '@/components/layout/AuthenticatedPageShell.vue';
+import AdminOperationPanel from '@/components/admin/AdminOperationPanel.vue';
 import { ref, onMounted } from 'vue';
 import { useLlmAdmin } from '@/composables/useLlmAdmin';
 import { useAsyncJob } from '@/composables/useAsyncJob';

--- a/app/src/views/admin/ManageLLM.vue
+++ b/app/src/views/admin/ManageLLM.vue
@@ -11,140 +11,207 @@
           <BCol col md="12">
             <AdminOperationPanel
               title="LLM Configuration"
-              :meta="config ? (config.gemini_configured ? config.current_model : 'Not configured') : null"
+              :meta="
+                config ? (config.gemini_configured ? config.current_model : 'Not configured') : null
+              "
               icon="bi-cpu"
             >
               <template #actions>
-                <BButton variant="outline-primary" size="sm" :disabled="loading" @click="refreshAll">
+                <BButton
+                  variant="outline-primary"
+                  size="sm"
+                  :disabled="loading"
+                  @click="refreshAll"
+                >
                   <BSpinner v-if="loading" small class="me-1" />
                   Refresh
                 </BButton>
               </template>
 
               <!-- Tab Navigation -->
-              <BTabs pills nav-class="admin-tabs">
-                <!-- Overview Tab -->
-                <BTab title="Overview">
-                  <BRow class="g-3 mb-4">
-                    <BCol md="3">
-                      <BCard class="text-center h-100">
-                        <div class="h2 mb-0">{{ cacheStats?.total_entries ?? 0 }}</div>
-                        <small class="text-muted">Total Summaries</small>
-                      </BCard>
+              <nav class="nav nav-pills admin-tabs mb-3" aria-label="LLM administration sections">
+                <RouterLink
+                  v-for="tab in tabs"
+                  :key="tab.id"
+                  :to="{ path: '/ManageLLM', hash: tab.hash }"
+                  class="nav-link"
+                  :class="{ active: activeTab === tab.id }"
+                  :aria-current="activeTab === tab.id ? 'page' : undefined"
+                  @click="setActiveTab(tab.id)"
+                >
+                  {{ tab.label }}
+                </RouterLink>
+              </nav>
+
+              <section v-show="activeTab === 'overview'" id="overview" role="tabpanel">
+                <BRow class="g-3 mb-4">
+                  <BCol md="3">
+                    <BCard class="text-center h-100">
+                      <div class="h2 mb-0">{{ cacheStats?.total_entries ?? 0 }}</div>
+                      <small class="text-muted">Total Summaries</small>
+                    </BCard>
+                  </BCol>
+                  <BCol md="3">
+                    <BCard class="text-center h-100 border-success">
+                      <div class="h2 mb-0 text-success">
+                        {{ cacheStats?.by_status?.validated ?? 0 }}
+                      </div>
+                      <small class="text-muted">Validated</small>
+                    </BCard>
+                  </BCol>
+                  <BCol md="3">
+                    <BCard class="text-center h-100 border-warning">
+                      <div class="h2 mb-0 text-warning">
+                        {{ cacheStats?.by_status?.pending ?? 0 }}
+                      </div>
+                      <small class="text-muted">Pending Review</small>
+                    </BCard>
+                  </BCol>
+                  <BCol md="3">
+                    <BCard class="text-center h-100">
+                      <div class="h2 mb-0">
+                        ${{ (cacheStats?.estimated_cost_usd ?? 0).toFixed(2) }}
+                      </div>
+                      <small class="text-muted">Est. Cost (USD)</small>
+                    </BCard>
+                  </BCol>
+                </BRow>
+
+                <!-- Quick Actions -->
+                <AdminOperationPanel title="Quick Actions" heading-tag="h3" icon="bi-lightning">
+                  <BRow class="g-2">
+                    <BCol md="4">
+                      <BButton
+                        variant="outline-danger"
+                        class="w-100"
+                        :disabled="!config?.gemini_configured || isAnyRegenerationLoading"
+                        @click="showClearModal = true"
+                      >
+                        <BSpinner v-if="isAnyRegenerationLoading" small class="me-1" />
+                        Clear Cache & Regenerate
+                      </BButton>
                     </BCol>
-                    <BCol md="3">
-                      <BCard class="text-center h-100 border-success">
-                        <div class="h2 mb-0 text-success">
-                          {{ cacheStats?.by_status?.validated ?? 0 }}
-                        </div>
-                        <small class="text-muted">Validated</small>
-                      </BCard>
+                    <BCol md="4">
+                      <BButton
+                        variant="outline-primary"
+                        class="w-100"
+                        data-testid="llm-regenerate-functional"
+                        :disabled="!config?.gemini_configured || isAnyRegenerationLoading"
+                        @click="handleRegenerate('functional')"
+                      >
+                        <BSpinner
+                          v-if="functionalRegenerationJob.isLoading.value"
+                          small
+                          class="me-1"
+                        />
+                        Regenerate Functional
+                      </BButton>
                     </BCol>
-                    <BCol md="3">
-                      <BCard class="text-center h-100 border-warning">
-                        <div class="h2 mb-0 text-warning">
-                          {{ cacheStats?.by_status?.pending ?? 0 }}
-                        </div>
-                        <small class="text-muted">Pending Review</small>
-                      </BCard>
-                    </BCol>
-                    <BCol md="3">
-                      <BCard class="text-center h-100">
-                        <div class="h2 mb-0">
-                          ${{ (cacheStats?.estimated_cost_usd ?? 0).toFixed(2) }}
-                        </div>
-                        <small class="text-muted">Est. Cost (USD)</small>
-                      </BCard>
+                    <BCol md="4">
+                      <BButton
+                        variant="outline-primary"
+                        class="w-100"
+                        data-testid="llm-regenerate-phenotype"
+                        :disabled="!config?.gemini_configured || isAnyRegenerationLoading"
+                        @click="handleRegenerate('phenotype')"
+                      >
+                        <BSpinner
+                          v-if="phenotypeRegenerationJob.isLoading.value"
+                          small
+                          class="me-1"
+                        />
+                        Regenerate Phenotype
+                      </BButton>
                     </BCol>
                   </BRow>
+                </AdminOperationPanel>
 
-                  <!-- Quick Actions -->
-                  <AdminOperationPanel title="Quick Actions" heading-tag="h3" icon="bi-lightning">
-                    <BRow class="g-2">
-                      <BCol md="4">
-                        <BButton
-                          variant="outline-danger"
-                          class="w-100"
-                          :disabled="!config?.gemini_configured || regenerationJob.isLoading.value"
-                          @click="showClearModal = true"
-                        >
-                          Clear Cache & Regenerate
-                        </BButton>
-                      </BCol>
-                      <BCol md="4">
-                        <BButton
-                          variant="outline-primary"
-                          class="w-100"
-                          :disabled="!config?.gemini_configured || regenerationJob.isLoading.value"
-                          @click="handleRegenerate('functional')"
-                        >
-                          Regenerate Functional
-                        </BButton>
-                      </BCol>
-                      <BCol md="4">
-                        <BButton
-                          variant="outline-primary"
-                          class="w-100"
-                          :disabled="!config?.gemini_configured || regenerationJob.isLoading.value"
-                          @click="handleRegenerate('phenotype')"
-                        >
-                          Regenerate Phenotype
-                        </BButton>
-                      </BCol>
-                    </BRow>
-                  </AdminOperationPanel>
+                <!-- Active Job Progress -->
+                <div v-if="regenerationFeedback" class="llm-regeneration-feedback">
+                  <BAlert :variant="regenerationFeedbackVariant" show class="mb-3">
+                    <i :class="regenerationFeedbackIcon" class="me-1" aria-hidden="true" />
+                    {{ regenerationFeedback }}
+                  </BAlert>
+                </div>
 
-                  <!-- Active Job Progress -->
-                  <BCard v-if="regenerationJob.isLoading.value" class="mb-4">
-                    <template #header>
-                      <h6 class="mb-0">Regeneration in Progress</h6>
-                    </template>
-                    <BProgress
-                      :value="
-                        regenerationJob.hasRealProgress.value
-                          ? (regenerationJob.progressPercent.value ?? 0)
-                          : 100
-                      "
-                      :max="100"
-                      show-progress
-                      animated
-                    />
-                    <div class="mt-2 text-muted small">
-                      {{ regenerationJob.step.value }}
-                      <span class="float-end">{{ regenerationJob.elapsedTimeDisplay.value }}</span>
+                <div v-if="visibleRegenerationJobs.length" class="llm-job-list mb-4">
+                  <BCard
+                    v-for="job in visibleRegenerationJobs"
+                    :key="job.type"
+                    class="llm-job-card"
+                    :data-testid="`llm-regeneration-job-${job.type}`"
+                  >
+                    <div class="llm-job-card__header">
+                      <div>
+                        <BBadge :class="job.runner.statusBadgeClass.value" class="me-2">
+                          {{ job.runner.status.value }}
+                        </BBadge>
+                        <strong>{{ job.label }}</strong>
+                        <span class="llm-job-card__id">Job {{ job.runner.jobId.value }}</span>
+                      </div>
+                      <span class="llm-job-card__elapsed">
+                        <i class="bi bi-clock me-1" aria-hidden="true" />
+                        {{ job.runner.elapsedTimeDisplay.value }}
+                      </span>
                     </div>
+                    <p v-if="job.runner.step.value" class="llm-job-card__step">
+                      {{ job.runner.step.value }}
+                    </p>
+                    <BProgress :max="100" height="0.875rem">
+                      <BProgressBar
+                        :value="
+                          job.runner.hasRealProgress.value
+                            ? (job.runner.progressPercent.value ?? 0)
+                            : 100
+                        "
+                        :variant="job.runner.progressVariant.value"
+                        :striped="!job.runner.hasRealProgress.value"
+                        :animated="job.runner.isLoading.value"
+                      >
+                        <template v-if="job.runner.hasRealProgress.value">
+                          {{ job.runner.progress.value.current }}/{{
+                            job.runner.progress.value.total
+                          }}
+                        </template>
+                        <template v-else-if="job.runner.isLoading.value">Processing...</template>
+                      </BProgressBar>
+                    </BProgress>
+                    <BAlert v-if="job.runner.error.value" variant="danger" show class="mt-3 mb-0">
+                      <i class="bi bi-exclamation-triangle-fill me-1" aria-hidden="true" />
+                      {{ job.runner.error.value }}
+                    </BAlert>
                   </BCard>
-                </BTab>
+                </div>
+              </section>
 
-                <!-- Configuration Tab -->
-                <BTab title="Configuration">
-                  <LlmConfigPanel
-                    :config="config"
-                    :loading="loading"
-                    @update-model="handleModelUpdate"
-                  />
-                </BTab>
+              <!-- Configuration Tab -->
+              <section v-show="activeTab === 'configuration'" id="configuration" role="tabpanel">
+                <LlmConfigPanel
+                  :config="config"
+                  :loading="loading"
+                  @update-model="handleModelUpdate"
+                />
+              </section>
 
-                <!-- Prompts Tab -->
-                <BTab title="Prompts">
-                  <LlmPromptEditor :prompts="prompts" :loading="loading" @save="handlePromptSave" />
-                </BTab>
+              <!-- Prompts Tab -->
+              <section v-show="activeTab === 'prompts'" id="prompts" role="tabpanel">
+                <LlmPromptEditor :prompts="prompts" :loading="loading" @save="handlePromptSave" />
+              </section>
 
-                <!-- Cache Tab -->
-                <BTab title="Cache">
-                  <LlmCacheManager
-                    :stats="cacheStats"
-                    @clear="handleCacheClear"
-                    @validate="handleValidate"
-                    @regenerate="handleRegenerate"
-                  />
-                </BTab>
+              <!-- Cache Tab -->
+              <section v-show="activeTab === 'cache'" id="cache" role="tabpanel">
+                <LlmCacheManager
+                  :stats="cacheStats"
+                  @clear="handleCacheClear"
+                  @validate="handleValidate"
+                  @regenerate="handleRegenerate"
+                />
+              </section>
 
-                <!-- Logs Tab -->
-                <BTab title="Logs">
-                  <LlmLogViewer />
-                </BTab>
-              </BTabs>
+              <!-- Logs Tab -->
+              <section v-show="activeTab === 'logs'" id="logs" role="tabpanel">
+                <LlmLogViewer />
+              </section>
             </AdminOperationPanel>
           </BCol>
         </BRow>
@@ -177,7 +244,7 @@
 <script setup lang="ts">
 import AuthenticatedPageShell from '@/components/layout/AuthenticatedPageShell.vue';
 import AdminOperationPanel from '@/components/admin/AdminOperationPanel.vue';
-import { ref, onMounted } from 'vue';
+import { computed, ref, onMounted, onUnmounted, watch } from 'vue';
 import { useLlmAdmin } from '@/composables/useLlmAdmin';
 import { useAsyncJob } from '@/composables/useAsyncJob';
 import useToast from '@/composables/useToast';
@@ -185,7 +252,7 @@ import LlmConfigPanel from '@/components/llm/LlmConfigPanel.vue';
 import LlmPromptEditor from '@/components/llm/LlmPromptEditor.vue';
 import LlmCacheManager from '@/components/llm/LlmCacheManager.vue';
 import LlmLogViewer from '@/components/llm/LlmLogViewer.vue';
-import type { PromptType, ClusterType } from '@/types/llm';
+import type { PromptType, ClusterType, RegenerationJobResponse } from '@/types/llm';
 
 const { makeToast } = useToast();
 const {
@@ -203,14 +270,67 @@ const {
   updateValidationStatus,
 } = useLlmAdmin();
 
-// Async job tracking for regeneration
-const regenerationJob = useAsyncJob(
-  (jobId) => `${import.meta.env.VITE_API_URL}/api/jobs/${jobId}/status`
-);
+const jobStatusUrl = (jobId: string) => `${import.meta.env.VITE_API_URL}/api/jobs/${jobId}/status`;
+
+// Async job tracking for regeneration. The LLM endpoint can submit one child
+// job per cluster type, so each type gets its own visible tracker.
+const functionalRegenerationJob = useAsyncJob(jobStatusUrl);
+const phenotypeRegenerationJob = useAsyncJob(jobStatusUrl);
+
+const regenerationJobs = {
+  functional: functionalRegenerationJob,
+  phenotype: phenotypeRegenerationJob,
+};
+
+const regenerationJobLabels: Record<ClusterType, string> = {
+  functional: 'Functional regeneration',
+  phenotype: 'Phenotype regeneration',
+};
 
 // Local state
 const showClearModal = ref(false);
 const clearType = ref<ClusterType | 'all'>('all');
+const regenerationFeedback = ref('');
+const regenerationFeedbackVariant = ref<'success' | 'danger' | 'info' | 'warning'>('info');
+
+type LlmAdminTabId = 'overview' | 'configuration' | 'prompts' | 'cache' | 'logs';
+
+const tabs: Array<{ id: LlmAdminTabId; label: string; hash: string }> = [
+  { id: 'overview', label: 'Overview', hash: '#overview' },
+  { id: 'configuration', label: 'Configuration', hash: '#configuration' },
+  { id: 'prompts', label: 'Prompts', hash: '#prompts' },
+  { id: 'cache', label: 'Cache', hash: '#cache' },
+  { id: 'logs', label: 'Logs', hash: '#logs' },
+];
+
+const activeTab = ref<LlmAdminTabId>('overview');
+
+const isAnyRegenerationLoading = computed(() =>
+  Object.values(regenerationJobs).some((job) => job.isLoading.value)
+);
+
+const visibleRegenerationJobs = computed(() =>
+  (Object.keys(regenerationJobs) as ClusterType[])
+    .map((type) => ({
+      type,
+      label: regenerationJobLabels[type],
+      runner: regenerationJobs[type],
+    }))
+    .filter((job) => Boolean(job.runner.jobId.value))
+);
+
+const regenerationFeedbackIcon = computed(() => {
+  switch (regenerationFeedbackVariant.value) {
+    case 'success':
+      return 'bi bi-check-circle-fill';
+    case 'danger':
+      return 'bi bi-exclamation-triangle-fill';
+    case 'warning':
+      return 'bi bi-exclamation-circle-fill';
+    default:
+      return 'bi bi-info-circle-fill';
+  }
+});
 
 const clearOptions = [
   { text: 'All clusters', value: 'all' },
@@ -218,9 +338,83 @@ const clearOptions = [
   { text: 'Phenotype clusters only', value: 'phenotype' },
 ];
 
+function tabFromHash(hash: string): LlmAdminTabId {
+  const normalized = hash.replace(/^#/, '');
+  return tabs.find((tab) => tab.id === normalized)?.id ?? 'overview';
+}
+
+function syncActiveTabFromLocation() {
+  activeTab.value = tabFromHash(window.location.hash);
+}
+
+function setActiveTab(tabId: LlmAdminTabId) {
+  activeTab.value = tabId;
+}
+
+function unwrapValue<T>(val: T | T[]): T {
+  return Array.isArray(val) && val.length === 1 ? val[0] : (val as T);
+}
+
+function requestedClusterTypes(type: ClusterType | 'all'): ClusterType[] {
+  return type === 'all' ? ['functional', 'phenotype'] : [type];
+}
+
+function jobIdFromRegenerationResult(result: RegenerationJobResponse, type: ClusterType) {
+  return result.results?.[type]?.job_id ?? null;
+}
+
+function startRegenerationTrackers(
+  result: RegenerationJobResponse,
+  requestedType: ClusterType | 'all'
+) {
+  const started: ClusterType[] = [];
+  const skipped: string[] = [];
+
+  requestedClusterTypes(requestedType).forEach((type) => {
+    const child = result.results?.[type];
+    const jobId = jobIdFromRegenerationResult(result, type);
+
+    if (jobId) {
+      regenerationJobs[type].reset();
+      regenerationJobs[type].startJob(unwrapValue(jobId));
+      started.push(type);
+      return;
+    }
+
+    if (child?.skipped) {
+      skipped.push(`${regenerationJobLabels[type]} skipped: ${child.reason || 'No job created'}`);
+    }
+  });
+
+  if (started.length) {
+    regenerationFeedback.value = `Tracking ${started
+      .map((type) => regenerationJobLabels[type].toLowerCase())
+      .join(' and ')}. You can leave this page and return to Logs or Cache later.`;
+    regenerationFeedbackVariant.value = 'info';
+    return;
+  }
+
+  if (skipped.length) {
+    regenerationFeedback.value = skipped.join(' ');
+    regenerationFeedbackVariant.value = 'warning';
+    return;
+  }
+
+  regenerationFeedback.value = 'No regeneration job was created. Check the API response and logs.';
+  regenerationFeedbackVariant.value = 'warning';
+}
+
 // Lifecycle
 onMounted(async () => {
+  syncActiveTabFromLocation();
+  window.addEventListener('hashchange', syncActiveTabFromLocation);
+  window.addEventListener('popstate', syncActiveTabFromLocation);
   await refreshAll();
+});
+
+onUnmounted(() => {
+  window.removeEventListener('hashchange', syncActiveTabFromLocation);
+  window.removeEventListener('popstate', syncActiveTabFromLocation);
 });
 
 // Methods.
@@ -268,10 +462,14 @@ async function handleCacheClear(type: ClusterType | 'all') {
 
 async function handleRegenerate(type: ClusterType | 'all', force = false) {
   try {
+    regenerationFeedback.value = '';
     const result = await triggerRegeneration(type, force);
-    regenerationJob.startJob(result.job_id);
-    makeToast('Regeneration job started', 'Info', 'info');
+    startRegenerationTrackers(result, type);
+    makeToast('Regeneration job submitted', 'Info', 'info');
   } catch {
+    regenerationFeedback.value =
+      'Failed to start regeneration. Check your configuration and API logs.';
+    regenerationFeedbackVariant.value = 'danger';
     makeToast('Failed to start regeneration', 'Error', 'danger');
   }
 }
@@ -291,4 +489,95 @@ async function handleValidate(cacheId: number, action: 'validate' | 'reject') {
     makeToast(`Failed to ${action} summary`, 'Error', 'danger');
   }
 }
+
+watch(
+  () => functionalRegenerationJob.status.value,
+  async (newStatus) => {
+    if (newStatus === 'completed') {
+      regenerationFeedback.value = 'Functional regeneration completed. Cache statistics refreshed.';
+      regenerationFeedbackVariant.value = 'success';
+      makeToast('Functional regeneration completed', 'Success', 'success');
+      await fetchCacheStats();
+    } else if (newStatus === 'failed') {
+      regenerationFeedback.value =
+        functionalRegenerationJob.error.value || 'Functional regeneration failed.';
+      regenerationFeedbackVariant.value = 'danger';
+      makeToast(regenerationFeedback.value, 'Error', 'danger');
+    }
+  }
+);
+
+watch(
+  () => phenotypeRegenerationJob.status.value,
+  async (newStatus) => {
+    if (newStatus === 'completed') {
+      regenerationFeedback.value = 'Phenotype regeneration completed. Cache statistics refreshed.';
+      regenerationFeedbackVariant.value = 'success';
+      makeToast('Phenotype regeneration completed', 'Success', 'success');
+      await fetchCacheStats();
+    } else if (newStatus === 'failed') {
+      regenerationFeedback.value =
+        phenotypeRegenerationJob.error.value || 'Phenotype regeneration failed.';
+      regenerationFeedbackVariant.value = 'danger';
+      makeToast(regenerationFeedback.value, 'Error', 'danger');
+    }
+  }
+);
 </script>
+
+<style scoped>
+.llm-job-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.llm-job-card {
+  border-color: #d9e0ea;
+}
+
+.llm-job-card__header {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.llm-job-card__id {
+  display: block;
+  margin-top: 0.25rem;
+  color: var(--neutral-600, #757575);
+  font-family: var(
+    --font-family-mono,
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    monospace
+  );
+  font-size: 0.8125rem;
+  overflow-wrap: anywhere;
+}
+
+.llm-job-card__elapsed {
+  flex: 0 0 auto;
+  color: var(--neutral-600, #757575);
+  font-size: 0.875rem;
+}
+
+.llm-job-card__step {
+  margin: 0.75rem 0 0.5rem;
+  color: var(--neutral-700, #424242);
+  font-size: 0.875rem;
+}
+
+@media (max-width: 575.98px) {
+  .admin-tabs {
+    gap: 0.25rem;
+  }
+
+  .llm-job-card__header {
+    display: grid;
+  }
+}
+</style>

--- a/app/src/views/admin/ManageLLM.vue
+++ b/app/src/views/admin/ManageLLM.vue
@@ -44,144 +44,242 @@
               </nav>
 
               <section v-show="activeTab === 'overview'" id="overview" role="tabpanel">
-                <BRow class="g-3 mb-4">
-                  <BCol md="3">
-                    <BCard class="text-center h-100">
-                      <div class="h2 mb-0">{{ cacheStats?.total_entries ?? 0 }}</div>
-                      <small class="text-muted">Total Summaries</small>
-                    </BCard>
-                  </BCol>
-                  <BCol md="3">
-                    <BCard class="text-center h-100 border-success">
-                      <div class="h2 mb-0 text-success">
-                        {{ cacheStats?.by_status?.validated ?? 0 }}
+                <TableShell
+                  title="LLM overview"
+                  :meta="`Summaries: ${cacheStats?.total_entries ?? 0}`"
+                  :description="overviewDescription"
+                  :loading="loading && !cacheStats"
+                >
+                  <template #toolbar>
+                    <div class="llm-overview-toolbar" aria-label="LLM quick actions">
+                      <div class="llm-overview-toolbar__group">
+                        <BButton
+                          variant="outline-primary"
+                          size="sm"
+                          data-testid="llm-regenerate-functional"
+                          :disabled="!config?.gemini_configured || isAnyRegenerationLoading"
+                          @click="handleRegenerate('functional')"
+                        >
+                          <BSpinner
+                            v-if="functionalRegenerationJob.isLoading.value"
+                            small
+                            class="me-1"
+                          />
+                          Regenerate Functional
+                        </BButton>
+                        <BButton
+                          variant="outline-primary"
+                          size="sm"
+                          data-testid="llm-regenerate-phenotype"
+                          :disabled="!config?.gemini_configured || isAnyRegenerationLoading"
+                          @click="handleRegenerate('phenotype')"
+                        >
+                          <BSpinner
+                            v-if="phenotypeRegenerationJob.isLoading.value"
+                            small
+                            class="me-1"
+                          />
+                          Regenerate Phenotype
+                        </BButton>
                       </div>
-                      <small class="text-muted">Validated</small>
-                    </BCard>
-                  </BCol>
-                  <BCol md="3">
-                    <BCard class="text-center h-100 border-warning">
-                      <div class="h2 mb-0 text-warning">
-                        {{ cacheStats?.by_status?.pending ?? 0 }}
-                      </div>
-                      <small class="text-muted">Pending Review</small>
-                    </BCard>
-                  </BCol>
-                  <BCol md="3">
-                    <BCard class="text-center h-100">
-                      <div class="h2 mb-0">
-                        ${{ (cacheStats?.estimated_cost_usd ?? 0).toFixed(2) }}
-                      </div>
-                      <small class="text-muted">Est. Cost (USD)</small>
-                    </BCard>
-                  </BCol>
-                </BRow>
-
-                <!-- Quick Actions -->
-                <AdminOperationPanel title="Quick Actions" heading-tag="h3" icon="bi-lightning">
-                  <BRow class="g-2">
-                    <BCol md="4">
                       <BButton
                         variant="outline-danger"
-                        class="w-100"
+                        size="sm"
                         :disabled="!config?.gemini_configured || isAnyRegenerationLoading"
                         @click="showClearModal = true"
                       >
                         <BSpinner v-if="isAnyRegenerationLoading" small class="me-1" />
                         Clear Cache & Regenerate
                       </BButton>
-                    </BCol>
-                    <BCol md="4">
-                      <BButton
-                        variant="outline-primary"
-                        class="w-100"
-                        data-testid="llm-regenerate-functional"
-                        :disabled="!config?.gemini_configured || isAnyRegenerationLoading"
-                        @click="handleRegenerate('functional')"
-                      >
-                        <BSpinner
-                          v-if="functionalRegenerationJob.isLoading.value"
-                          small
-                          class="me-1"
-                        />
-                        Regenerate Functional
-                      </BButton>
-                    </BCol>
-                    <BCol md="4">
-                      <BButton
-                        variant="outline-primary"
-                        class="w-100"
-                        data-testid="llm-regenerate-phenotype"
-                        :disabled="!config?.gemini_configured || isAnyRegenerationLoading"
-                        @click="handleRegenerate('phenotype')"
-                      >
-                        <BSpinner
-                          v-if="phenotypeRegenerationJob.isLoading.value"
-                          small
-                          class="me-1"
-                        />
-                        Regenerate Phenotype
-                      </BButton>
-                    </BCol>
-                  </BRow>
-                </AdminOperationPanel>
-
-                <!-- Active Job Progress -->
-                <div v-if="regenerationFeedback" class="llm-regeneration-feedback">
-                  <BAlert :variant="regenerationFeedbackVariant" show class="mb-3">
-                    <i :class="regenerationFeedbackIcon" class="me-1" aria-hidden="true" />
-                    {{ regenerationFeedback }}
-                  </BAlert>
-                </div>
-
-                <div v-if="visibleRegenerationJobs.length" class="llm-job-list mb-4">
-                  <BCard
-                    v-for="job in visibleRegenerationJobs"
-                    :key="job.type"
-                    class="llm-job-card"
-                    :data-testid="`llm-regeneration-job-${job.type}`"
-                  >
-                    <div class="llm-job-card__header">
-                      <div>
-                        <BBadge :class="job.runner.statusBadgeClass.value" class="me-2">
-                          {{ job.runner.status.value }}
-                        </BBadge>
-                        <strong>{{ job.label }}</strong>
-                        <span class="llm-job-card__id">Job {{ job.runner.jobId.value }}</span>
-                      </div>
-                      <span class="llm-job-card__elapsed">
-                        <i class="bi bi-clock me-1" aria-hidden="true" />
-                        {{ job.runner.elapsedTimeDisplay.value }}
-                      </span>
                     </div>
-                    <p v-if="job.runner.step.value" class="llm-job-card__step">
-                      {{ job.runner.step.value }}
-                    </p>
-                    <BProgress :max="100" height="0.875rem">
-                      <BProgressBar
-                        :value="
-                          job.runner.hasRealProgress.value
-                            ? (job.runner.progressPercent.value ?? 0)
-                            : 100
-                        "
-                        :variant="job.runner.progressVariant.value"
-                        :striped="!job.runner.hasRealProgress.value"
-                        :animated="job.runner.isLoading.value"
-                      >
-                        <template v-if="job.runner.hasRealProgress.value">
-                          {{ job.runner.progress.value.current }}/{{
-                            job.runner.progress.value.total
-                          }}
-                        </template>
-                        <template v-else-if="job.runner.isLoading.value">Processing...</template>
-                      </BProgressBar>
-                    </BProgress>
-                    <BAlert v-if="job.runner.error.value" variant="danger" show class="mt-3 mb-0">
-                      <i class="bi bi-exclamation-triangle-fill me-1" aria-hidden="true" />
-                      {{ job.runner.error.value }}
+                  </template>
+
+                  <div v-if="regenerationFeedback" class="llm-regeneration-feedback">
+                    <BAlert :variant="regenerationFeedbackVariant" show class="mb-3">
+                      <i :class="regenerationFeedbackIcon" class="me-1" aria-hidden="true" />
+                      {{ regenerationFeedback }}
                     </BAlert>
-                  </BCard>
-                </div>
+                  </div>
+
+                  <div class="llm-overview-sections">
+                    <section class="llm-overview-section" aria-labelledby="llm-cache-heading">
+                      <div class="llm-section-heading">
+                        <h3 id="llm-cache-heading">Cache status</h3>
+                        <span>{{ cacheHealthLabel }}</span>
+                      </div>
+                      <div class="llm-table-wrap d-none d-md-block">
+                        <table class="table table-sm align-middle llm-overview-table">
+                          <thead>
+                            <tr>
+                              <th scope="col">Metric</th>
+                              <th scope="col">Value</th>
+                              <th scope="col">Status</th>
+                              <th scope="col">Notes</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr v-for="row in cacheSummaryRows" :key="row.key">
+                              <th scope="row">{{ row.label }}</th>
+                              <td class="llm-overview-table__value">{{ row.value }}</td>
+                              <td>
+                                <span :class="['llm-status-chip', row.tone]">
+                                  {{ row.status }}
+                                </span>
+                              </td>
+                              <td>{{ row.note }}</td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </div>
+                      <div class="llm-mobile-rows d-md-none">
+                        <article
+                          v-for="row in cacheSummaryRows"
+                          :key="row.key"
+                          class="llm-mobile-row"
+                        >
+                          <div class="llm-mobile-row__main">
+                            <strong>{{ row.label }}</strong>
+                            <span class="llm-overview-table__value">{{ row.value }}</span>
+                          </div>
+                          <div class="llm-mobile-row__meta">
+                            <span :class="['llm-status-chip', row.tone]">{{ row.status }}</span>
+                            <span>{{ row.note }}</span>
+                          </div>
+                        </article>
+                      </div>
+                    </section>
+
+                    <section class="llm-overview-section" aria-labelledby="llm-jobs-heading">
+                      <div class="llm-section-heading">
+                        <h3 id="llm-jobs-heading">Regeneration jobs</h3>
+                        <span>{{ visibleRegenerationJobs.length }} active</span>
+                      </div>
+                      <div class="llm-table-wrap d-none d-md-block">
+                        <table class="table table-sm align-middle llm-overview-table">
+                          <thead>
+                            <tr>
+                              <th scope="col">Type</th>
+                              <th scope="col">Status</th>
+                              <th scope="col">Job</th>
+                              <th scope="col">Progress</th>
+                              <th scope="col">Elapsed</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr v-if="!visibleRegenerationJobs.length">
+                              <td colspan="5" class="llm-empty-row">
+                                No active regeneration jobs in this browser session.
+                              </td>
+                            </tr>
+                            <tr
+                              v-for="job in visibleRegenerationJobs"
+                              :key="job.type"
+                              :data-testid="`llm-regeneration-job-${job.type}`"
+                            >
+                              <th scope="row">{{ job.label }}</th>
+                              <td>
+                                <BBadge :class="job.runner.statusBadgeClass.value">
+                                  {{ job.runner.status.value }}
+                                </BBadge>
+                              </td>
+                              <td class="llm-job-id">Job {{ job.runner.jobId.value }}</td>
+                              <td class="llm-job-progress-cell">
+                                <div v-if="job.runner.step.value" class="llm-job-step">
+                                  {{ job.runner.step.value }}
+                                </div>
+                                <BProgress :max="100" height="0.875rem">
+                                  <BProgressBar
+                                    :value="
+                                      job.runner.hasRealProgress.value
+                                        ? (job.runner.progressPercent.value ?? 0)
+                                        : 100
+                                    "
+                                    :variant="job.runner.progressVariant.value"
+                                    :striped="!job.runner.hasRealProgress.value"
+                                    :animated="job.runner.isLoading.value"
+                                  >
+                                    <template v-if="job.runner.hasRealProgress.value">
+                                      {{ job.runner.progress.value.current }}/{{
+                                        job.runner.progress.value.total
+                                      }}
+                                    </template>
+                                    <template v-else-if="job.runner.isLoading.value">
+                                      Processing...
+                                    </template>
+                                  </BProgressBar>
+                                </BProgress>
+                                <BAlert
+                                  v-if="job.runner.error.value"
+                                  variant="danger"
+                                  show
+                                  class="mt-2 mb-0"
+                                >
+                                  <i
+                                    class="bi bi-exclamation-triangle-fill me-1"
+                                    aria-hidden="true"
+                                  />
+                                  {{ job.runner.error.value }}
+                                </BAlert>
+                              </td>
+                              <td class="llm-job-elapsed">
+                                <i class="bi bi-clock me-1" aria-hidden="true" />
+                                {{ job.runner.elapsedTimeDisplay.value }}
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </div>
+                      <div class="llm-mobile-rows d-md-none">
+                        <article v-if="!visibleRegenerationJobs.length" class="llm-mobile-row">
+                          <div class="llm-mobile-row__main">
+                            <strong>No active regeneration jobs</strong>
+                          </div>
+                          <div class="llm-mobile-row__meta">
+                            <span>Jobs started here will remain visible after navigation.</span>
+                          </div>
+                        </article>
+                        <article
+                          v-for="job in visibleRegenerationJobs"
+                          :key="job.type"
+                          class="llm-mobile-row"
+                          :data-testid="`llm-regeneration-job-${job.type}`"
+                        >
+                          <div class="llm-mobile-row__main">
+                            <strong>{{ job.label }}</strong>
+                            <BBadge :class="job.runner.statusBadgeClass.value">
+                              {{ job.runner.status.value }}
+                            </BBadge>
+                          </div>
+                          <div class="llm-job-id">Job {{ job.runner.jobId.value }}</div>
+                          <div v-if="job.runner.step.value" class="llm-job-step">
+                            {{ job.runner.step.value }}
+                          </div>
+                          <BProgress :max="100" height="0.875rem">
+                            <BProgressBar
+                              :value="
+                                job.runner.hasRealProgress.value
+                                  ? (job.runner.progressPercent.value ?? 0)
+                                  : 100
+                              "
+                              :variant="job.runner.progressVariant.value"
+                              :striped="!job.runner.hasRealProgress.value"
+                              :animated="job.runner.isLoading.value"
+                            >
+                              <template v-if="job.runner.hasRealProgress.value">
+                                {{ job.runner.progress.value.current }}/{{
+                                  job.runner.progress.value.total
+                                }}
+                              </template>
+                              <template v-else-if="job.runner.isLoading.value">
+                                Processing...
+                              </template>
+                            </BProgressBar>
+                          </BProgress>
+                        </article>
+                      </div>
+                    </section>
+                  </div>
+                </TableShell>
               </section>
 
               <!-- Configuration Tab -->
@@ -244,6 +342,7 @@
 <script setup lang="ts">
 import AuthenticatedPageShell from '@/components/layout/AuthenticatedPageShell.vue';
 import AdminOperationPanel from '@/components/admin/AdminOperationPanel.vue';
+import TableShell from '@/components/table/TableShell.vue';
 import { computed, ref, onMounted, onUnmounted, watch } from 'vue';
 import { useLlmAdmin } from '@/composables/useLlmAdmin';
 import { useAsyncJob } from '@/composables/useAsyncJob';
@@ -321,6 +420,52 @@ const visibleRegenerationJobs = computed(() =>
     }))
     .filter((job) => Boolean(job.runner.jobId.value))
 );
+
+const overviewDescription = computed(() => {
+  const model = config.value?.gemini_configured ? config.value.current_model : 'Not configured';
+  return `Model ${model}. Cache and regeneration controls use the same compact table layout as public data views.`;
+});
+
+const cacheHealthLabel = computed(() => {
+  if (!config.value?.gemini_configured) return 'Provider not configured';
+  const pending = cacheStats.value?.by_status?.pending ?? 0;
+  return pending > 0 ? `${pending} pending review` : 'No pending reviews';
+});
+
+const cacheSummaryRows = computed(() => [
+  {
+    key: 'total',
+    label: 'Total summaries',
+    value: String(cacheStats.value?.total_entries ?? 0),
+    status: 'Cached',
+    tone: 'neutral',
+    note: 'All stored functional and phenotype summaries',
+  },
+  {
+    key: 'validated',
+    label: 'Validated',
+    value: String(cacheStats.value?.by_status?.validated ?? 0),
+    status: 'Accepted',
+    tone: 'success',
+    note: 'Summaries approved for display',
+  },
+  {
+    key: 'pending',
+    label: 'Pending review',
+    value: String(cacheStats.value?.by_status?.pending ?? 0),
+    status: 'Needs review',
+    tone: 'warning',
+    note: 'Generated summaries awaiting validation',
+  },
+  {
+    key: 'cost',
+    label: 'Estimated cost',
+    value: `$${(cacheStats.value?.estimated_cost_usd ?? 0).toFixed(2)}`,
+    status: 'USD',
+    tone: 'info',
+    note: 'Approximate generation spend',
+  },
+]);
 
 const regenerationFeedbackIcon = computed(() => {
   switch (regenerationFeedbackVariant.value) {
@@ -606,26 +751,75 @@ watch(
 </script>
 
 <style scoped>
-.llm-job-list {
-  display: grid;
-  gap: 0.75rem;
-}
-
-.llm-job-card {
-  border-color: #d9e0ea;
-}
-
-.llm-job-card__header {
+.llm-overview-toolbar {
   display: flex;
-  gap: 0.75rem;
-  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
   justify-content: space-between;
 }
 
-.llm-job-card__id {
-  display: block;
-  margin-top: 0.25rem;
+.llm-overview-toolbar__group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.llm-overview-sections {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.llm-overview-section {
+  min-width: 0;
+}
+
+.llm-section-heading {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.llm-section-heading h3 {
+  margin: 0;
+  color: var(--neutral-900, #212121);
+  font-size: 0.95rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.llm-section-heading span {
   color: var(--neutral-600, #757575);
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
+.llm-table-wrap {
+  overflow-x: auto;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 0.5rem;
+}
+
+.llm-overview-table {
+  min-width: 760px;
+  margin: 0;
+}
+
+.llm-overview-table :deep(th) {
+  color: #475569;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.llm-overview-table :deep(td),
+.llm-overview-table :deep(th) {
+  padding: 0.65rem 0.75rem;
+}
+
+.llm-overview-table__value,
+.llm-job-id {
   font-family: var(
     --font-family-mono,
     ui-monospace,
@@ -636,19 +830,89 @@ watch(
     monospace
   );
   font-size: 0.8125rem;
+}
+
+.llm-job-id {
+  color: var(--neutral-600, #757575);
   overflow-wrap: anywhere;
 }
 
-.llm-job-card__elapsed {
-  flex: 0 0 auto;
-  color: var(--neutral-600, #757575);
-  font-size: 0.875rem;
+.llm-job-progress-cell {
+  min-width: 280px;
 }
 
-.llm-job-card__step {
-  margin: 0.75rem 0 0.5rem;
+.llm-job-step {
+  margin-bottom: 0.35rem;
   color: var(--neutral-700, #424242);
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
+}
+
+.llm-job-elapsed,
+.llm-empty-row {
+  color: var(--neutral-600, #757575);
+  font-size: 0.8125rem;
+}
+
+.llm-status-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.375rem;
+  padding: 0.125rem 0.5rem;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  border-radius: 999px;
+  background: #f8fafc;
+  color: #475569;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.llm-status-chip.success {
+  border-color: rgba(46, 125, 50, 0.18);
+  background: rgba(46, 125, 50, 0.08);
+  color: var(--status-success, #2e7d32);
+}
+
+.llm-status-chip.warning {
+  border-color: rgba(245, 124, 0, 0.2);
+  background: rgba(245, 124, 0, 0.1);
+  color: var(--status-warning, #f57c00);
+}
+
+.llm-status-chip.info {
+  border-color: rgba(2, 119, 189, 0.18);
+  background: rgba(2, 119, 189, 0.08);
+  color: var(--status-info, #0277bd);
+}
+
+.llm-mobile-rows {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.llm-mobile-row {
+  display: grid;
+  gap: 0.4rem;
+  padding: 0.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 0.5rem;
+  background: #fff;
+}
+
+.llm-mobile-row__main,
+.llm-mobile-row__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.llm-mobile-row__meta {
+  justify-content: flex-start;
+  color: var(--neutral-600, #757575);
+  font-size: 0.8125rem;
 }
 
 @media (max-width: 575.98px) {
@@ -656,8 +920,19 @@ watch(
     gap: 0.25rem;
   }
 
-  .llm-job-card__header {
+  .llm-overview-toolbar {
+    align-items: stretch;
+  }
+
+  .llm-overview-toolbar,
+  .llm-overview-toolbar__group,
+  .llm-overview-toolbar :deep(.btn) {
+    width: 100%;
+  }
+
+  .llm-section-heading {
     display: grid;
+    gap: 0.25rem;
   }
 }
 </style>

--- a/app/src/views/admin/ManageLLM.vue
+++ b/app/src/views/admin/ManageLLM.vue
@@ -287,6 +287,9 @@ const regenerationJobLabels: Record<ClusterType, string> = {
   phenotype: 'Phenotype regeneration',
 };
 
+const regenerationStorageKey = 'sysndd.llm.activeRegenerationJobs.v1';
+type StoredRegenerationJobs = Partial<Record<ClusterType, string>>;
+
 // Local state
 const showClearModal = ref(false);
 const clearType = ref<ClusterType | 'all'>('all');
@@ -355,6 +358,76 @@ function unwrapValue<T>(val: T | T[]): T {
   return Array.isArray(val) && val.length === 1 ? val[0] : (val as T);
 }
 
+function getSessionStorage(): Storage | null {
+  return typeof window === 'undefined' ? null : window.sessionStorage;
+}
+
+function readStoredRegenerationJobs(): StoredRegenerationJobs {
+  const storage = getSessionStorage();
+  if (!storage) return {};
+
+  try {
+    const parsed = JSON.parse(storage.getItem(regenerationStorageKey) || '{}') as unknown;
+    if (!parsed || typeof parsed !== 'object') return {};
+
+    return (['functional', 'phenotype'] as ClusterType[]).reduce<StoredRegenerationJobs>(
+      (jobs, type) => {
+        const jobId = (parsed as Record<string, unknown>)[type];
+        if (typeof jobId === 'string' && jobId.length > 0) {
+          jobs[type] = jobId;
+        }
+        return jobs;
+      },
+      {}
+    );
+  } catch {
+    return {};
+  }
+}
+
+function writeStoredRegenerationJobs(jobs: StoredRegenerationJobs) {
+  const storage = getSessionStorage();
+  if (!storage) return;
+
+  if (Object.keys(jobs).length === 0) {
+    storage.removeItem(regenerationStorageKey);
+    return;
+  }
+
+  storage.setItem(regenerationStorageKey, JSON.stringify(jobs));
+}
+
+function persistRegenerationJob(type: ClusterType, jobId: string) {
+  writeStoredRegenerationJobs({
+    ...readStoredRegenerationJobs(),
+    [type]: jobId,
+  });
+}
+
+function clearPersistedRegenerationJob(type: ClusterType) {
+  const jobs = readStoredRegenerationJobs();
+  delete jobs[type];
+  writeStoredRegenerationJobs(jobs);
+}
+
+function rehydrateRegenerationJobs() {
+  const storedJobs = readStoredRegenerationJobs();
+  const resumed = (Object.keys(regenerationJobs) as ClusterType[]).filter((type) => {
+    const jobId = storedJobs[type];
+    if (!jobId || regenerationJobs[type].jobId.value) return false;
+
+    regenerationJobs[type].startJob(jobId);
+    return true;
+  });
+
+  if (resumed.length) {
+    regenerationFeedback.value = `Resumed tracking ${resumed
+      .map((type) => regenerationJobLabels[type].toLowerCase())
+      .join(' and ')} from this browser session.`;
+    regenerationFeedbackVariant.value = 'info';
+  }
+}
+
 function requestedClusterTypes(type: ClusterType | 'all'): ClusterType[] {
   return type === 'all' ? ['functional', 'phenotype'] : [type];
 }
@@ -375,8 +448,10 @@ function startRegenerationTrackers(
     const jobId = jobIdFromRegenerationResult(result, type);
 
     if (jobId) {
+      const unwrappedJobId = unwrapValue(jobId);
       regenerationJobs[type].reset();
-      regenerationJobs[type].startJob(unwrapValue(jobId));
+      regenerationJobs[type].startJob(unwrappedJobId);
+      persistRegenerationJob(type, unwrappedJobId);
       started.push(type);
       return;
     }
@@ -407,6 +482,7 @@ function startRegenerationTrackers(
 // Lifecycle
 onMounted(async () => {
   syncActiveTabFromLocation();
+  rehydrateRegenerationJobs();
   window.addEventListener('hashchange', syncActiveTabFromLocation);
   window.addEventListener('popstate', syncActiveTabFromLocation);
   await refreshAll();
@@ -494,11 +570,13 @@ watch(
   () => functionalRegenerationJob.status.value,
   async (newStatus) => {
     if (newStatus === 'completed') {
+      clearPersistedRegenerationJob('functional');
       regenerationFeedback.value = 'Functional regeneration completed. Cache statistics refreshed.';
       regenerationFeedbackVariant.value = 'success';
       makeToast('Functional regeneration completed', 'Success', 'success');
       await fetchCacheStats();
     } else if (newStatus === 'failed') {
+      clearPersistedRegenerationJob('functional');
       regenerationFeedback.value =
         functionalRegenerationJob.error.value || 'Functional regeneration failed.';
       regenerationFeedbackVariant.value = 'danger';
@@ -511,11 +589,13 @@ watch(
   () => phenotypeRegenerationJob.status.value,
   async (newStatus) => {
     if (newStatus === 'completed') {
+      clearPersistedRegenerationJob('phenotype');
       regenerationFeedback.value = 'Phenotype regeneration completed. Cache statistics refreshed.';
       regenerationFeedbackVariant.value = 'success';
       makeToast('Phenotype regeneration completed', 'Success', 'success');
       await fetchCacheStats();
     } else if (newStatus === 'failed') {
+      clearPersistedRegenerationJob('phenotype');
       regenerationFeedback.value =
         phenotypeRegenerationJob.error.value || 'Phenotype regeneration failed.';
       regenerationFeedbackVariant.value = 'danger';

--- a/app/src/views/admin/ManagePubtator.spec.ts
+++ b/app/src/views/admin/ManagePubtator.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { ref, computed } from 'vue';
+
+import ManagePubtator from './ManagePubtator.vue';
+
+vi.mock('@/composables/usePubtatorAdmin', () => ({
+  usePubtatorAdmin: () => {
+    const lastStatus = ref({
+      query: 'neurodevelopmental disorder',
+      cached: true,
+      query_id: 12,
+      pages_cached: 8,
+      publications_cached: 214,
+      total_pages_available: 20,
+      total_results_available: 612,
+      pages_remaining: 12,
+      cache_date: '2026-05-01T12:00:00Z',
+      estimated_fetch_time_minutes: 30,
+      message: 'Cached',
+    });
+
+    return {
+      error: ref(null),
+      lastStatus,
+      isCheckingStatus: ref(false),
+      isClearing: ref(false),
+      isBackfilling: ref(false),
+      jobId: ref('job-123456789'),
+      jobStatus: ref('running'),
+      jobStep: ref('Fetching page 8 of 20'),
+      jobProgress: ref({ current: 8, total: 20 }),
+      jobError: ref(null),
+      hasRealProgress: ref(true),
+      progressPercent: ref(40),
+      elapsedTimeDisplay: ref('00:04:12'),
+      progressVariant: ref('info'),
+      statusBadgeClass: ref('bg-info'),
+      isJobLoading: ref(false),
+      cacheProgress: computed(() => 40),
+      getCacheStatus: vi.fn(),
+      submitFetchJob: vi.fn(),
+      clearCache: vi.fn(),
+      backfillGeneSymbols: vi.fn(),
+      stopPolling: vi.fn(),
+      resetJob: vi.fn(),
+    };
+  },
+}));
+
+function mountView() {
+  return mount(ManagePubtator, {
+    global: {
+      stubs: {
+        AuthenticatedPageShell: {
+          template: '<main data-testid="authenticated-page-shell"><slot /></main>',
+        },
+        BContainer: { template: '<div><slot /></div>' },
+        BRow: { template: '<div><slot /></div>' },
+        BCol: { template: '<div><slot /></div>' },
+        BCard: { template: '<section><slot name="header" /><slot /></section>' },
+        BFormGroup: {
+          props: ['label'],
+          template: '<label><span>{{ label }}</span><slot /></label>',
+        },
+        BInputGroup: { template: '<div><slot name="prepend" /><slot /></div>' },
+        BInputGroupText: { template: '<span><slot /></span>' },
+        BFormInput: {
+          props: ['type', 'modelValue', 'placeholder'],
+          template: '<input :type="type" :value="modelValue" :placeholder="placeholder" />',
+        },
+        BFormText: { template: '<small><slot /></small>' },
+        BFormCheckbox: { template: '<label><input type="checkbox" /><slot /></label>' },
+        BButton: { template: '<button><slot /></button>' },
+        BButtonGroup: { template: '<div><slot /></div>' },
+        BSpinner: { template: '<span />' },
+        BBadge: { template: '<span><slot /></span>' },
+        BAlert: { template: '<div><slot /></div>' },
+        BProgress: { template: '<div><slot /></div>' },
+        BProgressBar: { template: '<div><slot /></div>' },
+        BModal: { template: '<div><slot /></div>' },
+      },
+    },
+  });
+}
+
+describe('ManagePubtator visual structure', () => {
+  it('groups query, fetch, and destructive actions into distinct work zones', () => {
+    const wrapper = mountView();
+
+    expect(wrapper.get('[data-testid="pubtator-query-workspace"]').text()).toContain(
+      'PubTator query'
+    );
+    expect(wrapper.get('[data-testid="pubtator-status-metrics"]').text()).toContain('Cached');
+    expect(wrapper.get('[data-testid="pubtator-fetch-workspace"]').text()).toContain(
+      'Submit fetch job'
+    );
+    expect(wrapper.get('[data-testid="pubtator-danger-zone"]').text()).toContain('Clear all cache');
+  });
+});

--- a/app/src/views/admin/ManagePubtator.vue
+++ b/app/src/views/admin/ManagePubtator.vue
@@ -8,259 +8,239 @@ ManagePubtator */
 <template>
   <AuthenticatedPageShell
     title="Manage PubTator"
+    description="Check query coverage, fetch publication annotations, and maintain the PubTator cache."
     content-class="authenticated-route-content"
     full-width
   >
-    <div class="container-fluid">
-      <BContainer fluid>
-        <BRow class="justify-content-md-center py-2">
-          <BCol md="10">
-            <AdminOperationPanel
-              title="PubTator Cache Management"
-              description="Check query coverage, submit background fetches, backfill genes, and manage cache state."
-              icon="bi-journal-medical"
+    <BContainer fluid class="pubtator-admin">
+      <AdminOperationPanel
+        title="Search coverage"
+        description="Start with a PubTator query, then decide whether the local cache needs more pages or gene-symbol backfill."
+        icon="bi-search"
+        :meta="lastStatus ? cacheStateLabel : 'No query checked'"
+      >
+        <div data-testid="pubtator-query-workspace">
+          <form class="pubtator-query-form" @submit.prevent="checkStatus">
+            <BFormGroup
+              label="PubTator query"
+              label-for="query-input"
+              class="pubtator-query-form__field"
             >
-
-              <!-- Query Input Section -->
-              <BRow class="mb-4">
-                <BCol md="8">
-                  <BFormGroup label="Search Query" label-for="query-input">
-                    <BInputGroup>
-                      <template #prepend>
-                        <BInputGroupText><i class="bi bi-search" /></BInputGroupText>
-                      </template>
-                      <BFormInput
-                        id="query-input"
-                        v-model="query"
-                        placeholder="PubTator search query"
-                        :disabled="isJobLoading"
-                        @keyup.enter="checkStatus"
-                      />
-                      <BButton
-                        variant="outline-primary"
-                        :disabled="!query.trim() || isCheckingStatus"
-                        @click="checkStatus"
-                      >
-                        <BSpinner v-if="isCheckingStatus" small class="me-1" />
-                        Check Status
-                      </BButton>
-                    </BInputGroup>
-                  </BFormGroup>
-                </BCol>
-              </BRow>
-
-              <!-- Cache Status Display -->
-              <BCard v-if="lastStatus" class="mb-4" bg-variant="light">
-                <BRow>
-                  <BCol md="6">
-                    <h6><i class="bi bi-info-circle me-1" /> Cache Status</h6>
-                    <dl class="row mb-0">
-                      <dt class="col-6">Status:</dt>
-                      <dd class="col-6">
-                        <BBadge :variant="lastStatus.cached ? 'success' : 'warning'">
-                          {{ lastStatus.cached ? 'Cached' : 'Not Cached' }}
-                        </BBadge>
-                      </dd>
-
-                      <dt class="col-6">Pages Cached:</dt>
-                      <dd class="col-6">{{ lastStatus.pages_cached || 0 }}</dd>
-
-                      <dt class="col-6">Publications:</dt>
-                      <dd class="col-6">{{ lastStatus.publications_cached || 0 }}</dd>
-
-                      <dt
-                        v-if="lastStatus.cache_date && typeof lastStatus.cache_date === 'string'"
-                        class="col-6"
-                      >
-                        Last Updated:
-                      </dt>
-                      <dd
-                        v-if="lastStatus.cache_date && typeof lastStatus.cache_date === 'string'"
-                        class="col-6"
-                      >
-                        {{ formatDate(lastStatus.cache_date) }}
-                      </dd>
-                    </dl>
-                  </BCol>
-                  <BCol md="6">
-                    <h6><i class="bi bi-cloud-download me-1" /> Available from API</h6>
-                    <dl class="row mb-0">
-                      <dt class="col-6">Total Pages:</dt>
-                      <dd class="col-6">{{ lastStatus.total_pages_available || 0 }}</dd>
-
-                      <dt class="col-6">Total Results:</dt>
-                      <dd class="col-6">
-                        {{ (lastStatus.total_results_available || 0).toLocaleString() }}
-                      </dd>
-
-                      <dt class="col-6">Pages Remaining:</dt>
-                      <dd class="col-6">{{ lastStatus.pages_remaining || 0 }}</dd>
-
-                      <dt class="col-6">Est. Fetch Time:</dt>
-                      <dd class="col-6">~{{ lastStatus.estimated_fetch_time_minutes || 0 }} min</dd>
-                    </dl>
-                  </BCol>
-                </BRow>
-
-                <!-- Cache Progress Bar -->
-                <BRow v-if="lastStatus.cached" class="mt-3">
-                  <BCol>
-                    <BProgress :max="100" height="1.5rem" show-value>
-                      <BProgressBar :value="cacheProgress" variant="success">
-                        {{ cacheProgress }}% cached
-                      </BProgressBar>
-                    </BProgress>
-                  </BCol>
-                </BRow>
-              </BCard>
-
-              <!-- Fetch Controls -->
-              <AdminOperationPanel
-                title="Fetch Publications"
-                description="Fetches run in the background. You can close this page and the job will continue."
-                icon="bi-cloud-arrow-down"
-                heading-tag="h3"
+              <textarea
+                id="query-input"
+                v-model="query"
+                class="form-control pubtator-query-form__textarea"
+                placeholder="PubTator search query"
+                :disabled="isJobLoading"
+              ></textarea>
+            </BFormGroup>
+            <div class="pubtator-query-form__actions">
+              <BButton
+                type="submit"
+                variant="primary"
+                :disabled="!query.trim() || isCheckingStatus"
               >
-                <BRow class="mb-3">
-                  <BCol md="4">
-                    <BFormGroup label="Pages to Fetch" label-for="max-pages">
-                      <BFormInput
-                        id="max-pages"
-                        v-model.number="maxPages"
-                        type="number"
-                        min="1"
-                        max="2000"
-                        :disabled="isJobLoading"
-                      />
-                      <BFormText>
-                        ~{{ Math.round((maxPages * 2.5) / 60) }} min at 10 results/page
-                      </BFormText>
-                    </BFormGroup>
-                  </BCol>
-                  <BCol md="4">
-                    <BFormGroup label="Update Type">
-                      <BFormCheckbox v-model="clearOld" :disabled="isJobLoading" switch>
-                        Hard Update (clear existing cache first)
-                      </BFormCheckbox>
-                    </BFormGroup>
-                  </BCol>
-                </BRow>
+                <BSpinner v-if="isCheckingStatus" small class="me-1" />
+                <i v-else class="bi bi-search me-1" aria-hidden="true" />
+                Check status
+              </BButton>
+            </div>
+          </form>
 
-                <BButtonGroup>
-                  <BButton
-                    variant="primary"
-                    :disabled="!query.trim() || isJobLoading"
-                    @click="submitFetch"
-                  >
-                    <BSpinner v-if="isJobLoading && jobStatus === 'accepted'" small class="me-1" />
-                    <i v-else class="bi bi-download me-1" />
-                    Submit Fetch Job
-                  </BButton>
-                  <BButton v-if="isJobLoading" variant="outline-secondary" @click="stopPolling">
-                    <i class="bi bi-stop-circle me-1" />
-                    Stop Tracking
-                  </BButton>
-                  <BButton
-                    variant="outline-secondary"
-                    :disabled="!lastStatus?.cached || isJobLoading || isBackfilling"
-                    @click="backfillGenes"
-                  >
-                    <BSpinner v-if="isBackfilling" small class="me-1" />
-                    <i v-else class="bi bi-arrow-repeat me-1" />
-                    Backfill Gene Symbols
-                  </BButton>
-                </BButtonGroup>
-
-                <!-- Job Progress Panel -->
-                <BCard v-if="jobId" class="mt-3" :border-variant="progressVariant">
-                  <BRow>
-                    <BCol md="8">
-                      <h6 class="mb-2">
-                        <BBadge :class="statusBadgeClass" class="me-2">{{ jobStatus }}</BBadge>
-                        Job: {{ jobId.substring(0, 8) }}...
-                      </h6>
-                      <p v-if="jobStep" class="mb-2 text-muted small">{{ jobStep }}</p>
-
-                      <!-- Progress bar -->
-                      <BProgress :max="100" height="1.5rem" class="mb-2">
-                        <BProgressBar
-                          :value="hasRealProgress ? (progressPercent ?? 0) : 100"
-                          :variant="progressVariant"
-                          :striped="!hasRealProgress"
-                          :animated="isJobLoading"
-                        >
-                          <template v-if="hasRealProgress">
-                            {{ jobProgress.current }}/{{ jobProgress.total }} pages
-                          </template>
-                          <template v-else-if="isJobLoading"> Processing... </template>
-                        </BProgressBar>
-                      </BProgress>
-                    </BCol>
-                    <BCol md="4" class="text-end">
-                      <div class="text-muted">
-                        <i class="bi bi-clock me-1" />
-                        {{ elapsedTimeDisplay }}
-                      </div>
-                    </BCol>
-                  </BRow>
-
-                  <!-- Job error -->
-                  <BAlert v-if="jobError" variant="danger" class="mt-2 mb-0" show>
-                    <i class="bi bi-exclamation-triangle-fill me-1" />
-                    {{ jobError }}
-                  </BAlert>
-
-                  <!-- Job completed -->
-                  <BAlert v-if="jobStatus === 'completed'" variant="success" class="mt-2 mb-0" show>
-                    <i class="bi bi-check-circle-fill me-1" />
-                    Fetch completed successfully! Refresh cache status to see results.
-                  </BAlert>
-                </BCard>
-
-                <!-- Feedback messages -->
-                <BAlert v-if="feedbackMessage" :variant="feedbackVariant" class="mt-3 mb-0" show>
-                  <i :class="feedbackIcon" class="me-1" />
-                  {{ feedbackMessage }}
-                </BAlert>
-              </AdminOperationPanel>
-
-              <!-- Clear Cache Section -->
-              <AdminOperationPanel
-                title="Clear Cache"
-                description="Remove all cached publications and annotations. Use with caution."
-                icon="bi-trash"
-                heading-tag="h3"
-                tone="danger"
+          <div v-if="lastStatus" class="pubtator-status" data-testid="pubtator-status-metrics">
+            <div class="pubtator-status__summary">
+              <span
+                class="pubtator-status__badge"
+                :class="
+                  lastStatus.cached
+                    ? 'pubtator-status__badge--success'
+                    : 'pubtator-status__badge--warning'
+                "
               >
-                <BButton
-                  variant="danger"
-                  :disabled="isJobLoading || isClearing"
-                  @click="showClearAllModal = true"
-                >
-                  <BSpinner v-if="isClearing" small class="me-1" />
-                  Clear ALL Cache
-                </BButton>
-              </AdminOperationPanel>
-            </AdminOperationPanel>
-          </BCol>
-        </BRow>
+                <i
+                  :class="lastStatus.cached ? 'bi bi-check-circle' : 'bi bi-exclamation-circle'"
+                  aria-hidden="true"
+                />
+                {{ cacheStateLabel }}
+              </span>
+              <span v-if="lastStatus.cache_date" class="pubtator-status__updated">
+                Updated {{ formatDate(lastStatus.cache_date) }}
+              </span>
+            </div>
 
-        <!-- Clear All Confirmation Modal -->
-        <BModal
-          v-model="showClearAllModal"
-          title="Clear All PubTator Cache"
-          ok-variant="danger"
-          ok-title="Yes, Clear All"
-          @ok="clearAllCache"
-        >
+            <div class="pubtator-metrics">
+              <div class="pubtator-metric">
+                <span class="pubtator-metric__label">Pages cached</span>
+                <strong>{{ lastStatus.pages_cached || 0 }}</strong>
+              </div>
+              <div class="pubtator-metric">
+                <span class="pubtator-metric__label">Publications</span>
+                <strong>{{ (lastStatus.publications_cached || 0).toLocaleString() }}</strong>
+              </div>
+              <div class="pubtator-metric">
+                <span class="pubtator-metric__label">API results</span>
+                <strong>{{ (lastStatus.total_results_available || 0).toLocaleString() }}</strong>
+              </div>
+              <div class="pubtator-metric">
+                <span class="pubtator-metric__label">Pages remaining</span>
+                <strong>{{ lastStatus.pages_remaining || 0 }}</strong>
+              </div>
+              <div class="pubtator-metric">
+                <span class="pubtator-metric__label">Estimated fetch</span>
+                <strong>{{ lastStatus.estimated_fetch_time_minutes || 0 }} min</strong>
+              </div>
+            </div>
+
+            <div class="pubtator-cache-progress">
+              <div class="pubtator-cache-progress__header">
+                <span>Cache coverage</span>
+                <strong>{{ cacheProgress }}%</strong>
+              </div>
+              <BProgress :max="100" height="0.75rem">
+                <BProgressBar :value="cacheProgress" variant="success" />
+              </BProgress>
+            </div>
+          </div>
+
+          <div v-else class="pubtator-empty-state">
+            <i class="bi bi-info-circle" aria-hidden="true" />
+            Check a query to see local cache coverage and PubTator API availability.
+          </div>
+        </div>
+      </AdminOperationPanel>
+
+      <AdminOperationPanel
+        title="Fetch publications"
+        description="Fetches run as background jobs. You can leave this page after submission and return to check progress."
+        icon="bi-cloud-arrow-down"
+        heading-tag="h2"
+      >
+        <div class="pubtator-fetch" data-testid="pubtator-fetch-workspace">
+          <div class="pubtator-fetch__settings">
+            <BFormGroup label="Pages to fetch" label-for="max-pages">
+              <BFormInput
+                id="max-pages"
+                v-model.number="maxPages"
+                type="number"
+                min="1"
+                max="2000"
+                :disabled="isJobLoading"
+              />
+              <BFormText>~{{ Math.round((maxPages * 2.5) / 60) }} min at 10 results/page</BFormText>
+            </BFormGroup>
+
+            <BFormGroup label="Update type">
+              <BFormCheckbox v-model="clearOld" :disabled="isJobLoading" switch>
+                Hard update: clear existing cache first
+              </BFormCheckbox>
+            </BFormGroup>
+          </div>
+
+          <div class="pubtator-fetch__actions">
+            <BButton
+              variant="primary"
+              :disabled="!query.trim() || isJobLoading"
+              @click="submitFetch"
+            >
+              <BSpinner v-if="isJobLoading && jobStatus === 'accepted'" small class="me-1" />
+              <i v-else class="bi bi-download me-1" aria-hidden="true" />
+              Submit fetch job
+            </BButton>
+            <BButton v-if="isJobLoading" variant="outline-secondary" @click="stopPolling">
+              <i class="bi bi-stop-circle me-1" aria-hidden="true" />
+              Stop tracking
+            </BButton>
+            <BButton
+              variant="outline-secondary"
+              :disabled="!lastStatus?.cached || isJobLoading || isBackfilling"
+              @click="backfillGenes"
+            >
+              <BSpinner v-if="isBackfilling" small class="me-1" />
+              <i v-else class="bi bi-arrow-repeat me-1" aria-hidden="true" />
+              Backfill gene symbols
+            </BButton>
+          </div>
+
+          <div v-if="jobId" class="pubtator-job">
+            <div class="pubtator-job__header">
+              <div>
+                <BBadge :class="statusBadgeClass" class="me-2">{{ jobStatus }}</BBadge>
+                <span class="pubtator-job__id">Job {{ jobId.substring(0, 8) }}</span>
+              </div>
+              <span class="pubtator-job__elapsed">
+                <i class="bi bi-clock me-1" aria-hidden="true" />
+                {{ elapsedTimeDisplay }}
+              </span>
+            </div>
+            <p v-if="jobStep" class="pubtator-job__step">{{ jobStep }}</p>
+            <BProgress :max="100" height="0.875rem">
+              <BProgressBar
+                :value="hasRealProgress ? (progressPercent ?? 0) : 100"
+                :variant="progressVariant"
+                :striped="!hasRealProgress"
+                :animated="isJobLoading"
+              >
+                <template v-if="hasRealProgress">
+                  {{ jobProgress.current }}/{{ jobProgress.total }} pages
+                </template>
+                <template v-else-if="isJobLoading">Processing...</template>
+              </BProgressBar>
+            </BProgress>
+
+            <BAlert v-if="jobError" variant="danger" class="mt-3 mb-0" show>
+              <i class="bi bi-exclamation-triangle-fill me-1" aria-hidden="true" />
+              {{ jobError }}
+            </BAlert>
+            <BAlert v-if="jobStatus === 'completed'" variant="success" class="mt-3 mb-0" show>
+              <i class="bi bi-check-circle-fill me-1" aria-hidden="true" />
+              Fetch completed successfully. Refresh cache status to see results.
+            </BAlert>
+          </div>
+
+          <BAlert v-if="feedbackMessage" :variant="feedbackVariant" class="mt-3 mb-0" show>
+            <i :class="feedbackIcon" class="me-1" aria-hidden="true" />
+            {{ feedbackMessage }}
+          </BAlert>
+        </div>
+      </AdminOperationPanel>
+
+      <AdminOperationPanel
+        title="Clear cache"
+        description="Remove all cached PubTator publications and annotations for every query."
+        icon="bi-trash"
+        heading-tag="h2"
+        tone="danger"
+      >
+        <div class="pubtator-danger" data-testid="pubtator-danger-zone">
           <p>
-            Are you sure you want to clear <strong>all</strong> cached PubTator data? This will
-            delete all publications and annotations for all queries.
+            Use this only when the cache is invalid or needs a full rebuild. Fetch jobs should be
+            stopped or allowed to finish first.
           </p>
-          <p class="text-danger mb-0">This action cannot be undone.</p>
-        </BModal>
-      </BContainer>
-    </div>
+          <BButton
+            variant="danger"
+            :disabled="isJobLoading || isClearing"
+            @click="showClearAllModal = true"
+          >
+            <BSpinner v-if="isClearing" small class="me-1" />
+            Clear all cache
+          </BButton>
+        </div>
+      </AdminOperationPanel>
+
+      <BModal
+        v-model="showClearAllModal"
+        title="Clear All PubTator Cache"
+        ok-variant="danger"
+        ok-title="Yes, clear all"
+        @ok="clearAllCache"
+      >
+        <p>
+          Are you sure you want to clear <strong>all</strong> cached PubTator data? This will delete
+          all publications and annotations for all queries.
+        </p>
+        <p class="text-danger mb-0">This action cannot be undone.</p>
+      </BModal>
+    </BContainer>
   </AuthenticatedPageShell>
 </template>
 
@@ -270,17 +250,11 @@ import AdminOperationPanel from '@/components/admin/AdminOperationPanel.vue';
 import { ref, computed } from 'vue';
 import {
   BContainer,
-  BRow,
-  BCol,
-  BCard,
   BFormGroup,
-  BInputGroup,
-  BInputGroupText,
   BFormInput,
   BFormText,
   BFormCheckbox,
   BButton,
-  BButtonGroup,
   BSpinner,
   BBadge,
   BAlert,
@@ -356,6 +330,11 @@ const feedbackIcon = computed(() => {
   }
 });
 
+const cacheStateLabel = computed(() => {
+  if (!lastStatus.value) return 'No status';
+  return lastStatus.value.cached ? 'Cached' : 'Not cached';
+});
+
 // Methods
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return 'N/A';
@@ -422,11 +401,238 @@ async function clearAllCache() {
 </script>
 
 <style scoped>
-dl.row dt {
-  font-weight: 500;
+.pubtator-admin {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
 }
 
-dl.row dd {
-  color: var(--bs-body-color);
+.pubtator-query-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: end;
+}
+
+.pubtator-query-form__field {
+  margin-bottom: 0;
+}
+
+.pubtator-query-form__textarea {
+  min-height: 5.25rem;
+  resize: vertical;
+  font-family: var(
+    --font-family-mono,
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    monospace
+  );
+  font-size: 0.875rem;
+  line-height: 1.4;
+}
+
+.pubtator-query-form__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.pubtator-status {
+  display: grid;
+  gap: 0.875rem;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e6ebf2;
+}
+
+.pubtator-status__summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.pubtator-status__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-height: 1.6rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: var(--radius-full, 999px);
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+.pubtator-status__badge--success {
+  border: 1px solid rgba(46, 125, 50, 0.28);
+  background: #edf7ed;
+  color: var(--status-success, #2e7d32);
+}
+
+.pubtator-status__badge--warning {
+  border: 1px solid rgba(245, 124, 0, 0.3);
+  background: #fff7ed;
+  color: var(--status-warning, #f57c00);
+}
+
+.pubtator-status__updated {
+  color: #64748b;
+  font-size: 0.8125rem;
+}
+
+.pubtator-metrics {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(8rem, 1fr));
+  gap: 0.625rem;
+}
+
+.pubtator-metric {
+  min-width: 0;
+  padding: 0.75rem;
+  border: 1px solid #e1e7ef;
+  border-radius: 8px;
+  background: #f8fafc;
+}
+
+.pubtator-metric__label {
+  display: block;
+  margin-bottom: 0.25rem;
+  color: #64748b;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.pubtator-metric strong {
+  color: #172033;
+  font-size: 1rem;
+}
+
+.pubtator-cache-progress {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.pubtator-cache-progress__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  color: #41576f;
+  font-size: 0.8125rem;
+}
+
+.pubtator-empty-state {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-top: 1rem;
+  padding: 0.75rem;
+  border: 1px dashed #cbd5e1;
+  border-radius: 8px;
+  background: #f8fafc;
+  color: #526070;
+  font-size: 0.875rem;
+}
+
+.pubtator-fetch {
+  display: grid;
+  gap: 1rem;
+}
+
+.pubtator-fetch__settings {
+  display: grid;
+  grid-template-columns: minmax(10rem, 16rem) minmax(14rem, 1fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.pubtator-fetch__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.pubtator-job {
+  display: grid;
+  gap: 0.625rem;
+  padding: 0.875rem;
+  border: 1px solid #d7dee8;
+  border-radius: 8px;
+  background: #f8fafc;
+}
+
+.pubtator-job__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.pubtator-job__id {
+  color: #24364b;
+  font-weight: 700;
+}
+
+.pubtator-job__elapsed,
+.pubtator-job__step {
+  color: #64748b;
+  font-size: 0.8125rem;
+}
+
+.pubtator-job__step {
+  margin: 0;
+}
+
+.pubtator-danger {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.pubtator-danger p {
+  max-width: 58rem;
+  margin: 0;
+  color: #526070;
+  font-size: 0.875rem;
+}
+
+@media (max-width: 991.98px) {
+  .pubtator-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 767.98px) {
+  .pubtator-admin {
+    padding: 0.75rem;
+  }
+
+  .pubtator-query-form,
+  .pubtator-fetch__settings {
+    grid-template-columns: 1fr;
+  }
+
+  .pubtator-query-form__actions,
+  .pubtator-query-form__actions :deep(.btn),
+  .pubtator-fetch__actions,
+  .pubtator-fetch__actions :deep(.btn),
+  .pubtator-danger,
+  .pubtator-danger :deep(.btn) {
+    width: 100%;
+  }
+
+  .pubtator-fetch__actions,
+  .pubtator-danger {
+    align-items: stretch;
+  }
+
+  .pubtator-metrics {
+    grid-template-columns: 1fr;
+  }
 }
 </style>

--- a/app/src/views/admin/ManagePubtator.vue
+++ b/app/src/views/admin/ManagePubtator.vue
@@ -15,13 +15,11 @@ ManagePubtator */
       <BContainer fluid>
         <BRow class="justify-content-md-center py-2">
           <BCol md="10">
-            <BCard header-tag="header" border-variant="dark">
-              <template #header>
-                <h5 class="mb-0">
-                  <i class="bi bi-journal-medical me-2" />
-                  <strong>PubTator Cache Management</strong>
-                </h5>
-              </template>
+            <AdminOperationPanel
+              title="PubTator Cache Management"
+              description="Check query coverage, submit background fetches, backfill genes, and manage cache state."
+              icon="bi-journal-medical"
+            >
 
               <!-- Query Input Section -->
               <BRow class="mb-4">
@@ -117,12 +115,12 @@ ManagePubtator */
               </BCard>
 
               <!-- Fetch Controls -->
-              <BCard class="mb-4">
-                <h6><i class="bi bi-cloud-arrow-down me-1" /> Fetch Publications (Async)</h6>
-                <p class="text-muted small mb-3">
-                  Fetches run in the background. You can close this page and the job will continue.
-                </p>
-
+              <AdminOperationPanel
+                title="Fetch Publications"
+                description="Fetches run in the background. You can close this page and the job will continue."
+                icon="bi-cloud-arrow-down"
+                heading-tag="h3"
+              >
                 <BRow class="mb-3">
                   <BCol md="4">
                     <BFormGroup label="Pages to Fetch" label-for="max-pages">
@@ -224,15 +222,16 @@ ManagePubtator */
                   <i :class="feedbackIcon" class="me-1" />
                   {{ feedbackMessage }}
                 </BAlert>
-              </BCard>
+              </AdminOperationPanel>
 
               <!-- Clear Cache Section -->
-              <BCard border-variant="danger">
-                <h6 class="text-danger"><i class="bi bi-trash me-1" /> Clear Cache</h6>
-                <p class="text-muted small mb-3">
-                  Remove all cached publications and annotations. Use with caution.
-                </p>
-
+              <AdminOperationPanel
+                title="Clear Cache"
+                description="Remove all cached publications and annotations. Use with caution."
+                icon="bi-trash"
+                heading-tag="h3"
+                tone="danger"
+              >
                 <BButton
                   variant="danger"
                   :disabled="isJobLoading || isClearing"
@@ -241,8 +240,8 @@ ManagePubtator */
                   <BSpinner v-if="isClearing" small class="me-1" />
                   Clear ALL Cache
                 </BButton>
-              </BCard>
-            </BCard>
+              </AdminOperationPanel>
+            </AdminOperationPanel>
           </BCol>
         </BRow>
 
@@ -267,6 +266,7 @@ ManagePubtator */
 
 <script setup lang="ts">
 import AuthenticatedPageShell from '@/components/layout/AuthenticatedPageShell.vue';
+import AdminOperationPanel from '@/components/admin/AdminOperationPanel.vue';
 import { ref, computed } from 'vue';
 import {
   BContainer,

--- a/app/tests/e2e/manage-pubtator-ui.spec.ts
+++ b/app/tests/e2e/manage-pubtator-ui.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect, type Page } from './fixtures/auth';
+
+function captureHardErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text());
+  });
+  page.on('pageerror', (error) => {
+    errors.push(`pageerror: ${error.message}`);
+  });
+  return errors;
+}
+
+test('ManagePubtator exposes usable query, fetch, and danger controls', async ({ loggedInAs }) => {
+  const page = await loggedInAs('admin');
+  const errors = captureHardErrors(page);
+
+  await page.goto('/ManagePubtator');
+  await expect(page.getByTestId('authenticated-page-shell')).toBeVisible();
+
+  const queryWorkspace = page.getByTestId('pubtator-query-workspace');
+  await expect(queryWorkspace).toBeVisible();
+  await queryWorkspace.locator('#query-input').fill('autism AND gene');
+
+  const fetchWorkspace = page.getByTestId('pubtator-fetch-workspace');
+  await expect(fetchWorkspace).toBeVisible();
+  await fetchWorkspace.locator('#max-pages').fill('12');
+  await fetchWorkspace.getByText('Hard update: clear existing cache first').click();
+  await expect(fetchWorkspace.getByRole('button', { name: /submit fetch job/i })).toBeEnabled();
+
+  const dangerZone = page.getByTestId('pubtator-danger-zone');
+  await expect(dangerZone).toBeVisible();
+  await dangerZone.getByRole('button', { name: /clear all cache/i }).click();
+  await expect(page.getByRole('dialog', { name: /clear all pubtator cache/i })).toBeVisible();
+  await page.getByRole('button', { name: /cancel/i }).click();
+  await expect(page.getByRole('dialog', { name: /clear all pubtator cache/i })).toBeHidden();
+
+  expect(errors.filter((error) => !/websocket|hmr|devtools/i.test(error))).toEqual([]);
+});

--- a/app/tests/e2e/view-logs-loading.spec.ts
+++ b/app/tests/e2e/view-logs-loading.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from './fixtures/auth';
+
+test('ViewLogs shows an inline loader while logs are loading', async ({ loggedInAs }) => {
+  const page = await loggedInAs('admin');
+
+  await page.route('**/api/logs/?**', async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 800));
+    await route.continue();
+  });
+
+  await page.goto('/ViewLogs?sort=-id&page_size=10');
+
+  await expect(page.getByTestId('logs-loading-state')).toBeVisible();
+  await expect(page.getByTestId('logs-loading-state')).toBeHidden({ timeout: 15_000 });
+  await expect(page.getByText(/Loaded 10\//)).toBeVisible();
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -271,6 +271,9 @@ services:
       retries: 3
       start_period: 10s
     networks:
+      # Backend is internal-only; worker also needs proxy egress for external
+      # provider APIs such as Gemini, PubMed, and PubTator.
+      - proxy
       - backend
     develop:
       watch:

--- a/documentation/09-deployment.qmd
+++ b/documentation/09-deployment.qmd
@@ -55,6 +55,7 @@ External genomic proxy caches live under `/app/cache/external/{static,stable,dyn
 - `make cache-clear` removes nested `.rds` cache files under `/app/cache`, including external proxy caches.
 - Run the worker service alongside the API service; `mirai` daemons live in the worker service and jobs are executed by the worker entrypoint, not the web process.
 - The worker service healthcheck should verify the worker process is alive, not probe an HTTP endpoint from the worker container.
+- The worker service needs both internal database access and outbound provider access. In Compose it should stay on `backend` for MySQL/API internals and on the egress-capable `proxy` network for Gemini, PubMed, PubTator, and other external calls. Do not attach it only to the internal `backend` network.
 - Use HTTPS in production.
 
 ## SEO Prerender Operations

--- a/documentation/10-visual-design-guide.md
+++ b/documentation/10-visual-design-guide.md
@@ -1,0 +1,313 @@
+# SysNDD Visual Guide
+
+Date: 2026-05-14
+
+Scope: recent curation/admin design refactor plus reference public table/home surfaces
+
+Evidence: fresh Playwright review against `http://localhost:5173`
+
+## Visual Positioning
+
+SysNDD should feel like a clinical research operations tool: compact, trustworthy, table-first, and quiet. The product should avoid marketing-style decoration, oversized cards, and expressive gradients. The strongest current direction is already visible in the home page, public tables, authenticated page shell, `TableShell`, and curation review surfaces.
+
+Use the interface to help expert users scan, compare, and act. Do not make them read decorative explanations before they can use the data.
+
+## Current Reference Surfaces
+
+Use these routes as the current visual baseline when reviewing design changes:
+
+- Home: `/`
+- Public table: `/Entities?sort=%2Bentity_id&page_size=10`
+- Gene table: `/Genes?sort=%2Bsymbol&page_size=10`
+- Wizard: `/CreateEntity`
+- Review operations: `/ApproveReview` and `/ManageReReview`
+- Mobile records: `/ManageOntology` and `/ManageUser`
+- CMS/admin debt example: `/ManageAbout`
+
+Generated screenshot captures belong under `.planning/screenshots/` and are intentionally ignored when they are PNG files.
+
+## Design Tokens
+
+### Color
+
+Primary brand/action blue:
+
+- `--medical-blue-700: #0d47a1`
+- `--medical-blue-600: #1e88e5`
+- Use for primary navigation, focused active state, primary links, and selected pagination.
+
+Secondary operational accent:
+
+- `--medical-teal-600: #00897b`
+- Use sparingly for secondary positive actions and system accents.
+
+Status colors:
+
+- Success: `--status-success: #2e7d32`
+- Warning: `--status-warning: #f57c00`
+- Danger: `--status-danger: #c62828`
+- Info: `--status-info: #0277bd`
+
+Neutral foundation:
+
+- Text: `--neutral-900: #212121`
+- Secondary text: `--neutral-600: #757575`
+- Surface backgrounds: white and near-white neutrals
+- Borders: pale neutral/blue-gray lines with low visual weight
+
+Rules:
+
+- Do not create a one-hue blue-only screen. Use blue for action and navigation, green/teal for biological identifiers or positive state, amber/red only for status.
+- Never rely on color alone for status. Pair color with icons, labels, or both.
+- Avoid dark cards and heavy bordered Bootstrap panels in admin/curation pages.
+
+### Typography
+
+Base stack: system sans (`-apple-system`, `Segoe UI`, Roboto, Arial).
+
+Identifier stack: `--font-family-mono` for IDs, gene symbols, protein names, and compact scientific values.
+
+Recommended scale:
+
+- Page title: 18-22px, semibold, compact line height.
+- Section title: 16-18px, semibold.
+- Table headers and control labels: 12-14px, semibold.
+- Body/table text: 14-16px.
+- Helper/meta text: 12-14px.
+
+Rules:
+
+- Keep headings tight inside operational tools. Hero-scale type belongs only on true public-facing hero areas.
+- Gene names and stable identifiers should be scannable, preferably using existing badge/mono conventions.
+- Avoid negative letter spacing. It weakens dense table readability.
+
+### Shape And Density
+
+Radius:
+
+- Default cards/panels: `--radius-md` to `--radius-lg` (`6-8px`).
+- Pills/chips: `--radius-full`.
+- Avoid `12-16px` cards for normal operational surfaces.
+
+Spacing:
+
+- Dense table controls: 8px gaps.
+- Default form groups: 12px.
+- Section spacing: 24-32px.
+- Mobile row internal spacing: 8-12px.
+
+Rules:
+
+- Prefer one bounded surface per task area.
+- Do not put UI cards inside other UI cards unless the inner card is a repeated data record.
+- A page can be dense, but it must maintain stable alignment and clear grouping.
+
+## Layout System
+
+### Public Data Pages
+
+Use public table pages as the table reference:
+
+- Single table shell.
+- Compact header with entity count and loaded count.
+- Search and pagination in predictable rows.
+- Filters directly above columns.
+- Data chips for identifiers and classification.
+- Actions aligned at the far right.
+
+Do:
+
+- Keep table controls close to the data they affect.
+- Preserve column alignment and stable pagination width.
+- Use compact badges for category, NDD state, inheritance, and identifiers.
+
+Do not:
+
+- Hide core table controls in distant page headers.
+- Use large descriptive cards where a tight toolbar is enough.
+- Let badges become visually heavier than the data itself.
+
+### Authenticated Operation Pages
+
+Use `AuthenticatedPageShell` for curation/admin routes.
+
+Required structure:
+
+1. Shell title and one-line description.
+2. Optional KPI/stat row.
+3. Primary operation or table surface.
+4. Secondary tools in collapsed or lower-priority panels.
+5. Footer-safe scroll area.
+
+Rules:
+
+- Exactly one route-level `h1`.
+- Shell actions belong in the header when they affect the whole page.
+- Dangerous actions should be visually separated from routine actions.
+- Avoid duplicated route titles inside child cards.
+
+### Tables
+
+Use `TableShell` or match it closely.
+
+Desktop:
+
+- Toolbar first, table second.
+- Column filters sit immediately above column headers.
+- Row actions form a stable icon/action cluster.
+- Empty, loading, and error states occupy the table body, not a separate detached card.
+
+Mobile:
+
+- Replace stacked Bootstrap table output with purpose-built record rows.
+- Each row should have a primary identity line, secondary detail line, chip row, and action cluster.
+- Keep row actions fixed in placement across records.
+
+## Component Patterns
+
+### Page Shell
+
+Good pattern:
+
+- White surface
+- Thin border
+- Compact header
+- Subtle shadow
+- Footer-safe bottom spacing
+
+Avoid:
+
+- Full-page stacks of unrelated cards
+- Duplicate headings
+- Heavy black/dark borders
+- Centered narrow admin tools on desktop when the workflow is table-driven
+
+### Wizard
+
+The Create Entity wizard is a good baseline:
+
+- Horizontal desktop stepper
+- Short labels
+- One focused step body
+- Primary next action at bottom-right
+- Toggle-style binary input for NDD phenotype
+
+Improve next:
+
+- On mobile, ensure step navigation does not become a cramped horizontal strip.
+- Make required/optional field rhythm consistent across all steps.
+- Keep review/submit summary visually closer to table/detail page conventions.
+
+### Chips And Badges
+
+Use chips for:
+
+- Entity IDs
+- Gene symbols
+- Disease names
+- Inheritance mode
+- Category/classification
+- Review/user/status labels
+
+Rules:
+
+- Chips should be compact, readable, and semantically colored.
+- Avoid mixing several unrelated chip styles on one row.
+- Use icons only where they improve recognition. Icon-only controls need accessible labels/tooltips.
+
+### Forms
+
+Forms should be dense but not cryptic.
+
+Rules:
+
+- Labels above controls for normal forms.
+- Inline controls only when the relationship is obvious and the row remains scannable.
+- Primary action belongs at the end of the flow.
+- Secondary actions should be outline/neutral.
+- Destructive actions should be red outline or danger-confirmed, not placed next to primary success actions without separation.
+
+## Findings From Fresh Review
+
+Playwright audit:
+
+- 30 authenticated design checks passed across desktop and mobile.
+- Fresh screenshots captured for 13 representative routes at `1440x900` and `390x844`.
+- No captured route had document or main horizontal overflow.
+- Authenticated routes consistently used the authenticated shell in the tested design spec.
+
+Measured remaining debt:
+
+| Surface | Evidence | Recommendation |
+|---|---|---|
+| `ManageOntology` mobile | `5183px` captured main scroll height | Keep compact rows, but reduce toolbar vertical stack and compress pagination/filter controls. |
+| `ManageUser` mobile | `4400px` captured main scroll height | Move quick filters and pagination into denser segmented/filter rows; keep user rows compact. |
+| `AdminStatistics` mobile | `3764px` captured main scroll height | Convert date controls and chart mode toggles into a tighter responsive control bar. |
+| `ManageReReview` | `68` visible buttons on desktop capture | Reduce simultaneous action exposure; progressive disclosure is correct, but action density remains high. |
+| `ManageAbout` | `16` card elements and nested publication sections | Convert to a true CMS layout: section list plus editor/preview pane, not repeated collapsible cards. |
+| `ManageLLM` | `14` card elements | Keep dashboard intent but flatten nested card chrome. |
+
+## Design Priorities
+
+1. Finish converging admin/curation pages on the shell/table language.
+2. Reduce mobile control stacks before reducing data density.
+3. Replace nested card stacks with task-specific layouts.
+4. Standardize action hierarchy: primary, secondary, icon utility, danger.
+5. Keep public data pages stable; they are currently the best visual anchor.
+
+## Practical Acceptance Checklist
+
+For every new or changed page:
+
+- Has one route-level `h1`.
+- Uses `AuthenticatedPageShell` when authenticated.
+- Uses `TableShell` or matching structure for data tables.
+- Has no horizontal overflow at `1440x900` or `390x844`.
+- Has visible interactive content above the fixed footer at the bottom of scroll.
+- Has mobile-specific record rows for complex tables.
+- Uses no nested cards except repeated record rows or true disclosure panels.
+- Keeps cards at `8px` radius or less.
+- Uses existing token colors rather than new one-off palette values.
+- Has icon-only controls labelled for assistive tech.
+
+## Route Guidance
+
+### Keep As Reference
+
+- `/`
+- `/Entities`
+- `/Genes`
+- `/CreateEntity`
+- `/ApproveReview`
+
+### Improve Next
+
+- `/ManageAbout`: rebuild as CMS editor layout.
+- `/ManageOntology`: compress mobile controls.
+- `/ManageUser`: compress mobile controls and quick filters.
+- `/ManageReReview`: reduce visible action count and continue guided batch-builder work.
+- `/AdminStatistics`: tighten mobile date/filter/chart controls.
+- `/ManageLLM`: flatten dashboard card nesting.
+
+## Verification Commands
+
+Use these for visual/design safety:
+
+```bash
+cd app && PLAYWRIGHT_BASE_URL=http://localhost:5173 npx playwright test tests/e2e/authenticated-admin-curation-design.spec.ts --project=chromium-desktop
+```
+
+Use these before handoff:
+
+```bash
+make lint-app
+cd app && npm run type-check
+cd app && npm run type-check:strict
+cd app && npm run test:unit
+```
+
+For full local parity:
+
+```bash
+make ci-local
+```

--- a/documentation/11-admin-visual-review.md
+++ b/documentation/11-admin-visual-review.md
@@ -1,0 +1,42 @@
+# Admin Visual Review
+
+Date: 2026-05-14
+
+Scope: `app/src/views/admin/*` authenticated administrator surfaces, reviewed against `documentation/10-visual-design-guide.md`.
+
+## Rating Scale
+
+- `5`: Matches the visual guide; only minor refinements remain.
+- `4`: Strong, guide-aligned surface with manageable local debt.
+- `3`: Functional and shell-aligned, but still visually inconsistent or too dense.
+- `2`: Legacy structure remains; redesign should be prioritized.
+- `1`: Serious usability blocker.
+
+## Ratings
+
+| Route | Rating | Notes |
+|---|---:|---|
+| `/ManageUser` | 4 | Strong `TableShell` and mobile-row implementation. Remaining debt is mobile control height and hidden desktop action-label discoverability. |
+| `/ManageAnnotations` | 4 | Operation panels now match the guide and remove dark card chrome. Remaining debt is long mobile scroll caused by many operation groups. |
+| `/ManageOntology` | 4 | Strong table/mobile-row surface with no overflow. Remaining debt is high mobile scroll depth and dense filter/pagination stack. |
+| `/ManageAbout` | 3.5 | Main CMS wrapper now uses the shared operation panel. Section editor internals still rely on many repeated cards and should eventually become a section-list/editor-pane layout. |
+| `/ViewLogs` | 4 | Strong table-shell surface with compact controls and mobile rows. Keep as an admin table reference. |
+| `/AdminStatistics` | 3.5 | Legacy dark statistic cards were replaced for text summaries. Chart controls remain dense on mobile and need a tighter responsive toolbar. |
+| `/ManageBackups` | 4 | Good `TableShell` plus separated backup/import zones. Remaining debt is action density and modal flow review for destructive operations. |
+| `/ManagePubtator` | 4 | Rebuilt as operation panels with clearer fetch and danger zones. Lighthouse on the authenticated route scored Performance `0.96`, Accessibility `1.00`, Best Practices `0.96`. |
+| `/ManageLLM` | 3.5 | Outer dark card replaced and quick actions now use the shared panel. KPI/tab internals still use several nested cards but are functional and scannable. |
+
+## Verification Summary
+
+- `cd app && npx vitest run src/components/admin/AdminOperationPanel.spec.ts src/views/admin/ManageAnnotations.spec.ts src/views/admin/AdminStatistics.spec.ts src/views/admin/ManageUser.spec.ts`
+- `cd app && npm run type-check`
+- `cd app && PLAYWRIGHT_BASE_URL=http://127.0.0.1:5174 npx playwright test tests/e2e/authenticated-admin-curation-design.spec.ts --project=chromium-desktop`
+- Authenticated Playwright interaction audit covered nav/user dropdowns, admin filters/selects, tab switching, and confirmation modals for backups, PubTator cache, and LLM regeneration without hard console errors.
+- Lighthouse was run against authenticated `/ManagePubtator`.
+
+## Remaining Design Priorities
+
+1. Compress mobile filter/pagination stacks in `/ManageUser` and `/ManageOntology`.
+2. Convert `/ManageAbout` from repeated collapsible cards into a true CMS section-list/editor-pane layout.
+3. Tighten `/AdminStatistics` mobile chart controls.
+4. Reduce nested KPI/card chrome inside `/ManageLLM`.


### PR DESCRIPTION
## Summary
- Adds a shared `AdminOperationPanel` component and unit coverage for the admin operation surface pattern.
- Migrates admin operation views away from dark Bootstrap card chrome toward the new visual guide language.
- Adds `documentation/11-admin-visual-review.md` with per-admin-route ratings and remaining design priorities.

## Validation
- `make lint-app` passed with existing warnings only.
- `cd app && npm run type-check` passed.
- `cd app && npm run type-check:strict` passed.
- `cd app && npx vitest run src/components/admin/AdminOperationPanel.spec.ts src/views/admin/*.spec.ts src/components/annotations/*.spec.ts` passed: 8 files, 27 passed, 1 todo.
- `cd app && PLAYWRIGHT_BASE_URL=http://127.0.0.1:5174 npx playwright test tests/e2e/authenticated-admin-curation-design.spec.ts --project=chromium-desktop` passed: 30 passed.
- Authenticated Playwright interaction audit covered admin/user dropdowns, filters/selects, tab switching, and non-destructive confirmation modal open/cancel flows with no hard console errors.
- Lighthouse on authenticated `/ManagePubtator`: Performance 0.96, Accessibility 1.00, Best Practices 0.96.

## Notes
- Playwright user seeding warned because Docker `mysql` was not running, but the active backend already had usable Playwright users and authenticated checks completed.
- Destructive admin actions were opened and cancelled only; no destructive operations were submitted.
