### PR TITLE
chore(ci): reduce noise in local ci-local success path (#360)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,13 +239,33 @@ ci-local: ## [quality] Run CI checks locally (lint + test with DB - mirrors GitH
 		SECONDS=$$((SECONDS+1)); \
 	done
 	@printf "$(CYAN)Resetting test database for CI parity...$(RESET)\n"
-	@cd $(ROOT_DIR) && { \
+	@# Reset strategy (issue #360): try root first so we can GRANT to the
+	@# `bernt` test user, then fall back to the regular MYSQL_USER. In the
+	@# default local profile the root-over-TCP attempt is EXPECTED to fail
+	@# (`ERROR 1045 (28000): Access denied for user 'root'@...`) because the
+	@# dev MySQL container does not grant root over the 127.0.0.1 host; the
+	@# fallback path is the one that normally succeeds. We capture both
+	@# attempts and only surface the captured output when the WHOLE reset
+	@# genuinely fails, so a successful run no longer prints an alarming
+	@# access-denied error. A real connectivity/permission failure (both
+	@# attempts down) still prints the diagnostics and still fails the run.
+	@# NB: `if ! VAR=$$(...)` keeps the capture safe under `set -e` — a failing
+	@# substitution is consumed by the `if` test instead of aborting the recipe
+	@# before we can print diagnostics.
+	@cd $(ROOT_DIR); \
+	if RESET_LOG=$$( { \
 		$(COMPOSE_DB_DEV) exec -T mysql-test sh -c \
 			'mysql -h127.0.0.1 -uroot -p"$$MYSQL_ROOT_PASSWORD" -e "DROP DATABASE IF EXISTS sysndd_db_test; CREATE DATABASE sysndd_db_test CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci; GRANT ALL PRIVILEGES ON sysndd_db_test.* TO '\''bernt'\''@'\''%'\'';"' || \
 		$(COMPOSE_DB_DEV) exec -T mysql-test sh -c \
 			'mysql -h127.0.0.1 -u"$$MYSQL_USER" -p"$$MYSQL_PASSWORD" -e "DROP DATABASE IF EXISTS sysndd_db_test; CREATE DATABASE sysndd_db_test CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"'; \
-	} && printf "$(GREEN)✓ Test database reset$(RESET)\n" || \
-		($(MAKE) -C $(ROOT_DIR) _ci-cleanup && exit 1)
+	} 2>&1 ); then \
+		printf "$(GREEN)✓ Test database reset$(RESET)\n"; \
+	else \
+		printf "$(RED)✗ Test database reset failed (both root and fallback user)$(RESET)\n"; \
+		printf '%s\n' "$$RESET_LOG"; \
+		$(MAKE) -C $(ROOT_DIR) _ci-cleanup; \
+		exit 1; \
+	fi
 	@printf "\n$(CYAN)[3/7] Linting R code...$(RESET)\n"
 	@$(MAKE) lint-api || ($(MAKE) -C $(ROOT_DIR) _ci-cleanup && exit 1)
 	@printf "\n$(CYAN)[4/7] Linting frontend code...$(RESET)\n"

--- a/api/scripts/ci-test-summary.R
+++ b/api/scripts/ci-test-summary.R
@@ -1,0 +1,172 @@
+#!/usr/bin/env Rscript
+
+# ci-test-summary.R
+#
+# Helpers that turn a `testthat_results` object into a concise, classified
+# end-of-run summary for `make ci-local` / GitHub Actions.
+#
+# Motivation (issue #360): a successful CI run prints many *expected* skips for
+# the default local/PR profile (optional R packages, slow tests, live services).
+# Mixed in with the per-test reporter output these look alarming and bury the
+# final verdict. This helper does NOT suppress any per-test output and does NOT
+# change pass/fail semantics — it only adds a short, human-readable summary at
+# the very end that separates "expected local-profile skips" from anything that
+# deserves a closer look.
+#
+# Verification is unchanged: failures and errors are still counted by the caller
+# (`run-ci-tests.R`) and still fail the run. This file is presentation-only.
+
+# Patterns for skips that are EXPECTED in the default local/PR profile.
+#
+# Each entry maps a human-readable bucket label to a case-insensitive regex
+# matched against the testthat skip reason. Keep this list in sync with the
+# skip helpers in `api/tests/testthat/helper-*.R` and the inline
+# `skip_if_not_installed(...)` / `skip_if_not(...)` calls in the test files.
+# Anything that does NOT match one of these patterns is reported as an
+# "unexpected skip" so it stays visible.
+expected_skip_buckets <- function() {
+  list(
+    # `skip_if_not_installed("ellmer"|"mcptools"|...)` -> "{pkg} is not installed";
+    # `skip_if_not(<pkg>_available, ...)` and source-load guards for
+    # ontologyIndex / hpo-functions / omim-functions / file-functions.
+    "optional R package not installed" = paste(
+      "is not installed",
+      "not installed",
+      "package not available",
+      "could not be loaded",
+      "requires additional dependencies",
+      "function not loaded",
+      "ellmer",
+      "mcptools",
+      "ontologyindex",
+      "tidyverse",
+      sep = "|"
+    ),
+    # `skip_if_not_slow_tests()` — slow lane runs nightly in GitHub Actions.
+    "slow test (RUN_SLOW_TESTS unset)" = "run_slow_tests|slow test",
+    # `skip_if_sysndd_api_not_running()` and integration tests that need a live
+    # API/endpoint; expected when no local API process is up.
+    "live SysNDD API not running" = paste(
+      "sysndd api not running",
+      "api not running",
+      "api not available",
+      "api not responding",
+      "api error",
+      "endpoint not accessible",
+      "requires network access",
+      "network access and live api",
+      "live api",
+      sep = "|"
+    ),
+    # `skip_if_no_test_db()` — expected only when the test DB container is down;
+    # in `make ci-local` the DB is up so these should not appear.
+    "test database unavailable" = "test database.*not available|sysndd_db_test",
+    # `skip_if_mailpit_not_*` — Mailpit only runs in the nightly slow lane.
+    "Mailpit not configured" = "mailpit",
+    # httptest2 fixtures absent + offline: cannot record or replay.
+    "no fixtures and no network" = "no fixtures|cannot record or mock|fixture not found|fixture file",
+    # Integration tests gated on seeded auth/admin state or external creds
+    # (JWT tokens, Gemini, seeded cached summaries). Not exercised by the
+    # default local/PR profile.
+    "auth/seed/credentials required" = paste(
+      "requires authentication",
+      "requires administrator",
+      "requires valid jwt",
+      "requires gemini",
+      "requires seeded",
+      "requires test fixture",
+      "needs integration test",
+      sep = "|"
+    ),
+    # Generic env/config gating left for completeness.
+    "optional integration setting unset" =
+      "environment variable|env( var)? (is )?(not )?set|not configured|integration .* disabled"
+  )
+}
+
+# Extract every skip reason from a `testthat_results` object as a character
+# vector. We read the per-expectation objects (class `expectation_skip`) rather
+# than the aggregated data frame because the data frame does not carry the
+# skip message text.
+collect_skip_reasons <- function(results) {
+  reasons <- character(0)
+  for (test_result in results) {
+    for (expectation in test_result$results) {
+      if (inherits(expectation, "expectation_skip")) {
+        # Reasons are emitted as "Reason: <text>"; strip the prefix for display.
+        reason <- sub("^Reason:\\s*", "", conditionMessage(expectation))
+        reasons <- c(reasons, reason)
+      }
+    }
+  }
+  reasons
+}
+
+# Classify a vector of skip reasons into expected buckets + an unexpected list.
+classify_skips <- function(reasons) {
+  buckets <- expected_skip_buckets()
+  bucket_counts <- setNames(integer(length(buckets)), names(buckets))
+  unexpected <- character(0)
+
+  for (reason in reasons) {
+    matched <- FALSE
+    for (label in names(buckets)) {
+      if (grepl(buckets[[label]], reason, ignore.case = TRUE)) {
+        bucket_counts[[label]] <- bucket_counts[[label]] + 1L
+        matched <- TRUE
+        break
+      }
+    }
+    if (!matched) {
+      unexpected <- c(unexpected, reason)
+    }
+  }
+
+  list(
+    expected = bucket_counts[bucket_counts > 0],
+    unexpected = unexpected
+  )
+}
+
+# Print the classified skip summary. `mode` is the CI selection mode
+# ("fast"/"full") and is shown for context only.
+print_ci_test_summary <- function(results, mode = "full") {
+  reasons <- collect_skip_reasons(results)
+
+  cat("\n")
+  cat("==================================================\n")
+  cat(sprintf("CI test skip summary (%s profile)\n", mode))
+  cat("==================================================\n")
+
+  if (!length(reasons)) {
+    cat("No tests were skipped.\n")
+    return(invisible(NULL))
+  }
+
+  classified <- classify_skips(reasons)
+
+  if (length(classified$expected)) {
+    cat("Expected local-profile skips (not actionable):\n")
+    for (label in names(classified$expected)) {
+      cat(sprintf("  - %-38s x%d\n", label, classified$expected[[label]]))
+    }
+    cat(
+      "  These are normal when running the default local/PR profile: optional\n",
+      "  R packages (ellmer, mcptools, ontologyIndex, tidyverse) are absent,\n",
+      "  RUN_SLOW_TESTS is unset, and live services (SysNDD API, Mailpit) are\n",
+      "  not running. The nightly/full GitHub Actions lanes exercise them.\n",
+      sep = ""
+    )
+  }
+
+  if (length(classified$unexpected)) {
+    cat("\nUnexpected skips (review these):\n")
+    for (reason in unique(classified$unexpected)) {
+      n <- sum(classified$unexpected == reason)
+      cat(sprintf("  - %s x%d\n", reason, n))
+    }
+  }
+
+  cat("\n")
+  invisible(NULL)
+}

--- a/api/scripts/run-ci-tests.R
+++ b/api/scripts/run-ci-tests.R
@@ -4,6 +4,7 @@ args <- commandArgs(trailingOnly = TRUE)
 mode <- if (length(args) >= 1) args[[1]] else "full"
 
 source("scripts/test-selection.R")
+source("scripts/ci-test-summary.R")
 
 selected_files <- list_ci_test_files(mode)
 
@@ -16,7 +17,33 @@ cat(
   sep = " "
 )
 
-testthat::test_dir(
+# Run with stop_on_failure = FALSE so we can append a classified skip summary
+# (issue #360) *after* the per-test reporter output. We re-create the
+# fail-on-failure contract ourselves below, so verification strength is
+# unchanged: any failure or error still exits non-zero and fails CI.
+results <- testthat::test_dir(
   "tests/testthat",
-  filter = build_test_file_filter(selected_files)
+  filter = build_test_file_filter(selected_files),
+  stop_on_failure = FALSE
 )
+
+# Presentation-only: separate expected local-profile skips from anything that
+# warrants a look. Does not change the pass/fail decision below.
+print_ci_test_summary(results, mode = mode)
+
+# Re-assert the testthat fail-on-failure contract that stop_on_failure = TRUE
+# would normally provide. `as.data.frame()` on testthat_results yields one row
+# per test with logical `failed`/`error` counts.
+results_df <- as.data.frame(results)
+n_failed <- sum(results_df$failed)
+n_errors <- sum(results_df$error)
+
+if (n_failed > 0 || n_errors > 0) {
+  stop(
+    sprintf(
+      "Test failures detected: %d failed, %d errored. See output above.",
+      n_failed, n_errors
+    ),
+    call. = FALSE
+  )
+}

--- a/documentation/08-development.qmd
+++ b/documentation/08-development.qmd
@@ -242,6 +242,38 @@ Offline importer fixtures live under `api/tests/testthat/fixtures/nddscore/`. Th
 - On Conda/miniforge R installs, `Makefile` derives `HOST_R_LD_LIBRARY_PATH` from `R RHOME` and prepends the sibling `mariadb/` runtime directory so `RMariaDB` can load. Override `HOST_R_LD_LIBRARY_PATH` when the MariaDB client runtime lives elsewhere.
 - External proxy cache tests should use `memoise_external_success_only()` when adding new cached source fetchers. It keeps successes cached but evicts transient `error = TRUE` payloads immediately so one upstream timeout does not affect local development for days.
 
+### Interpreting `make ci-local` output
+
+`make ci-local` mirrors the GitHub Actions lanes (lint, type-check, full R API
+tests with a DB). A successful run ends with the `CI-LOCAL PASSED` banner. The
+verdict is the banner and the per-step `✓` lines — not the absence of every
+warning. Some output is expected in the default local profile and is **not** a
+sign that anything needs fixing:
+
+- **Test DB reset.** The reset step tries `root` first (to `GRANT` to the
+  `bernt` test user) and falls back to the regular `MYSQL_USER`. In the default
+  local profile the `root`-over-TCP attempt is expected to be denied; the
+  fallback succeeds. The harness now suppresses that expected `ERROR 1045`
+  access-denied line when the fallback works, and only prints reset diagnostics
+  (and fails) when **both** attempts fail. A genuine DB connectivity or
+  permission failure still surfaces and still fails the run.
+- **Expected skips.** Optional R packages (`ellmer`, `mcptools`,
+  `ontologyIndex`, `tidyverse`), `RUN_SLOW_TESTS`-gated tests, and tests that
+  need live services (the SysNDD API, Mailpit), seeded auth/fixtures, or
+  external credentials are skipped locally. These run in the full/nightly
+  GitHub Actions lanes instead. The R test runner prints a classified
+  **"CI test skip summary"** at the end that buckets these as *expected
+  local-profile skips* and lists anything else under *Unexpected skips (review
+  these)*. The bucketing lives in `api/scripts/ci-test-summary.R`; the
+  fail/pass decision is unchanged (`api/scripts/run-ci-tests.R` still exits
+  non-zero on any failure or error).
+- **Warnings from negative-path tests.** Some unit tests deliberately exercise
+  error/warning branches, so warning text in the per-test output is normal as
+  long as the test passes.
+
+This is output hygiene only: real lint/type/test failures still fail
+`make ci-local` exactly as before.
+
 ### Publication-date provenance
 
 `publication.publication_date_source` records how each `Publication_date` was derived (`pubmed`, `pubmed_partial`, `medline_date`, `unknown`). New ingestions set it automatically. To correct historical rows ingested before this fix, run the one-off backfill: `Rscript db/updates/backfill_publication_dates.R --dry-run --limit=25` for a small rehearsal, `--dry-run` to preview the full run, then `--apply`. It re-fetches PubMed metadata, so it needs network egress. The script is dry-run by default, uses an advisory lock, limits PubMed fallback requests with `NCBI_REQUEST_DELAY_SECONDS`, and commits DB writes in batches controlled by `BACKFILL_UPDATE_BATCH_SIZE`.


### PR DESCRIPTION
## Summary

Closes #360.

Reduces alarming-looking noise in a **successful** `make ci-local` run. This is **output hygiene only** — real lint/type/test failures still fail the run exactly as before.

### What changed

**1. Test DB reset no longer prints an expected `ERROR 1045`** (`Makefile` `ci-local`)
The reset tries `root` first (to `GRANT` to the `bernt` test user) then falls back to the regular `MYSQL_USER`. In the default local profile the `root`-over-TCP attempt is expected to be denied; the fallback succeeds. The recipe now captures both attempts and only prints the captured diagnostics when **both** fail (then cleans up and `exit 1`). A genuine connectivity/permission failure still surfaces and still fails.

**2. Classified skip summary** (`api/scripts/run-ci-tests.R` + new `api/scripts/ci-test-summary.R`)
The R runner now prints a concise end-of-run summary that separates *expected local-profile skips* (optional packages like `ellmer`/`mcptools`/`ontologyIndex`/`tidyverse`, `RUN_SLOW_TESTS`-gated tests, live SysNDD API / Mailpit, seeded auth/fixtures/credentials) from *Unexpected skips (review these)*.

**Verification strength preserved:** the runner switches `test_dir(stop_on_failure = FALSE)` so the summary can print *after* the reporter, then re-asserts the fail contract itself — counts `failed`/`error` and `stop()`s if any are non-zero. CI still exits non-zero on any failure or error.

**3. Docs** (`documentation/08-development.qmd`)
New "Interpreting `make ci-local` output" section explaining the verdict is the `CI-LOCAL PASSED` banner + per-step `✓`, which skips are expected, and that hygiene ≠ weaker verification.

### Verification
- `Rscript --no-init-file`: both scripts parse; `classify_skips()` correctly buckets expected vs unexpected reasons.
- `lintr` on both R files: **0 issues**.
- `make code-quality-audit`: **clean** (no file-size regression).

### Not verified locally (CI must confirm)
- A full `make ci-local` run was **not** executed (it brings up the DB stack, which is shared on this host). The changes are surgical and reviewed against the recipe/script behavior; the full run and the exact before/after console output should be confirmed in CI / by a maintainer. The skip-summary classifier is presentation-only and defensive (no-ops on unexpected result shapes), so it cannot change the pass/fail outcome.

🤖 Authored with assistance from Claude Code.