### PR TITLE
[codex] Repair admin job polling and entity deactivation payloads

### DIFF
--- a/api/functions/async-job-handlers.R
+++ b/api/functions/async-job-handlers.R
@@ -514,10 +514,10 @@
   progress("prepare", "Processing OMIM ontology update...", 0, 5)
 
   disease_ontology_set_update <- process_combine_ontology(
-    payload$non_alt_loci_set,
-    payload$mode_of_inheritance_list,
-    3,
-    "data/",
+    hgnc_list = payload$non_alt_loci_set,
+    mode_of_inheritance_list = payload$mode_of_inheritance_list,
+    max_file_age = 0,
+    output_path = "data/",
     progress_callback = progress
   )
 

--- a/api/functions/ontology-functions.R
+++ b/api/functions/ontology-functions.R
@@ -224,8 +224,8 @@ identify_critical_ontology_changes <- function(disease_ontology_set_update, dise
 #'
 #' @param hgnc_list A tibble containing non-alternative loci gene data (columns: hgnc_id, symbol).
 #' @param mode_of_inheritance_list A tibble containing mode of inheritance data.
-#' @param max_file_age Numeric, maximum age in months for OMIM mim2gene
-#'   deprecation cache reuse. Use 0 to force a fresh mim2gene download.
+#' @param max_file_age Numeric, maximum age in months for combined ontology and
+#'   OMIM mim2gene cache reuse. Use 0 to force fresh source downloads.
 #' @param output_path String, the path where the output CSV file will be stored.
 #' @param progress_callback Optional function for async progress reporting.
 #'   Called with (step, message, current, total) parameters.
@@ -252,8 +252,9 @@ process_combine_ontology <- function(hgnc_list, mode_of_inheritance_list, max_fi
 # nolint end
   csv_file_name <- paste0(output_path, "disease_ontology_set.", format(Sys.Date(), "%Y-%m-%d"), ".csv")
 
-  # Check if file exists and is not too old
-  if (check_file_age("disease_ontology_set", output_path, 1)) {
+  # Check if file exists and is not too old. max_file_age = 0 is the manual
+  # refresh path and must bypass the combined ontology CSV cache.
+  if (max_file_age > 0 && check_file_age("disease_ontology_set", output_path, max_file_age)) {
     return(read_csv(get_newest_file("disease_ontology_set", output_path), na = "NULL")) # Load and return the existing tibble # nolint: line_length_linter
   } else {
     # Process ontology if file is too old or doesn't exist

--- a/api/tests/testthat/test-unit-async-job-handlers.R
+++ b/api/tests/testthat/test-unit-async-job-handlers.R
@@ -21,3 +21,10 @@ test_that(".async_job_run_force_apply_ontology uses helper-managed transaction l
   expect_false(grepl("\\bTRUNCATE\\b", body_txt, ignore.case = TRUE))
   expect_false(grepl("DBI::dbRollback\\(sysndd_db\\)", body_txt))
 })
+
+test_that(".async_job_run_omim_update forces a fresh combined ontology build", {
+  body_txt <- handler_body(.async_job_run_omim_update)
+
+  expect_match(body_txt, "process_combine_ontology")
+  expect_match(body_txt, "max_file_age\\s*=\\s*0")
+})

--- a/api/tests/testthat/test-unit-ontology-functions.R
+++ b/api/tests/testthat/test-unit-ontology-functions.R
@@ -217,6 +217,92 @@ test_that("mixed scenario: some auto-fixable, some critical", {
   expect_equal(result$critical$disease_ontology_id_version[1], "OMIM:400002_1")
 })
 
+test_that("process_combine_ontology max_file_age = 0 bypasses cached combined ontology CSV", {
+  if (!source_ontology()) skip("ontology-functions.R requires additional dependencies")
+
+  ontology_cache <- withr::local_tempdir()
+  data_dir <- file.path(ontology_cache, "data")
+  dir.create(data_dir)
+  output_path <- paste0(data_dir, "/")
+
+  cached <- tibble(
+    disease_ontology_id_version = "OMIM:CACHED",
+    disease_ontology_id = "OMIM:CACHED",
+    disease_ontology_name = "Cached Disease",
+    disease_ontology_source = "omim",
+    disease_ontology_date = as.character(Sys.Date()),
+    disease_ontology_is_specific = TRUE,
+    hgnc_id = "HGNC:1",
+    hpo_mode_of_inheritance_term = "HP:0000006"
+  )
+  readr::write_csv(
+    cached,
+    file.path(data_dir, paste0("disease_ontology_set.", Sys.Date(), ".csv")),
+    na = "NULL"
+  )
+
+  regenerated_omim <- tibble(
+    disease_ontology_id_version = "OMIM:FRESH",
+    disease_ontology_id = "OMIM:FRESH",
+    disease_ontology_name = "Fresh Disease",
+    disease_ontology_source = "omim",
+    disease_ontology_date = as.character(Sys.Date()),
+    disease_ontology_is_specific = TRUE,
+    hgnc_id = "HGNC:1",
+    hpo_mode_of_inheritance_term = "HP:0000006"
+  )
+  empty_mondo <- tibble(
+    disease_ontology_id_version = character(0),
+    disease_ontology_id = character(0),
+    disease_ontology_name = character(0),
+    disease_ontology_source = character(0),
+    disease_ontology_date = character(0),
+    disease_ontology_is_specific = logical(0),
+    hgnc_id = character(0),
+    hpo_mode_of_inheritance_term = character(0)
+  )
+  empty_mappings <- tibble(
+    OMIM = character(0),
+    MONDO = character(0),
+    DOID = character(0),
+    Orphanet = character(0),
+    EFO = character(0)
+  )
+
+  mock_bindings <- list(
+    process_mondo_ontology = function(...) empty_mondo,
+    process_omim_ontology = function(...) regenerated_omim,
+    get_ontology_object = function(...) list(),
+    get_mondo_mappings = function(...) empty_mappings,
+    download_mondo_sssom = function(...) "mock.sssom.tsv",
+    parse_mondo_sssom = function(...) tibble(omim_id = character(0), mondo_id = character(0)),
+    add_mondo_mappings_to_ontology = function(disease_ontology_set, ...) disease_ontology_set
+  )
+  mock_names <- names(mock_bindings)
+  old_exists <- vapply(mock_names, exists, logical(1), envir = globalenv(), inherits = FALSE)
+  old_values <- mget(mock_names[old_exists], envir = globalenv(), inherits = FALSE)
+  withr::defer({
+    for (name in mock_names) {
+      if (isTRUE(old_exists[[name]])) {
+        assign(name, old_values[[name]], envir = globalenv())
+      } else if (exists(name, envir = globalenv(), inherits = FALSE)) {
+        rm(list = name, envir = globalenv())
+      }
+    }
+  })
+  list2env(mock_bindings, envir = globalenv())
+
+  result <- process_combine_ontology(
+    hgnc_list = tibble(hgnc_id = "HGNC:1", symbol = "GENE1"),
+    mode_of_inheritance_list = tibble(),
+    max_file_age = 0,
+    output_path = output_path
+  )
+
+  expect_true("OMIM:FRESH" %in% result$disease_ontology_id_version)
+  expect_false("OMIM:CACHED" %in% result$disease_ontology_id_version)
+})
+
 # =============================================================================
 # Pure transformation tests (without external data)
 # =============================================================================

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysndd",
-  "version": "0.20.13",
+  "version": "0.20.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysndd",
-      "version": "0.20.13",
+      "version": "0.20.14",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@unhead/vue": "^3.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.20.13",
+  "version": "0.20.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/app/src/composables/useAsyncJob.ts
+++ b/app/src/composables/useAsyncJob.ts
@@ -85,9 +85,9 @@ export interface UseAsyncJobReturn {
  *
  * @example
  * ```ts
- * const { startJob, status, progress, elapsedTimeDisplay, stopPolling } = useAsyncJob(
- *   (jobId) => `${import.meta.env.VITE_API_URL}/api/jobs/${jobId}/status`
- * );
+   * const { startJob, status, progress, elapsedTimeDisplay, stopPolling } = useAsyncJob(
+   *   (jobId) => `/api/jobs/${encodeURIComponent(jobId)}/status`
+   * );
  *
  * // Start tracking a job
  * const response = await axios.post('/api/start-job');

--- a/app/src/composables/usePubtatorAdmin.ts
+++ b/app/src/composables/usePubtatorAdmin.ts
@@ -82,7 +82,7 @@ export function usePubtatorAdmin() {
   const baseUrl = `${URLS.API_URL}/api/publication/pubtator`;
 
   // Use the async job composable for fetch operations
-  const asyncJob = useAsyncJob((jobId: string) => `${URLS.API_URL}/api/jobs/${jobId}/status`, {
+  const asyncJob = useAsyncJob((jobId: string) => `/api/jobs/${encodeURIComponent(jobId)}/status`, {
     pollingInterval: 3000,
   });
 

--- a/app/src/views/admin/ManageAnnotations.spec.ts
+++ b/app/src/views/admin/ManageAnnotations.spec.ts
@@ -408,6 +408,50 @@ describe('ManageAnnotations — Phase C.C5 functional spec', () => {
     expect(html).toContain('completed');
   });
 
+  it('polls job status with a relative URL when VITE_API_URL is not configured', async () => {
+    vi.unstubAllEnvs();
+    delete (import.meta.env as Record<string, string | undefined>).VITE_API_URL;
+
+    let goodPollCount = 0;
+    let badPollCount = 0;
+    server.use(
+      http.put('/api/admin/update_ontology_async', () =>
+        HttpResponse.json({
+          job_id: ['ontology-update-no-env'],
+          status: ['accepted'],
+        })
+      ),
+      http.get('/api/jobs/:job_id/status', () => {
+        goodPollCount += 1;
+        return HttpResponse.json({
+          job_id: ['ontology-update-no-env'],
+          status: ['completed'],
+          step: ['Done'],
+          result: [{ status: ['ok'], auto_fixes_applied: [0] }],
+        });
+      }),
+      http.get('/undefined/api/jobs/:job_id/status', () => {
+        badPollCount += 1;
+        return HttpResponse.json({ error: 'bad status URL' }, { status: 500 });
+      })
+    );
+
+    const wrapper = await mountView();
+    const buttons = wrapper.findAll('button');
+    const updateOntology = buttons.find((button) =>
+      button.text().includes('Update Ontology Annotations')
+    );
+    expect(updateOntology, 'Update Ontology Annotations button exists').toBeTruthy();
+
+    await updateOntology!.trigger('click');
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(3000);
+    await flushPromises();
+
+    expect(goodPollCount).toBe(2);
+    expect(badPollCount).toBe(0);
+  });
+
   // -------------------------------------------------------------------------
   // Error path: ontology update returns Phase 76 `status = "blocked"` shape
   // -------------------------------------------------------------------------

--- a/app/src/views/admin/ManageAnnotations.vue
+++ b/app/src/views/admin/ManageAnnotations.vue
@@ -149,8 +149,7 @@ import JobHistoryCard, { type JobHistoryItem } from '@/components/annotations/Jo
 const route = useRoute();
 const { makeToast } = useToast();
 
-const jobStatusUrl = (jobId: string): string =>
-  `${import.meta.env.VITE_API_URL}/api/jobs/${jobId}/status`;
+const jobStatusUrl = (jobId: string): string => `/api/jobs/${encodeURIComponent(jobId)}/status`;
 
 const ontologyJob = useAsyncJob(jobStatusUrl);
 const forceApplyJob = useAsyncJob(jobStatusUrl);

--- a/app/src/views/admin/ManageBackups.vue
+++ b/app/src/views/admin/ManageBackups.vue
@@ -465,10 +465,10 @@ const { makeToast } = useToast();
 
 // Create job instances for backup and restore operations
 const backupJob = useAsyncJob(
-  (jobId: string) => `${import.meta.env.VITE_API_URL}/api/jobs/${jobId}/status`
+  (jobId: string) => `/api/jobs/${encodeURIComponent(jobId)}/status`
 );
 const restoreJob = useAsyncJob(
-  (jobId: string) => `${import.meta.env.VITE_API_URL}/api/jobs/${jobId}/status`
+  (jobId: string) => `/api/jobs/${encodeURIComponent(jobId)}/status`
 );
 
 // Reactive state

--- a/app/src/views/admin/ManageLLM.vue
+++ b/app/src/views/admin/ManageLLM.vue
@@ -369,7 +369,7 @@ const {
   updateValidationStatus,
 } = useLlmAdmin();
 
-const jobStatusUrl = (jobId: string) => `${import.meta.env.VITE_API_URL}/api/jobs/${jobId}/status`;
+const jobStatusUrl = (jobId: string) => `/api/jobs/${encodeURIComponent(jobId)}/status`;
 
 // Async job tracking for regeneration. The LLM endpoint can submit one child
 // job per cluster type, so each type gets its own visible tracker.

--- a/app/src/views/admin/ManageNDDScore.vue
+++ b/app/src/views/admin/ManageNDDScore.vue
@@ -287,7 +287,7 @@ import {
 
 type AdminRecord = Record<string, unknown>;
 
-const jobStatusUrl = (jobId: string) => `${import.meta.env.VITE_API_URL}/api/jobs/${jobId}/status`;
+const jobStatusUrl = (jobId: string) => `/api/jobs/${encodeURIComponent(jobId)}/status`;
 const importJob = useAsyncJob(jobStatusUrl);
 
 const status = ref<NddScoreAdminStatus | null>(null);

--- a/app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts
+++ b/app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts
@@ -22,6 +22,42 @@ describe('useEntityInfo', () => {
     expect(e.entity_info.value.symbol).toBe('GRIN2B');
   });
 
+  test('loadEntity requests fields required by entity mutation endpoints', async () => {
+    let requestedFields: string | null = null;
+    server.use(
+      http.get('*/api/entity/*', ({ request }) => {
+        requestedFields = new URL(request.url).searchParams.get('fields');
+        return HttpResponse.json({
+          data: [
+            {
+              entity_id: 3367,
+              symbol: 'FGF13',
+              hgnc_id: 'HGNC:3670',
+              hpo_mode_of_inheritance_term: 'HP:0001417',
+              hpo_mode_of_inheritance_term_name: 'X-linked inheritance',
+              disease_ontology_id_version: 'OMIM:300070',
+              disease_ontology_name: 'developmental and epileptic encephalopathy',
+              ndd_phenotype: 1,
+              is_active: 1,
+              replaced_by: null,
+            },
+          ],
+        });
+      })
+    );
+
+    const e = useEntityInfo();
+    await e.loadEntity(3367);
+
+    expect(requestedFields).toContain('hgnc_id');
+    expect(requestedFields).toContain('hpo_mode_of_inheritance_term');
+    expect(requestedFields).toContain('disease_ontology_id_version');
+    expect(requestedFields).toContain('ndd_phenotype');
+    expect(requestedFields).toContain('is_active');
+    expect(requestedFields).toContain('replaced_by');
+    expect(e.entity_info.value.hgnc_id).toBe('HGNC:3670');
+  });
+
   test('loadEntity surfaces a not-found toast and clears entity_info', async () => {
     server.use(http.get('*/api/entity/*', () => HttpResponse.json({ data: [] })));
     const toasts: any[] = [];

--- a/app/src/views/curate/composables/useEntityInfo.ts
+++ b/app/src/views/curate/composables/useEntityInfo.ts
@@ -28,6 +28,22 @@ interface ReviewSnapshot {
   genereviews: string[];
 }
 
+const ENTITY_MUTATION_FIELDS = [
+  'entity_id',
+  'symbol',
+  'hgnc_id',
+  'disease_ontology_name',
+  'disease_ontology_id_version',
+  'hpo_mode_of_inheritance_term',
+  'hpo_mode_of_inheritance_term_name',
+  'category',
+  'ndd_phenotype',
+  'ndd_phenotype_word',
+  'is_active',
+  'replaced_by',
+  'details',
+].join(',');
+
 const arrEqual = (a: string[], b: string[]) => {
   if (a.length !== b.length) return false;
   const sa = [...a].sort();
@@ -64,7 +80,12 @@ export function useEntityInfo(options: UseEntityInfoOptions = {}) {
 
   async function loadEntity(entityId: number): Promise<void> {
     try {
-      const response: any = await listEntities({ filter: `equals(entity_id,${entityId})` });
+      const response: any = await listEntities({
+        filter: `equals(entity_id,${entityId})`,
+        fields: ENTITY_MUTATION_FIELDS,
+        page_size: '1',
+        compact: true,
+      });
       const data = response?.data;
       if (!Array.isArray(data) || data.length === 0) {
         onToast?.(`Entity ${entityId} not found`, 'Error', 'danger');


### PR DESCRIPTION
## Summary

Fixes two production admin failures reported by Christiane on 2026-05-29:

- OMIM ontology refresh could show `Failed to check job status` when admin job polling built `/undefined/api/jobs/...` URLs in deployments without `VITE_API_URL`.
- OMIM update could reuse a stale combined ontology CSV even when the admin requested a manual refresh, leaving the visible OMIM date stale.
- Modify Entity deactivation could submit incomplete entity payloads because the compact entity read did not request mutation-critical fields such as HGNC ID, inheritance, disease ontology version, active state, and replacement.

## Root Cause

The admin job pollers mixed absolute environment-based URLs with endpoint paths that work best through the existing API client/proxy boundary. Separately, `process_combine_ontology()` ignored the manual-refresh freshness intent for the combined ontology CSV. The entity modify flow was loading a compact entity row without the fields required by the deactivate endpoint's validation contract.

## Validation

- `cd app && npm run type-check`
- `cd app && npx vitest run src/views/admin/ManageAnnotations.spec.ts src/views/curate/composables/__tests__/useEntityInfo.spec.ts`
- `make pre-commit`

## Notes

`make pre-commit` completed with existing warning-only frontend/R test output and `test-api-fast` reported 0 failures.
