### PR TITLE
[codex] Gene network cluster selection UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 _Nothing yet._
 
+## [0.19.1] — 2026-05-15
+
+Patch bump for the GeneNetworks cluster-selection UX.
+
+### Added
+
+- **Functional cluster parent nodes are selectable.** Clicking a Cytoscape compound cluster parent filters the graph and table to that cluster while gene-node clicks continue to open the gene page.
+- **All-clusters summary cue.** The GeneNetworks table shows a compact AI-summary cue in all-clusters mode with a direct action to focus the first available cluster.
+
+### Fixed
+
+- **Cluster selection can be cleared from the graph.** Clicking the empty network background returns the graph and table to the all-clusters view.
+- **Stale AI summary requests no longer replace the active cluster summary.** Rapid cluster changes now ignore older summary responses once a newer cluster selection is active.
+
 ## [0.19.0] — 2026-05-14
 
 Minor bump for PR #338's admin visual-design pass, log-table performance work, LLM regeneration feedback fixes, and worker egress correction.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysndd",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysndd",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@unhead/vue": "^3.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/app/src/components/analyses/AnalyseGeneClusters.spec.ts
+++ b/app/src/components/analyses/AnalyseGeneClusters.spec.ts
@@ -1,8 +1,9 @@
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import AnalyseGeneClusters from './AnalyseGeneClusters.vue';
 
 const mocks = vi.hoisted(() => ({
+  getFunctionalClusterSummary: vi.fn(),
   networkSelectSingleCluster: vi.fn(),
 }));
 
