### PR TITLE
[codex] Refactor admin curation typed client boundaries

### DIFF
--- a/.planning/superpowers/plans/2026-05-20-admin-curation-boundary-sprint-plan.md
+++ b/.planning/superpowers/plans/2026-05-20-admin-curation-boundary-sprint-plan.md
@@ -1,0 +1,951 @@
+# Admin Curation Boundary Sprint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move high-risk admin/curation request construction out of oversized Vue components and into typed API helpers plus focused local orchestration helpers.
+
+**Architecture:** Keep Vue pages responsible for presentation, modal state, toasts, aria-live announcements, and URL updates. Put endpoint paths, query parameter names, and response envelope types in `app/src/api/*`. Put local duplicate-request/cache coordination for the logs table in a colocated helper.
+
+**Tech Stack:** Vue 3, TypeScript, Vitest, MSW, Vite type-checking, SysNDD `apiClient`, `make code-quality-audit`.
+
+---
+
+## Guardrails
+
+- Work on a normal branch, for example `plan/admin-curation-boundary-sprint`.
+- Do not create git worktrees unless the user explicitly asks.
+- Do not change public routes, route guards, UI copy, table columns, or API endpoint paths.
+- Add or strengthen focused tests before touching each production component.
+- Prefer typed clients from `app/src/api/*`; do not add new raw axios calls.
+- Do not broaden scope to unrelated `VITE_API_URL` call sites.
+- After each cohesive extraction, run targeted tests, `cd app && npm run type-check`, and `make code-quality-audit`.
+- Update `scripts/code-quality-file-size-baseline.tsv` downward only.
+- Commit after each cohesive extraction.
+
+## File Map
+
+- Modify: `app/src/api/re_review.ts`
+  - Own re-review endpoint paths, query params, and consumed response shapes.
+- Modify: `app/src/api/re_review.spec.ts`
+  - Pin new re-review typed client helpers.
+- Modify: `app/src/api/logging.ts`
+  - Keep logs list/export/delete helpers returning component-useful values.
+- Modify: `app/src/api/logging.spec.ts`
+  - Pin log helper query params and binary export behavior.
+- Inspect: `app/src/api/user.ts`
+  - Reuse existing `listUsersByRole()` from components.
+- Modify: `app/src/views/curate/ManageReReview.vue`
+  - Replace inline URL construction with typed clients and small response-mapping helpers.
+- Modify: `app/src/views/curate/ManageReReview.spec.ts`
+  - Update tests to assert relative API paths and behavior after client migration.
+- Modify: `app/src/components/tables/TablesLogs.vue`
+  - Replace inline URL construction with typed clients and extracted request/cache helper.
+- Create: `app/src/components/tables/logTableRequests.ts`
+  - Own duplicate-call detection and logs API call coordination.
+- Create: `app/src/components/tables/logTableRequests.spec.ts`
+  - Pin duplicate-request/cache behavior without mounting the full component.
+- Inspect/run: `app/src/components/tables/TablesLogs.spec.ts`
+  - No planned edit. Existing Bearer-header tests should still pass through the typed clients and `apiClient` interceptor; edit only if the migration changes component-observable behavior.
+- Modify: `scripts/code-quality-file-size-baseline.tsv`
+  - Lower only changed oversized file entries after shrink.
+
+---
+
+### Task 1: Complete Re-Review Typed API Surface
+
+**Files:**
+- Modify: `app/src/api/re_review.spec.ts`
+- Modify: `app/src/api/re_review.ts`
+
+- [ ] **Step 1: Add failing API-client tests for available entities and tighter batch entries**
+
+`app/src/api/re_review.spec.ts` already has coverage for `assignReReviewEntities()` and `recalculateReReviewBatch()` request bodies. Keep those existing tests if they pin useful body fields; the tests below add the missing available-entities helper and tighten the returned `entry` shape consumed by `ManageReReview.vue`.
+
+Add these imports to `app/src/api/re_review.spec.ts` if they are not already present:
+
+```ts
+import {
+  listAvailableReReviewEntities,
+  assignReReviewEntities,
+  recalculateReReviewBatch,
+} from './re_review';
+```
+
+Add these tests near the other re-review API helper tests:
+
+```ts
+it('GET /api/re_review/entities/available sends q/page/page_size params', async () => {
+  let observedQuery: URLSearchParams | null = null;
+  server.use(
+    http.get('/api/re_review/entities/available', ({ request }) => {
+      observedQuery = new URL(request.url).searchParams;
+      return HttpResponse.json({
+        data: [{ entity_id: 11, symbol: 'ARID1B' }],
+        meta: { total: 1 },
+      });
+    })
+  );
+
+  const result = await listAvailableReReviewEntities({ q: 'ARI', page: 2, page_size: 50 });
+
+  expect(observedQuery?.get('q')).toBe('ARI');
+  expect(observedQuery?.get('page')).toBe('2');
+  expect(observedQuery?.get('page_size')).toBe('50');
+  expect(result.data).toEqual([{ entity_id: 11, symbol: 'ARID1B' }]);
+  expect(result.meta?.total).toBe(1);
+});
+
+it('PUT /api/re_review/entities/assign returns the created batch entry', async () => {
+  server.use(
+    http.put('/api/re_review/entities/assign', async ({ request }) => {
+      expect(await request.json()).toEqual({
+        entity_ids: [11, 12],
+        user_id: 7,
+        batch_name: 'Manual ARID batch',
+      });
+      return HttpResponse.json({
+        status: 200,
+        entry: { batch_id: 4, entity_count: 2 },
+      });
+    })
+  );
+
+  const result = await assignReReviewEntities({
+    entity_ids: [11, 12],
+    user_id: 7,
+    batch_name: 'Manual ARID batch',
+  });
+
+  expect(result.entry?.batch_id).toBe(4);
+  expect(result.entry?.entity_count).toBe(2);
+});
+
+it('PUT /api/re_review/batch/recalculate sends criteria body and returns entry', async () => {
+  server.use(
+    http.put('/api/re_review/batch/recalculate', async ({ request }) => {
+      expect(await request.json()).toEqual({
+        re_review_batch: 9,
+        batch_size: 20,
+        status_filter: 3,
+      });
+      return HttpResponse.json({
+        status: 200,
+        entry: { batch_id: 9, entity_count: 17 },
+      });
+    })
+  );
+
+  const result = await recalculateReReviewBatch({
+    re_review_batch: 9,
+    batch_size: 20,
+    status_filter: 3,
+  });
+
+  expect(result.entry?.batch_id).toBe(9);
+  expect(result.entry?.entity_count).toBe(17);
+});
+```
+
+- [ ] **Step 2: Run the API-client tests and confirm the new helper test fails**
+
+Run:
+
+```bash
+cd app && npx vitest run src/api/re_review.spec.ts
+```
+
+Expected: fail because `listAvailableReReviewEntities` is not exported yet.
+
+- [ ] **Step 3: Implement the typed helper and consumed response types**
+
+In `app/src/api/re_review.ts`, add these interfaces near the batch-management types:
+
+```ts
+export interface AvailableReReviewEntitiesParams {
+  q?: string;
+  page?: number;
+  page_size?: number;
+}
+
+export interface AvailableReReviewEntity {
+  entity_id: number;
+  symbol?: string | null;
+  disease_ontology_name?: string | null;
+  category?: string | null;
+  [key: string]: unknown;
+}
+
+export interface AvailableReReviewEntitiesResponse {
+  data: AvailableReReviewEntity[];
+  meta?: {
+    total?: number | number[];
+    [key: string]: unknown;
+  };
+}
+
+export interface BatchEntry {
+  batch_id?: number;
+  re_review_batch?: number;
+  entity_count?: number;
+  [key: string]: unknown;
+}
+```
+
+Update `BatchServiceResponse` so `entry` is typed:
+
+```ts
+export interface BatchServiceResponse {
+  status: number;
+  message?: string;
+  entry?: BatchEntry;
+  error?: string;
+  [key: string]: unknown;
+}
+```
+
+Update `AssignEntitiesRequest` to preserve the current component wire shape for empty optional batch names:
+
+```ts
+export interface AssignEntitiesRequest {
+  entity_ids: number[];
+  user_id: number;
+  batch_name?: string | null;
+}
+```
+
+Add the helper after `getAssignmentTable()`:
+
+```ts
+/**
+ * GET /api/re_review/entities/available
+ * Mirrors api/endpoints/re_review_endpoints.R available-entities handler.
+ *
+ * Curator+ only. Returns entities currently available for manual batch
+ * assignment.
+ */
+export async function listAvailableReReviewEntities(
+  params: AvailableReReviewEntitiesParams = {},
+  config?: AxiosRequestConfig
+): Promise<AvailableReReviewEntitiesResponse> {
+  return apiClient.get<AvailableReReviewEntitiesResponse>('/api/re_review/entities/available', {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...params },
+  });
+}
+```
+
+- [ ] **Step 4: Verify re-review API-client tests pass**
+
+Run:
+
+```bash
+cd app && npx vitest run src/api/re_review.spec.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit the typed API helper**
+
+Run:
+
+```bash
+git add app/src/api/re_review.ts app/src/api/re_review.spec.ts
+git commit -m "refactor: complete re-review typed api helpers"
+```
+
+---
+
+### Task 2: Migrate ManageReReview To Typed Clients
+
+**Files:**
+- Modify: `app/src/views/curate/ManageReReview.spec.ts`
+- Modify: `app/src/views/curate/ManageReReview.vue`
+- Modify: `scripts/code-quality-file-size-baseline.tsv`
+
+- [ ] **Step 1: Strengthen component tests before production changes**
+
+In `app/src/views/curate/ManageReReview.spec.ts`, add a test that proves the user-list call uses the relative API path:
+
+```ts
+it('loadUserList maps Curator/Reviewer rows from the typed user client', async () => {
+  primeAuth('re-review-users-token');
+  let observedUrl = '';
+
+  server.use(
+    http.get('/api/user/list', ({ request }) => {
+      observedUrl = request.url;
+      expectBearerHeader(request, 're-review-users-token');
+      return HttpResponse.json([
+        { user_id: 7, user_name: 'curator_a', user_role: 'Curator' },
+        { user_id: 8, user_name: 'reviewer_b', user_role: 'Reviewer' },
+      ]);
+    }),
+    http.get('/api/re_review/assignment_table', () => HttpResponse.json([])),
+    http.get('/api/re_review/entities/available', () =>
+      HttpResponse.json({ data: [], meta: { total: 0 } })
+    ),
+    http.get('/api/list/status', () => HttpResponse.json({ data: [] }))
+  );
+
+  const wrapper = await mountManageReReview();
+  await flushPromises();
+
+  expect(new URL(observedUrl).searchParams.get('roles')).toBe('Curator,Reviewer');
+  expect(vm(wrapper).user_options).toEqual([
+    { value: 7, text: 'curator_a', role: 'Curator' },
+    { value: 8, text: 'reviewer_b', role: 'Reviewer' },
+  ]);
+});
+```
+
+Add another test for available-entity normalization:
+
+```ts
+it('loadAvailableEntities normalizes entity rows and scalar total from the typed client', async () => {
+  primeAuth('re-review-entities-token');
+
+  server.use(
+    http.get('/api/user/list', () => HttpResponse.json([])),
+    http.get('/api/re_review/assignment_table', () => HttpResponse.json([])),
+    http.get('/api/list/status', () => HttpResponse.json({ data: [] })),
+    http.get('/api/re_review/entities/available', ({ request }) => {
+      const query = new URL(request.url).searchParams;
+      expect(query.get('q')).toBe('ARID');
+      expect(query.get('page')).toBe('1');
+      expect(query.get('page_size')).toBe('100');
+      return HttpResponse.json({
+        data: [{ entity_id: 11, symbol: 'ARID1B' }],
+        meta: { total: 1 },
+      });
+    })
+  );
+
+  const wrapper = await mountManageReReview();
+  const component = vm(wrapper);
+  component.manualEntityFilter = 'ARID';
+
+  await component.loadAvailableEntities();
+  await flushPromises();
+
+  expect(component.availableEntities).toEqual([{ entity_id: 11, symbol: 'ARID1B' }]);
+  expect(component.availableEntityTotal).toBe(1);
+});
+```
+
+- [ ] **Step 2: Run ManageReReview tests on unchanged production code**
+
+Run:
+
+```bash
+cd app && npx vitest run src/views/curate/ManageReReview.spec.ts
+```
+
+Expected: pass or fail only where assertions expose current absolute URL construction. Do not edit production code until this is observed.
+
+- [ ] **Step 3: Replace inline request construction with typed clients**
+
+In `app/src/views/curate/ManageReReview.vue`, replace the `apiClient` import with typed imports:
+
+```ts
+import {
+  assignReReviewBatch,
+  assignReReviewEntities,
+  getAssignmentTable,
+  listAvailableReReviewEntities,
+  recalculateReReviewBatch,
+  reassignReReviewBatch,
+  unassignReReviewBatch,
+} from '@/api/re_review';
+import { listUsersByRole } from '@/api/user';
+import { listStatusCategories } from '@/api/list';
+```
+
+Update methods as follows:
+
+```ts
+async loadUserList() {
+  try {
+    const data = await listUsersByRole({ roles: 'Curator,Reviewer' });
+    this.user_options = Array.isArray(data)
+      ? data.map((item) => ({
+          value: item.user_id,
+          text: item.user_name,
+          role: item.user_role,
+        }))
+      : [];
+  } catch (e) {
+    this.makeToast(e, 'Error', 'danger');
+    this.user_options = [];
+  }
+},
+async loadReReviewTableData() {
+  this.loadingReReviewManagment = true;
+  try {
+    const data = await getAssignmentTable();
+    this.items_ReReviewTable = Array.isArray(data) ? data : [];
+    this.totalRows = this.items_ReReviewTable.length;
+  } catch (e) {
+    this.makeToast(e, 'Error', 'danger');
+    this.items_ReReviewTable = [];
+    this.totalRows = 0;
+  } finally {
+    const uiStore = useUiStore();
+    uiStore.requestScrollbarUpdate();
+    this.loadingReReviewManagment = false;
+  }
+},
+async handleNewBatchAssignment() {
+  try {
+    await assignReReviewBatch({ user_id: this.user_id_assignment });
+    this.makeToast('New batch assigned successfully.', 'Success', 'success');
+    this.announce('New batch assigned successfully');
+  } catch (e) {
+    this.makeToast(e, 'Error', 'danger');
+    this.announce('Failed to assign batch', 'assertive');
+  }
+  this.loadReReviewTableData();
+},
+async handleBatchUnAssignment(batch_id) {
+  try {
+    await unassignReReviewBatch({ re_review_batch: batch_id });
+    this.makeToast('Batch unassigned successfully.', 'Success', 'success');
+    this.announce('Batch unassigned successfully');
+  } catch (e) {
+    this.makeToast(e, 'Error', 'danger');
+    this.announce('Failed to unassign batch', 'assertive');
+  }
+  this.loadReReviewTableData();
+},
+async loadAvailableEntities() {
+  this.isLoadingEntities = true;
+  try {
+    const responseData = await listAvailableReReviewEntities({
+      q: this.manualEntityFilter || '',
+      page: 1,
+      page_size: 100,
+    });
+    this.availableEntities = responseData.data || [];
+    const total = responseData.meta?.total;
+    this.availableEntityTotal = Array.isArray(total)
+      ? (total[0] ?? this.availableEntities.length)
+      : (total ?? this.availableEntities.length);
+    this.previewBoundaryGene = null;
+    this.previewGeneCount = 0;
+    this.previewEntityCount = 0;
+  } catch (_e) {
+    this.makeToast('Failed to load available entities', 'Error', 'danger');
+  } finally {
+    this.isLoadingEntities = false;
+  }
+},
+```
+
+Update entity assignment, reassignment, recalculation, and status methods. Preserve the surrounding validation, payload-building, toast/announce messages, modal state updates, and table/entity refresh calls exactly as they are today; replace only the API invocation blocks.
+
+```ts
+const responseData = await assignReReviewEntities({
+  entity_ids: this.selectedEntityIds,
+  user_id: this.entityAssignUserId,
+  batch_name: this.entityAssignBatchName || null,
+});
+```
+
+`batch_name: null` intentionally preserves the current wire shape for an empty optional batch name.
+
+```ts
+await reassignReReviewBatch({
+  re_review_batch: this.reassignBatchId,
+  user_id: this.reassignNewUserId,
+});
+```
+
+```ts
+const responseData = await recalculateReReviewBatch(payload);
+```
+
+```ts
+const responseData = await listStatusCategories();
+const data = responseData?.data || [];
+```
+
+Also update any existing `ManageReReview.spec.ts` status-list MSW handlers that currently return a raw array for `/api/list/status` to return the typed-client envelope:
+
+```ts
+HttpResponse.json({ data: [{ category_id: 1, category: 'Definitive' }] })
+```
+
+This keeps status-option population aligned with `listStatusCategories()`. Tests that only assert the Bearer interceptor may still pass with a raw array, but the fixture should represent the typed-client contract.
+
+- [ ] **Step 4: Remove obsolete `apiClient` import**
+
+Run:
+
+```bash
+rg -n "apiClient|VITE_API_URL" app/src/views/curate/ManageReReview.vue
+```
+
+Expected: no matches.
+
+- [ ] **Step 5: Verify ManageReReview migration**
+
+Run:
+
+```bash
+cd app && npx vitest run src/api/re_review.spec.ts src/api/user.spec.ts src/api/list.spec.ts
+cd app && npx vitest run src/views/curate/ManageReReview.spec.ts
+cd app && npm run type-check
+make code-quality-audit
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 6: Ratchet baseline and commit**
+
+Run:
+
+```bash
+wc -l app/src/views/curate/ManageReReview.vue
+```
+
+If the current line count is lower than the existing `scripts/code-quality-file-size-baseline.tsv` entry, lower that entry to the current count.
+
+Then commit:
+
+```bash
+git add app/src/api/re_review.ts app/src/api/re_review.spec.ts app/src/views/curate/ManageReReview.vue app/src/views/curate/ManageReReview.spec.ts scripts/code-quality-file-size-baseline.tsv
+git commit -m "refactor: route re-review admin calls through typed clients"
+```
+
+---
+
+### Task 3: Extract Logs Request Cache Helper
+
+**Files:**
+- Create: `app/src/components/tables/logTableRequests.ts`
+- Create: `app/src/components/tables/logTableRequests.spec.ts`
+
+- [ ] **Step 1: Add helper tests first**
+
+Create `app/src/components/tables/logTableRequests.spec.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createLogTableRequestCache, logRequestKey } from './logTableRequests';
+
+describe('logTableRequests', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('builds a stable request key from table params', () => {
+    expect(
+      logRequestKey({
+        sort: '-timestamp',
+        filter: 'status==500',
+        page_after: 10,
+        page_size: 25,
+      })
+    ).toBe('sort=-timestamp&filter=status==500&page_after=10&page_size=25');
+  });
+
+  it('reuses a fresh cached response for duplicate requests', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-20T00:00:00Z'));
+
+    const cache = createLogTableRequestCache();
+    const fetcher = vi.fn().mockResolvedValue({ data: [], meta: [{ totalItems: 0 }] });
+
+    const first = await cache.load(
+      { sort: '-id', filter: '', page_after: 0, page_size: 10 },
+      fetcher
+    );
+    const second = await cache.load(
+      { sort: '-id', filter: '', page_after: 0, page_size: 10 },
+      fetcher
+    );
+
+    expect(first?.fromCache).toBe(false);
+    expect(second?.fromCache).toBe(true);
+    expect(first?.response).toBe(second?.response);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reuse stale cached responses after the duplicate window', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-20T00:00:00Z'));
+
+    const cache = createLogTableRequestCache();
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce({ data: [{ id: 1 }], meta: [{ totalItems: 1 }] })
+      .mockResolvedValueOnce({ data: [{ id: 2 }], meta: [{ totalItems: 1 }] });
+
+    await cache.load({ sort: '-id', filter: '', page_after: 0, page_size: 10 }, fetcher);
+    vi.setSystemTime(new Date('2026-05-20T00:00:01Z'));
+    const result = await cache.load(
+      { sort: '-id', filter: '', page_after: 0, page_size: 10 },
+      fetcher
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.response.data).toEqual([{ id: 2 }]);
+    expect(result!.fromCache).toBe(false);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run helper tests and confirm failure**
+
+Run:
+
+```bash
+cd app && npx vitest run src/components/tables/logTableRequests.spec.ts
+```
+
+Expected: fail because `logTableRequests.ts` does not exist.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `app/src/components/tables/logTableRequests.ts`:
+
+```ts
+import type { LogListResponse, ListLogsParams } from '@/api/logging';
+
+export type LogTableRequestParams = Required<
+  Pick<ListLogsParams, 'sort' | 'filter' | 'page_after' | 'page_size'>
+>;
+
+export function logRequestKey(params: LogTableRequestParams): string {
+  return `sort=${params.sort}&filter=${params.filter}&page_after=${params.page_after}&page_size=${params.page_size}`;
+}
+
+export interface LogTableRequestResult {
+  response: LogListResponse;
+  fromCache: boolean;
+}
+
+export function createLogTableRequestCache(windowMs = 500) {
+  let lastKey = '';
+  let lastCallTime = 0;
+  let lastResponse: LogListResponse | null = null;
+  let inProgressKey: string | null = null;
+  let inProgressPromise: Promise<LogListResponse> | null = null;
+
+  return {
+    async load(
+      params: LogTableRequestParams,
+      fetcher: () => Promise<LogListResponse>
+    ): Promise<LogTableRequestResult | null> {
+      const key = logRequestKey(params);
+      const now = Date.now();
+
+      if (lastKey === key && lastResponse && now - lastCallTime < windowMs) {
+        return { response: lastResponse, fromCache: true };
+      }
+
+      if (inProgressKey === key && inProgressPromise) {
+        return null;
+      }
+
+      lastKey = key;
+      lastCallTime = now;
+      inProgressKey = key;
+      inProgressPromise = fetcher();
+
+      try {
+        lastResponse = await inProgressPromise;
+        return { response: lastResponse, fromCache: false };
+      } finally {
+        inProgressKey = null;
+        inProgressPromise = null;
+      }
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Verify helper tests pass**
+
+Run:
+
+```bash
+cd app && npx vitest run src/components/tables/logTableRequests.spec.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit helper extraction**
+
+Run:
+
+```bash
+git add app/src/components/tables/logTableRequests.ts app/src/components/tables/logTableRequests.spec.ts
+git commit -m "refactor: extract log table request cache"
+```
+
+---
+
+### Task 4: Migrate TablesLogs To Typed Clients
+
+**Files:**
+- Modify: `app/src/api/logging.spec.ts`
+- Modify: `app/src/components/tables/TablesLogs.vue`
+- Modify: `scripts/code-quality-file-size-baseline.tsv`
+
+- [ ] **Step 1: Strengthen logs API-client tests**
+
+In `app/src/api/logging.spec.ts`, ensure these behaviors are covered:
+
+```ts
+it('listLogs forces format=json and preserves table params', async () => {
+  let observedQuery: URLSearchParams | null = null;
+  server.use(
+    http.get('/api/logs/', ({ request }) => {
+      observedQuery = new URL(request.url).searchParams;
+      return HttpResponse.json({ data: [], meta: [{ totalItems: 0 }] });
+    })
+  );
+
+  await listLogs({
+    sort: '-timestamp',
+    filter: 'status==500',
+    page_after: 10,
+    page_size: 25,
+  });
+
+  expect(observedQuery?.get('format')).toBe('json');
+  expect(observedQuery?.get('sort')).toBe('-timestamp');
+  expect(observedQuery?.get('filter')).toBe('status==500');
+  expect(observedQuery?.get('page_after')).toBe('10');
+  expect(observedQuery?.get('page_size')).toBe('25');
+});
+
+it('listLogsXlsx returns a Blob from the xlsx export path', async () => {
+  server.use(
+    http.get('/api/logs/', ({ request }) => {
+      expect(new URL(request.url).searchParams.get('format')).toBe('xlsx');
+      return new HttpResponse(new Blob(['xlsx-bytes']), {
+        headers: {
+          'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        },
+      });
+    })
+  );
+
+  const result = await listLogsXlsx({ page_after: 0, page_size: 'all' });
+
+  expect(result).toBeInstanceOf(Blob);
+});
+
+it('deleteLogs sends older_than_days as a query param', async () => {
+  let observedQuery: URLSearchParams | null = null;
+  server.use(
+    http.delete('/api/logs/', ({ request }) => {
+      observedQuery = new URL(request.url).searchParams;
+      return HttpResponse.json({ message: 'deleted', deleted_count: 12 });
+    })
+  );
+
+  const result = await deleteLogs({ older_than_days: 30 });
+
+  expect(observedQuery?.get('older_than_days')).toBe('30');
+  expect(result.deleted_count).toBe(12);
+});
+```
+
+- [ ] **Step 2: Run logging API tests on unchanged production code**
+
+Run:
+
+```bash
+cd app && npx vitest run src/api/logging.spec.ts
+```
+
+Expected: pass. If a duplicate test already exists, keep the existing equivalent and do not add redundant assertions.
+
+- [ ] **Step 3: Replace TablesLogs inline API calls**
+
+In `app/src/components/tables/TablesLogs.vue`, import typed clients and cache helper:
+
+```ts
+import { listLogs, listLogsXlsx, deleteLogs as deleteLogsApi } from '@/api/logging';
+import { listUsersByRole } from '@/api/user';
+import { createLogTableRequestCache } from './logTableRequests';
+```
+
+Create module cache near the existing module-level cache variables:
+
+```ts
+const moduleLogRequestCache = createLogTableRequestCache();
+```
+
+Update `loadUserList()`:
+
+```ts
+async loadUserList() {
+  try {
+    const data = await listUsersByRole();
+    this.user_options = data.map((item) => ({
+      value: item.user_name,
+      text: `${item.user_name} (${item.user_role})`,
+    }));
+  } catch (_e) {
+    this.makeToast('Failed to load user list', 'Error', 'danger');
+  }
+},
+```
+
+Update `doLoadData()` to call the cache helper:
+
+```ts
+async doLoadData() {
+  const params = {
+    sort: this.sort,
+    filter: this.filter_string,
+    page_after: this.currentItemID,
+    page_size: this.perPage,
+  };
+
+  this.isBusy = true;
+
+  try {
+    const result = await moduleLogRequestCache.load(params, () => listLogs(params));
+    if (result) {
+      this.applyApiResponse(result.response);
+      if (!result.fromCache) {
+        this.updateBrowserUrl();
+      }
+    }
+    this.isBusy = false;
+  } catch (error) {
+    this.makeToast(`Error: ${error.message}`, 'Error loading logs', 'danger');
+    this.isBusy = false;
+  }
+},
+```
+
+Update `requestExcel()`:
+
+```ts
+const blob = await listLogsXlsx({
+  page_after: 0,
+  page_size: 'all',
+  filter: this.filter_string,
+  sort: this.sort,
+});
+
+const fileURL = window.URL.createObjectURL(new Blob([blob]));
+```
+
+Update `deleteLogs()`:
+
+```ts
+const response = await deleteLogsApi({ older_than_days: olderThanDays });
+const deletedCount = response.deleted_count || 0;
+```
+
+- [ ] **Step 4: Remove obsolete raw URL state**
+
+Run:
+
+```bash
+rg -n "VITE_API_URL|apiClient|moduleLastApi|moduleApiCallInProgress" app/src/components/tables/TablesLogs.vue
+```
+
+Expected: no matches for `VITE_API_URL`, `apiClient`, `moduleLastApi`, or `moduleApiCallInProgress`.
+
+- [ ] **Step 5: Verify TablesLogs migration**
+
+Run:
+
+```bash
+cd app && npx vitest run src/api/logging.spec.ts src/api/user.spec.ts
+cd app && npx vitest run src/components/tables/logTableRequests.spec.ts
+cd app && npx vitest run src/components/tables/TablesLogs.spec.ts
+cd app && npm run type-check
+make code-quality-audit
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 6: Ratchet baseline and commit**
+
+Run:
+
+```bash
+wc -l app/src/components/tables/TablesLogs.vue
+```
+
+If the current line count is lower than the existing `scripts/code-quality-file-size-baseline.tsv` entry, lower that entry to the current count.
+
+Then commit:
+
+```bash
+git add app/src/api/logging.spec.ts app/src/components/tables/TablesLogs.vue app/src/components/tables/logTableRequests.ts app/src/components/tables/logTableRequests.spec.ts scripts/code-quality-file-size-baseline.tsv
+git commit -m "refactor: route log table calls through typed clients"
+```
+
+---
+
+### Task 5: Final Audit And Handoff
+
+**Files:**
+- Inspect all changed files.
+
+- [ ] **Step 1: Confirm no touched component uses raw request URL construction**
+
+Run:
+
+```bash
+rg -n "VITE_API_URL|apiClient|getAxios|inject\\('axios'\\)|inject<Axios" app/src/views/curate/ManageReReview.vue app/src/components/tables/TablesLogs.vue
+```
+
+Expected: no matches, unless a remaining match is unrelated to request construction and documented in the handoff.
+
+- [ ] **Step 2: Run final deterministic checks**
+
+Run:
+
+```bash
+git diff --check
+cd app && npx vitest run src/api/re_review.spec.ts src/api/logging.spec.ts src/api/user.spec.ts src/api/list.spec.ts
+cd app && npx vitest run src/views/curate/ManageReReview.spec.ts src/components/tables/TablesLogs.spec.ts src/components/tables/logTableRequests.spec.ts
+cd app && npm run type-check
+make code-quality-audit
+make pre-commit
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 3: Run local CI parity if practical**
+
+Run:
+
+```bash
+make ci-local
+```
+
+Expected: exits 0. If the environment blocks it, record the exact blocker and the last passing command.
+
+- [ ] **Step 4: Review code-quality risks**
+
+Use `.agents/skills/sysndd-code-quality/SKILL.md` and check:
+
+- `ManageReReview.vue` and `TablesLogs.vue` shrank or did not grow.
+- No new oversized handwritten source files were created.
+- API helpers use relative paths.
+- Component tests still cover Bearer-header behavior through `apiClient`.
+- No public route, UI, table-column, or backend endpoint behavior changed.
+
+- [ ] **Step 5: Final commit if any verification-only edits were made**
+
+If verification required follow-up edits, commit them:
+
+```bash
+git status --short
+git add <changed-files>
+git commit -m "test: cover admin curation typed client boundaries"
+```
+
+Expected: working tree clean after the final commit.

--- a/.planning/superpowers/specs/2026-05-20-admin-curation-boundary-sprint-design.md
+++ b/.planning/superpowers/specs/2026-05-20-admin-curation-boundary-sprint-design.md
@@ -1,0 +1,159 @@
+# Admin Curation Boundary Sprint Design
+
+## Goal
+
+Reduce architectural risk in the authenticated admin/curation frontend by moving request construction and workflow orchestration out of oversized Vue components and into typed API helpers plus focused local composables.
+
+This sprint is intentionally narrow enough for one LLM implementation session. It targets two high-risk surfaces:
+
+- `app/src/views/curate/ManageReReview.vue`
+- `app/src/components/tables/TablesLogs.vue`
+
+## Why This Sprint
+
+The merged top-10 refactor lowered file-size baselines and extracted pure helpers, but several large components still mix UI state, raw request URLs, response normalization, caching, error handling, and workflow side effects. That makes future changes risky for humans and LLM agents because editing one method requires understanding auth, API shape, table state, and user feedback at the same time.
+
+`ManageReReview.vue` and `TablesLogs.vue` are the best next targets because they are authenticated operational pages and still contain direct `import.meta.env.VITE_API_URL` request construction. These call sites duplicate typed client behavior, create local-dev CSP risk when production API URLs leak into builds, and obscure which API contracts the component actually depends on.
+
+## Scope
+
+### In Scope
+
+1. Complete the typed API-client boundary for the touched admin/curation calls.
+2. Remove raw URL construction from the touched methods in `ManageReReview.vue` and `TablesLogs.vue`.
+3. Extract one local orchestration boundary for each component:
+   - re-review assignment workflow helpers or composable state for `ManageReReview.vue`
+   - log table request/cache helpers for `TablesLogs.vue`
+4. Preserve route names, URLs, visible UI behavior, emitted events, table columns, pagination behavior, and toast/aria-live copy.
+5. Add or strengthen tests before each production extraction.
+6. Ratchet `scripts/code-quality-file-size-baseline.tsv` downward only when a touched file shrinks.
+
+### Out of Scope
+
+1. Broad UI redesign of admin pages.
+2. Backend endpoint changes.
+3. Rewriting generic table infrastructure.
+4. Replacing the existing module-level duplicate-request cache with a global store.
+5. Refactoring unrelated raw `VITE_API_URL` call sites outside this sprint.
+6. Playwright suite repair for pre-existing local stack data/CSP failures.
+
+## Current Architecture
+
+`app/src/api/re_review.ts` already exposes typed helpers for most re-review operations, including assignment table, batch assignment, unassignment, entity assignment, reassignment, archive, and recalculation. `app/src/api/logging.ts` already exposes typed helpers for listing logs, exporting logs as XLSX, and deleting logs. `app/src/api/user.ts` exposes `listUsersByRole`, and `app/src/api/list.ts` exposes status-list helpers.
+
+Despite those clients, `ManageReReview.vue` still builds request URLs inline for:
+
+- `GET /api/user/list?roles=Curator,Reviewer`
+- `GET /api/re_review/assignment_table`
+- `PUT /api/re_review/batch/assign`
+- `DELETE /api/re_review/batch/unassign`
+- `GET /api/re_review/entities/available`
+- `PUT /api/re_review/entities/assign`
+- `PUT /api/re_review/batch/reassign`
+- `PUT /api/re_review/batch/recalculate`
+- `GET /api/list/status`
+
+`TablesLogs.vue` still builds request URLs inline for:
+
+- `GET /api/user/list`
+- `GET /api/logs/`
+- `GET /api/logs/?format=xlsx`
+- `DELETE /api/logs/`
+
+## Target Architecture
+
+### API Layer
+
+The API layer owns endpoint paths, query parameter names, and raw envelope types. Components should call functions with typed parameter objects instead of string-building endpoint URLs.
+
+Add or complete these helpers:
+
+- `app/src/api/re_review.ts`
+  - `listAvailableReReviewEntities(params)`
+  - tighten response types for `getAssignmentTable`, `assignReReviewEntities`, and `recalculateReReviewBatch` where the component currently reads `entry.batch_id`, `entry.entity_count`, `data`, and `meta.total`.
+- `app/src/api/logging.ts`
+  - ensure `listLogs`, `listLogsXlsx`, and `deleteLogs` return component-useful data without exposing raw axios responses.
+- `app/src/api/user.ts`
+  - reuse `listUsersByRole({ roles: 'Curator,Reviewer' })` and `listUsersByRole()` instead of direct component calls.
+- `app/src/api/list.ts`
+  - reuse `listStatusCategories()` for `ManageReReview.vue` status options.
+
+### Component Orchestration
+
+The components remain the owners of presentation, modal state, selected rows, toast calls, aria-live announcements, and router/URL behavior. Extracted orchestration must not hide user-facing decisions in generic helpers.
+
+For `ManageReReview.vue`, extract a small local helper module or composable only after typed clients are in place. The likely boundary is "re-review admin request normalization": converting API responses into component option rows and assignment table rows.
+
+For `TablesLogs.vue`, extract request/cache coordination into `app/src/components/tables/logTableRequests.ts`. The helper should own duplicate-request detection and API calls, while the component owns applying returned data to Vue state and updating browser history after a successful fresh API load. Cache hits must apply cached response data without calling `updateBrowserUrl()`, preserving the current behavior where URL replacement happens only after a non-cached API success.
+
+## Testing Strategy
+
+Tests must be added or strengthened before touching production code in each slice.
+
+### API Client Tests
+
+Use existing MSW-based API client spec patterns:
+
+- `app/src/api/re_review.spec.ts`
+- `app/src/api/logging.spec.ts`
+- `app/src/api/user.spec.ts`
+- `app/src/api/list.spec.ts`
+
+Pin exact paths and query parameters. These tests should fail if a future component or helper reintroduces absolute production URLs or wrong parameter names.
+
+### Component Tests
+
+Use existing component specs:
+
+- `app/src/views/curate/ManageReReview.spec.ts`
+- `app/src/components/tables/TablesLogs.spec.ts`
+
+Keep the existing Bearer-header tests, but update expectations so they prove the component reaches the typed API clients through relative `/api/...` paths. Add focused tests for behavior that the extraction touches:
+
+- user-list mapping to select options
+- assignment-table response normalization
+- available-entity response normalization
+- successful assignment/reassignment/recalculation refresh behavior
+- log list request caching and API response application
+- log XLSX export receiving a `Blob`
+- log delete request parameter normalization
+
+## Verification
+
+Each slice must run the smallest targeted tests first, then the stack checks relevant to the files touched.
+
+Frontend slice commands:
+
+```bash
+cd app && npx vitest run src/api/re_review.spec.ts src/api/user.spec.ts src/api/list.spec.ts
+cd app && npx vitest run src/views/curate/ManageReReview.spec.ts
+cd app && npx vitest run src/api/logging.spec.ts
+cd app && npx vitest run src/components/tables/TablesLogs.spec.ts
+cd app && npm run type-check
+make code-quality-audit
+```
+
+Final session commands:
+
+```bash
+git diff --check
+make pre-commit
+```
+
+Run `make ci-local` if the local environment is available and time permits. If blocked, document the exact command and blocker.
+
+## Success Criteria
+
+1. No touched `ManageReReview.vue` or `TablesLogs.vue` request method constructs URLs with `import.meta.env.VITE_API_URL`.
+2. API paths and query names for the touched operations live in `app/src/api/*`.
+3. The two large components shrink meaningfully without mechanical splitting.
+4. No public routes, admin route guards, table columns, UI copy, or typed client boundaries regress.
+5. Tests and `make code-quality-audit` pass.
+
+## Risks
+
+- Component tests currently stub broad Bootstrap and composable surfaces. Keep new tests narrow and method-level to avoid brittle DOM assertions.
+- Some existing methods expect flexible API envelopes. Tighten types only around fields that are actually consumed by the component.
+- `TablesLogs.vue` duplicate-request caching is module-level and intentional. Preserve that behavior until it is covered by focused tests.
+- `ManageReReview.vue` currently sends `batch_name: null` when the optional manual assignment batch name is empty. Preserve that wire shape unless the R handler is verified to require a different representation.
+- Do not convert all raw axios/VITE_API_URL call sites in the repo. That would turn this into a broad rewrite.

--- a/.planning/superpowers/specs/2026-05-20-admin-curation-boundary-sprint-design.md
+++ b/.planning/superpowers/specs/2026-05-20-admin-curation-boundary-sprint-design.md
@@ -86,6 +86,8 @@ For `ManageReReview.vue`, extract a small local helper module or composable only
 
 For `TablesLogs.vue`, extract request/cache coordination into `app/src/components/tables/logTableRequests.ts`. The helper should own duplicate-request detection and API calls, while the component owns applying returned data to Vue state and updating browser history after a successful fresh API load. Cache hits must apply cached response data without calling `updateBrowserUrl()`, preserving the current behavior where URL replacement happens only after a non-cached API success.
 
+The helper should also share an in-flight matching request with a remounted table instance instead of returning early. This intentionally fixes a latent busy-state edge case in the old inline module cache: a remount during an in-flight logs request could previously keep the new instance busy without applying the eventual response.
+
 ## Testing Strategy
 
 Tests must be added or strengthened before touching production code in each slice.

--- a/api/version_spec.json
+++ b/api/version_spec.json
@@ -1,7 +1,7 @@
 {
   "title": "SysNDD API",
   "description": "This is the API powering the SysNDD website, allowing programmatic access to the database contents.",
-  "version": "0.20.7",
+  "version": "0.20.8",
   "contact": {
     "name": "API Support",
     "url": "https://berntpopp.github.io/sysndd/api.html",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysndd",
-  "version": "0.20.7",
+  "version": "0.20.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysndd",
-      "version": "0.20.7",
+      "version": "0.20.8",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@unhead/vue": "^3.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.20.7",
+  "version": "0.20.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/app/src/api/logging.spec.ts
+++ b/app/src/api/logging.spec.ts
@@ -16,7 +16,7 @@ import { isApiError } from './client';
 import { server } from '@/test-utils/mocks/server';
 
 describe('api/logs — listLogs', () => {
-  it('forwards format=json + sort/filter params', async () => {
+  it('forwards format=json + table params', async () => {
     let observedQuery: URLSearchParams | null = null;
     const ok: LogListResponse = { links: {}, meta: {}, data: [] };
     server.use(
@@ -26,11 +26,18 @@ describe('api/logs — listLogs', () => {
       })
     );
 
-    await listLogs({ sort: '-timestamp', filter: 'status==500' });
+    await listLogs({
+      sort: '-timestamp',
+      filter: 'status==500',
+      page_after: 10,
+      page_size: 25,
+    });
     const q = observedQuery as unknown as URLSearchParams;
     expect(q.get('format')).toBe('json');
     expect(q.get('sort')).toBe('-timestamp');
     expect(q.get('filter')).toBe('status==500');
+    expect(q.get('page_after')).toBe('10');
+    expect(q.get('page_size')).toBe('25');
   });
 
   it('throws AxiosError on 400 (invalid filter)', async () => {

--- a/app/src/api/re_review.spec.ts
+++ b/app/src/api/re_review.spec.ts
@@ -14,6 +14,7 @@ import {
   assignReReviewBatch,
   unassignReReviewBatch,
   getAssignmentTable,
+  listAvailableReReviewEntities,
   createReReviewBatch,
   previewReReviewBatch,
   reassignReReviewBatch,
@@ -186,6 +187,30 @@ describe('api/re_review — getAssignmentTable', () => {
   });
 });
 
+describe('api/re_review — listAvailableReReviewEntities', () => {
+  it('sends q/page/page_size params and returns available rows', async () => {
+    let observedQuery: URLSearchParams | null = null;
+    server.use(
+      http.get('/api/re_review/entities/available', ({ request }) => {
+        observedQuery = new URL(request.url).searchParams;
+        return HttpResponse.json({
+          data: [{ entity_id: 11, symbol: 'ARID1B' }],
+          meta: { total: 1 },
+        });
+      })
+    );
+
+    const result = await listAvailableReReviewEntities({ q: 'ARI', page: 2, page_size: 50 });
+
+    const q = observedQuery as unknown as URLSearchParams;
+    expect(q.get('q')).toBe('ARI');
+    expect(q.get('page')).toBe('2');
+    expect(q.get('page_size')).toBe('50');
+    expect(result.data).toEqual([{ entity_id: 11, symbol: 'ARID1B' }]);
+    expect(result.meta?.total).toBe(1);
+  });
+});
+
 describe('api/re_review — createReReviewBatch', () => {
   it('POSTs the criteria body', async () => {
     let receivedBody: unknown = null;
@@ -263,6 +288,31 @@ describe('api/re_review — assignReReviewEntities', () => {
     await assignReReviewEntities({ entity_ids: [1, 2], user_id: 7 });
     expect((receivedBody as { user_id?: number }).user_id).toBe(7);
   });
+
+  it('returns the created batch entry', async () => {
+    server.use(
+      http.put('/api/re_review/entities/assign', async ({ request }) => {
+        expect(await request.json()).toEqual({
+          entity_ids: [11, 12],
+          user_id: 7,
+          batch_name: 'Manual ARID batch',
+        });
+        return HttpResponse.json({
+          status: 200,
+          entry: { batch_id: 4, entity_count: 2 },
+        });
+      })
+    );
+
+    const result = await assignReReviewEntities({
+      entity_ids: [11, 12],
+      user_id: 7,
+      batch_name: 'Manual ARID batch',
+    });
+
+    expect(result.entry?.batch_id).toBe(4);
+    expect(result.entry?.entity_count).toBe(2);
+  });
 });
 
 describe('api/re_review — recalculateReReviewBatch', () => {
@@ -277,5 +327,30 @@ describe('api/re_review — recalculateReReviewBatch', () => {
 
     await recalculateReReviewBatch({ re_review_batch: 5, batch_size: 30 });
     expect((receivedBody as { re_review_batch?: number }).re_review_batch).toBe(5);
+  });
+
+  it('sends criteria body and returns entry', async () => {
+    server.use(
+      http.put('/api/re_review/batch/recalculate', async ({ request }) => {
+        expect(await request.json()).toEqual({
+          re_review_batch: 9,
+          batch_size: 20,
+          status_filter: 3,
+        });
+        return HttpResponse.json({
+          status: 200,
+          entry: { batch_id: 9, entity_count: 17 },
+        });
+      })
+    );
+
+    const result = await recalculateReReviewBatch({
+      re_review_batch: 9,
+      batch_size: 20,
+      status_filter: 3,
+    });
+
+    expect(result.entry?.batch_id).toBe(9);
+    expect(result.entry?.entity_count).toBe(17);
   });
 });

--- a/app/src/api/re_review.ts
+++ b/app/src/api/re_review.ts
@@ -78,6 +78,28 @@ export interface AssignmentRow {
   entity_count: number;
 }
 
+export interface AvailableReReviewEntitiesParams {
+  q?: string;
+  page?: number;
+  page_size?: number;
+}
+
+export interface AvailableReReviewEntity {
+  entity_id: number;
+  symbol?: string | null;
+  disease_ontology_name?: string | null;
+  category?: string | null;
+  [key: string]: unknown;
+}
+
+export interface AvailableReReviewEntitiesResponse {
+  data: AvailableReReviewEntity[];
+  meta?: {
+    total?: number | number[];
+    [key: string]: unknown;
+  };
+}
+
 // Batch management types
 
 export interface BatchCriteria {
@@ -95,6 +117,13 @@ export interface CreateBatchRequest extends BatchCriteria {
   batch_name?: string;
 }
 
+export interface BatchEntry {
+  batch_id?: number;
+  re_review_batch?: number;
+  entity_count?: number;
+  [key: string]: unknown;
+}
+
 /**
  * Service-layer envelope used by `batch_*` repository functions:
  * `{ status, message, entry?, ... }`.
@@ -102,7 +131,7 @@ export interface CreateBatchRequest extends BatchCriteria {
 export interface BatchServiceResponse {
   status: number;
   message?: string;
-  entry?: Record<string, unknown>;
+  entry?: BatchEntry;
   error?: string;
   [key: string]: unknown;
 }
@@ -119,7 +148,7 @@ export interface ArchiveBatchParams {
 export interface AssignEntitiesRequest {
   entity_ids: number[];
   user_id: number;
-  batch_name?: string;
+  batch_name?: string | null;
 }
 
 export interface RecalculateBatchRequest extends BatchCriteria {
@@ -254,6 +283,23 @@ export async function getAssignmentTable(
   config?: AxiosRequestConfig
 ): Promise<AssignmentRow[]> {
   return apiClient.get<AssignmentRow[]>('/api/re_review/assignment_table', {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...params },
+  });
+}
+
+/**
+ * GET /api/re_review/entities/available
+ * Mirrors api/endpoints/re_review_endpoints.R available-entities handler.
+ *
+ * Curator+ only. Returns entities currently available for manual batch
+ * assignment.
+ */
+export async function listAvailableReReviewEntities(
+  params: AvailableReReviewEntitiesParams = {},
+  config?: AxiosRequestConfig
+): Promise<AvailableReReviewEntitiesResponse> {
+  return apiClient.get<AvailableReReviewEntitiesResponse>('/api/re_review/entities/available', {
     ...config,
     params: { ...(config?.params as object | undefined), ...params },
   });

--- a/app/src/components/tables/TablesLogs.spec.ts
+++ b/app/src/components/tables/TablesLogs.spec.ts
@@ -268,7 +268,6 @@ describe('TablesLogs — v11.0 closeout F2b apiClient migration', () => {
     const logsReady = new Promise<void>((resolve) => {
       resolveLogs = resolve;
     });
-    const replaceStateSpy = vi.spyOn(window.history, 'replaceState').mockImplementation(() => {});
 
     server.use(
       http.get('/api/user/list', () => HttpResponse.json([])),
@@ -300,6 +299,7 @@ describe('TablesLogs — v11.0 closeout F2b apiClient migration', () => {
     }
     vm.isInitializing = false;
     vm.sort = '-timestamp';
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState').mockImplementation(() => {});
 
     const loadPromise = vm.doLoadData();
     await Promise.resolve();
@@ -310,13 +310,12 @@ describe('TablesLogs — v11.0 closeout F2b apiClient migration', () => {
     await loadPromise;
     await flushPromises();
 
-    expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+    expect(replaceStateSpy).toHaveBeenCalled();
     replaceStateSpy.mockRestore();
   });
 
   it('does not update the browser URL after a failed logs response', async () => {
     primeAuth('logs-url-failure-token');
-    const replaceStateSpy = vi.spyOn(window.history, 'replaceState').mockImplementation(() => {});
 
     server.use(
       http.get('/api/user/list', () => HttpResponse.json([])),
@@ -331,6 +330,7 @@ describe('TablesLogs — v11.0 closeout F2b apiClient migration', () => {
     }
     vm.isInitializing = false;
     vm.sort = '+timestamp';
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState').mockImplementation(() => {});
 
     await vm.doLoadData();
     await flushPromises();

--- a/app/src/components/tables/TablesLogs.spec.ts
+++ b/app/src/components/tables/TablesLogs.spec.ts
@@ -74,6 +74,9 @@ interface LogsVm {
   totalRows: number;
   user_options: unknown[];
   isBusy: boolean;
+  isInitializing: boolean;
+  sort: string;
+  loadDataDebounceTimer: ReturnType<typeof setTimeout> | null;
 }
 
 function makeRouter() {
@@ -257,5 +260,82 @@ describe('TablesLogs — v11.0 closeout F2b apiClient migration', () => {
     await flushPromises();
 
     expect(sawBearer).toBe(true);
+  });
+
+  it('updates the browser URL only after a successful fresh logs response', async () => {
+    primeAuth('logs-url-success-token');
+    let resolveLogs: () => void;
+    const logsReady = new Promise<void>((resolve) => {
+      resolveLogs = resolve;
+    });
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+
+    server.use(
+      http.get('/api/user/list', () => HttpResponse.json([])),
+      http.get('/api/logs/', async () => {
+        await logsReady;
+        return HttpResponse.json({
+          data: [],
+          meta: [
+            {
+              totalItems: 0,
+              currentPage: 1,
+              totalPages: 1,
+              prevItemID: 0,
+              currentItemID: 0,
+              nextItemID: 0,
+              lastItemID: 0,
+              executionTime: 5,
+            },
+          ],
+        });
+      })
+    );
+
+    const wrapper = await mountTable();
+    const vm = wrapper.vm as unknown as LogsVm;
+    if (vm.loadDataDebounceTimer) {
+      clearTimeout(vm.loadDataDebounceTimer);
+      vm.loadDataDebounceTimer = null;
+    }
+    vm.isInitializing = false;
+    vm.sort = '-timestamp';
+
+    const loadPromise = vm.doLoadData();
+    await Promise.resolve();
+
+    expect(replaceStateSpy).not.toHaveBeenCalled();
+
+    resolveLogs!();
+    await loadPromise;
+    await flushPromises();
+
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+    replaceStateSpy.mockRestore();
+  });
+
+  it('does not update the browser URL after a failed logs response', async () => {
+    primeAuth('logs-url-failure-token');
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState').mockImplementation(() => {});
+
+    server.use(
+      http.get('/api/user/list', () => HttpResponse.json([])),
+      http.get('/api/logs/', () => HttpResponse.json({ error: 'INVALID_FILTER' }, { status: 400 }))
+    );
+
+    const wrapper = await mountTable();
+    const vm = wrapper.vm as unknown as LogsVm;
+    if (vm.loadDataDebounceTimer) {
+      clearTimeout(vm.loadDataDebounceTimer);
+      vm.loadDataDebounceTimer = null;
+    }
+    vm.isInitializing = false;
+    vm.sort = '+timestamp';
+
+    await vm.doLoadData();
+    await flushPromises();
+
+    expect(replaceStateSpy).not.toHaveBeenCalled();
+    replaceStateSpy.mockRestore();
   });
 });

--- a/app/src/components/tables/TablesLogs.spec.ts
+++ b/app/src/components/tables/TablesLogs.spec.ts
@@ -197,7 +197,12 @@ describe('TablesLogs — v11.0 closeout F2b apiClient migration', () => {
     );
 
     const wrapper = await mountTable();
-    (wrapper.vm as unknown as LogsVm).isBusy = true;
+    const vm = wrapper.vm as unknown as LogsVm;
+    if (vm.loadDataDebounceTimer) {
+      clearTimeout(vm.loadDataDebounceTimer);
+      vm.loadDataDebounceTimer = null;
+    }
+    vm.isBusy = true;
     await flushPromises();
 
     expect(wrapper.get('[data-testid="logs-loading-state"]').text()).toContain('Loading logs');

--- a/app/src/components/tables/TablesLogs.vue
+++ b/app/src/components/tables/TablesLogs.vue
@@ -582,7 +582,6 @@ export default {
       modified: { content: null, join_char: ',', operator: 'contains' },
     });
 
-    // Route context for shared table helpers.
     const route = useRoute();
 
     // Table methods composable
@@ -593,8 +592,6 @@ export default {
       route,
     });
 
-    // Destructure to exclude methods that are overridden in the component's methods section
-    // This matches the pattern used in TablesEntities for proper method overriding
     const {
       filtered: _filtered,
       handlePageChange: _handlePageChange,
@@ -602,6 +599,9 @@ export default {
       handleSortByOrDescChange: _handleSortByOrDescChange,
       removeFilters: _removeFilters,
       removeSearch: _removeSearch,
+      requestExcel: _requestExcel,
+      copyLinkToClipboard: _copyLinkToClipboard,
+      truncate: _truncate,
       ...restTableMethods
     } = tableMethods;
 

--- a/app/src/components/tables/TablesLogs.vue
+++ b/app/src/components/tables/TablesLogs.vue
@@ -481,7 +481,7 @@
 
 <script>
 // Import Vue utilities
-import { ref, inject } from 'vue';
+import { ref } from 'vue';
 import { useRoute } from 'vue-router';
 
 // Import composables
@@ -513,18 +513,11 @@ import {
   getLogMethodVariant,
   getLogStatusVariant,
 } from './logTableFormatters';
-// v11.0 closeout F2b: apiClient is the single outbound surface — the
-// request interceptor injects `Authorization: Bearer <token>` from
-// `useAuth().token.value`, so this component stops building the header
-// by hand.
-import { apiClient } from '@/api/client';
+import { listLogs, listLogsXlsx, deleteLogs as deleteLogsApi } from '@/api/logging';
+import { listUsersByRole } from '@/api/user';
+import { createLogTableRequestCache } from './logTableRequests';
 
-// Module-level variables to track API calls across component remounts
-// This survives when Vue Router remounts the component on URL changes
-let moduleLastApiParams = null;
-let moduleApiCallInProgress = false;
-let moduleLastApiCallTime = 0;
-let moduleLastApiResponse = null;
+const moduleLogRequestCache = createLogTableRequestCache();
 
 export default {
   name: 'TablesLogs',
@@ -589,8 +582,7 @@ export default {
       modified: { content: null, join_char: ',', operator: 'contains' },
     });
 
-    // Inject axios and route
-    const axios = inject('axios');
+    // Route context for shared table helpers.
     const route = useRoute();
 
     // Table methods composable
@@ -598,7 +590,6 @@ export default {
       filter,
       filterObjToStr,
       apiEndpoint: props.apiEndpoint,
-      axios,
       route,
     });
 
@@ -625,7 +616,6 @@ export default {
       ...tableData,
       ...restTableMethods,
       filter,
-      axios,
     };
   },
   data() {
@@ -860,8 +850,8 @@ export default {
     // Load user list for filter dropdown
     async loadUserList() {
       try {
-        const response = await apiClient.raw.get(`${import.meta.env.VITE_API_URL}/api/user/list`);
-        this.user_options = response.data.map((item) => ({
+        const data = await listUsersByRole();
+        this.user_options = data.map((item) => ({
           value: item.user_name,
           text: `${item.user_name} (${item.user_role})`,
         }));
@@ -881,51 +871,25 @@ export default {
     },
     // Actual data loading with module-level caching
     async doLoadData() {
-      const urlParam = `sort=${this.sort}&filter=${this.filter_string}&page_after=${this.currentItemID}&page_size=${this.perPage}`;
-      const now = Date.now();
-
-      // Prevent duplicate API calls using module-level tracking
-      // This works across component remounts caused by router.replace()
-      if (moduleLastApiParams === urlParam && now - moduleLastApiCallTime < 500) {
-        // Use cached response data for remounted component
-        if (moduleLastApiResponse) {
-          this.applyApiResponse(moduleLastApiResponse);
-          this.isBusy = false;
-        }
-        return;
-      }
-
-      // Also prevent if a call is already in progress with same params
-      if (moduleApiCallInProgress && moduleLastApiParams === urlParam) {
-        return;
-      }
-
-      moduleLastApiParams = urlParam;
-      moduleLastApiCallTime = now;
-      moduleApiCallInProgress = true;
+      const params = {
+        sort: this.sort,
+        filter: this.filter_string,
+        page_after: this.currentItemID,
+        page_size: this.perPage,
+      };
       this.isBusy = true;
 
       try {
-        const response = await apiClient.raw.get(`${import.meta.env.VITE_API_URL}/api/logs/`, {
-          params: {
-            sort: this.sort,
-            filter: this.filter_string,
-            page_after: this.currentItemID,
-            page_size: this.perPage,
-          },
-        });
-
-        moduleApiCallInProgress = false;
-        // Cache response for remounted components
-        moduleLastApiResponse = response.data;
-        this.applyApiResponse(response.data);
+        const result = await moduleLogRequestCache.load(params, () => listLogs(params));
+        this.applyApiResponse(result.response);
 
         // Update URL AFTER API success to prevent component remount during API call
-        this.updateBrowserUrl();
+        if (!result.fromCache) {
+          this.updateBrowserUrl();
+        }
 
         this.isBusy = false;
       } catch (error) {
-        moduleApiCallInProgress = false;
         this.makeToast(`Error: ${error.message}`, 'Error loading logs', 'danger');
         this.isBusy = false;
       }
@@ -1066,22 +1030,18 @@ export default {
       }
 
       try {
-        const response = await apiClient.raw.get(`${import.meta.env.VITE_API_URL}/api/logs/`, {
-          params: {
-            page_after: 0,
-            page_size: 'all',
-            format: 'xlsx',
-            filter: this.filter_string, // Apply current filters
-            sort: this.sort,
-          },
-          responseType: 'blob', // Important for binary download
+        const blob = await listLogsXlsx({
+          page_after: 0,
+          page_size: 'all',
+          filter: this.filter_string,
+          sort: this.sort,
         });
 
         // Generate filename with date
         const date = new Date().toISOString().split('T')[0];
         const filename = `sysndd_audit_logs_${date}.xlsx`;
 
-        const fileURL = window.URL.createObjectURL(new Blob([response.data]));
+        const fileURL = window.URL.createObjectURL(new Blob([blob]));
         const fileLink = document.createElement('a');
 
         fileLink.href = fileURL;
@@ -1151,13 +1111,9 @@ export default {
       this.isDeleting = true;
       try {
         const olderThanDays = this.deleteMode === 'all' ? 0 : parseInt(this.deleteMode, 10);
-        const response = await apiClient.raw.delete(`${import.meta.env.VITE_API_URL}/api/logs/`, {
-          params: {
-            older_than_days: olderThanDays,
-          },
-        });
+        const response = await deleteLogsApi({ older_than_days: olderThanDays });
 
-        const deletedCount = response.data.deleted_count || 0;
+        const deletedCount = response.deleted_count || 0;
         const message =
           this.deleteMode === 'all'
             ? `Successfully deleted ${deletedCount.toLocaleString()} log entries`

--- a/app/src/components/tables/logTableRequests.spec.ts
+++ b/app/src/components/tables/logTableRequests.spec.ts
@@ -14,7 +14,25 @@ describe('logTableRequests', () => {
         page_after: 10,
         page_size: 25,
       })
-    ).toBe('sort=-timestamp&filter=status==500&page_after=10&page_size=25');
+    ).toBe('sort=-timestamp&filter=status%3D%3D500&page_after=10&page_size=25');
+  });
+
+  it('encodes param values so filters cannot collide with pagination fields', () => {
+    const keyWithEmbeddedDelimiter = logRequestKey({
+      sort: '-id',
+      filter: 'path contains &page_after=25',
+      page_after: 0,
+      page_size: 10,
+    });
+    const keyWithDifferentPage = logRequestKey({
+      sort: '-id',
+      filter: 'path contains ',
+      page_after: 25,
+      page_size: 10,
+    });
+
+    expect(keyWithEmbeddedDelimiter).not.toBe(keyWithDifferentPage);
+    expect(keyWithEmbeddedDelimiter).toContain('filter=path+contains+%26page_after%3D25');
   });
 
   it('reuses a fresh cached response for duplicate requests', async () => {
@@ -87,5 +105,31 @@ describe('logTableRequests', () => {
     expect(result.response.data).toEqual([{ id: 2 }]);
     expect(result.fromCache).toBe(false);
     expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not reuse a previous successful response after a different request fails', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-20T00:00:00Z'));
+
+    const cache = createLogTableRequestCache();
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce({ data: [{ id: 1 }], meta: [{ totalItems: 1 }] })
+      .mockRejectedValueOnce(new Error('invalid filter'))
+      .mockResolvedValueOnce({ data: [{ id: 2 }], meta: [{ totalItems: 1 }] });
+
+    await cache.load({ sort: '-id', filter: 'status==200', page_after: 0, page_size: 10 }, fetcher);
+    await expect(
+      cache.load({ sort: '-id', filter: 'status==500', page_after: 0, page_size: 10 }, fetcher)
+    ).rejects.toThrow('invalid filter');
+
+    const retry = await cache.load(
+      { sort: '-id', filter: 'status==500', page_after: 0, page_size: 10 },
+      fetcher
+    );
+
+    expect(retry.response.data).toEqual([{ id: 2 }]);
+    expect(retry.fromCache).toBe(false);
+    expect(fetcher).toHaveBeenCalledTimes(3);
   });
 });

--- a/app/src/components/tables/logTableRequests.spec.ts
+++ b/app/src/components/tables/logTableRequests.spec.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createLogTableRequestCache, logRequestKey } from './logTableRequests';
+
+describe('logTableRequests', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('builds a stable request key from table params', () => {
+    expect(
+      logRequestKey({
+        sort: '-timestamp',
+        filter: 'status==500',
+        page_after: 10,
+        page_size: 25,
+      })
+    ).toBe('sort=-timestamp&filter=status==500&page_after=10&page_size=25');
+  });
+
+  it('reuses a fresh cached response for duplicate requests', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-20T00:00:00Z'));
+
+    const cache = createLogTableRequestCache();
+    const fetcher = vi.fn().mockResolvedValue({ data: [], meta: [{ totalItems: 0 }] });
+
+    const first = await cache.load(
+      { sort: '-id', filter: '', page_after: 0, page_size: 10 },
+      fetcher
+    );
+    const second = await cache.load(
+      { sort: '-id', filter: '', page_after: 0, page_size: 10 },
+      fetcher
+    );
+
+    expect(first.fromCache).toBe(false);
+    expect(second.fromCache).toBe(true);
+    expect(first.response).toBe(second.response);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares an in-flight duplicate request without calling the fetcher twice', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-20T00:00:00Z'));
+
+    const cache = createLogTableRequestCache();
+    let resolveResponse: (value: { data: unknown[]; meta: Array<{ totalItems: number }> }) => void;
+    const responsePromise = new Promise<{ data: unknown[]; meta: Array<{ totalItems: number }> }>(
+      (resolve) => {
+        resolveResponse = resolve;
+      }
+    );
+    const fetcher = vi.fn().mockReturnValue(responsePromise);
+
+    const firstPromise = cache.load({ sort: '-id', filter: '', page_after: 0, page_size: 10 }, fetcher);
+    const secondPromise = cache.load(
+      { sort: '-id', filter: '', page_after: 0, page_size: 10 },
+      fetcher
+    );
+
+    resolveResponse!({ data: [{ id: 1 }], meta: [{ totalItems: 1 }] });
+    const [first, second] = await Promise.all([firstPromise, secondPromise]);
+
+    expect(first.fromCache).toBe(false);
+    expect(second.fromCache).toBe(true);
+    expect(second.response).toBe(first.response);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reuse stale cached responses after the duplicate window', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-20T00:00:00Z'));
+
+    const cache = createLogTableRequestCache();
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce({ data: [{ id: 1 }], meta: [{ totalItems: 1 }] })
+      .mockResolvedValueOnce({ data: [{ id: 2 }], meta: [{ totalItems: 1 }] });
+
+    await cache.load({ sort: '-id', filter: '', page_after: 0, page_size: 10 }, fetcher);
+    vi.setSystemTime(new Date('2026-05-20T00:00:01Z'));
+    const result = await cache.load(
+      { sort: '-id', filter: '', page_after: 0, page_size: 10 },
+      fetcher
+    );
+
+    expect(result.response.data).toEqual([{ id: 2 }]);
+    expect(result.fromCache).toBe(false);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/src/components/tables/logTableRequests.ts
+++ b/app/src/components/tables/logTableRequests.ts
@@ -1,0 +1,53 @@
+import type { LogListResponse, ListLogsParams } from '@/api/logging';
+
+export type LogTableRequestParams = Required<
+  Pick<ListLogsParams, 'sort' | 'filter' | 'page_after' | 'page_size'>
+>;
+
+export interface LogTableRequestResult {
+  response: LogListResponse;
+  fromCache: boolean;
+}
+
+export function logRequestKey(params: LogTableRequestParams): string {
+  return `sort=${params.sort}&filter=${params.filter}&page_after=${params.page_after}&page_size=${params.page_size}`;
+}
+
+export function createLogTableRequestCache(windowMs = 500) {
+  let lastKey = '';
+  let lastCallTime = 0;
+  let lastResponse: LogListResponse | null = null;
+  let inProgressKey: string | null = null;
+  let inProgressPromise: Promise<LogListResponse> | null = null;
+
+  return {
+    async load(
+      params: LogTableRequestParams,
+      fetcher: () => Promise<LogListResponse>
+    ): Promise<LogTableRequestResult> {
+      const key = logRequestKey(params);
+      const now = Date.now();
+
+      if (lastKey === key && lastResponse && now - lastCallTime < windowMs) {
+        return { response: lastResponse, fromCache: true };
+      }
+
+      if (inProgressKey === key && inProgressPromise) {
+        return { response: await inProgressPromise, fromCache: true };
+      }
+
+      lastKey = key;
+      lastCallTime = now;
+      inProgressKey = key;
+      inProgressPromise = fetcher();
+
+      try {
+        lastResponse = await inProgressPromise;
+        return { response: lastResponse, fromCache: false };
+      } finally {
+        inProgressKey = null;
+        inProgressPromise = null;
+      }
+    },
+  };
+}

--- a/app/src/components/tables/logTableRequests.ts
+++ b/app/src/components/tables/logTableRequests.ts
@@ -10,7 +10,12 @@ export interface LogTableRequestResult {
 }
 
 export function logRequestKey(params: LogTableRequestParams): string {
-  return `sort=${params.sort}&filter=${params.filter}&page_after=${params.page_after}&page_size=${params.page_size}`;
+  return new URLSearchParams({
+    sort: String(params.sort),
+    filter: String(params.filter),
+    page_after: String(params.page_after),
+    page_size: String(params.page_size),
+  }).toString();
 }
 
 export function createLogTableRequestCache(windowMs = 500) {
@@ -36,17 +41,21 @@ export function createLogTableRequestCache(windowMs = 500) {
         return { response: await inProgressPromise, fromCache: true };
       }
 
-      lastKey = key;
-      lastCallTime = now;
       inProgressKey = key;
-      inProgressPromise = fetcher();
+      const requestPromise = fetcher();
+      inProgressPromise = requestPromise;
 
       try {
-        lastResponse = await inProgressPromise;
-        return { response: lastResponse, fromCache: false };
+        const response = await requestPromise;
+        lastKey = key;
+        lastCallTime = Date.now();
+        lastResponse = response;
+        return { response, fromCache: false };
       } finally {
-        inProgressKey = null;
-        inProgressPromise = null;
+        if (inProgressKey === key && inProgressPromise === requestPromise) {
+          inProgressKey = null;
+          inProgressPromise = null;
+        }
       }
     },
   };

--- a/app/src/views/curate/ManageReReview.spec.ts
+++ b/app/src/views/curate/ManageReReview.spec.ts
@@ -185,12 +185,18 @@ const mountManageReReview = async (): Promise<VueWrapper> => {
 // declare only the subset the tests touch.
 // ---------------------------------------------------------------------------
 interface ManageReReviewVm {
+  user_options: Array<{ value: number; text: string; role: string }>;
   user_id_assignment: number;
+  availableEntities: Array<Record<string, unknown>>;
+  availableEntityTotal: number;
+  manualEntityFilter: string | null;
   selectedEntityIds: number[];
   entityAssignUserId: number | null;
   entityAssignBatchName: string;
+  reassignModalShow: boolean;
   reassignBatchId: number | null;
   reassignNewUserId: number | null;
+  recalculateModalShow: boolean;
   recalculateBatchId: number | null;
   recalculateCriteria: {
     date_range: { start: string | null; end: string | null };
@@ -198,11 +204,18 @@ interface ManageReReviewVm {
     status_filter: number | null;
     batch_size: number;
   };
+  status_options: Array<{ value: number; text: string }>;
+  loadUserList: () => Promise<void>;
+  loadReReviewTableData: () => Promise<void>;
+  loadAvailableEntities: () => Promise<void>;
+  loadStatusOptions: () => Promise<void>;
   handleNewBatchAssignment: () => Promise<void>;
   handleBatchUnAssignment: (batchId: number) => Promise<void>;
   handleEntityAssignment: () => Promise<void>;
   handleBatchReassignment: () => Promise<void>;
   handleBatchRecalculation: () => Promise<void>;
+  makeToast: ReturnType<typeof vi.fn>;
+  announce: ReturnType<typeof vi.fn>;
 }
 
 const vm = (wrapper: VueWrapper): ManageReReviewVm => wrapper.vm as unknown as ManageReReviewVm;
@@ -224,7 +237,7 @@ function installDefaultHandlers(): void {
     http.get('*/api/re_review/entities/available', () =>
       HttpResponse.json({ data: [], meta: { total: 0 } })
     ),
-    http.get('*/api/list/status', () => HttpResponse.json([]))
+    http.get('*/api/list/status', () => HttpResponse.json({ data: [] }))
   );
 }
 
@@ -485,17 +498,196 @@ describe('ManageReReview.vue — apiClient Bearer header on every authed endpoin
       http.get('*/api/list/status', ({ request }) => {
         expectBearerHeader(request, token);
         sawCall = true;
+        return HttpResponse.json({
+          data: [
+            { category_id: 1, category: 'Definitive' },
+            { category_id: 2, category: 'Moderate' },
+          ],
+        });
+      })
+    );
+
+    const wrapper = await mountManageReReview();
+    await flushPromises();
+
+    expect(sawCall).toBe(true);
+    expect(vm(wrapper).status_options).toEqual([
+      { value: 1, text: 'Definitive' },
+      { value: 2, text: 'Moderate' },
+    ]);
+  });
+});
+
+describe('ManageReReview.vue — typed client migration behavior', () => {
+  it('loadUserList maps Curator/Reviewer rows from the typed user client', async () => {
+    primeAuth('re-review-users-token');
+    let observedUrl = '';
+
+    server.use(
+      http.get('*/api/user/list', ({ request }) => {
+        observedUrl = request.url;
+        expectBearerHeader(request, 're-review-users-token');
         return HttpResponse.json([
-          { category_id: 1, category: 'Definitive' },
-          { category_id: 2, category: 'Moderate' },
+          { user_id: 7, user_name: 'curator_a', user_role: 'Curator' },
+          { user_id: 8, user_name: 'reviewer_b', user_role: 'Reviewer' },
         ]);
       })
     );
 
-    await mountManageReReview();
+    const wrapper = await mountManageReReview();
     await flushPromises();
 
-    expect(sawCall).toBe(true);
+    expect(new URL(observedUrl).searchParams.get('roles')).toBe('Curator,Reviewer');
+    expect(vm(wrapper).user_options).toEqual([
+      { value: 7, text: 'curator_a', role: 'Curator' },
+      { value: 8, text: 'reviewer_b', role: 'Reviewer' },
+    ]);
+  });
+
+  it('loadAvailableEntities normalizes entity rows and scalar total', async () => {
+    primeAuth('re-review-entities-token');
+
+    server.use(
+      http.get('*/api/re_review/entities/available', ({ request }) => {
+        const query = new URL(request.url).searchParams;
+        expect(query.get('q')).toBe('ARID');
+        expect(query.get('page')).toBe('1');
+        expect(query.get('page_size')).toBe('100');
+        return HttpResponse.json({
+          data: [{ entity_id: 11, symbol: 'ARID1B' }],
+          meta: { total: 1 },
+        });
+      })
+    );
+
+    const wrapper = await mountManageReReview();
+    const component = vm(wrapper);
+    component.manualEntityFilter = 'ARID';
+
+    await component.loadAvailableEntities();
+    await flushPromises();
+
+    expect(component.availableEntities).toEqual([{ entity_id: 11, symbol: 'ARID1B' }]);
+    expect(component.availableEntityTotal).toBe(1);
+  });
+
+  it('handleEntityAssignment preserves null batch name and success side effects', async () => {
+    primeAuth('re-review-assign-token');
+    let receivedBody: unknown = null;
+
+    server.use(
+      http.put('*/api/re_review/entities/assign', async ({ request }) => {
+        receivedBody = await request.json();
+        return HttpResponse.json({
+          entry: { batch_id: 77, entity_count: 2 },
+        });
+      })
+    );
+
+    const wrapper = await mountManageReReview();
+    const component = vm(wrapper);
+    const tableRefresh = vi.spyOn(component, 'loadReReviewTableData').mockResolvedValue();
+    const entityRefresh = vi.spyOn(component, 'loadAvailableEntities').mockResolvedValue();
+
+    component.selectedEntityIds = [11, 22];
+    component.entityAssignUserId = 3;
+    component.entityAssignBatchName = '';
+
+    await component.handleEntityAssignment();
+    await flushPromises();
+
+    expect(receivedBody).toEqual({
+      entity_ids: [11, 22],
+      user_id: 3,
+      batch_name: null,
+    });
+    expect(component.makeToast).toHaveBeenCalledWith(
+      'Created batch 77 with 2 entities',
+      'Success',
+      'success'
+    );
+    expect(component.announce).toHaveBeenCalledWith('Created batch 77 with 2 entities');
+    expect(component.selectedEntityIds).toEqual([]);
+    expect(component.entityAssignUserId).toBeNull();
+    expect(component.entityAssignBatchName).toBe('');
+    expect(tableRefresh).toHaveBeenCalledTimes(1);
+    expect(entityRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('handleEntityAssignment validation avoids API calls for missing inputs', async () => {
+    primeAuth('re-review-validation-token');
+    let sawAssignCall = false;
+    server.use(
+      http.put('*/api/re_review/entities/assign', () => {
+        sawAssignCall = true;
+        return HttpResponse.json({});
+      })
+    );
+
+    const wrapper = await mountManageReReview();
+    const component = vm(wrapper);
+    component.selectedEntityIds = [];
+    component.entityAssignUserId = 3;
+
+    await component.handleEntityAssignment();
+
+    expect(sawAssignCall).toBe(false);
+    expect(component.makeToast).toHaveBeenCalledWith(
+      'Please select at least one entity',
+      'Validation',
+      'warning'
+    );
+  });
+
+  it('handleBatchReassignment closes the modal and refreshes only the table', async () => {
+    primeAuth('re-review-reassign-token');
+    server.use(
+      http.put('*/api/re_review/batch/reassign', () => HttpResponse.json({ status: 200 }))
+    );
+    const wrapper = await mountManageReReview();
+    const component = vm(wrapper);
+    const tableRefresh = vi.spyOn(component, 'loadReReviewTableData').mockResolvedValue();
+    const entityRefresh = vi.spyOn(component, 'loadAvailableEntities').mockResolvedValue();
+
+    component.reassignModalShow = true;
+    component.reassignBatchId = 42;
+    component.reassignNewUserId = 9;
+
+    await component.handleBatchReassignment();
+    await flushPromises();
+
+    expect(component.reassignModalShow).toBe(false);
+    expect(tableRefresh).toHaveBeenCalledTimes(1);
+    expect(entityRefresh).not.toHaveBeenCalled();
+  });
+
+  it('handleBatchRecalculation closes the modal and refreshes table plus entities', async () => {
+    primeAuth('re-review-recalculate-token');
+    server.use(
+      http.put('*/api/re_review/batch/recalculate', () =>
+        HttpResponse.json({ entry: { batch_id: 42, entity_count: 20 } })
+      )
+    );
+    const wrapper = await mountManageReReview();
+    const component = vm(wrapper);
+    const tableRefresh = vi.spyOn(component, 'loadReReviewTableData').mockResolvedValue();
+    const entityRefresh = vi.spyOn(component, 'loadAvailableEntities').mockResolvedValue();
+
+    component.recalculateModalShow = true;
+    component.recalculateBatchId = 42;
+    component.recalculateCriteria = {
+      date_range: { start: null, end: null },
+      gene_list: [],
+      status_filter: null,
+      batch_size: 20,
+    };
+
+    await component.handleBatchRecalculation();
+    await flushPromises();
+
+    expect(component.recalculateModalShow).toBe(false);
+    expect(tableRefresh).toHaveBeenCalledTimes(1);
+    expect(entityRefresh).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/app/src/views/curate/ManageReReview.spec.ts
+++ b/app/src/views/curate/ManageReReview.spec.ts
@@ -571,6 +571,28 @@ describe('ManageReReview.vue — typed client migration behavior', () => {
     expect(component.availableEntityTotal).toBe(1);
   });
 
+  it('loadAvailableEntities unwraps Plumber scalar-array total values', async () => {
+    primeAuth('re-review-entities-array-total-token');
+
+    server.use(
+      http.get('*/api/re_review/entities/available', () =>
+        HttpResponse.json({
+          data: [{ entity_id: 22, symbol: 'SCN2A' }],
+          meta: { total: [1] },
+        })
+      )
+    );
+
+    const wrapper = await mountManageReReview();
+    const component = vm(wrapper);
+
+    await component.loadAvailableEntities();
+    await flushPromises();
+
+    expect(component.availableEntities).toEqual([{ entity_id: 22, symbol: 'SCN2A' }]);
+    expect(component.availableEntityTotal).toBe(1);
+  });
+
   it('handleEntityAssignment preserves null batch name and success side effects', async () => {
     primeAuth('re-review-assign-token');
     let receivedBody: unknown = null;
@@ -639,6 +661,38 @@ describe('ManageReReview.vue — typed client migration behavior', () => {
     );
   });
 
+  it('handleEntityAssignment uses fallback copy when the server omits batch summary fields', async () => {
+    primeAuth('re-review-assign-empty-entry-token');
+
+    server.use(
+      http.put('*/api/re_review/entities/assign', () =>
+        HttpResponse.json({
+          entry: {},
+        })
+      )
+    );
+
+    const wrapper = await mountManageReReview();
+    const component = vm(wrapper);
+    vi.spyOn(component, 'loadReReviewTableData').mockResolvedValue();
+    vi.spyOn(component, 'loadAvailableEntities').mockResolvedValue();
+
+    component.selectedEntityIds = [11];
+    component.entityAssignUserId = 3;
+
+    await component.handleEntityAssignment();
+    await flushPromises();
+
+    expect(component.makeToast).toHaveBeenCalledWith(
+      'Created assignment batch, but the batch summary was unavailable',
+      'Success',
+      'success'
+    );
+    expect(component.announce).toHaveBeenCalledWith(
+      'Created assignment batch, but the batch summary was unavailable'
+    );
+  });
+
   it('handleBatchReassignment closes the modal and refreshes only the table', async () => {
     primeAuth('re-review-reassign-token');
     server.use(
@@ -688,6 +742,33 @@ describe('ManageReReview.vue — typed client migration behavior', () => {
     expect(component.recalculateModalShow).toBe(false);
     expect(tableRefresh).toHaveBeenCalledTimes(1);
     expect(entityRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('handleBatchRecalculation uses fallback copy when the server omits batch summary fields', async () => {
+    primeAuth('re-review-recalculate-empty-entry-token');
+    server.use(
+      http.put('*/api/re_review/batch/recalculate', () => HttpResponse.json({ entry: {} }))
+    );
+    const wrapper = await mountManageReReview();
+    const component = vm(wrapper);
+    vi.spyOn(component, 'loadReReviewTableData').mockResolvedValue();
+    vi.spyOn(component, 'loadAvailableEntities').mockResolvedValue();
+
+    component.recalculateModalShow = true;
+    component.recalculateBatchId = 42;
+
+    await component.handleBatchRecalculation();
+    await flushPromises();
+
+    expect(component.makeToast).toHaveBeenCalledWith(
+      'Batch recalculated, but the batch summary was unavailable',
+      'Success',
+      'success'
+    );
+    expect(component.announce).toHaveBeenCalledWith(
+      'Batch recalculated, but the batch summary was unavailable'
+    );
+    expect(component.recalculateModalShow).toBe(false);
   });
 });
 

--- a/app/src/views/curate/ManageReReview.vue
+++ b/app/src/views/curate/ManageReReview.vue
@@ -651,12 +651,17 @@ import {
   filterReReviewBatches,
   sortReReviewBatches,
 } from '@/views/curate/utils/reReviewFilters';
-
-// v11.0 closeout F2d: typed api client. The request interceptor in
-// `@/api/client` reads `useAuth().token.value` on every outbound call and
-// injects `Authorization: Bearer <token>` — no inline header construction
-// here.
-import { apiClient } from '@/api/client';
+import {
+  assignReReviewBatch,
+  assignReReviewEntities,
+  getAssignmentTable,
+  listAvailableReReviewEntities,
+  recalculateReReviewBatch,
+  reassignReReviewBatch,
+  unassignReReviewBatch,
+} from '@/api/re_review';
+import { listUsersByRole } from '@/api/user';
+import { listStatusCategories } from '@/api/list';
 
 // Import the Pinia store
 import { useUiStore } from '@/stores/ui';
@@ -872,9 +877,8 @@ export default {
   },
   methods: {
     async loadUserList() {
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/user/list?roles=Curator,Reviewer`;
       try {
-        const data = await apiClient.get(apiUrl);
+        const data = await listUsersByRole({ roles: 'Curator,Reviewer' });
         this.user_options = Array.isArray(data)
           ? data.map((item) => ({
               value: item.user_id,
@@ -889,9 +893,8 @@ export default {
     },
     async loadReReviewTableData() {
       this.loadingReReviewManagment = true;
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/re_review/assignment_table`;
       try {
-        const data = await apiClient.get(apiUrl);
+        const data = await getAssignmentTable();
         if (Array.isArray(data)) {
           this.items_ReReviewTable = data;
           this.totalRows = data.length;
@@ -914,12 +917,8 @@ export default {
       }
     },
     async handleNewBatchAssignment() {
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/re_review/batch/assign?user_id=${
-        this.user_id_assignment
-      }`;
-
       try {
-        await apiClient.put(apiUrl, {});
+        await assignReReviewBatch({ user_id: this.user_id_assignment });
         this.makeToast('New batch assigned successfully.', 'Success', 'success');
         this.announce('New batch assigned successfully');
       } catch (e) {
@@ -940,12 +939,8 @@ export default {
       this.currentPage = 1;
     },
     async handleBatchUnAssignment(batch_id) {
-      const apiUrl = `${
-        import.meta.env.VITE_API_URL
-      }/api/re_review/batch/unassign?re_review_batch=${batch_id}`;
-
       try {
-        await apiClient.delete(apiUrl);
+        await unassignReReviewBatch({ re_review_batch: batch_id });
         this.makeToast('Batch unassigned successfully.', 'Success', 'success');
         this.announce('Batch unassigned successfully');
       } catch (e) {
@@ -975,15 +970,12 @@ export default {
     // Load available entities for manual assignment (RRV-06)
     async loadAvailableEntities() {
       this.isLoadingEntities = true;
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/re_review/entities/available`;
 
       try {
-        const responseData = await apiClient.get(apiUrl, {
-          params: {
-            q: this.manualEntityFilter || '',
-            page: 1,
-            page_size: 100,
-          },
+        const responseData = await listAvailableReReviewEntities({
+          q: this.manualEntityFilter || '',
+          page: 1,
+          page_size: 100,
         });
         this.availableEntities = responseData.data || [];
         const total = responseData.meta?.total;
@@ -1031,10 +1023,9 @@ export default {
       }
 
       this.isAssigningEntities = true;
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/re_review/entities/assign`;
 
       try {
-        const responseData = await apiClient.put(apiUrl, {
+        const responseData = await assignReReviewEntities({
           entity_ids: this.selectedEntityIds,
           user_id: this.entityAssignUserId,
           batch_name: this.entityAssignBatchName || null,
@@ -1075,10 +1066,11 @@ export default {
         return;
       }
 
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/re_review/batch/reassign?re_review_batch=${this.reassignBatchId}&user_id=${this.reassignNewUserId}`;
-
       try {
-        await apiClient.put(apiUrl, {});
+        await reassignReReviewBatch({
+          re_review_batch: this.reassignBatchId,
+          user_id: this.reassignNewUserId,
+        });
         this.makeToast('Batch reassigned successfully', 'Success', 'success');
         this.announce('Batch reassigned successfully');
         this.reassignModalShow = false;
@@ -1104,7 +1096,6 @@ export default {
 
     async handleBatchRecalculation() {
       this.isRecalculating = true;
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/re_review/batch/recalculate`;
 
       try {
         // Build criteria payload
@@ -1121,7 +1112,7 @@ export default {
           payload.status_filter = this.recalculateCriteria.status_filter;
         }
 
-        const responseData = await apiClient.put(apiUrl, payload);
+        const responseData = await recalculateReReviewBatch(payload);
 
         const result = responseData.entry;
         this.makeToast(
@@ -1144,9 +1135,8 @@ export default {
 
     // Load status options for recalculate modal
     async loadStatusOptions() {
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/list/status`;
       try {
-        const responseData = await apiClient.get(apiUrl);
+        const responseData = await listStatusCategories();
         // Handle paginated response format
         const data = responseData?.data || responseData;
         this.status_options = Array.isArray(data)

--- a/app/src/views/curate/ManageReReview.vue
+++ b/app/src/views/curate/ManageReReview.vue
@@ -1032,12 +1032,12 @@ export default {
         });
 
         const result = responseData.entry;
-        this.makeToast(
-          `Created batch ${result.batch_id} with ${result.entity_count} entities`,
-          'Success',
-          'success'
-        );
-        this.announce(`Created batch ${result.batch_id} with ${result.entity_count} entities`);
+        const message =
+          result?.batch_id != null && result?.entity_count != null
+            ? `Created batch ${result.batch_id} with ${result.entity_count} entities`
+            : 'Created assignment batch, but the batch summary was unavailable';
+        this.makeToast(message, 'Success', 'success');
+        this.announce(message);
 
         // Reset and refresh
         this.selectedEntityIds = [];
@@ -1115,12 +1115,12 @@ export default {
         const responseData = await recalculateReReviewBatch(payload);
 
         const result = responseData.entry;
-        this.makeToast(
-          `Batch ${result.batch_id} recalculated with ${result.entity_count} entities`,
-          'Success',
-          'success'
-        );
-        this.announce(`Batch ${result.batch_id} recalculated with ${result.entity_count} entities`);
+        const message =
+          result?.batch_id != null && result?.entity_count != null
+            ? `Batch ${result.batch_id} recalculated with ${result.entity_count} entities`
+            : 'Batch recalculated, but the batch summary was unavailable';
+        this.makeToast(message, 'Success', 'success');
+        this.announce(message);
         this.recalculateModalShow = false;
         this.loadReReviewTableData();
         this.loadAvailableEntities();

--- a/scripts/code-quality-file-size-baseline.tsv
+++ b/scripts/code-quality-file-size-baseline.tsv
@@ -59,7 +59,7 @@ app/src/views/admin/ManageUser.vue	675
 app/src/views/curate/ApproveReview.vue	841
 app/src/views/curate/ApproveUser.vue	842
 app/src/views/curate/CreateEntity.vue	637
-app/src/views/curate/ManageReReview.vue	1718
+app/src/views/curate/ManageReReview.vue	1708
 app/src/views/curate/ModifyEntity.vue	762
 app/src/views/pages/EntityView.vue	806
 db/11_Rcommands_sysndd_db_table_database_comparisons.R	638

--- a/scripts/code-quality-file-size-baseline.tsv
+++ b/scripts/code-quality-file-size-baseline.tsv
@@ -44,7 +44,7 @@ app/src/components/nddscore/NddScoreGeneTable.vue	1156
 app/src/components/small/GenericTable.vue	923
 app/src/components/tables/TablesEntities.vue	842
 app/src/components/tables/TablesGenes.vue	782
-app/src/components/tables/TablesLogs.vue	1265
+app/src/components/tables/TablesLogs.vue	1221
 app/src/components/tables/TablesPhenotypes.vue	1155
 app/src/composables/useCytoscape.ts	637
 app/src/composables/useD3Lollipop.ts	1125


### PR DESCRIPTION
## Summary

- Move re-review admin request construction from `ManageReReview.vue` into typed API helpers.
- Add the missing available re-review entities client and tighten consumed batch response types.
- Move log table request/cache coordination into `logTableRequests.ts` and route log list/export/delete/user calls through typed clients.
- Strengthen component and API specs around relative API paths, response normalization, cache behavior, URL update timing, and workflow side effects.
- Lower file-size baseline entries for `ManageReReview.vue` and `TablesLogs.vue`.

## Validation

- `cd app && npx vitest run src/api/re_review.spec.ts src/api/logging.spec.ts src/api/user.spec.ts src/api/list.spec.ts`
- `cd app && npx vitest run src/views/curate/ManageReReview.spec.ts src/components/tables/TablesLogs.spec.ts src/components/tables/logTableRequests.spec.ts`
- `cd app && npm run type-check`
- `make code-quality-audit`
- `git diff --check`
- `make pre-commit`
- `make ci-local`

## Notes

`make pre-commit` and `make ci-local` pass with existing warning/skip noise from the broader suite. `make ci-local` logged an initial MySQL reset access warning but continued and exited successfully with `CI-LOCAL PASSED`.
