### PR TITLE
feat(ops): scheduled DB log cleanup service (#105)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,21 @@ GEMINI_API_KEY=your_gemini_api_key_here
 OMIM_DOWNLOAD_KEY=your_omim_download_key_here
 
 # -----------------------------------------------------------------------------
+# Log Cleanup (scheduled DB retention) — issue #105
+# -----------------------------------------------------------------------------
+# The `log-cleanup` service prunes old rows from the operational request log
+# table (`logging`) on a daily schedule. It reuses the API image and connects
+# via the same RMariaDB pool/config as the API. Override these to tune it.
+#
+#   LOG_RETENTION_DAYS    Delete `logging` rows older than this many days (default 30)
+#   LOG_CLEANUP_AT        Daily run time, HH:MM in container (UTC) time (default 03:00)
+#   LOG_CLEANUP_DRY_RUN   When 1/true/yes/on: count-only, never delete (default false)
+
+LOG_RETENTION_DAYS=30
+LOG_CLEANUP_AT=03:00
+LOG_CLEANUP_DRY_RUN=false
+
+# -----------------------------------------------------------------------------
 # Optional Settings
 # -----------------------------------------------------------------------------
 # Docker Compose project name (affects container naming)

--- a/api/functions/log-cleanup.R
+++ b/api/functions/log-cleanup.R
@@ -1,0 +1,231 @@
+# functions/log-cleanup.R
+#### Reusable, testable helpers for retention-based cleanup of operational log
+#### rows in the database. The thin entrypoint `scripts/delete_old_logs.R`
+#### bootstraps config + the connection pool and delegates to `run_log_cleanup()`.
+####
+#### Scope: the high-volume operational request log table `logging`
+#### (DATETIME `timestamp` column, indexed by `idx_logging_timestamp`). This is
+#### the table the Plumber `postroute` hook writes one row per request to via
+#### `log_message_to_db()`. Other low-volume audit tables (e.g.
+#### `llm_generation_log`, `async_job_events`) are intentionally NOT pruned here;
+#### they are operationally useful history and `async_job_events` already cascades
+#### from `async_jobs`.
+
+#' Default operational log table pruned by the cleanup job.
+LOG_CLEANUP_DEFAULT_TABLE <- "logging"
+
+#' Default timestamp column used for the retention predicate.
+LOG_CLEANUP_DEFAULT_TIMESTAMP_COLUMN <- "timestamp"
+
+#' Default retention window in days when none is configured.
+LOG_CLEANUP_DEFAULT_RETENTION_DAYS <- 30L
+
+#' Validate and coerce a log-retention value to a positive integer day count.
+#'
+#' The retention window is the only value that flows into the SQL predicate as a
+#' literal (MySQL `INTERVAL` does not accept a bound placeholder for the unit
+#' count in a portable way), so it must be strictly validated to an integer
+#' before it is ever interpolated. String interpolation of an unvalidated value
+#' would be an injection vector; coercing to a bounded integer removes it.
+#'
+#' @param value Raw retention value (character from env, or numeric).
+#' @param default Fallback used when `value` is empty/NULL.
+#' @return A single positive integer number of days.
+#' @export
+validate_retention_days <- function(value, default = LOG_CLEANUP_DEFAULT_RETENTION_DAYS) {
+  if (is.null(value) || length(value) != 1L) {
+    if (is.null(value)) {
+      return(as.integer(default))
+    }
+    stop("retention days must be a single value", call. = FALSE)
+  }
+
+  if (is.character(value)) {
+    value <- trimws(value)
+    if (!nzchar(value)) {
+      return(as.integer(default))
+    }
+    # Reject anything that is not a bare non-negative integer literal. This is
+    # the guard that makes literal interpolation into the DELETE safe.
+    if (!grepl("^[0-9]+$", value)) {
+      stop(sprintf("invalid retention days: '%s' (expected a positive integer)", value), call. = FALSE)
+    }
+  }
+
+  num <- suppressWarnings(as.numeric(value))
+  if (is.na(num) || num != as.integer(num) || num < 1L) {
+    stop(sprintf("invalid retention days: '%s' (expected a positive integer >= 1)", as.character(value)), call. = FALSE)
+  }
+
+  as.integer(num)
+}
+
+#' Validate a SQL identifier (table or column name) against a strict allowlist.
+#'
+#' Only bare ASCII identifiers (letters, digits, underscore; not starting with a
+#' digit) are accepted. Identifiers are never user-supplied here, but validating
+#' them keeps the SQL builders injection-proof by construction.
+#'
+#' @param identifier The identifier to validate.
+#' @param what Human-readable label used in error messages.
+#' @return The identifier, unchanged, when valid.
+#' @export
+validate_sql_identifier <- function(identifier, what = "identifier") {
+  if (is.null(identifier) || length(identifier) != 1L || !is.character(identifier) ||
+        is.na(identifier) || !nzchar(identifier)) {
+    stop(sprintf("invalid %s: must be a non-empty string", what), call. = FALSE)
+  }
+  if (!grepl("^[A-Za-z_][A-Za-z0-9_]*$", identifier)) {
+    stop(sprintf("invalid %s: '%s' is not a bare SQL identifier", what, identifier), call. = FALSE)
+  }
+  identifier
+}
+
+#' Build the COUNT(*) query used to report how many rows would be deleted.
+#'
+#' @param table Validated table name.
+#' @param timestamp_column Validated timestamp column name.
+#' @param retention_days Validated positive integer day count.
+#' @return A single SQL string.
+#' @export
+build_log_cleanup_count_sql <- function(table = LOG_CLEANUP_DEFAULT_TABLE,
+                                        timestamp_column = LOG_CLEANUP_DEFAULT_TIMESTAMP_COLUMN,
+                                        retention_days = LOG_CLEANUP_DEFAULT_RETENTION_DAYS) {
+  table <- validate_sql_identifier(table, "table name")
+  timestamp_column <- validate_sql_identifier(timestamp_column, "timestamp column")
+  retention_days <- validate_retention_days(retention_days)
+
+  sprintf(
+    "SELECT COUNT(*) AS n FROM %s WHERE %s < (NOW() - INTERVAL %d DAY)",
+    table, timestamp_column, retention_days
+  )
+}
+
+#' Build the DELETE statement that prunes rows older than the retention window.
+#'
+#' The retention day count is interpolated as a validated integer; the table and
+#' column are validated bare identifiers. No untrusted value reaches the SQL.
+#'
+#' @param table Validated table name.
+#' @param timestamp_column Validated timestamp column name.
+#' @param retention_days Validated positive integer day count.
+#' @return A single SQL string.
+#' @export
+build_log_cleanup_delete_sql <- function(table = LOG_CLEANUP_DEFAULT_TABLE,
+                                         timestamp_column = LOG_CLEANUP_DEFAULT_TIMESTAMP_COLUMN,
+                                         retention_days = LOG_CLEANUP_DEFAULT_RETENTION_DAYS) {
+  table <- validate_sql_identifier(table, "table name")
+  timestamp_column <- validate_sql_identifier(timestamp_column, "timestamp column")
+  retention_days <- validate_retention_days(retention_days)
+
+  sprintf(
+    "DELETE FROM %s WHERE %s < (NOW() - INTERVAL %d DAY)",
+    table, timestamp_column, retention_days
+  )
+}
+
+#' Resolve the cleanup configuration from environment variables.
+#'
+#' Env vars (with defaults):
+#' - `LOG_RETENTION_DAYS`  -> retention window in days (default 30)
+#' - `LOG_CLEANUP_DRY_RUN` -> when truthy, count only, do not delete
+#' - `LOG_CLEANUP_TABLE`   -> override table name (default `logging`)
+#' - `LOG_CLEANUP_TIMESTAMP_COLUMN` -> override timestamp column (default `timestamp`)
+#'
+#' @param getenv Function used to read env vars (injectable for tests).
+#' @return A validated list: table, timestamp_column, retention_days, dry_run.
+#' @export
+log_cleanup_config_from_env <- function(getenv = Sys.getenv) {
+  retention_days <- validate_retention_days(getenv("LOG_RETENTION_DAYS", ""))
+  table <- getenv("LOG_CLEANUP_TABLE", LOG_CLEANUP_DEFAULT_TABLE)
+  timestamp_column <- getenv("LOG_CLEANUP_TIMESTAMP_COLUMN", LOG_CLEANUP_DEFAULT_TIMESTAMP_COLUMN)
+  dry_run <- log_cleanup_env_is_true(getenv("LOG_CLEANUP_DRY_RUN", ""))
+
+  list(
+    table = validate_sql_identifier(table, "table name"),
+    timestamp_column = validate_sql_identifier(timestamp_column, "timestamp column"),
+    retention_days = retention_days,
+    dry_run = dry_run
+  )
+}
+
+#' Interpret a truthy environment-variable string.
+#'
+#' @param value Raw env value.
+#' @return TRUE when the value is one of 1/true/yes/on (case-insensitive).
+#' @export
+log_cleanup_env_is_true <- function(value) {
+  if (is.null(value) || length(value) != 1L || is.na(value)) {
+    return(FALSE)
+  }
+  tolower(trimws(as.character(value))) %in% c("1", "true", "yes", "on")
+}
+
+#' Run the log-cleanup routine.
+#'
+#' Counts the candidate rows, then (unless dry-run) deletes them, returning a
+#' structured summary. The DB layer is injected so the routine is fully testable
+#' without a live database.
+#'
+#' @param config A config list (see `log_cleanup_config_from_env()`).
+#' @param count_fn Function(sql) -> integer count of matching rows.
+#' @param execute_fn Function(sql) -> integer rows affected by the DELETE.
+#' @param logger Function(msg) used for human-readable progress output.
+#' @return Invisibly, a summary list (table, retention_days, dry_run,
+#'   candidate_rows, deleted_rows).
+#' @export
+run_log_cleanup <- function(config,
+                            count_fn,
+                            execute_fn,
+                            logger = message) {
+  stopifnot(is.list(config), is.function(count_fn), is.function(execute_fn))
+
+  count_sql <- build_log_cleanup_count_sql(
+    config$table, config$timestamp_column, config$retention_days
+  )
+  candidate_rows <- as.integer(count_fn(count_sql))
+  if (length(candidate_rows) != 1L || is.na(candidate_rows)) {
+    candidate_rows <- 0L
+  }
+
+  logger(sprintf(
+    "[log-cleanup] table=%s column=%s retention_days=%d candidates=%d dry_run=%s",
+    config$table, config$timestamp_column, config$retention_days,
+    candidate_rows, tolower(as.character(config$dry_run))
+  ))
+
+  if (isTRUE(config$dry_run)) {
+    logger(sprintf(
+      "[log-cleanup] DRY RUN: would delete %d row(s) from %s; no rows removed",
+      candidate_rows, config$table
+    ))
+    return(invisible(list(
+      table = config$table,
+      retention_days = config$retention_days,
+      dry_run = TRUE,
+      candidate_rows = candidate_rows,
+      deleted_rows = 0L
+    )))
+  }
+
+  delete_sql <- build_log_cleanup_delete_sql(
+    config$table, config$timestamp_column, config$retention_days
+  )
+  deleted_rows <- as.integer(execute_fn(delete_sql))
+  if (length(deleted_rows) != 1L || is.na(deleted_rows)) {
+    deleted_rows <- 0L
+  }
+
+  logger(sprintf(
+    "[log-cleanup] deleted %d row(s) from %s (retention %d day(s))",
+    deleted_rows, config$table, config$retention_days
+  ))
+
+  invisible(list(
+    table = config$table,
+    retention_days = config$retention_days,
+    dry_run = FALSE,
+    candidate_rows = candidate_rows,
+    deleted_rows = deleted_rows
+  ))
+}

--- a/api/scripts/delete_old_logs.R
+++ b/api/scripts/delete_old_logs.R
@@ -1,0 +1,91 @@
+#!/usr/bin/env Rscript
+# scripts/delete_old_logs.R
+#
+# Retention-based cleanup of the operational request log table (`logging`).
+#
+# This is a thin entrypoint: it bootstraps libraries + config + the DB pool the
+# same way start_async_worker.R does, then delegates all logic to the reusable,
+# unit-tested helpers in functions/log-cleanup.R. The connection helpers and
+# config loading are reused (no hand-rolled dbConnect / RMySQL) so the script
+# stays aligned with the rest of the API runtime (renv deps + RMariaDB).
+#
+# Configuration (environment variables):
+#   LOG_RETENTION_DAYS            Retention window in days (default 30)
+#   LOG_CLEANUP_DRY_RUN           When truthy (1/true/yes/on): count only, no delete
+#   LOG_CLEANUP_TABLE             Override table name (default "logging")
+#   LOG_CLEANUP_TIMESTAMP_COLUMN  Override timestamp column (default "timestamp")
+#   ENVIRONMENT                   production | development | <other> -> config block
+#
+# Exit codes: 0 on success, non-zero on any failure (so a scheduler/cron can
+# surface failures).
+#
+# Run inside the API image, e.g.:
+#   Rscript scripts/delete_old_logs.R
+
+# --- Bootstrap (mirrors start_async_worker.R) -------------------------------
+source("bootstrap/init_libraries.R", local = FALSE)
+source("bootstrap/create_pool.R", local = FALSE)
+
+bootstrap_init_libraries()
+
+# Reusable cleanup logic + the DB execution helpers it needs.
+source("functions/db-helpers.R", local = FALSE)
+source("functions/log-cleanup.R", local = FALSE)
+
+env_mode <- Sys.getenv("ENVIRONMENT", "local")
+if (tolower(env_mode) == "production") {
+  Sys.setenv(API_CONFIG = "sysndd_db")
+} else if (tolower(env_mode) == "development") {
+  Sys.setenv(API_CONFIG = "sysndd_db_dev")
+} else {
+  Sys.setenv(API_CONFIG = "sysndd_db_local")
+}
+
+main <- function() {
+  config <- log_cleanup_config_from_env()
+
+  dw <- config::get(Sys.getenv("API_CONFIG"))
+  if (!is.null(dw$workdir) && dir.exists(dw$workdir)) {
+    setwd(dw$workdir)
+  }
+
+  pool <- bootstrap_create_pool(dw)
+  on.exit(pool::poolClose(pool), add = TRUE)
+
+  # The shared db-helpers execute/query against a global `pool` by default; bind
+  # it so db_execute_statement()/db_get_query() resolve it via get_db_connection().
+  assign("pool", pool, envir = .GlobalEnv)
+
+  count_fn <- function(sql) {
+    res <- db_execute_query(sql)
+    if (is.data.frame(res) && nrow(res) >= 1L && "n" %in% names(res)) {
+      return(as.integer(res$n[[1]]))
+    }
+    0L
+  }
+  execute_fn <- function(sql) {
+    as.integer(db_execute_statement(sql))
+  }
+
+  summary <- run_log_cleanup(
+    config = config,
+    count_fn = count_fn,
+    execute_fn = execute_fn,
+    logger = function(msg) message(sprintf("[%s] %s", format(Sys.time(), "%Y-%m-%dT%H:%M:%S%z"), msg))
+  )
+
+  invisible(summary)
+}
+
+result <- tryCatch(
+  main(),
+  error = function(e) {
+    message(sprintf(
+      "[%s] [log-cleanup] FAILED: %s",
+      format(Sys.time(), "%Y-%m-%dT%H:%M:%S%z"), conditionMessage(e)
+    ))
+    quit(status = 1L, save = "no")
+  }
+)
+
+quit(status = 0L, save = "no")

--- a/api/tests/testthat/test-unit-log-cleanup.R
+++ b/api/tests/testthat/test-unit-log-cleanup.R
@@ -1,0 +1,162 @@
+# Unit tests for retention-based log cleanup logic (functions/log-cleanup.R).
+#
+# These tests exercise the pure logic (validation, SQL construction, dry-run vs
+# delete, env parsing) with an injected fake DB layer, so they run on host R
+# without RMariaDB / a live database.
+source_api_file("functions/log-cleanup.R", local = FALSE)
+
+# --- validate_retention_days ------------------------------------------------
+
+test_that("retention defaults apply for empty / NULL input", {
+  expect_identical(validate_retention_days(""), 30L)
+  expect_identical(validate_retention_days(NULL), 30L)
+  expect_identical(validate_retention_days("", default = 14L), 14L)
+})
+
+test_that("valid integer-like retention values are accepted", {
+  expect_identical(validate_retention_days("30"), 30L)
+  expect_identical(validate_retention_days("7"), 7L)
+  expect_identical(validate_retention_days(90), 90L)
+  expect_identical(validate_retention_days("  45  "), 45L)
+})
+
+test_that("non-integer / unsafe retention values are rejected (injection guard)", {
+  expect_error(validate_retention_days("30; DROP TABLE logging"))
+  expect_error(validate_retention_days("30 OR 1=1"))
+  expect_error(validate_retention_days("abc"))
+  expect_error(validate_retention_days("-5"))
+  expect_error(validate_retention_days("0"))
+  expect_error(validate_retention_days("3.5"))
+})
+
+# --- validate_sql_identifier ------------------------------------------------
+
+test_that("bare identifiers are accepted, unsafe ones rejected", {
+  expect_identical(validate_sql_identifier("logging"), "logging")
+  expect_identical(validate_sql_identifier("timestamp", "column"), "timestamp")
+  expect_error(validate_sql_identifier("logging; DROP TABLE x"))
+  expect_error(validate_sql_identifier("log table"))
+  expect_error(validate_sql_identifier("1bad"))
+  expect_error(validate_sql_identifier(""))
+  expect_error(validate_sql_identifier(NULL))
+})
+
+# --- SQL builders -----------------------------------------------------------
+
+test_that("count SQL targets the real table/column with a validated integer", {
+  sql <- build_log_cleanup_count_sql("logging", "timestamp", 30L)
+  expect_match(sql, "^SELECT COUNT\\(\\*\\) AS n FROM logging WHERE timestamp < \\(NOW\\(\\) - INTERVAL 30 DAY\\)$")
+})
+
+test_that("delete SQL targets the real table/column with a validated integer", {
+  sql <- build_log_cleanup_delete_sql("logging", "timestamp", 30L)
+  expect_match(sql, "^DELETE FROM logging WHERE timestamp < \\(NOW\\(\\) - INTERVAL 30 DAY\\)$")
+})
+
+test_that("SQL builders coerce string retention and reject unsafe values", {
+  expect_match(build_log_cleanup_delete_sql("logging", "timestamp", "15"), "INTERVAL 15 DAY")
+  expect_error(build_log_cleanup_delete_sql("logging", "timestamp", "x; DROP TABLE logging"))
+})
+
+# --- env parsing ------------------------------------------------------------
+
+test_that("truthy env detection is case-insensitive and conservative", {
+  expect_true(log_cleanup_env_is_true("1"))
+  expect_true(log_cleanup_env_is_true("true"))
+  expect_true(log_cleanup_env_is_true("TRUE"))
+  expect_true(log_cleanup_env_is_true("yes"))
+  expect_true(log_cleanup_env_is_true("on"))
+  expect_false(log_cleanup_env_is_true("0"))
+  expect_false(log_cleanup_env_is_true("false"))
+  expect_false(log_cleanup_env_is_true(""))
+  expect_false(log_cleanup_env_is_true(NULL))
+})
+
+test_that("config is assembled from env with validated defaults", {
+  fake_env <- function(name, unset = "") {
+    vals <- list(
+      LOG_RETENTION_DAYS = "45",
+      LOG_CLEANUP_DRY_RUN = "true"
+    )
+    if (!is.null(vals[[name]])) vals[[name]] else unset
+  }
+  cfg <- log_cleanup_config_from_env(getenv = fake_env)
+  expect_identical(cfg$retention_days, 45L)
+  expect_identical(cfg$table, "logging")
+  expect_identical(cfg$timestamp_column, "timestamp")
+  expect_true(cfg$dry_run)
+})
+
+test_that("config falls back to defaults when env is unset", {
+  empty_env <- function(name, unset = "") unset
+  cfg <- log_cleanup_config_from_env(getenv = empty_env)
+  expect_identical(cfg$retention_days, 30L)
+  expect_identical(cfg$table, "logging")
+  expect_identical(cfg$timestamp_column, "timestamp")
+  expect_false(cfg$dry_run)
+})
+
+# --- run_log_cleanup orchestration -----------------------------------------
+
+test_that("dry-run reports candidates but never calls the executor", {
+  count_calls <- character(0)
+  execute_called <- FALSE
+  cfg <- list(table = "logging", timestamp_column = "timestamp", retention_days = 30L, dry_run = TRUE)
+
+  res <- run_log_cleanup(
+    config = cfg,
+    count_fn = function(sql) {
+      count_calls <<- c(count_calls, sql)
+      42L
+    },
+    execute_fn = function(sql) {
+      execute_called <<- TRUE
+      stop("executor must not run in dry-run mode")
+    },
+    logger = function(msg) invisible(NULL)
+  )
+
+  expect_false(execute_called)
+  expect_length(count_calls, 1L)
+  expect_match(count_calls[[1]], "^SELECT COUNT")
+  expect_identical(res$candidate_rows, 42L)
+  expect_identical(res$deleted_rows, 0L)
+  expect_true(res$dry_run)
+})
+
+test_that("non-dry-run counts then deletes and reports affected rows", {
+  seen_sql <- character(0)
+  cfg <- list(table = "logging", timestamp_column = "timestamp", retention_days = 30L, dry_run = FALSE)
+
+  res <- run_log_cleanup(
+    config = cfg,
+    count_fn = function(sql) {
+      seen_sql <<- c(seen_sql, sql)
+      100L
+    },
+    execute_fn = function(sql) {
+      seen_sql <<- c(seen_sql, sql)
+      100L
+    },
+    logger = function(msg) invisible(NULL)
+  )
+
+  expect_length(seen_sql, 2L)
+  expect_match(seen_sql[[1]], "^SELECT COUNT")
+  expect_match(seen_sql[[2]], "^DELETE FROM logging")
+  expect_identical(res$candidate_rows, 100L)
+  expect_identical(res$deleted_rows, 100L)
+  expect_false(res$dry_run)
+})
+
+test_that("non-integer count/delete results degrade safely to zero", {
+  cfg <- list(table = "logging", timestamp_column = "timestamp", retention_days = 30L, dry_run = FALSE)
+  res <- run_log_cleanup(
+    config = cfg,
+    count_fn = function(sql) NA_integer_,
+    execute_fn = function(sql) NA_integer_,
+    logger = function(msg) invisible(NULL)
+  )
+  expect_identical(res$candidate_rows, 0L)
+  expect_identical(res$deleted_rows, 0L)
+})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -375,6 +375,88 @@ services:
         - action: rebuild
           path: ./api/renv.lock
 
+  # Scheduled retention cleanup of the operational request log table (`logging`).
+  # Reuses the API image so renv deps + RMariaDB + the existing DB connection
+  # helpers/config are available — no separate r-base/RMySQL container. It runs
+  # a small no-root cron loop that invokes scripts/delete_old_logs.R once a day
+  # at LOG_CLEANUP_AT (HH:MM, container UTC). Attached to `backend` only: it
+  # needs the DB but no outbound egress. See db/migrations/000 (`logging` table)
+  # and AGENTS.md (network boundary).
+  log-cleanup:
+    image: ${SYSNDD_API_IMAGE:-sysndd-api:latest}
+    build:
+      context: ./api/
+      args:
+        UID: ${HOST_UID:-1000}
+        GID: ${HOST_GID:-1000}
+    container_name: sysndd_log_cleanup
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    depends_on:
+      mysql:
+        condition: service_healthy
+    # Daily scheduler loop (no root / system cron needed). Sleeps until the next
+    # LOG_CLEANUP_AT (HH:MM) and then runs the cleanup script; on script failure
+    # it logs and continues to the next day rather than crash-looping.
+    command:
+      - bash
+      - -lc
+      - >
+          set -u;
+          at="$${LOG_CLEANUP_AT:-03:00}";
+          echo "[log-cleanup] scheduler started; daily run at $$at (container time), retention=$${LOG_RETENTION_DAYS:-30}d, dry_run=$${LOG_CLEANUP_DRY_RUN:-false}";
+          while true; do
+            now=$$(date +%s);
+            target=$$(date -d "today $$at" +%s 2>/dev/null || date +%s);
+            if [ "$$target" -le "$$now" ]; then target=$$(date -d "tomorrow $$at" +%s); fi;
+            sleep_for=$$(( target - now ));
+            echo "[log-cleanup] sleeping $$sleep_for s until next run";
+            sleep "$$sleep_for";
+            echo "[log-cleanup] running scripts/delete_old_logs.R";
+            Rscript scripts/delete_old_logs.R || echo "[log-cleanup] run failed (exit $$?); will retry next cycle";
+          done
+    volumes:
+      - ./api/functions:/app/functions:ro
+      - ./api/core:/app/core:ro
+      - ./api/bootstrap:/app/bootstrap:ro
+      - ./api/config:/app/config:ro
+      - ./api/scripts:/app/scripts:ro
+      - ./api/config.yml:/app/config.yml:ro
+    environment:
+      ENVIRONMENT: production
+      # Single connection is plenty for a once-a-day prune.
+      DB_POOL_SIZE: ${LOG_CLEANUP_DB_POOL_SIZE:-1}
+      # Retention window in days (rows older than this are deleted).
+      LOG_RETENTION_DAYS: ${LOG_RETENTION_DAYS:-30}
+      # Daily run time, HH:MM in container (UTC) time.
+      LOG_CLEANUP_AT: ${LOG_CLEANUP_AT:-03:00}
+      # Set to 1/true to count-only and never delete (safe verification).
+      LOG_CLEANUP_DRY_RUN: ${LOG_CLEANUP_DRY_RUN:-false}
+    networks:
+      # DB access only; no proxy/egress needed for a DB-local cleanup.
+      - backend
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: '0.25'
+    develop:
+      watch:
+        - action: sync
+          path: ./api/functions
+          target: /app/functions
+        - action: sync
+          path: ./api/scripts
+          target: /app/scripts
+        - action: rebuild
+          path: ./api/renv.lock
+
   app:
     build:
       context: ./app/

--- a/documentation/09-deployment.qmd
+++ b/documentation/09-deployment.qmd
@@ -62,6 +62,18 @@ External genomic proxy caches live under `/app/cache/external/{static,stable,dyn
 
 External provider request budgets default to short fail-fast values: `EXTERNAL_PROXY_TIMEOUT_SECONDS=6`, `EXTERNAL_PROXY_MAX_SECONDS=10`, `EXTERNAL_PROXY_MAX_TRIES=2`, and `EXTERNAL_PROXY_AGGREGATE_MAX_SECONDS=12`. Override per source with names such as `EXTERNAL_PROXY_MGI_TIMEOUT_SECONDS`, `EXTERNAL_PROXY_MGI_MAX_SECONDS`, and `EXTERNAL_PROXY_MGI_MAX_TRIES`. The aggregate external gene route remains serial and returns `partial = TRUE` with `skipped_sources` when the aggregate budget is exhausted.
 
+### Log retention cleanup
+
+The `log-cleanup` Compose service prunes old rows from the operational request log table (`logging`) on a daily schedule so the table does not grow unbounded. It reuses the API image (so it shares the `renv` dependencies, `RMariaDB`, and the existing connection-pool/config helpers) and connects over the internal `backend` network only — it needs the database but no outbound egress. The service runs a small no-root scheduler loop that invokes `api/scripts/delete_old_logs.R` once per day; the script delegates to the unit-tested helpers in `api/functions/log-cleanup.R`.
+
+Configuration (environment variables, with defaults):
+
+- `LOG_RETENTION_DAYS=30` — delete `logging` rows whose `timestamp` is older than this many days. Validated to a positive integer before it reaches SQL.
+- `LOG_CLEANUP_AT=03:00` — daily run time, `HH:MM` in container (UTC) time.
+- `LOG_CLEANUP_DRY_RUN=false` — when truthy (`1`/`true`/`yes`/`on`), count and log the candidate rows but delete nothing. Use this to verify scope before enabling deletion.
+
+Only the high-volume `logging` table is pruned. Low-volume audit tables (for example `llm_generation_log`, `async_job_events`) are intentionally left alone; `async_job_events` already cascades from `async_jobs`. The script exits non-zero on failure and the scheduler logs and continues to the next cycle rather than crash-looping.
+
 ### Public analysis snapshots
 
 Public analysis endpoints and MCP analysis tools read public-ready rows from `analysis_snapshot_manifest` and normalized snapshot payload tables. They do not compute STRING networks, phenotype clusters, correlations, fCoSE layouts, external provider calls, or Gemini summaries on request-path miss.


### PR DESCRIPTION
## Summary

Closes #105.

Adds a daily retention cleanup for the high-volume operational request log table (`logging`) so it does not grow unbounded.

### Design (the SysNDD way, not the naive sketch)
The issue body sketched a brand-new `r-base` + `RMySQL` + system-`cron` container. That conflicts with repo conventions (the stack uses `renv` + **RMariaDB**, has existing DB connection/config helpers, and already runs a worker container). Instead this **reuses the API image** so the cleanup shares the exact `renv` deps, `RMariaDB` driver, connection pool, and config loading as the rest of the runtime. The `scripts/delete_old_logs.R` entrypoint mirrors `start_async_worker.R`'s bootstrap and delegates to unit-tested helpers.

### Target (verified)
- Table `logging`, column `timestamp`, index `idx_logging_timestamp` — confirmed in `db/migrations/000_initialize_base_schema.sql` and `db/migrations/011_logging_indexes.sql`. This is the table the Plumber post-route hook writes one row per request to.
- Low-volume audit tables (`llm_generation_log`, `async_job_events`) are intentionally **not** pruned (`async_job_events` already cascades from `async_jobs`).

### Service
`log-cleanup` Compose service: API image, `backend` network **only** (DB access, no egress needed), `no-new-privileges`, memory/cpu limits, and a small no-root scheduler loop that runs the script daily at `LOG_CLEANUP_AT`. `config.yml` is provided via the read-only mount (not baked into the image, per AGENTS.md).

### Configuration
| Env | Default | Meaning |
|---|---|---|
| `LOG_RETENTION_DAYS` | `30` | delete `logging` rows older than N days (validated to a positive integer) |
| `LOG_CLEANUP_AT` | `03:00` | daily run time, HH:MM container/UTC |
| `LOG_CLEANUP_DRY_RUN` | `false` | truthy → count-only, never delete |

### Safety
- Retention value is **validated to a bounded positive integer** before it is ever interpolated into SQL (the only value that flows into the `INTERVAL` literal); table/column are validated bare identifiers. Injection guards are unit-tested.
- A dry-run mode counts candidates without deleting, for safe verification before enabling.

### Tests / verification
- `api/tests/testthat/test-unit-log-cleanup.R` — **55 assertions, all pass** on host (`Rscript --no-init-file`): retention validation incl. injection attempts, identifier validation, SQL builders, env parsing, and dry-run vs delete orchestration with an injected fake DB layer (no live DB needed).
- `lintr` on both new R files: **0 issues**.

### Not verified locally (needs CI / a live stack)
- The host lacks `RMariaDB`, so the script was not executed against a live DB. The logic is fully covered by the injected-DB unit tests; a live run should be confirmed in CI / staging (start with `LOG_CLEANUP_DRY_RUN=true`).
- `docker compose` was not brought up (shared host); the new service block should be smoke-tested in CI/staging.

🤖 Authored with assistance from Claude Code.