@@ -30,7 +31,7 @@ vi.mock('@/api/jobs', () => ({
 
 vi.mock('@/api/analysis', () => ({
   getFunctionalClustering: vi.fn(),
-  getFunctionalClusterSummary: vi.fn(),
+  getFunctionalClusterSummary: mocks.getFunctionalClusterSummary,
 }));
 
 const globalStubs = {
@@ -83,6 +84,7 @@ function mountComponent() {
 
 describe('AnalyseGeneClusters', () => {
   beforeEach(() => {
+    mocks.getFunctionalClusterSummary.mockReset();
     mocks.networkSelectSingleCluster.mockClear();
   });
 
@@ -191,5 +193,69 @@ describe('AnalyseGeneClusters', () => {
     await wrapper.get('button[aria-label="View cluster 0 summary"]').trigger('click');
 
     expect(mocks.networkSelectSingleCluster).toHaveBeenCalledWith(0);
+  });
+
+  it('keeps stale AI summary responses from replacing the active cluster summary', async () => {
+    let resolveClusterOne: (value: unknown) => void = () => {};
+    let resolveClusterTwo: (value: unknown) => void = () => {};
+    const clusterOneSummary = {
+      summary_json: { summary: 'Cluster 1 stale summary' },
+      model_name: 'gemini-test',
+      created_at: '2026-05-15T00:00:00Z',
+      validation_status: 'approved',
+    };
+    const clusterTwoSummary = {
+      summary_json: { summary: 'Cluster 2 active summary' },
+      model_name: 'gemini-test',
+      created_at: '2026-05-15T00:00:00Z',
+      validation_status: 'approved',
+    };
+
+    mocks.getFunctionalClusterSummary
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveClusterOne = resolve;
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveClusterTwo = resolve;
+          })
+      );
+
+    const wrapper = mountComponent();
+    wrapper.vm.loading = false;
+    wrapper.vm.itemsCluster = [
+      {
+        cluster: 1,
+        cluster_size: 10,
+        hash_filter: 'equals(hash,one)',
+        term_enrichment: [],
+        identifiers: [],
+      },
+      {
+        cluster: 2,
+        cluster_size: 8,
+        hash_filter: 'equals(hash,two)',
+        term_enrichment: [],
+        identifiers: [],
+      },
+    ];
+
+    wrapper.vm.handleClustersChanged([1], false);
+    wrapper.vm.handleClustersChanged([2], false);
+
+    resolveClusterTwo(clusterTwoSummary);
+    await flushPromises();
+
+    expect(wrapper.vm.currentSummary).toEqual(clusterTwoSummary);
+    expect(wrapper.vm.summaryLoading).toBe(false);
+
+    resolveClusterOne(clusterOneSummary);
+    await flushPromises();
+
+    expect(wrapper.vm.currentSummary).toEqual(clusterTwoSummary);
   });
 });

--- a/app/src/components/analyses/AnalyseGeneClusters.spec.ts
+++ b/app/src/components/analyses/AnalyseGeneClusters.spec.ts
@@ -1,0 +1,195 @@
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AnalyseGeneClusters from './AnalyseGeneClusters.vue';
+
+const mocks = vi.hoisted(() => ({
+  networkSelectSingleCluster: vi.fn(),
+}));
+
+vi.mock('@/composables', () => ({
+  useToast: () => ({ makeToast: vi.fn() }),
+  useColorAndSymbols: () => ({}),
+  useFilterSync: () => ({
+    filterState: { search: '' },
+    setSearch: vi.fn(),
+  }),
+  useWildcardSearch: () => ({
+    pattern: { value: '' },
+    matches: vi.fn(() => true),
+  }),
+  useExcelExport: () => ({
+    isExporting: false,
+    exportToExcel: vi.fn(),
+  }),
+}));
+
+vi.mock('@/api/jobs', () => ({
+  submitClustering: vi.fn(() => new Promise(() => {})),
+  getJobStatus: vi.fn(),
+}));
+
+vi.mock('@/api/analysis', () => ({
+  getFunctionalClustering: vi.fn(),
+  getFunctionalClusterSummary: vi.fn(),
+}));
+
+const globalStubs = {
+  AnalysisPanel: {
+    template: '<section><slot name="actions" /><slot /></section>',
+  },
+  InlineHelpBadge: { template: '<button />' },
+  BPopover: { template: '<div />' },
+  BRow: { template: '<div><slot /></div>' },
+  BCol: { template: '<div><slot /></div>' },
+  BInputGroup: { template: '<div><slot /></div>' },
+  BFormSelect: { template: '<select />' },
+  BFormInput: { template: '<input />' },
+  BButton: {
+    template:
+      '<button :aria-label="ariaLabel" :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
+    props: ['ariaLabel', 'disabled'],
+  },
+  BSpinner: { template: '<span />' },
+  BCard: { template: '<div><slot name="header" /><slot /></div>' },
+  BCardText: { template: '<div><slot /></div>' },
+  BBadge: { template: '<span><slot /></span>' },
+  BLink: { template: '<a><slot /></a>' },
+  GenericTable: { template: '<table><slot name="filter-controls" /></table>' },
+  TablePaginationControls: { template: '<nav />' },
+  TermSearch: { template: '<input />' },
+  CategoryFilter: { template: '<select />' },
+  ScoreSlider: { template: '<input />' },
+  LlmSummaryCard: { template: '<article>AI Summary</article>' },
+  Splitpanes: { template: '<div><slot /></div>' },
+  Pane: { template: '<div><slot /></div>' },
+  NetworkVisualization: {
+    template: '<div data-testid="network-viz" />',
+    methods: {
+      selectSingleCluster: mocks.networkSelectSingleCluster,
+    },
+  },
+};
+
+function mountComponent() {
+  return mount(AnalyseGeneClusters, {
+    global: {
+      stubs: globalStubs,
+      directives: {
+        bTooltip: {},
+      },
+    },
+  });
+}
+
+describe('AnalyseGeneClusters', () => {
+  beforeEach(() => {
+    mocks.networkSelectSingleCluster.mockClear();
+  });
+
+  it('shows a compact AI summary cue in all-clusters mode', async () => {
+    const wrapper = mountComponent();
+    wrapper.vm.loading = false;
+    wrapper.vm.itemsCluster = [
+      {
+        cluster: 1,
+        cluster_size: 10,
+        hash_filter: 'equals(hash,abc)',
+        term_enrichment: [],
+        identifiers: [],
+      },
+    ];
+    wrapper.vm.showAllClustersInTable = true;
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).toContain('Select one cluster to view its AI summary');
+    expect(wrapper.text()).toContain('View cluster 1');
+  });
+
+  it('selects cluster 1 through the network ref from the cue button', async () => {
+    const wrapper = mountComponent();
+    wrapper.vm.loading = false;
+    wrapper.vm.itemsCluster = [
+      {
+        cluster: 1,
+        cluster_size: 10,
+        hash_filter: 'equals(hash,abc)',
+        term_enrichment: [],
+        identifiers: [],
+      },
+    ];
+    wrapper.vm.showAllClustersInTable = true;
+    await wrapper.vm.$nextTick();
+
+    await wrapper.get('button[aria-label="View cluster 1 summary"]').trigger('click');
+
+    expect(mocks.networkSelectSingleCluster).toHaveBeenCalledWith(1);
+  });
+
+  it('does not show the cue while cluster data is loading', async () => {
+    const wrapper = mountComponent();
+    wrapper.vm.loading = true;
+    wrapper.vm.itemsCluster = [
+      {
+        cluster: 1,
+        cluster_size: 10,
+        hash_filter: 'equals(hash,abc)',
+        term_enrichment: [],
+        identifiers: [],
+      },
+    ];
+    wrapper.vm.showAllClustersInTable = true;
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).not.toContain('Select one cluster to view its AI summary');
+    expect(wrapper.find('button[aria-label="View cluster 1 summary"]').exists()).toBe(false);
+  });
+
+  it('shows the summary card and not the cue in selected single-cluster summary mode', async () => {
+    const wrapper = mountComponent();
+    wrapper.vm.loading = false;
+    wrapper.vm.itemsCluster = [
+      {
+        cluster: 1,
+        cluster_size: 10,
+        hash_filter: 'equals(hash,abc)',
+        term_enrichment: [],
+        identifiers: [],
+      },
+    ];
+    wrapper.vm.currentSummary = {
+      summary_json: { summary: 'Cluster summary' },
+      model_name: 'gemini-test',
+      created_at: '2026-05-15T00:00:00Z',
+      validation_status: 'approved',
+    };
+    wrapper.vm.summaryLoading = false;
+    wrapper.vm.showAllClustersInTable = false;
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).toContain('AI Summary');
+    expect(wrapper.text()).not.toContain('Select one cluster to view its AI summary');
+    expect(wrapper.find('button[aria-label="View cluster 1 summary"]').exists()).toBe(false);
+  });
+
+  it('treats cluster 0 as a valid available cluster', async () => {
+    const wrapper = mountComponent();
+    wrapper.vm.loading = false;
+    wrapper.vm.itemsCluster = [
+      {
+        cluster: 0,
+        cluster_size: 10,
+        hash_filter: 'equals(hash,zero)',
+        term_enrichment: [],
+        identifiers: [],
+      },
+    ];
+    wrapper.vm.showAllClustersInTable = true;
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).toContain('View cluster 0');
+
+    await wrapper.get('button[aria-label="View cluster 0 summary"]').trigger('click');
+
+    expect(mocks.networkSelectSingleCluster).toHaveBeenCalledWith(0);
+  });
+});

--- a/app/src/components/analyses/AnalyseGeneClusters.vue
+++ b/app/src/components/analyses/AnalyseGeneClusters.vue
@@ -68,6 +68,22 @@
             <BSpinner small class="me-2" />
             <span class="text-muted">Loading AI summary...</span>
           </div>
+          <div v-else-if="showAllClustersSummaryCue" class="cluster-summary-cue" role="status">
+            <div class="cluster-summary-cue__text">
+              <i class="bi bi-stars" aria-hidden="true" />
+              <span>Select one cluster to view its AI summary and focused enrichment table.</span>
+            </div>
+            <BButton
+              v-if="firstAvailableCluster !== null"
+              size="sm"
+              variant="outline-primary"
+              class="cluster-summary-cue__action"
+              :aria-label="`View cluster ${firstAvailableCluster} summary`"
+              @click="selectDefaultClusterForSummary"
+            >
+              View cluster {{ firstAvailableCluster }}
+            </BButton>
+          </div>
           <!-- No placeholder when summary doesn't exist -->
 
           <BCard
@@ -515,6 +531,15 @@ export default {
      */
     isShowingCombinedData() {
       return this.showAllClustersInTable || this.displayedClusters.length > 1;
+    },
+
+    firstAvailableCluster() {
+      const firstCluster = this.itemsCluster?.[0]?.cluster;
+      return firstCluster == null ? null : Number(firstCluster);
+    },
+
+    showAllClustersSummaryCue() {
+      return !this.loading && this.itemsCluster.length > 0 && this.showAllClustersInTable;
     },
 
     /**
@@ -1075,6 +1100,11 @@ export default {
       console.log('Gene selected from network:', hgncId);
     },
 
+    selectDefaultClusterForSummary() {
+      if (this.firstAvailableCluster === null) return;
+      this.$refs.networkVisualization?.selectSingleCluster?.(this.firstAvailableCluster);
+    },
+
     /**
      * Handle network node hover - highlight corresponding table row
      * Part of bidirectional hover highlighting (NAVL-05)
@@ -1312,6 +1342,42 @@ mark {
   padding: 12px;
   height: 100%;
   overflow: auto;
+}
+
+.cluster-summary-cue {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid #d9e0ea;
+  border-radius: 8px;
+  background: #f8fbff;
+  color: #495057;
+  font-size: 0.875rem;
+}
+
+.cluster-summary-cue__text {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.cluster-summary-cue__text .bi {
+  color: #0d47a1;
+}
+
+.cluster-summary-cue__action {
+  flex: 0 0 auto;
+}
+
+@media (max-width: 767.98px) {
+  .cluster-summary-cue {
+    align-items: flex-start;
+    flex-direction: column;
+  }
 }
 
 /* Override splitpanes default theme for better visibility */

--- a/app/src/components/analyses/AnalyseGeneClusters.vue
+++ b/app/src/components/analyses/AnalyseGeneClusters.vue
@@ -510,6 +510,7 @@ export default {
       // LLM Summary data
       currentSummary: null,
       summaryLoading: false,
+      summaryRequestId: 0,
     };
   },
   computed: {
@@ -1146,18 +1147,21 @@ export default {
      */
     async fetchClusterSummary(clusterHash, clusterNumber) {
       if (!clusterHash) {
-        this.currentSummary = null;
+        this.clearClusterSummary();
         return;
       }
 
+      const requestId = ++this.summaryRequestId;
       this.summaryLoading = true;
       try {
         const data = await getFunctionalClusterSummary({
           cluster_hash: clusterHash,
           cluster_number: String(clusterNumber),
         });
+        if (requestId !== this.summaryRequestId) return;
         this.currentSummary = data;
       } catch (error) {
+        if (requestId !== this.summaryRequestId) return;
         // 404 is expected when summary doesn't exist yet - treat as no summary
         if (isApiError(error) && error.response && error.response.status === 404) {
           this.currentSummary = null;
@@ -1171,8 +1175,16 @@ export default {
         );
         this.currentSummary = null;
       } finally {
-        this.summaryLoading = false;
+        if (requestId === this.summaryRequestId) {
+          this.summaryLoading = false;
+        }
       }
+    },
+
+    clearClusterSummary() {
+      this.summaryRequestId += 1;
+      this.currentSummary = null;
+      this.summaryLoading = false;
     },
 
     /**
@@ -1190,7 +1202,7 @@ export default {
         // Show combined data from all clusters
         this.selectedCluster = this.combineClusterData(this.itemsCluster);
         // Clear summary when showing all clusters
-        this.currentSummary = null;
+        this.clearClusterSummary();
       } else if (clusters.length === 1) {
         // Single cluster selected - show that cluster's data
         this.activeParentCluster = clusters[0];
@@ -1200,7 +1212,7 @@ export default {
         if (clusterData?.hash_filter) {
           this.fetchClusterSummary(clusterData.hash_filter, clusters[0]);
         } else {
-          this.currentSummary = null;
+          this.clearClusterSummary();
         }
       } else {
         // Multiple clusters selected - combine their data
@@ -1209,7 +1221,7 @@ export default {
         );
         this.selectedCluster = this.combineClusterData(selectedClusterData);
         // Clear summary when showing multiple clusters
-        this.currentSummary = null;
+        this.clearClusterSummary();
       }
 
       // Update pagination

--- a/app/src/components/analyses/NetworkVisualization.spec.ts
+++ b/app/src/components/analyses/NetworkVisualization.spec.ts
@@ -1,0 +1,139 @@
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, ref } from 'vue';
+import NetworkVisualization from './NetworkVisualization.vue';
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  capturedCytoscapeOptions: null as Record<string, unknown> | null,
+}));
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: mocks.push }),
+}));
+
+vi.mock('@/utils/clusterColors', () => ({
+  getClusterColor: (cluster: number | string) => `cluster-color-${cluster}`,
+}));
+
+vi.mock('@/composables', () => ({
+  useNetworkData: () => ({
+    isLoading: ref(false),
+    error: ref(null),
+    metadata: ref({
+      node_count: 2,
+      edge_count: 1,
+      cluster_count: 2,
+      total_edges: 1,
+      edges_filtered: false,
+      total_ndd_genes: 2,
+      genes_with_string: 2,
+      elapsed_seconds: 0.1,
+      category_counts: { Definitive: 2, Moderate: 0, Limited: 0 },
+    }),
+    fetchNetworkData: vi.fn().mockResolvedValue(undefined),
+    cytoscapeElements: ref([]),
+  }),
+  useNetworkFilters: () => {
+    const selectedClusters = ref(new Set<number>());
+    const showAllClusters = ref(true);
+
+    return {
+      categoryLevel: ref('Definitive'),
+      selectedClusters,
+      showAllClusters,
+      applyFilters: vi.fn(),
+      getVisibleNodeCount: vi.fn(() => 2),
+      getVisibleEdgeCount: vi.fn(() => 1),
+    };
+  },
+  useFilterSync: () => ({
+    filterState: ref({ search: '' }),
+  }),
+  useWildcardSearch: () => ({
+    pattern: ref(''),
+    regex: computed(() => null),
+    matches: vi.fn(() => false),
+  }),
+  useNetworkHighlight: () => ({
+    highlightState: ref({ hoveredNodeId: null }),
+    setupNetworkListeners: vi.fn(),
+    highlightNodeFromTable: vi.fn(),
+    clearHighlights: vi.fn(),
+    isRowHighlighted: vi.fn(() => false),
+  }),
+  useCytoscape: (options: Record<string, unknown>) => {
+    mocks.capturedCytoscapeOptions = options;
+
+    return {
+      cy: () => null,
+      isInitialized: ref(true),
+      isLoading: ref(false),
+      initializeCytoscape: vi.fn(),
+      updateElements: vi.fn(),
+      fitToScreen: vi.fn(),
+      resetLayout: vi.fn(),
+      zoomIn: vi.fn(),
+      zoomOut: vi.fn(),
+      exportPNG: vi.fn(() => ''),
+      exportSVG: vi.fn(() => ''),
+    };
+  },
+}));
+
+const globalStubs = {
+  BButton: { template: '<button><slot /></button>' },
+  BBadge: { template: '<span><slot /></span>' },
+  BSpinner: { template: '<span />' },
+  BDropdown: { template: '<div><slot /></div>', props: ['text'] },
+  BDropdownItemButton: {
+    template: '<button @click="$emit(\'click\')"><slot /></button>',
+  },
+  BDropdownDivider: { template: '<hr />' },
+};
+
+describe('NetworkVisualization', () => {
+  beforeEach(() => {
+    mocks.push.mockClear();
+    mocks.capturedCytoscapeOptions = null;
+    global.ResizeObserver = class ResizeObserver {
+      observe = vi.fn();
+      disconnect = vi.fn();
+      unobserve = vi.fn();
+    };
+  });
+
+  it('selects a cluster when the Cytoscape cluster parent is clicked', async () => {
+    const wrapper = mount(NetworkVisualization, {
+      global: { stubs: globalStubs },
+    });
+
+    const onClusterClick = mocks.capturedCytoscapeOptions?.onClusterClick as
+      | ((clusterId: number) => void)
+      | undefined;
+
+    expect(onClusterClick).toBeTypeOf('function');
+    onClusterClick?.(1);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('clusters-changed')).toEqual([[[1], false]]);
+  });
+
+  it('keeps gene node clicks routed to the gene page', () => {
+    mount(NetworkVisualization, {
+      global: { stubs: globalStubs },
+    });
+
+    const onNodeClick = mocks.capturedCytoscapeOptions?.onNodeClick as
+      | ((nodeId: string) => void)
+      | undefined;
+
+    expect(onNodeClick).toBeTypeOf('function');
+    onNodeClick?.('HGNC:1234');
+
+    expect(mocks.push).toHaveBeenCalledWith({
+      name: 'Gene',
+      params: { id: 'HGNC:1234' },
+    });
+  });
+});

--- a/app/src/components/analyses/NetworkVisualization.spec.ts
+++ b/app/src/components/analyses/NetworkVisualization.spec.ts
@@ -136,4 +136,31 @@ describe('NetworkVisualization', () => {
       params: { id: 'HGNC:1234' },
     });
   });
+
+  it('returns to all clusters when the Cytoscape background is clicked', async () => {
+    const wrapper = mount(NetworkVisualization, {
+      global: { stubs: globalStubs },
+    });
+
+    const onClusterClick = mocks.capturedCytoscapeOptions?.onClusterClick as
+      | ((clusterId: number) => void)
+      | undefined;
+    const onBackgroundClick = mocks.capturedCytoscapeOptions?.onBackgroundClick as
+      | (() => void)
+      | undefined;
+
+    expect(onClusterClick).toBeTypeOf('function');
+    expect(onBackgroundClick).toBeTypeOf('function');
+
+    onClusterClick?.(1);
+    await wrapper.vm.$nextTick();
+
+    onBackgroundClick?.();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('clusters-changed')).toEqual([
+      [[1], false],
+      [[], true],
+    ]);
+  });
 });

--- a/app/src/components/analyses/NetworkVisualization.vue
+++ b/app/src/components/analyses/NetworkVisualization.vue
@@ -409,6 +409,9 @@ const {
   onClusterClick: (clusterId: number) => {
     selectSingleCluster(clusterId);
   },
+  onBackgroundClick: () => {
+    setShowAllClusters(true);
+  },
 });
 
 // Network highlight composable for bidirectional hover

--- a/app/src/components/analyses/NetworkVisualization.vue
+++ b/app/src/components/analyses/NetworkVisualization.vue
@@ -406,6 +406,9 @@ const {
     // Emit for potential table sync
     emit('cluster-selected', nodeId);
   },
+  onClusterClick: (clusterId: number) => {
+    selectSingleCluster(clusterId);
+  },
 });
 
 // Network highlight composable for bidirectional hover
@@ -896,6 +899,7 @@ defineExpose({
   clearHighlights,
   searchMatchCount,
   selectCluster,
+  selectSingleCluster,
 });
 </script>
 

--- a/app/src/composables/useCytoscape.spec.ts
+++ b/app/src/composables/useCytoscape.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { useCytoscape } from './useCytoscape';
+
+type TapEvent = { target: unknown };
+type TapHandler = (event: TapEvent) => void;
+type HandlerEntry = {
+  event: string;
+  selectorOrHandler: unknown;
+  handler?: TapHandler;
+};
+
+const mocks = vi.hoisted(() => {
+  const handlers: HandlerEntry[] = [];
+  const collection = {
+    remove: vi.fn(),
+    removeClass: vi.fn(),
+    not: vi.fn(() => collection),
+    addClass: vi.fn(),
+    boundingBox: vi.fn(() => ({ w: 0, h: 0 })),
+  };
+  const core = {
+    on: vi.fn((event: string, selectorOrHandler: unknown, handler?: TapHandler) => {
+      handlers.push({ event, selectorOrHandler, handler });
+      return core;
+    }),
+    destroy: vi.fn(),
+    elements: vi.fn(() => collection),
+    add: vi.fn(),
+    layout: vi.fn(() => ({ run: vi.fn() })),
+    resize: vi.fn(),
+    fit: vi.fn(),
+    nodes: vi.fn(() => ({ length: 0 })),
+    zoom: vi.fn(() => 1),
+  };
+  const cytoscapeMock = Object.assign(vi.fn(() => core), { use: vi.fn() });
+
+  return { collection, core, cytoscapeMock, handlers };
+});
+
+vi.mock('cytoscape', () => ({
+  default: mocks.cytoscapeMock,
+}));
+
+vi.mock('cytoscape-fcose', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('cytoscape-svg', () => ({
+  default: vi.fn(),
+}));
+
+function getCoreTapHandler(): TapHandler | undefined {
+  return mocks.handlers.find(
+    (entry) => entry.event === 'tap' && typeof entry.selectorOrHandler === 'function'
+  )?.selectorOrHandler as TapHandler | undefined;
+}
+
+describe('useCytoscape', () => {
+  beforeEach(() => {
+    mocks.handlers.length = 0;
+    mocks.cytoscapeMock.mockClear();
+    mocks.core.on.mockClear();
+  });
+
+  it('calls the background click callback only for core background taps', () => {
+    const container = document.createElement('div');
+    const onBackgroundClick = vi.fn();
+
+    const { initializeCytoscape } = useCytoscape({
+      container: ref(container),
+      onBackgroundClick,
+    });
+
+    initializeCytoscape();
+
+    const coreTapHandler = getCoreTapHandler();
+
+    expect(coreTapHandler).toBeTypeOf('function');
+
+    coreTapHandler?.({ target: mocks.core });
+    coreTapHandler?.({ target: { id: () => 'HGNC:1234' } });
+
+    expect(onBackgroundClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/composables/useCytoscape.ts
+++ b/app/src/composables/useCytoscape.ts
@@ -79,8 +79,10 @@ export interface CytoscapeOptions {
   container: Ref<HTMLElement | null>;
   /** Initial elements to render */
   elements?: ElementDefinition[];
-  /** Callback when a node is clicked */
+  /** Callback when a regular gene node is clicked */
   onNodeClick?: (nodeId: string, nodeData: Record<string, unknown>) => void;
+  /** Callback when a compound cluster parent node is clicked */
+  onClusterClick?: (clusterId: number, nodeData: Record<string, unknown>) => void;
 }
 
 /**
@@ -109,6 +111,22 @@ export interface CytoscapeState {
   exportPNG: () => string;
   /** Export graph as SVG string */
   exportSVG: () => string;
+}
+
+/**
+ * Parse a compound cluster parent node ID from Cytoscape node data.
+ */
+function parseClusterParentId(nodeId: string, nodeData: Record<string, unknown>): number | null {
+  const rawClusterId =
+    typeof nodeData.cluster === 'number' || typeof nodeData.cluster === 'string'
+      ? nodeData.cluster
+      : typeof nodeData.label === 'string'
+        ? nodeData.label.replace(/^Cluster\s+/i, '')
+        : nodeId.replace(/^cluster-/, '');
+
+  const clusterId = Number.parseInt(String(rawClusterId).split('.')[0], 10);
+
+  return Number.isFinite(clusterId) ? clusterId : null;
 }
 
 /**
@@ -168,7 +186,7 @@ function getCytoscapeStyle(): CytoscapeStylesheet {
     {
       selector: 'node:selected',
       style: {
-        'border-color': '#e74c3c',
+        'border-color': '#0d47a1',
         'border-width': 4,
         'font-size': '12px',
         'font-weight': 'bold',
@@ -377,12 +395,21 @@ export function useCytoscape(options: CytoscapeOptions): CytoscapeState {
     console.log(`[useCytoscape] Initialized in ${elapsed.toFixed(0)}ms`);
 
     // Event handlers - node click
-    if (options.onNodeClick) {
+    if (options.onNodeClick || options.onClusterClick) {
       cy.on('tap', 'node', (event) => {
         const node = event.target;
         const nodeId = node.id();
         const nodeData = node.data();
-        options.onNodeClick!(nodeId, nodeData);
+
+        if (nodeData.isClusterParent === true) {
+          const clusterId = parseClusterParentId(nodeId, nodeData);
+          if (clusterId !== null) {
+            options.onClusterClick?.(clusterId, nodeData);
+          }
+          return;
+        }
+
+        options.onNodeClick?.(nodeId, nodeData);
       });
     }
 

--- a/app/src/composables/useCytoscape.ts
+++ b/app/src/composables/useCytoscape.ts
@@ -83,6 +83,8 @@ export interface CytoscapeOptions {
   onNodeClick?: (nodeId: string, nodeData: Record<string, unknown>) => void;
   /** Callback when a compound cluster parent node is clicked */
   onClusterClick?: (clusterId: number, nodeData: Record<string, unknown>) => void;
+  /** Callback when the graph background is clicked */
+  onBackgroundClick?: () => void;
 }
 
 /**
@@ -410,6 +412,15 @@ export function useCytoscape(options: CytoscapeOptions): CytoscapeState {
         }
 
         options.onNodeClick?.(nodeId, nodeData);
+      });
+    }
+
+    // Event handlers - graph background click
+    if (options.onBackgroundClick) {
+      cy.on('tap', (event) => {
+        if (event.target === cy) {
+          options.onBackgroundClick?.();
+        }
       });
     }
 

--- a/documentation/02-web-tool.qmd
+++ b/documentation/02-web-tool.qmd
@@ -282,7 +282,7 @@ The *Entries over time* view displays the changes in NDD entity numbers since cu
 ### Functional clusters
 
 The *Functional clusters* view displays gene clusters of functionally enriched interacting proteins, along with their corresponding ontology annotations. Using the "get_clusters" function from the [STRINGdb](https://rdrr.io/bioc/STRINGdb) R package and the "walktrap" clustering algorithm from the [igraph](https://igraph.org/) R package, we perform clustering.
-By clicking on the different colored bubbles on the panel to the left, the user can select the respective main- or sub-clusters. When clicking a cluster the gene count is displayed in the upper part along the cluster name. The link in this panel's lower section leads to a view of the Gene table that is restricted to the genes in the selected cluster.
+Users can focus the functional cluster view by selecting a cluster directly in the network visualization, from the cluster legend, or from the cluster dropdown. A single-cluster selection filters the enrichment and gene tables to that cluster and displays the AI-generated cluster summary when an approved summary is available. The all-clusters view remains available for broad comparison across clusters.
 The right-hand panel displays a table with either (1) the *Term enrichment* including the ontology annotations, the number of enriched genes, the FDR-corrected p-value, and a link to the corresponding ontology term or (2) the gene *Identifiers* with links to the respective single entry page and to the [STRING](https://string-db.org/) website of the protein.
 
 ::: {style="max-width:1000px;"}

--- a/documentation/02-web-tool.qmd
+++ b/documentation/02-web-tool.qmd
@@ -282,7 +282,7 @@ The *Entries over time* view displays the changes in NDD entity numbers since cu
 ### Functional clusters
 
 The *Functional clusters* view displays gene clusters of functionally enriched interacting proteins, along with their corresponding ontology annotations. Using the "get_clusters" function from the [STRINGdb](https://rdrr.io/bioc/STRINGdb) R package and the "walktrap" clustering algorithm from the [igraph](https://igraph.org/) R package, we perform clustering.
-Users can focus the functional cluster view by selecting a cluster directly in the network visualization, from the cluster legend, or from the cluster dropdown. A single-cluster selection filters the enrichment and gene tables to that cluster and displays the AI-generated cluster summary when an approved summary is available. The all-clusters view remains available for broad comparison across clusters.
+Users can focus the functional cluster view by selecting a cluster directly in the network visualization, from the cluster legend, or from the cluster dropdown. A single-cluster selection filters the enrichment and gene tables to that cluster and displays the AI-generated cluster summary when an approved summary is available. Clicking the empty network background or choosing *All Clusters* returns to the broad all-clusters comparison view.
 The right-hand panel displays a table with either (1) the *Term enrichment* including the ontology annotations, the number of enriched genes, the FDR-corrected p-value, and a link to the corresponding ontology term or (2) the gene *Identifiers* with links to the respective single entry page and to the [STRING](https://string-db.org/) website of the protein.
 
 ::: {style="max-width:1000px;"}


### PR DESCRIPTION
## Summary
- Route Cytoscape compound cluster parent taps to cluster selection while preserving gene node navigation.
- Add empty-background graph tap handling to return to the all-clusters view.
- Add the compact all-clusters AI-summary cue and focused Vitest coverage.
- Document the GeneNetworks cluster selection behavior.

## Validation
- `make format-app`
- `make lint-app`
- `cd app && npm run type-check`
- `make ci-local`
- Focused Vitest and Playwright checks were run during implementation before this publish pass.

## Notes
- Frontend lint exits 0 with the repository's existing warning set.
- `make ci-local` exits 0 with existing API test warnings/skips reported by the suite.