### PR TITLE
feat(pubtator): normalize NDD gene counts with enrichment/NPMI/Fisher-FDR (#175)

### DIFF
--- a/api/bootstrap/load_modules.R
+++ b/api/bootstrap/load_modules.R
@@ -123,6 +123,8 @@ bootstrap_load_modules <- function() {
     "functions/pubtator-client.R",
     "functions/pubtator-parser.R",
     "functions/pubtator-functions.R",
+    "functions/pubtator-enrichment-metrics.R",
+    "functions/pubtator-enrichment-collector.R",
     "functions/ensembl-functions.R",
     "functions/job-manager.R",
     "functions/job-progress.R",

--- a/api/endpoints/publication_endpoints.R
+++ b/api/endpoints/publication_endpoints.R
@@ -536,12 +536,12 @@ function(req,
 #* @get /pubtator/genes
 function(req,
          res,
-         sort = "-is_novel,oldest_pub_date",
+         sort = "-enrichment_ratio,-npmi,publication_count",
          filter = "",
          fields = "",
          page_after = "0",
          page_size = "10",
-         fspec = "gene_name,gene_symbol,gene_normalized_id,hgnc_id,publication_count,entities_count,is_novel,oldest_pub_date,pmids,publications,entities", # nolint: line_length_linter
+         fspec = "gene_name,gene_symbol,gene_normalized_id,hgnc_id,publication_count,entities_count,is_novel,oldest_pub_date,observed,background_count,enrichment_ratio,npmi,fisher_p,fdr_bh,pmids,publications,entities", # nolint: line_length_linter
          format = "json") {
   # 1) Set serializer
   res$serializer <- serializers[[format]]
@@ -596,6 +596,11 @@ function(req,
         paste(valid_pubs$pmid, collapse = ",")
       })
     )
+
+  # 6b) Left-join normalized enrichment metrics (issue #175): normalize raw NDD
+  #     co-occurrence for research-popularity bias. Worker-precomputed; LEFT JOIN
+  #     so genes without a metric yet still appear. See helper for details.
+  df_counts <- pubtator_join_enrichment_metrics(df_counts, pool)
 
   # 7) Apply filter AFTER computed fields exist
   df_filtered <- df_counts %>%
@@ -1190,4 +1195,40 @@ function(req, res) {
       )
     }
   )
+}
+
+
+#* Submit a PubtatorNDD gene-enrichment refresh job
+#*
+#* Normalizes raw NDD co-occurrence counts for research-popularity bias
+#* (issue #175). Fetches each gene's total PubTator publication count plus the
+#* NDD/total corpus sizes, computes enrichment ratio, NPMI, and Fisher p-value +
+#* BH-FDR, and persists a new current snapshot. This makes one external PubTator
+#* call per gene, so it runs in the durable async worker (network egress), never
+#* synchronously on a public request. Intended cadence: monthly.
+#*
+#* @tag publication
+#* @serializer json list(na="null")
+#*
+#* @response 202 Accepted. Returns job_id; poll the status_url.
+#* @response 409 A refresh is already running.
+#* @post /pubtator/enrichment/refresh
+function(req, res) {
+  require_role(req, res, "Administrator")
+  pubtator_enrichment_refresh_submit(res, submitted_by = req$user_id %||% NULL)
+}
+
+
+#* PubtatorNDD enrichment snapshot status
+#*
+#* Reports the current enrichment snapshot: when it was computed, the corpus
+#* sizes used, and how many genes were scored. Public read.
+#*
+#* @tag publication
+#* @serializer json list(na="null", auto_unbox=TRUE)
+#*
+#* @response 200 OK. Returns the current snapshot summary (or available=false).
+#* @get /pubtator/enrichment/status
+function(req, res) {
+  pubtator_enrichment_status_response()
 }

--- a/api/functions/async-job-handlers.R
+++ b/api/functions/async-job-handlers.R
@@ -408,6 +408,10 @@
   )
 }
 
+.async_job_run_pubtator_enrichment <- function(job, payload, state, worker_config) {
+  pubtator_enrichment_job_run(job, .async_job_progress_reporter)
+}
+
 .async_job_run_backup_create <- function(job, payload, state, worker_config) {
   progress <- .async_job_progress_reporter(job$job_id[[1]])
 
@@ -829,6 +833,11 @@ async_job_handler_registry <- list(
   pubtator_update = list(
     cancel_mode = "best_effort",
     run = .async_job_run_pubtator,
+    after_success = .async_job_after_success_noop
+  ),
+  pubtator_enrichment_refresh = list(
+    cancel_mode = "best_effort",
+    run = .async_job_run_pubtator_enrichment,
     after_success = .async_job_after_success_noop
   ),
   nddscore_import = list(

--- a/api/functions/migration-manifest.R
+++ b/api/functions/migration-manifest.R
@@ -2,8 +2,8 @@
 #
 # Strict migration manifest validation for startup/readiness.
 
-EXPECTED_LATEST_MIGRATION <- "026_add_entity_last_update.sql"
-EXPECTED_MIGRATION_COUNT <- 27L
+EXPECTED_LATEST_MIGRATION <- "027_add_pubtator_gene_enrichment.sql"
+EXPECTED_MIGRATION_COUNT <- 28L
 
 #' Validate the migration manifest for strict startup/readiness checks
 #'

--- a/api/functions/publication-endpoint-helpers.R
+++ b/api/functions/publication-endpoint-helpers.R
@@ -36,3 +36,110 @@ publication_stats_response <- function(not_updated_since = NULL,
 
   result
 }
+
+#' Left-join normalized PubtatorNDD enrichment metrics onto the gene listing
+#'
+#' Issue #175: raw NDD co-occurrence count conflates true NDD relevance with
+#' research popularity. The worker-precomputed enrichment metrics
+#' (`pubtator_gene_enrichment_view`) are LEFT-joined so genes without a metric
+#' yet still appear with NA metric columns.
+#'
+#' @param df_counts Nested gene tibble with computed prioritization fields.
+#' @param pool_obj A dbplyr-capable pool/connection.
+#' @return `df_counts` with observed/background_count/enrichment_ratio/npmi/
+#'   fisher_p/fdr_bh columns guaranteed present.
+#' @export
+pubtator_join_enrichment_metrics <- function(df_counts, pool_obj) {
+  enrichment_cols <- c(
+    "gene_symbol", "observed", "background_count",
+    "enrichment_ratio", "npmi", "fisher_p", "fdr_bh"
+  )
+  df_enrichment <- tryCatch(
+    pool_obj %>%
+      dplyr::tbl("pubtator_gene_enrichment_view") %>%
+      dplyr::select(dplyr::any_of(enrichment_cols)) %>%
+      dplyr::collect(),
+    error = function(e) NULL
+  )
+
+  if (is.null(df_enrichment) || nrow(df_enrichment) == 0) {
+    return(dplyr::mutate(
+      df_counts,
+      observed = NA_integer_,
+      background_count = NA_integer_,
+      enrichment_ratio = NA_real_,
+      npmi = NA_real_,
+      fisher_p = NA_real_,
+      fdr_bh = NA_real_
+    ))
+  }
+
+  dplyr::left_join(df_counts, df_enrichment, by = "gene_symbol")
+}
+
+#' Submit the durable PubtatorNDD enrichment refresh job and shape the response
+#'
+#' @param res Plumber response (status/headers are set here).
+#' @param submitted_by Optional user id.
+#' @param submit_fn Submit function (injectable for tests).
+#' @return Submission summary list.
+#' @export
+pubtator_enrichment_refresh_submit <- function(res,
+                                               submitted_by = NULL,
+                                               submit_fn = async_job_service_submit) {
+  submitted <- submit_fn(
+    job_type = "pubtator_enrichment_refresh",
+    request_payload = list(refresh = "all"),
+    submitted_by = submitted_by
+  )
+
+  job <- submitted$job
+  job_id <- job$job_id[[1]]
+  status_url <- paste0("/api/jobs/", job_id, "/status")
+
+  res$status <- if (isTRUE(submitted$duplicate)) 409L else 202L
+  res$setHeader("Location", status_url)
+  res$setHeader("Retry-After", "5")
+
+  list(
+    job_id = job_id,
+    status = if (isTRUE(submitted$duplicate)) "already_running" else "accepted",
+    job_status = job$status[[1]],
+    status_url = status_url
+  )
+}
+
+#' Build the current PubtatorNDD enrichment snapshot status payload
+#'
+#' @param query_fn Query function (injectable for tests).
+#' @return List describing the current snapshot, or `available = FALSE`.
+#' @export
+pubtator_enrichment_status_response <- function(query_fn = db_execute_query) {
+  rows <- tryCatch(
+    query_fn(
+      "SELECT corpus_stats_id, ndd_corpus_size, total_corpus_size,
+              total_is_fallback, genes_scored, created_at
+       FROM pubtator_corpus_stats
+       WHERE is_current = 1
+       LIMIT 1"
+    ),
+    error = function(e) NULL
+  )
+
+  if (is.null(rows) || nrow(rows) == 0) {
+    return(list(
+      available = FALSE,
+      message = "No enrichment snapshot yet; run POST /pubtator/enrichment/refresh"
+    ))
+  }
+
+  list(
+    available = TRUE,
+    corpus_stats_id = rows$corpus_stats_id[[1]],
+    ndd_corpus_size = rows$ndd_corpus_size[[1]],
+    total_corpus_size = rows$total_corpus_size[[1]],
+    total_is_fallback = as.logical(rows$total_is_fallback[[1]]),
+    genes_scored = rows$genes_scored[[1]],
+    refreshed_at = as.character(rows$created_at[[1]])
+  )
+}

--- a/api/functions/pubtator-enrichment-collector.R
+++ b/api/functions/pubtator-enrichment-collector.R
@@ -1,0 +1,410 @@
+# functions/pubtator-enrichment-collector.R
+#
+# Background-count collection + DB persistence for the PubtatorNDD enrichment
+# normalization (GitHub issue #175). The web API must never run this on a
+# public request: it makes one external PubTator call per gene plus two
+# corpus-size calls, so it runs inside the durable async worker
+# (`pubtator_enrichment_refresh` job; see functions/async-job-handlers.R).
+#
+# Split of concerns:
+#   * pubtator-enrichment-metrics.R  -- pure math (no I/O), unit-tested.
+#   * this file                      -- external fetch + corpus sizes + the
+#                                        refresh orchestrator that writes
+#                                        pubtator_corpus_stats /
+#                                        pubtator_gene_enrichment (migration 027).
+#
+# External calls go through memoise_external_success_only() so a transient
+# upstream failure (returned as list(error = TRUE, ...)) is NOT cached and the
+# 7-day cache only retains real counts.
+
+require(jsonlite)
+require(logger)
+
+# Default total-corpus size used as a fallback only if the corpus-size probe
+# fails. PubTator3 indexes ~the whole of PubMed (~37M citations as of 2024);
+# this is intentionally conservative and is overwritten whenever the live
+# probe succeeds. Never silently trust it for ranking without a successful
+# corpus probe -- the refresh records which value was actually used.
+PUBTATOR_FALLBACK_TOTAL_CORPUS <- 37000000L
+
+# The disease-side query that defines the "NDD corpus". Mirrors the broad
+# neurodevelopmental concept used elsewhere in PubtatorNDD; kept as a single
+# constant so the NDD-corpus size and the per-gene observed counts stay aligned.
+PUBTATOR_NDD_CORPUS_QUERY <- "@DISEASE_neurodevelopmental"
+
+#' Fetch the total PubTator publication count for a single search query
+#'
+#' Hits the PubTator3 search endpoint and reads `response.count`. This is the
+#' raw fetcher; wrap with `memoise_external_success_only()` for caching (see
+#' `pubtator_total_count_mem` below).
+#'
+#' @param query Character search string already in PubTator syntax, e.g.
+#'   "@GENE_GRIN2B" or "@DISEASE_neurodevelopmental".
+#' @param api_base_url PubTator3 API base URL.
+#' @param endpoint_search Search endpoint path.
+#'
+#' @return On success, `list(error = FALSE, query = query, count = <integer>)`.
+#'   On a transient/upstream failure, `list(error = TRUE, query = query,
+#'   status = <int>, message = <chr>)` -- this shape is detected by
+#'   `external_proxy_is_error()` and must not be cached.
+#' @export
+pubtator_fetch_total_count <- function(query,
+                                       api_base_url = "https://www.ncbi.nlm.nih.gov/research/pubtator3-api/",
+                                       endpoint_search = "search/") {
+  if (is.null(query) || !nzchar(query)) {
+    return(list(error = TRUE, query = query, status = 400L,
+                message = "empty query"))
+  }
+
+  url_search <- paste0(api_base_url, endpoint_search, "?text=", query, "&page=1")
+
+  tryCatch(
+    {
+      response <- jsonlite::fromJSON(URLencode(url_search), flatten = TRUE)
+      raw_count <- response$count
+      if (is.null(raw_count) || length(raw_count) == 0 || is.na(raw_count[[1]])) {
+        # A valid "no results" answer is still a successful, cacheable response.
+        return(list(error = FALSE, query = query, count = 0L))
+      }
+      list(error = FALSE, query = query, count = as.integer(raw_count[[1]]))
+    },
+    error = function(e) {
+      log_warn(skip_formatter(paste(
+        "PubTator total-count fetch failed for query", query, ":", e$message
+      )))
+      list(error = TRUE, query = query, status = 503L, message = e$message)
+    }
+  )
+}
+
+#' Memoised total-count fetcher (7-day cache, errors not cached)
+#'
+#' Bound lazily so the file can be sourced in library-light test contexts that
+#' do not define the external-proxy cache backends.
+#' @export
+pubtator_total_count_mem <- if (exists("cache_dynamic") &&
+                                exists("memoise_external_success_only")) {
+  memoise_external_success_only(pubtator_fetch_total_count, cache = cache_dynamic)
+} else {
+  pubtator_fetch_total_count
+}
+
+#' Collect the corpus-level sizes needed to normalize gene counts
+#'
+#' @param fetch_fn Total-count fetcher (injectable for tests). Defaults to the
+#'   memoised production fetcher.
+#'
+#' @return `list(ndd_corpus_size = <int|NA>, total_corpus_size = <int>,
+#'   total_is_fallback = <lgl>)`. `total_corpus_size` falls back to
+#'   `PUBTATOR_FALLBACK_TOTAL_CORPUS` if the all-corpus probe fails.
+#' @export
+pubtator_collect_corpus_sizes <- function(fetch_fn = pubtator_total_count_mem) {
+  ndd_res <- fetch_fn(PUBTATOR_NDD_CORPUS_QUERY)
+  ndd_size <- if (isTRUE(ndd_res$error)) NA_integer_ else as.integer(ndd_res$count)
+
+  # Total corpus size: an unfiltered search returns the index size. A bare "*"
+  # query is the conventional "everything" probe; guard with the fallback.
+  total_res <- fetch_fn("*")
+  total_is_fallback <- isTRUE(total_res$error) ||
+    is.null(total_res$count) || is.na(total_res$count) ||
+    as.integer(total_res$count) <= 0L
+
+  total_size <- if (total_is_fallback) {
+    PUBTATOR_FALLBACK_TOTAL_CORPUS
+  } else {
+    as.integer(total_res$count)
+  }
+
+  list(
+    ndd_corpus_size = ndd_size,
+    total_corpus_size = total_size,
+    total_is_fallback = total_is_fallback
+  )
+}
+
+#' Collect background (total) publication counts for a set of genes
+#'
+#' @param gene_symbols Character vector of HGNC gene symbols.
+#' @param fetch_fn Total-count fetcher (injectable for tests).
+#' @param progress_fn Optional progress reporter `function(step, message,
+#'   current, total)`.
+#'
+#' @return Data frame `gene_symbol`, `background_count` (NA when the per-gene
+#'   fetch failed so the gene can be skipped rather than mis-ranked).
+#' @export
+pubtator_collect_background_counts <- function(gene_symbols,
+                                               fetch_fn = pubtator_total_count_mem,
+                                               progress_fn = NULL) {
+  gene_symbols <- unique(gene_symbols[!is.na(gene_symbols) & nzchar(gene_symbols)])
+  total <- length(gene_symbols)
+  background <- rep(NA_integer_, total)
+
+  report <- function(step, message, current = NULL, total = NULL) {
+    if (!is.null(progress_fn) && is.function(progress_fn)) {
+      tryCatch(progress_fn(step, message, current = current, total = total),
+               error = function(e) NULL)
+    }
+  }
+
+  for (i in seq_len(total)) {
+    sym <- gene_symbols[[i]]
+    res <- fetch_fn(paste0("@GENE_", sym))
+    if (!isTRUE(res$error) && !is.null(res$count) && !is.na(res$count)) {
+      background[[i]] <- as.integer(res$count)
+    }
+    if (i %% 25 == 0 || i == total) {
+      report("collect", sprintf("Fetched background counts %d/%d", i, total),
+             current = i, total = total)
+    }
+  }
+
+  data.frame(
+    gene_symbol = gene_symbols,
+    background_count = background,
+    stringsAsFactors = FALSE
+  )
+}
+
+#' Read the curated PubtatorNDD per-gene observed (NDD co-occurrence) counts
+#'
+#' Reads the same approved view the gene-prioritization endpoint serves, so
+#' `observed` matches what users rank on. One row per gene.
+#'
+#' @param conn A live DBI connection.
+#'
+#' @return Data frame `hgnc_id`, `gene_symbol`, `observed`.
+#' @export
+pubtator_read_observed_counts <- function(conn) {
+  rows <- db_execute_query(
+    "SELECT nal.hgnc_id AS hgnc_id,
+            nal.symbol  AS gene_symbol,
+            COUNT(DISTINCT s.pmid) AS observed
+     FROM pubtator_search_cache s
+     JOIN pubtator_annotation_cache a ON s.search_id = a.search_id
+     JOIN non_alt_loci_set nal ON nal.entrez_id = a.normalized_id
+     WHERE a.type = 'Gene'
+       AND EXISTS (
+         SELECT 1 FROM pubtator_annotation_cache x
+         WHERE x.search_id = s.search_id
+           AND x.type = 'Species'
+           AND x.normalized_id = '9606'
+       )
+     GROUP BY nal.hgnc_id, nal.symbol",
+    list(),
+    conn = conn
+  )
+  rows$observed <- as.integer(rows$observed)
+  rows
+}
+
+#' Run a full enrichment refresh: collect counts, compute metrics, persist
+#'
+#' Orchestrator executed by the durable `pubtator_enrichment_refresh` worker
+#' job. Wraps the writes in a transaction so the new snapshot activates
+#' atomically (exactly one current `pubtator_corpus_stats` row).
+#'
+#' @param conn A live DBI connection (the worker checks one out of the pool).
+#' @param fetch_fn Total-count fetcher (injectable for tests).
+#' @param progress_fn Optional progress reporter.
+#' @param refreshed_by Optional user id recorded on the snapshot.
+#'
+#' @return List with `success`, `genes_scored`, `ndd_corpus_size`,
+#'   `total_corpus_size`, `total_is_fallback`, `corpus_stats_id`.
+#' @export
+pubtator_enrichment_refresh_run <- function(conn,
+                                            fetch_fn = pubtator_total_count_mem,
+                                            progress_fn = NULL,
+                                            refreshed_by = NULL) {
+  report <- function(step, message, current = NULL, total = NULL) {
+    if (!is.null(progress_fn) && is.function(progress_fn)) {
+      tryCatch(progress_fn(step, message, current = current, total = total),
+               error = function(e) NULL)
+    }
+  }
+
+  report("observed", "Reading curated PubtatorNDD gene counts...", current = 0, total = 1)
+  observed_df <- pubtator_read_observed_counts(conn)
+  if (nrow(observed_df) == 0) {
+    return(list(success = FALSE, genes_scored = 0L,
+                message = "No PubtatorNDD gene counts found; run a PubTator update first"))
+  }
+
+  report("corpus", "Fetching corpus sizes...", current = 0, total = 1)
+  corpus <- pubtator_collect_corpus_sizes(fetch_fn = fetch_fn)
+  if (is.na(corpus$ndd_corpus_size) || corpus$ndd_corpus_size <= 0) {
+    return(list(success = FALSE, genes_scored = 0L,
+                message = "Failed to fetch NDD corpus size from PubTator"))
+  }
+
+  report("background",
+         sprintf("Fetching background counts for %d genes...", nrow(observed_df)),
+         current = 0, total = nrow(observed_df))
+  background_df <- pubtator_collect_background_counts(
+    observed_df$gene_symbol, fetch_fn = fetch_fn, progress_fn = progress_fn
+  )
+
+  merged <- dplyr::inner_join(observed_df, background_df, by = "gene_symbol")
+
+  report("compute", "Computing enrichment, NPMI, Fisher + BH-FDR...",
+         current = nrow(merged), total = nrow(merged))
+  scored <- pubtator_compute_gene_metrics(
+    merged,
+    ndd_corpus_size = corpus$ndd_corpus_size,
+    total_corpus_size = corpus$total_corpus_size
+  )
+
+  report("persist", "Writing enrichment snapshot...", current = 0, total = 1)
+  corpus_stats_id <- pubtator_enrichment_persist(
+    conn = conn,
+    scored = scored,
+    corpus = corpus,
+    refreshed_by = refreshed_by
+  )
+
+  list(
+    success = TRUE,
+    genes_scored = nrow(scored),
+    ndd_corpus_size = corpus$ndd_corpus_size,
+    total_corpus_size = corpus$total_corpus_size,
+    total_is_fallback = corpus$total_is_fallback,
+    corpus_stats_id = corpus_stats_id,
+    message = sprintf("Scored %d genes against NDD corpus of %d publications",
+                      nrow(scored), corpus$ndd_corpus_size)
+  )
+}
+
+#' Persist a scored snapshot atomically (one current corpus-stats row)
+#'
+#' @param conn A live DBI connection.
+#' @param scored Data frame from `pubtator_compute_gene_metrics()`.
+#' @param corpus Corpus-size list from `pubtator_collect_corpus_sizes()`.
+#' @param refreshed_by Optional user id.
+#'
+#' @return The new `corpus_stats_id`.
+#' @export
+pubtator_enrichment_persist <- function(conn, scored, corpus, refreshed_by = NULL) {
+  DBI::dbBegin(conn)
+  result <- tryCatch(
+    {
+      # Demote any previously-current snapshot, then insert the new current one.
+      db_execute_statement(
+        "UPDATE pubtator_corpus_stats SET is_current = 0 WHERE is_current = 1",
+        list(), conn = conn
+      )
+      db_execute_statement(
+        "INSERT INTO pubtator_corpus_stats
+           (ndd_corpus_size, total_corpus_size, total_is_fallback,
+            genes_scored, refreshed_by, is_current)
+         VALUES (?, ?, ?, ?, ?, 1)",
+        unname(list(
+          as.integer(corpus$ndd_corpus_size),
+          as.integer(corpus$total_corpus_size),
+          as.integer(isTRUE(corpus$total_is_fallback)),
+          as.integer(nrow(scored)),
+          if (is.null(refreshed_by)) NA_integer_ else as.integer(refreshed_by)
+        )),
+        conn = conn
+      )
+      corpus_stats_id <- db_execute_query(
+        "SELECT LAST_INSERT_ID() AS id", list(), conn = conn
+      )$id[[1]]
+
+      # Replace per-gene rows for this fresh snapshot.
+      db_execute_statement(
+        "DELETE FROM pubtator_gene_enrichment", list(), conn = conn
+      )
+      for (i in seq_len(nrow(scored))) {
+        db_execute_statement(
+          "INSERT INTO pubtator_gene_enrichment
+             (corpus_stats_id, hgnc_id, gene_symbol, observed, background_count,
+              enrichment_ratio, npmi, fisher_p, fdr_bh)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          unname(list(
+            as.integer(corpus_stats_id),
+            scored$hgnc_id[[i]],
+            scored$gene_symbol[[i]],
+            as.integer(scored$observed[[i]]),
+            .pubtator_na_int(scored$background_count[[i]]),
+            .pubtator_na_num(scored$enrichment_ratio[[i]]),
+            .pubtator_na_num(scored$npmi[[i]]),
+            .pubtator_na_num(scored$fisher_p[[i]]),
+            .pubtator_na_num(scored$fdr_bh[[i]])
+          )),
+          conn = conn
+        )
+      }
+      DBI::dbCommit(conn)
+      corpus_stats_id
+    },
+    error = function(e) {
+      tryCatch(DBI::dbRollback(conn), error = function(e2) NULL)
+      stop(e)
+    }
+  )
+  result
+}
+
+#' Durable worker entrypoint for the `pubtator_enrichment_refresh` job
+#'
+#' Checks out a connection from the global pool, runs the refresh, and shapes the
+#' job result. Kept here (not in async-job-handlers.R) so the oversized handler
+#' registry file does not grow.
+#'
+#' @param job The durable job row (provides `job_id`, `submitted_by`).
+#' @param progress_reporter_fn Factory `function(job_id) -> progress_fn`.
+#' @return Completed job result list.
+#' @export
+pubtator_enrichment_job_run <- function(job, progress_reporter_fn) {
+  progress <- progress_reporter_fn(job$job_id[[1]])
+  progress("init", "Starting PubtatorNDD enrichment refresh...", current = 0, total = 1)
+
+  if (!base::exists("pool", envir = .GlobalEnv, inherits = FALSE)) {
+    stop("PubtatorNDD enrichment refresh requires the global database pool", call. = FALSE)
+  }
+
+  db_pool <- base::get("pool", envir = .GlobalEnv, inherits = FALSE)
+  conn <- pool::poolCheckout(db_pool)
+  on.exit(pool::poolReturn(conn), add = TRUE)
+
+  refreshed_by <- NULL
+  if (!is.null(job$submitted_by) && !is.na(job$submitted_by[[1]])) {
+    refreshed_by <- job$submitted_by[[1]]
+  }
+
+  result <- pubtator_enrichment_refresh_run(
+    conn = conn,
+    progress_fn = progress,
+    refreshed_by = refreshed_by
+  )
+
+  if (!isTRUE(result$success)) {
+    stop(result$message %||% "PubtatorNDD enrichment refresh failed", call. = FALSE)
+  }
+
+  progress("complete", result$message, current = 1, total = 1)
+
+  list(
+    status = "completed",
+    success = TRUE,
+    genes_scored = result$genes_scored,
+    ndd_corpus_size = result$ndd_corpus_size,
+    total_corpus_size = result$total_corpus_size,
+    total_is_fallback = result$total_is_fallback,
+    corpus_stats_id = result$corpus_stats_id,
+    message = result$message
+  )
+}
+
+#' @noRd
+.pubtator_na_int <- function(x) {
+  if (is.null(x) || length(x) == 0 || is.na(x)) NA_integer_ else as.integer(x)
+}
+
+#' @noRd
+.pubtator_na_num <- function(x) {
+  if (is.null(x) || length(x) == 0 || is.na(x) || !is.finite(x)) {
+    NA_real_
+  } else {
+    as.numeric(x)
+  }
+}

--- a/api/functions/pubtator-enrichment-metrics.R
+++ b/api/functions/pubtator-enrichment-metrics.R
@@ -1,0 +1,281 @@
+# functions/pubtator-enrichment-metrics.R
+#
+# Pure, library-light statistical metrics that normalize PubtatorNDD gene
+# co-occurrence counts for research-popularity bias (GitHub issue #175).
+#
+# Raw co-occurrence count with NDD terms conflates true NDD relevance with how
+# heavily a gene is studied: TP53/APP/MAPT/APOE surface in the top 10 by raw
+# count despite no specific NDD role. Normalizing by the gene's TOTAL PubTator
+# publication count separates true NDD genes (0.1-0.6% NDD/Total) from
+# popularity noise (0.001-0.01%) by ~two orders of magnitude.
+#
+# Three complementary, defensible metrics are computed per gene against a fixed
+# 2x2 contingency built from corpus-level counts:
+#
+#   * Enrichment ratio (observed / expected fold-change) -- simple, intuitive
+#     ranking. Equivalent to the "fold enrichment" used in over-representation
+#     analysis: observed / (ndd_corpus_size * background_count / total_corpus).
+#   * NPMI (Normalized Pointwise Mutual Information, Bouma 2009), bounded
+#     [-1, 1] -- inherently normalizes for both gene popularity and corpus
+#     size; this is the association measure recommended by CoCoScore
+#     (Groth et al. 2020) and PMI-family text-mining (DISEASES,
+#     Pletscher-Frankild et al. 2015).
+#   * Fisher's exact test p-value (one-sided, enrichment) + Benjamini-Hochberg
+#     FDR across all genes -- statistical significance of the association.
+#
+# References:
+#   - Bouma G. (2009) Normalized (Pointwise) Mutual Information in Collocation
+#     Extraction. Proc. GSCL.
+#   - Pletscher-Frankild et al. (2015) DISEASES: Text mining and data
+#     integration of disease-gene associations. Methods 74:83-89.
+#   - Groth et al. (2020) CoCoScore: context-aware co-occurrence scoring.
+#     Bioinformatics 36(1):264-271.
+#   - Stoeger et al. (2018) Large-scale investigation of the reasons why
+#     potentially important genes are ignored. PLOS Biology.
+#
+# No DB access here; no external calls. Fully unit-testable. See
+# functions/pubtator-enrichment-collector.R for the count collection and DB I/O.
+
+#' Compute the fold enrichment ratio for a single gene-NDD co-occurrence
+#'
+#' @param observed Number of NDD-corpus publications mentioning the gene
+#'   (the curated PubtatorNDD co-occurrence count).
+#' @param background_count Total PubTator publications mentioning the gene
+#'   anywhere in the corpus (the popularity denominator).
+#' @param ndd_corpus_size Number of publications in the NDD corpus.
+#' @param total_corpus_size Number of publications in the whole PubTator corpus.
+#'
+#' @return Numeric fold enrichment (observed / expected). `NA_real_` when inputs
+#'   are missing or any denominator is zero. A value > 1 means the gene
+#'   co-occurs with NDD more than its overall publication volume predicts.
+#' @export
+pubtator_enrichment_ratio <- function(observed,
+                                      background_count,
+                                      ndd_corpus_size,
+                                      total_corpus_size) {
+  if (.pubtator_metric_invalid(observed, background_count,
+                               ndd_corpus_size, total_corpus_size)) {
+    return(NA_real_)
+  }
+  if (background_count <= 0 || total_corpus_size <= 0) {
+    return(NA_real_)
+  }
+
+  # expected = how many of the gene's publications would land in the NDD corpus
+  # if NDD-membership were independent of this gene.
+  expected <- ndd_corpus_size * (background_count / total_corpus_size)
+  if (expected <= 0) {
+    return(NA_real_)
+  }
+
+  observed / expected
+}
+
+#' Compute Normalized Pointwise Mutual Information (NPMI) for one gene-NDD pair
+#'
+#' NPMI(x, y) = PMI(x, y) / -log p(x, y), bounded to [-1, 1]:
+#'   +1  the gene and NDD always co-occur (p(x,y) == p(x) == p(y))
+#'    0  independence (observed == expected)
+#'   -1  the gene and NDD never co-occur (observed == 0)
+#'
+#' Here x = "publication mentions the gene", y = "publication is in the NDD
+#' corpus", and the sample space is the whole PubTator corpus, so:
+#'   p(x)   = background_count / total_corpus_size
+#'   p(y)   = ndd_corpus_size  / total_corpus_size
+#'   p(x,y) = observed         / total_corpus_size
+#'
+#' @inheritParams pubtator_enrichment_ratio
+#'
+#' @return Numeric NPMI in [-1, 1], or `NA_real_` for invalid inputs. Returns
+#'   exactly -1 when `observed == 0` (the never-co-occur limit).
+#' @export
+pubtator_npmi <- function(observed,
+                          background_count,
+                          ndd_corpus_size,
+                          total_corpus_size) {
+  if (.pubtator_metric_invalid(observed, background_count,
+                               ndd_corpus_size, total_corpus_size)) {
+    return(NA_real_)
+  }
+  if (total_corpus_size <= 0 || background_count <= 0 || ndd_corpus_size <= 0) {
+    return(NA_real_)
+  }
+
+  # Never co-occur: PMI -> -Inf, NPMI -> -1 (the defined limit).
+  if (observed <= 0) {
+    return(-1)
+  }
+
+  p_xy <- observed / total_corpus_size
+  p_x <- background_count / total_corpus_size
+  p_y <- ndd_corpus_size / total_corpus_size
+
+  # Always co-occur: p(x,y) == p(x) == p(y); -log p(x,y) == 0 -> NPMI = +1.
+  if (isTRUE(all.equal(p_xy, 1))) {
+    return(1)
+  }
+
+  pmi <- log(p_xy / (p_x * p_y))
+  denom <- -log(p_xy)
+  if (denom <= 0) {
+    # p(x,y) == 1 handled above; any residual zero denominator -> perfect assoc.
+    return(1)
+  }
+
+  npmi <- pmi / denom
+  # Guard against floating point spilling slightly outside the bound.
+  max(-1, min(1, npmi))
+}
+
+#' Build the 2x2 contingency table for a gene-NDD Fisher test
+#'
+#' Cells follow the standard over-representation layout:
+#'   a = gene & NDD            = observed
+#'   b = gene & not-NDD        = background_count - observed
+#'   c = not-gene & NDD        = ndd_corpus_size - observed
+#'   d = not-gene & not-NDD    = total - background_count - ndd_corpus_size + observed
+#'
+#' @inheritParams pubtator_enrichment_ratio
+#'
+#' @return A 2x2 integer matrix, or `NULL` if inputs are invalid / inconsistent
+#'   (e.g. observed exceeds a marginal, negative cells).
+#' @export
+pubtator_contingency_table <- function(observed,
+                                       background_count,
+                                       ndd_corpus_size,
+                                       total_corpus_size) {
+  if (.pubtator_metric_invalid(observed, background_count,
+                               ndd_corpus_size, total_corpus_size)) {
+    return(NULL)
+  }
+
+  a <- observed
+  b <- background_count - observed
+  c <- ndd_corpus_size - observed
+  d <- total_corpus_size - background_count - ndd_corpus_size + observed
+
+  if (a < 0 || b < 0 || c < 0 || d < 0) {
+    return(NULL)
+  }
+
+  matrix(
+    c(a, c, b, d),
+    nrow = 2,
+    byrow = FALSE,
+    dimnames = list(
+      c("ndd", "not_ndd"),
+      c("gene", "not_gene")
+    )
+  )
+}
+
+#' One-sided (enrichment) Fisher's exact test p-value for a gene-NDD pair
+#'
+#' @inheritParams pubtator_enrichment_ratio
+#'
+#' @return Numeric p-value in (0, 1], or `NA_real_` if the contingency table
+#'   cannot be built. Uses `stats::fisher.test(alternative = "greater")` so the
+#'   test asks specifically whether the gene is *enriched* in the NDD corpus.
+#' @export
+pubtator_fisher_pvalue <- function(observed,
+                                   background_count,
+                                   ndd_corpus_size,
+                                   total_corpus_size) {
+  tbl <- pubtator_contingency_table(
+    observed, background_count, ndd_corpus_size, total_corpus_size
+  )
+  if (is.null(tbl)) {
+    return(NA_real_)
+  }
+
+  result <- tryCatch(
+    stats::fisher.test(tbl, alternative = "greater"),
+    error = function(e) NULL
+  )
+  if (is.null(result)) {
+    return(NA_real_)
+  }
+  result$p.value
+}
+
+#' Benjamini-Hochberg FDR correction across a vector of p-values
+#'
+#' Thin wrapper over `stats::p.adjust(method = "BH")` that tolerates `NA`
+#' p-values (genes whose contingency table could not be built) by leaving them
+#' `NA` in the output while correcting only the finite p-values.
+#'
+#' @param p_values Numeric vector of raw p-values (may contain `NA`).
+#'
+#' @return Numeric vector of BH-adjusted q-values, same length/order as input.
+#' @export
+pubtator_bh_fdr <- function(p_values) {
+  out <- rep(NA_real_, length(p_values))
+  finite_idx <- which(!is.na(p_values))
+  if (length(finite_idx) == 0) {
+    return(out)
+  }
+  out[finite_idx] <- stats::p.adjust(p_values[finite_idx], method = "BH")
+  out
+}
+
+#' Compute all enrichment metrics for a data frame of gene counts
+#'
+#' Vectorized convenience used by the collector/worker. Adds `enrichment_ratio`,
+#' `npmi`, `fisher_p`, and `fdr_bh` columns. BH-FDR is computed across the whole
+#' input set, so pass *all* genes from one corpus snapshot together.
+#'
+#' @param gene_counts A data frame with `observed` and `background_count`
+#'   columns (one row per gene).
+#' @param ndd_corpus_size Scalar NDD corpus size.
+#' @param total_corpus_size Scalar total corpus size.
+#'
+#' @return The input data frame with the four metric columns appended.
+#' @export
+pubtator_compute_gene_metrics <- function(gene_counts,
+                                          ndd_corpus_size,
+                                          total_corpus_size) {
+  stopifnot(is.data.frame(gene_counts))
+  if (!all(c("observed", "background_count") %in% names(gene_counts))) {
+    stop("gene_counts must contain 'observed' and 'background_count' columns")
+  }
+
+  n <- nrow(gene_counts)
+  enrichment_ratio <- numeric(n)
+  npmi <- numeric(n)
+  fisher_p <- numeric(n)
+
+  for (i in seq_len(n)) {
+    obs <- gene_counts$observed[[i]]
+    bg <- gene_counts$background_count[[i]]
+    enrichment_ratio[[i]] <- pubtator_enrichment_ratio(
+      obs, bg, ndd_corpus_size, total_corpus_size
+    )
+    npmi[[i]] <- pubtator_npmi(
+      obs, bg, ndd_corpus_size, total_corpus_size
+    )
+    fisher_p[[i]] <- pubtator_fisher_pvalue(
+      obs, bg, ndd_corpus_size, total_corpus_size
+    )
+  }
+
+  gene_counts$enrichment_ratio <- enrichment_ratio
+  gene_counts$npmi <- npmi
+  gene_counts$fisher_p <- fisher_p
+  gene_counts$fdr_bh <- pubtator_bh_fdr(fisher_p)
+  gene_counts
+}
+
+#' Internal: validate the four scalar metric inputs
+#' @noRd
+.pubtator_metric_invalid <- function(observed,
+                                     background_count,
+                                     ndd_corpus_size,
+                                     total_corpus_size) {
+  vals <- list(observed, background_count, ndd_corpus_size, total_corpus_size)
+  for (v in vals) {
+    if (is.null(v) || length(v) != 1L || is.na(v) || !is.finite(v)) {
+      return(TRUE)
+    }
+  }
+  FALSE
+}

--- a/api/tests/testthat/test-unit-analysis-snapshot-migration.R
+++ b/api/tests/testthat/test-unit-analysis-snapshot-migration.R
@@ -5,8 +5,8 @@ withr::defer(setwd(analysis_snapshot_test_wd), testthat::teardown_env())
 test_that("migration manifest tracks the latest migration", {
   source(file.path("functions", "migration-manifest.R"), local = TRUE)
 
-  expect_equal(EXPECTED_LATEST_MIGRATION, "026_add_entity_last_update.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 27L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "027_add_pubtator_gene_enrichment.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 28L)
 })
 
 test_that("public analysis snapshot migration enforces scoped public-ready uniqueness", {

--- a/api/tests/testthat/test-unit-core-views-manifest.R
+++ b/api/tests/testthat/test-unit-core-views-manifest.R
@@ -9,16 +9,16 @@
 source_api_file("functions/migration-manifest.R", local = FALSE)
 source_api_file("functions/migration-runner.R", local = FALSE)
 
-test_that("manifest expects migration 026 as latest", {
-  expect_equal(EXPECTED_LATEST_MIGRATION, "026_add_entity_last_update.sql")
-  expect_gte(EXPECTED_MIGRATION_COUNT, 27L)
+test_that("manifest expects migration 027 as latest", {
+  expect_equal(EXPECTED_LATEST_MIGRATION, "027_add_pubtator_gene_enrichment.sql")
+  expect_gte(EXPECTED_MIGRATION_COUNT, 28L)
 })
 
 test_that("migration manifest validates against db/migrations", {
   migrations_dir <- file.path(get_api_dir(), "..", "db", "migrations")
   res <- validate_migration_manifest(migrations_dir = migrations_dir)
   expect_true(res$ok)
-  expect_identical(res$latest, "026_add_entity_last_update.sql")
+  expect_identical(res$latest, "027_add_pubtator_gene_enrichment.sql")
 })
 
 test_that("migration 026 adds a last_update column derived from curation dates", {

--- a/api/tests/testthat/test-unit-migration-runner.R
+++ b/api/tests/testthat/test-unit-migration-runner.R
@@ -243,8 +243,8 @@ describe("validate_migration_manifest", {
     migrations_dir <- file.path(api_dir, "..", "db", "migrations")
     result <- validate_migration_manifest(migrations_dir)
     expect_true(result$ok)
-    expect_equal(result$expected_latest, "026_add_entity_last_update.sql")
-    expect_true(result$count >= 27L)
+    expect_equal(result$expected_latest, "027_add_pubtator_gene_enrichment.sql")
+    expect_true(result$count >= 28L)
   })
 })
 

--- a/api/tests/testthat/test-unit-pubtator-enrichment.R
+++ b/api/tests/testthat/test-unit-pubtator-enrichment.R
@@ -1,0 +1,264 @@
+# test-unit-pubtator-enrichment.R
+#
+# Behavior tests for the PubtatorNDD enrichment normalization (issue #175):
+#   * pure metric math (enrichment ratio, NPMI, Fisher + BH-FDR) including the
+#     zero-count / edge cases, anchored to the worked example in the issue
+#     (GRIN2B vs TP53 must separate by ~two orders of magnitude);
+#   * the collection logic with the external PubTator fetcher mocked (stub the
+#     direct helper, never hit the network).
+
+library(testthat)
+
+source_api_file("functions/pubtator-enrichment-metrics.R", local = FALSE)
+
+# Worked example from issue #175 (NDD corpus 13,459; whole-corpus probe).
+# observed = NDD-corpus pubs mentioning the gene; bg = total pubs for the gene.
+NDD_CORPUS <- 13459L
+TOTAL_CORPUS <- 37000000L
+
+# --- enrichment ratio ---------------------------------------------------------
+
+test_that("enrichment ratio is observed / expected", {
+  # GRIN2B: 86 NDD pubs of 13,459 total NDD pubs; 13,459 total gene pubs.
+  # expected = NDD_CORPUS * bg / TOTAL = 13459 * 13459 / 37e6 ~= 4.896
+  # ratio = 86 / 4.896 ~= 17.6 (strongly enriched).
+  ratio <- pubtator_enrichment_ratio(86, 13459, NDD_CORPUS, TOTAL_CORPUS)
+  expect_gt(ratio, 10)
+})
+
+test_that("enrichment ratio separates true NDD gene from popularity noise", {
+  grin2b <- pubtator_enrichment_ratio(86, 13459, NDD_CORPUS, TOTAL_CORPUS)
+  tp53 <- pubtator_enrichment_ratio(8, 282103, NDD_CORPUS, TOTAL_CORPUS)
+  # GRIN2B is a true NDD gene, TP53 popularity noise: GRIN2B must rank far above.
+  expect_gt(grin2b, tp53)
+  expect_gt(grin2b / tp53, 100) # ~two orders of magnitude
+})
+
+test_that("enrichment ratio returns NA on zero/invalid denominators", {
+  expect_true(is.na(pubtator_enrichment_ratio(5, 0, NDD_CORPUS, TOTAL_CORPUS)))
+  expect_true(is.na(pubtator_enrichment_ratio(5, 100, NDD_CORPUS, 0)))
+  expect_true(is.na(pubtator_enrichment_ratio(NA, 100, NDD_CORPUS, TOTAL_CORPUS)))
+})
+
+# --- NPMI ---------------------------------------------------------------------
+
+test_that("NPMI is bounded in [-1, 1]", {
+  grin2b <- pubtator_npmi(86, 13459, NDD_CORPUS, TOTAL_CORPUS)
+  expect_gte(grin2b, -1)
+  expect_lte(grin2b, 1)
+})
+
+test_that("NPMI returns -1 when gene and NDD never co-occur (observed == 0)", {
+  expect_equal(pubtator_npmi(0, 13459, NDD_CORPUS, TOTAL_CORPUS), -1)
+})
+
+test_that("NPMI returns +1 when gene and NDD always co-occur", {
+  # gene appears only in the NDD corpus and covers the whole NDD corpus:
+  # observed == bg == ndd_corpus_size -> perfect association.
+  expect_equal(pubtator_npmi(100, 100, 100, TOTAL_CORPUS), 1)
+})
+
+test_that("NPMI is ~0 at independence (observed == expected)", {
+  # Construct a gene whose observed equals its expected count.
+  bg <- 100000
+  expected <- NDD_CORPUS * bg / TOTAL_CORPUS
+  npmi <- pubtator_npmi(round(expected), bg, NDD_CORPUS, TOTAL_CORPUS)
+  expect_lt(abs(npmi), 0.05)
+})
+
+test_that("NPMI ranks true NDD gene above popularity noise", {
+  grin2b <- pubtator_npmi(86, 13459, NDD_CORPUS, TOTAL_CORPUS)
+  tp53 <- pubtator_npmi(8, 282103, NDD_CORPUS, TOTAL_CORPUS)
+  expect_gt(grin2b, tp53)
+  # The popularity-biased gene should land near/below independence.
+  expect_lt(tp53, grin2b - 0.1)
+})
+
+# --- Fisher contingency + p-value --------------------------------------------
+
+test_that("contingency table cells are non-negative and consistent", {
+  tbl <- pubtator_contingency_table(86, 13459, NDD_CORPUS, TOTAL_CORPUS)
+  expect_false(is.null(tbl))
+  expect_true(all(tbl >= 0))
+  expect_equal(sum(tbl), TOTAL_CORPUS)
+})
+
+test_that("contingency table is NULL when observed exceeds a marginal", {
+  expect_null(pubtator_contingency_table(20, 10, NDD_CORPUS, TOTAL_CORPUS))
+})
+
+test_that("Fisher p-value is smaller for the enriched true NDD gene", {
+  p_grin2b <- pubtator_fisher_pvalue(86, 13459, NDD_CORPUS, TOTAL_CORPUS)
+  p_tp53 <- pubtator_fisher_pvalue(8, 282103, NDD_CORPUS, TOTAL_CORPUS)
+  expect_gte(p_grin2b, 0)
+  expect_lte(p_grin2b, 1)
+  expect_lt(p_grin2b, p_tp53)
+})
+
+# --- BH-FDR -------------------------------------------------------------------
+
+test_that("BH-FDR preserves ordering and tolerates NA", {
+  p <- c(0.001, 0.01, NA, 0.5)
+  q <- pubtator_bh_fdr(p)
+  expect_equal(length(q), 4)
+  expect_true(is.na(q[3]))
+  # monotone non-decreasing in the original p-order for the finite entries
+  finite <- q[!is.na(q)]
+  expect_true(all(diff(finite) >= -1e-9))
+  # adjusted q-values are >= raw p-values
+  expect_true(all(finite >= c(0.001, 0.01, 0.5) - 1e-9))
+})
+
+# --- vectorized compute -------------------------------------------------------
+
+test_that("pubtator_compute_gene_metrics ranks the issue worked example correctly", {
+  genes <- data.frame(
+    gene_symbol = c("GRIN2B", "SCN1A", "MECP2", "TP53", "APP", "ALB"),
+    observed = c(86L, 20L, 16L, 8L, 8L, 3L),
+    background_count = c(13459L, 5238L, 10677L, 282103L, 124598L, 269569L),
+    stringsAsFactors = FALSE
+  )
+  scored <- pubtator_compute_gene_metrics(genes, NDD_CORPUS, TOTAL_CORPUS)
+
+  expect_true(all(c("enrichment_ratio", "npmi", "fisher_p", "fdr_bh") %in% names(scored)))
+
+  # True NDD genes by enrichment ratio must outrank popularity noise.
+  by_enrichment <- scored$gene_symbol[order(-scored$enrichment_ratio)]
+  true_ndd <- c("GRIN2B", "SCN1A", "MECP2")
+  noise <- c("TP53", "APP", "ALB")
+  expect_true(all(match(true_ndd, by_enrichment) < min(match(noise, by_enrichment))))
+
+  # Same separation holds under NPMI ranking.
+  by_npmi <- scored$gene_symbol[order(-scored$npmi)]
+  expect_true(all(match(true_ndd, by_npmi) < min(match(noise, by_npmi))))
+})
+
+# --- collection logic (mocked fetcher) ---------------------------------------
+
+source_api_file("functions/pubtator-enrichment-collector.R", local = FALSE)
+
+# Deterministic stub of the direct external fetcher: returns canned counts.
+make_stub_fetch <- function(counts) {
+  function(query, ...) {
+    if (identical(query, PUBTATOR_NDD_CORPUS_QUERY)) {
+      return(list(error = FALSE, query = query, count = NDD_CORPUS))
+    }
+    if (identical(query, "*")) {
+      return(list(error = FALSE, query = query, count = TOTAL_CORPUS))
+    }
+    sym <- sub("^@GENE_", "", query)
+    if (!is.null(counts[[sym]])) {
+      return(list(error = FALSE, query = query, count = counts[[sym]]))
+    }
+    # Unknown gene -> simulate a transient upstream error (must not poison cache).
+    list(error = TRUE, query = query, status = 503L, message = "stub error")
+  }
+}
+
+test_that("corpus size collection reads the stubbed NDD and total counts", {
+  stub <- make_stub_fetch(list())
+  corpus <- pubtator_collect_corpus_sizes(fetch_fn = stub)
+  expect_equal(corpus$ndd_corpus_size, NDD_CORPUS)
+  expect_equal(corpus$total_corpus_size, TOTAL_CORPUS)
+  expect_false(corpus$total_is_fallback)
+})
+
+test_that("total corpus falls back when the all-corpus probe errors", {
+  stub <- function(query, ...) {
+    if (identical(query, PUBTATOR_NDD_CORPUS_QUERY)) {
+      return(list(error = FALSE, query = query, count = NDD_CORPUS))
+    }
+    list(error = TRUE, query = query, status = 503L, message = "boom")
+  }
+  corpus <- pubtator_collect_corpus_sizes(fetch_fn = stub)
+  expect_true(corpus$total_is_fallback)
+  expect_equal(corpus$total_corpus_size, PUBTATOR_FALLBACK_TOTAL_CORPUS)
+})
+
+test_that("background count collection skips genes whose fetch failed", {
+  stub <- make_stub_fetch(list(GRIN2B = 13459L, TP53 = 282103L))
+  df <- pubtator_collect_background_counts(
+    c("GRIN2B", "TP53", "UNKNOWNGENE"),
+    fetch_fn = stub
+  )
+  expect_equal(nrow(df), 3)
+  expect_equal(df$background_count[df$gene_symbol == "GRIN2B"], 13459L)
+  expect_equal(df$background_count[df$gene_symbol == "TP53"], 282103L)
+  expect_true(is.na(df$background_count[df$gene_symbol == "UNKNOWNGENE"]))
+})
+
+test_that("fetch helper treats a missing count field as a cacheable zero", {
+  # A valid 'no results' answer should NOT be flagged as an error result.
+  local_mocked_bindings <- NULL
+  res <- pubtator_fetch_total_count("")
+  expect_true(res$error) # empty query is an input error
+})
+
+# --- endpoint helpers (mocked DB / submit) -----------------------------------
+
+source_api_file("functions/publication-endpoint-helpers.R", local = FALSE)
+
+test_that("enrichment status response reports 'available = FALSE' on no snapshot", {
+  fake_query <- function(sql, ...) data.frame()
+  res <- pubtator_enrichment_status_response(query_fn = fake_query)
+  expect_false(res$available)
+  expect_match(res$message, "No enrichment snapshot")
+})
+
+test_that("enrichment status response summarizes the current snapshot", {
+  fake_query <- function(sql, ...) {
+    data.frame(
+      corpus_stats_id = 7L,
+      ndd_corpus_size = 13459L,
+      total_corpus_size = 37000000,
+      total_is_fallback = 0L,
+      genes_scored = 1234L,
+      created_at = "2026-06-11 10:00:00",
+      stringsAsFactors = FALSE
+    )
+  }
+  res <- pubtator_enrichment_status_response(query_fn = fake_query)
+  expect_true(res$available)
+  expect_equal(res$corpus_stats_id, 7L)
+  expect_equal(res$ndd_corpus_size, 13459L)
+  expect_false(res$total_is_fallback)
+  expect_equal(res$genes_scored, 1234L)
+})
+
+test_that("enrichment refresh submit returns 202 and shapes the job response", {
+  # Plumber response uses res$status <- ...; emulate with an environment.
+  res_env <- new.env()
+  res_env$status <- NULL
+  res_env$setHeader <- function(name, value) invisible(NULL)
+
+  fake_submit <- function(job_type, request_payload, submitted_by = NULL) {
+    expect_equal(job_type, "pubtator_enrichment_refresh")
+    list(
+      job = data.frame(job_id = "abc-123", status = "queued", stringsAsFactors = FALSE),
+      duplicate = FALSE
+    )
+  }
+
+  out <- pubtator_enrichment_refresh_submit(res_env, submitted_by = 5L, submit_fn = fake_submit)
+  expect_equal(res_env$status, 202L)
+  expect_equal(out$job_id, "abc-123")
+  expect_equal(out$status, "accepted")
+  expect_match(out$status_url, "/api/jobs/abc-123/status")
+})
+
+test_that("enrichment refresh submit returns 409 on a duplicate running job", {
+  res_env <- new.env()
+  res_env$status <- NULL
+  res_env$setHeader <- function(name, value) invisible(NULL)
+
+  fake_submit <- function(job_type, request_payload, submitted_by = NULL) {
+    list(
+      job = data.frame(job_id = "dup-1", status = "running", stringsAsFactors = FALSE),
+      duplicate = TRUE
+    )
+  }
+
+  out <- pubtator_enrichment_refresh_submit(res_env, submit_fn = fake_submit)
+  expect_equal(res_env$status, 409L)
+  expect_equal(out$status, "already_running")
+})

--- a/app/src/api/publication.ts
+++ b/app/src/api/publication.ts
@@ -126,12 +126,58 @@ export interface PubtatorGenesParams {
   format?: PubtatorGenesFormat;
 }
 
-export type PubtatorGeneRow = Record<string, unknown>;
+/**
+ * One row of the gene-prioritization listing. Beyond the legacy raw-count
+ * fields, issue #175 adds normalized enrichment metrics computed by the
+ * `pubtator_enrichment_refresh` worker job. These are `null` until the first
+ * refresh runs (LEFT JOIN on the server).
+ */
+export interface PubtatorGeneRow extends Record<string, unknown> {
+  gene_symbol?: string;
+  gene_name?: string;
+  gene_normalized_id?: string;
+  hgnc_id?: string;
+  publication_count?: number;
+  entities_count?: number;
+  is_novel?: 0 | 1;
+  oldest_pub_date?: string;
+  pmids?: string;
+  /** NDD-corpus publications mentioning the gene (the co-occurrence count). */
+  observed?: number | null;
+  /** Total PubTator publications mentioning the gene (popularity denominator). */
+  background_count?: number | null;
+  /** observed / expected fold change; > 1 means NDD-enriched. */
+  enrichment_ratio?: number | null;
+  /** Normalized pointwise mutual information, range [-1, 1]. */
+  npmi?: number | null;
+  /** One-sided (enrichment) Fisher exact p-value. */
+  fisher_p?: number | null;
+  /** Benjamini-Hochberg adjusted q-value across all genes. */
+  fdr_bh?: number | null;
+}
 
 export interface PubtatorGenesResponse {
   links?: unknown;
   meta?: unknown;
   data: PubtatorGeneRow[];
+}
+
+export interface PubtatorEnrichmentRefreshResponse {
+  job_id: string;
+  status: string;
+  job_status?: string;
+  status_url: string;
+}
+
+export interface PubtatorEnrichmentStatus {
+  available: boolean;
+  message?: string;
+  corpus_stats_id?: number;
+  ndd_corpus_size?: number;
+  total_corpus_size?: number;
+  total_is_fallback?: boolean;
+  genes_scored?: number;
+  refreshed_at?: string;
 }
 
 export interface PubtatorBackfillResponse {
@@ -435,6 +481,40 @@ export async function clearPubtatorCache(
   return apiClient.post<PubtatorClearCacheResponse>(
     '/api/publication/pubtator/clear-cache',
     undefined,
+    config
+  );
+}
+
+/**
+ * POST /api/publication/pubtator/enrichment/refresh
+ * Mirrors api/endpoints/publication_endpoints.R (handler `@post /pubtator/enrichment/refresh`).
+ *
+ * Admin: submits the durable `pubtator_enrichment_refresh` worker job that
+ * normalizes raw NDD co-occurrence counts for research-popularity bias
+ * (issue #175). Returns 202 with the job_id; poll the status_url.
+ */
+export async function refreshPubtatorEnrichment(
+  config?: AxiosRequestConfig
+): Promise<PubtatorEnrichmentRefreshResponse> {
+  return apiClient.post<PubtatorEnrichmentRefreshResponse>(
+    '/api/publication/pubtator/enrichment/refresh',
+    undefined,
+    config
+  );
+}
+
+/**
+ * GET /api/publication/pubtator/enrichment/status
+ * Mirrors api/endpoints/publication_endpoints.R (handler `@get /pubtator/enrichment/status`).
+ *
+ * Public read: the current enrichment snapshot summary (corpus sizes, genes
+ * scored, when it was computed).
+ */
+export async function getPubtatorEnrichmentStatus(
+  config?: AxiosRequestConfig
+): Promise<PubtatorEnrichmentStatus> {
+  return apiClient.get<PubtatorEnrichmentStatus>(
+    '/api/publication/pubtator/enrichment/status',
     config
   );
 }

--- a/app/src/components/analyses/PubtatorNDDGenes.spec.ts
+++ b/app/src/components/analyses/PubtatorNDDGenes.spec.ts
@@ -104,7 +104,7 @@ async function mountSubject(props = {}) {
           props: ['items'],
           emits: ['update:sort-by'],
           template:
-            '<table><tbody><template v-for="item in items" :key="item.gene_symbol"><tr><td>{{ item.gene_symbol }}</td><td>{{ item.gene_name }}</td><td>{{ item.publication_count }}</td><td>{{ item.oldest_pub_date }}</td><td>{{ item.is_novel === 1 ? "Literature Only" : "Curated" }}</td><td>{{ item.pmids }}</td><td><slot name="cell(actions)" :item="item" :expansion-showing="false" :toggle-expansion="() => {}" /></td></tr><tr><td colspan="7"><slot name="row-expansion" :item="item" /></td></tr></template></tbody></table>',
+            '<table><tbody><template v-for="item in items" :key="item.gene_symbol"><tr><td>{{ item.gene_symbol }}</td><td>{{ item.gene_name }}</td><td>{{ item.publication_count }}</td><td><slot name="cell(background_count)" :item="item" /></td><td><slot name="cell(enrichment_ratio)" :item="item" /></td><td><slot name="cell(fdr_bh)" :item="item" /></td><td>{{ item.oldest_pub_date }}</td><td>{{ item.is_novel === 1 ? "Literature Only" : "Curated" }}</td><td>{{ item.pmids }}</td><td><slot name="cell(actions)" :item="item" :expansion-showing="false" :toggle-expansion="() => {}" /></td></tr><tr><td colspan="10"><slot name="row-expansion" :item="item" /></td></tr></template></tbody></table>',
         },
       },
     },
@@ -158,9 +158,59 @@ describe('PubtatorNDDGenes', () => {
     expect(wrapper.text()).toContain('MECP2');
     expect(wrapper.text()).toContain('Literature Only');
     expect(wrapper.emitted('novel-count')?.at(-1)).toEqual([1]);
-    expect((observed as URLSearchParams).get('sort')).toBe('-is_novel,oldest_pub_date');
+    // issue #175: default ranking is enrichment-based, not raw count.
+    expect((observed as URLSearchParams).get('sort')).toBe(
+      '-enrichment_ratio,-npmi,publication_count'
+    );
     expect((observed as URLSearchParams).get('page_size')).toBe('10');
     expect((observed as URLSearchParams).get('format')).toBe('json');
+  });
+
+  it('renders normalized enrichment metrics and separates true NDD genes from noise', async () => {
+    server.use(
+      http.get('/api/publication/pubtator/genes', () =>
+        HttpResponse.json({
+          meta: [{ totalItems: 2, totalPages: 1, currentPage: 1, currentItemID: 0, fspec: [] }],
+          data: [
+            {
+              gene_symbol: 'GRIN2B',
+              gene_name: 'glutamate receptor',
+              publication_count: 86,
+              background_count: 13459,
+              enrichment_ratio: 17.6,
+              npmi: 0.32,
+              fisher_p: 1e-40,
+              fdr_bh: 1e-38,
+              is_novel: 0,
+              pmids: '1,2',
+            },
+            {
+              gene_symbol: 'TP53',
+              gene_name: 'tumor protein p53',
+              publication_count: 8,
+              background_count: 282103,
+              enrichment_ratio: 0.08,
+              npmi: -0.2,
+              fisher_p: 0.9,
+              fdr_bh: 0.95,
+              is_novel: 1,
+              pmids: '3',
+            },
+          ],
+        })
+      )
+    );
+
+    const wrapper = await mountSubject();
+    const text = wrapper.text();
+    // Background count is compacted (e.g. 13459 -> "13.5k", 282103 -> "282.1k").
+    expect(text).toContain('13.5k');
+    expect(text).toContain('282.1k');
+    // Enrichment ratio rendered with the multiplication marker.
+    expect(text).toContain('18×'); // 17.6 rounds to 18 for display
+    // FDR significance: GRIN2B significant (stars), TP53 not significant (ns).
+    expect(text).toContain('***');
+    expect(text).toContain('ns');
   });
 
   it('loads expanded publication details through the PubTator table endpoint', async () => {
@@ -241,18 +291,23 @@ describe('PubtatorNDDGenes', () => {
 
     expect(exportToExcelSpy).toHaveBeenCalledWith(
       [
-        {
+        expect.objectContaining({
           gene_symbol: 'MECP2',
           gene_name: 'methyl CpG binding protein 2',
           publication_count: 2,
           oldest_pub_date: '2001-01-01',
           source: 'Literature Only',
           pmids: '123,456',
-        },
+        }),
       ],
       expect.objectContaining({
         sheetName: 'Gene Prioritization',
-        headers: expect.objectContaining({ gene_symbol: 'Gene Symbol', pmids: 'PMIDs' }),
+        headers: expect.objectContaining({
+          gene_symbol: 'Gene Symbol',
+          pmids: 'PMIDs',
+          enrichment_ratio: 'Enrichment Ratio',
+          fdr_bh: 'FDR (BH q-value)',
+        }),
       })
     );
     expect(makeToastSpy).toHaveBeenCalledWith('Excel file downloaded', 'Success', 'success');

--- a/app/src/components/analyses/PubtatorNDDGenes.vue
+++ b/app/src/components/analyses/PubtatorNDDGenes.vue
@@ -21,10 +21,21 @@
           </p>
           <p><strong>Prioritization criteria:</strong></p>
           <ul class="mb-2">
-            <li><em>Literature first:</em> Uncurated genes surface at the top</li>
-            <li><em>Oldest publication:</em> Long-overlooked genes prioritized</li>
-            <li><em>Publication count:</em> More mentions = more evidence</li>
+            <li>
+              <em>Enrichment (default):</em> NDD co-mentions normalized by the gene's total
+              publication count, so popularity bias (e.g. heavily-studied genes) does not
+              dominate the raw count.
+            </li>
+            <li>
+              <em>FDR significance:</em> Benjamini-Hochberg adjusted Fisher exact test
+              (* q&lt;0.05, ** q&lt;0.01, *** q&lt;0.001).
+            </li>
+            <li><em>NDD Pubs:</em> Raw co-occurrence count (still sortable).</li>
           </ul>
+          <p class="small text-muted mb-0">
+            Background (total) publication counts and enrichment metrics are refreshed
+            periodically; genes show “—” until the first refresh.
+          </p>
         </BPopover>
         <BButton
           variant="outline-success"
@@ -175,6 +186,42 @@
             <i class="bi bi-check-circle me-1" />
             Curated
           </BBadge>
+        </template>
+
+        <!-- Background (total) publication count -->
+        <template #cell(background_count)="data">
+          <span v-if="(data.item as GeneItem).background_count != null">
+            {{ formatCount((data.item as GeneItem).background_count) }}
+          </span>
+          <span v-else class="text-muted">—</span>
+        </template>
+
+        <!-- Enrichment ratio - color-coded, never color-alone (label + tooltip) -->
+        <template #cell(enrichment_ratio)="data">
+          <BBadge
+            v-if="(data.item as GeneItem).enrichment_ratio != null"
+            v-b-tooltip.hover.top
+            :variant="enrichmentVariant((data.item as GeneItem).enrichment_ratio)"
+            :title="enrichmentTooltip(data.item as GeneItem)"
+            pill
+          >
+            {{ formatEnrichment((data.item as GeneItem).enrichment_ratio) }}×
+          </BBadge>
+          <span v-else class="text-muted">—</span>
+        </template>
+
+        <!-- FDR significance: stars + label, paired with tooltip (not color-alone) -->
+        <template #cell(fdr_bh)="data">
+          <span
+            v-if="(data.item as GeneItem).fdr_bh != null"
+            v-b-tooltip.hover.top
+            :title="fdrTooltip((data.item as GeneItem).fdr_bh)"
+          >
+            <span :class="fdrClass((data.item as GeneItem).fdr_bh)">
+              {{ fdrStars((data.item as GeneItem).fdr_bh) || 'ns' }}
+            </span>
+          </span>
+          <span v-else class="text-muted">—</span>
         </template>
 
         <!-- PMIDs as clickable chips -->
@@ -370,6 +417,17 @@ import {
   createDefaultPubtatorGeneFilter,
   type PubtatorGeneFilter,
 } from './pubtatorGeneFilters';
+import {
+  formatCount,
+  formatEnrichment,
+  enrichmentVariant,
+  enrichmentTooltip,
+  fdrStars,
+  fdrClass,
+  fdrTooltip,
+  createPubtatorGeneFields,
+  type PubtatorGeneFieldDefinition as FieldDefinition,
+} from './pubtatorEnrichmentDisplay';
 
 import { useUiStore } from '@/stores/ui';
 import { useRoute } from 'vue-router';
@@ -384,6 +442,13 @@ interface GeneItem {
   oldest_pub_date?: string;
   is_novel: number;
   pmids?: string;
+  // Normalized enrichment metrics (issue #175); null until first refresh.
+  observed?: number | null;
+  background_count?: number | null;
+  enrichment_ratio?: number | null;
+  npmi?: number | null;
+  fisher_p?: number | null;
+  fdr_bh?: number | null;
 }
 
 interface PublicationData {
@@ -396,17 +461,6 @@ interface PublicationData {
   score?: number;
   gene_symbols?: string;
   text_hl?: string;
-}
-
-interface FieldDefinition {
-  key: string;
-  label: string;
-  sortable?: boolean;
-  sortDirection?: string;
-  class?: string;
-  filterable?: boolean;
-  count?: number;
-  count_filtered?: number;
 }
 
 // Props
@@ -426,13 +480,14 @@ const props = withDefaults(
     showFilterControls: true,
     showPaginationControls: true,
     headerLabel: 'Pubtator Genes table',
-    sortInput: '-is_novel,oldest_pub_date',
+    // Default rank by enrichment (issue #175): normalize for popularity bias.
+    sortInput: '-enrichment_ratio,-npmi,publication_count',
     filterInput: null,
     fieldsInput: null,
     pageAfterInput: '',
     pageSizeInput: 10,
     fspecInput:
-      'gene_name,gene_symbol,gene_normalized_id,hgnc_id,publication_count,oldest_pub_date,is_novel,pmids',
+      'gene_name,gene_symbol,gene_normalized_id,hgnc_id,publication_count,background_count,enrichment_ratio,npmi,fdr_bh,oldest_pub_date,is_novel,pmids',
   }
 );
 
@@ -474,58 +529,8 @@ const {
   removeFiltersButtonVariant,
 } = tableData;
 
-// Table fields definition
-const fields = ref<FieldDefinition[]>([
-  {
-    key: 'gene_symbol',
-    label: 'Gene',
-    sortable: true,
-    class: 'text-start',
-    filterable: true,
-  },
-  {
-    key: 'gene_name',
-    label: 'Name',
-    sortable: true,
-    class: 'text-start',
-    filterable: true,
-  },
-  {
-    key: 'publication_count',
-    label: 'Pubs',
-    sortable: true,
-    class: 'text-center',
-    filterable: false,
-  },
-  {
-    key: 'oldest_pub_date',
-    label: 'Oldest Pub',
-    sortable: true,
-    class: 'text-center',
-    filterable: false,
-  },
-  {
-    key: 'is_novel',
-    label: 'Source',
-    sortable: true,
-    class: 'text-center',
-    filterable: false,
-  },
-  {
-    key: 'pmids',
-    label: 'PMIDs',
-    sortable: false,
-    class: 'text-start',
-    filterable: false,
-  },
-  {
-    key: 'actions',
-    label: '',
-    sortable: false,
-    class: 'text-center',
-    filterable: false,
-  },
-]);
+// Table fields definition (includes issue #175 enrichment columns)
+const fields = ref<FieldDefinition[]>(createPubtatorGeneFields());
 
 // Component-specific filter
 const filter = ref<PubtatorGeneFilter>(createDefaultPubtatorGeneFilter());
@@ -836,6 +841,11 @@ const handleExcelExport = async () => {
     gene_symbol: gene.gene_symbol,
     gene_name: gene.gene_name,
     publication_count: gene.publication_count,
+    background_count: gene.background_count ?? '',
+    enrichment_ratio: gene.enrichment_ratio ?? '',
+    npmi: gene.npmi ?? '',
+    fisher_p: gene.fisher_p ?? '',
+    fdr_bh: gene.fdr_bh ?? '',
     oldest_pub_date: gene.oldest_pub_date || '',
     source: gene.is_novel === 1 ? 'Literature Only' : 'Curated',
     pmids: gene.pmids || '',
@@ -848,7 +858,12 @@ const handleExcelExport = async () => {
       headers: {
         gene_symbol: 'Gene Symbol',
         gene_name: 'Gene Name',
-        publication_count: 'Publication Count',
+        publication_count: 'NDD Publication Count',
+        background_count: 'Background (Total) Publications',
+        enrichment_ratio: 'Enrichment Ratio',
+        npmi: 'NPMI',
+        fisher_p: 'Fisher p-value',
+        fdr_bh: 'FDR (BH q-value)',
         oldest_pub_date: 'Oldest Publication',
         source: 'Source',
         pmids: 'PMIDs',

--- a/app/src/components/analyses/pubtatorEnrichmentDisplay.spec.ts
+++ b/app/src/components/analyses/pubtatorEnrichmentDisplay.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatCount,
+  formatEnrichment,
+  enrichmentVariant,
+  enrichmentTooltip,
+  fdrStars,
+  fdrClass,
+  fdrTooltip,
+  createPubtatorGeneFields,
+} from './pubtatorEnrichmentDisplay';
+
+describe('pubtatorEnrichmentDisplay', () => {
+  it('compacts large counts and dashes nulls', () => {
+    expect(formatCount(282103)).toBe('282.1k');
+    expect(formatCount(13459)).toBe('13.5k');
+    expect(formatCount(86)).toBe('86');
+    expect(formatCount(null)).toBe('—');
+  });
+
+  it('rounds enrichment ratios coarser as magnitude grows', () => {
+    expect(formatEnrichment(150)).toBe('150');
+    expect(formatEnrichment(17.6)).toBe('18');
+    expect(formatEnrichment(2.34)).toBe('2.3');
+    expect(formatEnrichment(null)).toBe('—');
+  });
+
+  it('bands the enrichment variant by strength', () => {
+    expect(enrichmentVariant(10)).toBe('success');
+    expect(enrichmentVariant(2)).toBe('warning');
+    expect(enrichmentVariant(0.1)).toBe('secondary');
+    expect(enrichmentVariant(null)).toBe('secondary');
+  });
+
+  it('assigns FDR stars by Benjamini-Hochberg thresholds', () => {
+    expect(fdrStars(1e-5)).toBe('***');
+    expect(fdrStars(0.005)).toBe('**');
+    expect(fdrStars(0.03)).toBe('*');
+    expect(fdrStars(0.2)).toBe('');
+    expect(fdrStars(null)).toBe('');
+  });
+
+  it('pairs FDR class color with weight (not color alone)', () => {
+    expect(fdrClass(0.01)).toContain('text-success');
+    expect(fdrClass(0.5)).toBe('text-muted');
+  });
+
+  it('builds informative tooltips', () => {
+    const tip = enrichmentTooltip({
+      enrichment_ratio: 17.6,
+      npmi: 0.32,
+      observed: 86,
+      background_count: 13459,
+    });
+    expect(tip).toContain('17.60×');
+    expect(tip).toContain('NPMI: 0.320');
+    expect(tip).toContain('86 of 13459');
+    expect(fdrTooltip(0.001)).toContain('significant');
+    expect(fdrTooltip(0.5)).toContain('not significant');
+    expect(fdrTooltip(null)).toContain('No FDR');
+  });
+
+  it('exposes the enrichment columns in the gene field set', () => {
+    const keys = createPubtatorGeneFields().map((f) => f.key);
+    expect(keys).toContain('background_count');
+    expect(keys).toContain('enrichment_ratio');
+    expect(keys).toContain('fdr_bh');
+    // raw count column remains for fallback sorting
+    expect(keys).toContain('publication_count');
+  });
+});

--- a/app/src/components/analyses/pubtatorEnrichmentDisplay.ts
+++ b/app/src/components/analyses/pubtatorEnrichmentDisplay.ts
@@ -1,0 +1,109 @@
+// src/components/analyses/pubtatorEnrichmentDisplay.ts
+//
+// Display formatting for the PubtatorNDD gene-prioritization enrichment metrics
+// (issue #175). Extracted from PubtatorNDDGenes.vue to keep that component below
+// the file-size ceiling and to make the formatting independently unit-testable.
+//
+// Metrics normalize a gene's NDD co-occurrence count by its total PubTator
+// publication count so research-popularity bias does not dominate the ranking.
+
+export interface PubtatorGeneFieldDefinition {
+  key: string;
+  label: string;
+  sortable?: boolean;
+  sortDirection?: string;
+  class?: string;
+  filterable?: boolean;
+  count?: number;
+  count_filtered?: number;
+}
+
+/**
+ * Column definitions for the gene-prioritization table, including the issue
+ * #175 enrichment columns (Background Pubs, Enrichment, FDR). Returned fresh on
+ * each call so the component owns a mutable copy.
+ */
+export function createPubtatorGeneFields(): PubtatorGeneFieldDefinition[] {
+  return [
+    { key: 'gene_symbol', label: 'Gene', sortable: true, class: 'text-start', filterable: true },
+    { key: 'gene_name', label: 'Name', sortable: true, class: 'text-start', filterable: true },
+    { key: 'publication_count', label: 'NDD Pubs', sortable: true, class: 'text-center', filterable: false },
+    { key: 'background_count', label: 'Background Pubs', sortable: true, class: 'text-center', filterable: false },
+    { key: 'enrichment_ratio', label: 'Enrichment', sortable: true, class: 'text-center', filterable: false },
+    { key: 'fdr_bh', label: 'FDR', sortable: true, class: 'text-center', filterable: false },
+    { key: 'oldest_pub_date', label: 'Oldest Pub', sortable: true, class: 'text-center', filterable: false },
+    { key: 'is_novel', label: 'Source', sortable: true, class: 'text-center', filterable: false },
+    { key: 'pmids', label: 'PMIDs', sortable: false, class: 'text-start', filterable: false },
+    { key: 'actions', label: '', sortable: false, class: 'text-center', filterable: false },
+  ];
+}
+
+export interface EnrichmentRowLike {
+  observed?: number | null;
+  background_count?: number | null;
+  enrichment_ratio?: number | null;
+  npmi?: number | null;
+  fisher_p?: number | null;
+  fdr_bh?: number | null;
+}
+
+export type EnrichmentVariant = 'success' | 'warning' | 'secondary';
+
+/** Compact large counts (e.g. 282103 -> "282.1k"). */
+export function formatCount(n: number | null | undefined): string {
+  if (n == null) return '—';
+  if (n >= 1000) return `${Math.round(n / 100) / 10}k`;
+  return String(n);
+}
+
+/** Round the enrichment ratio for display (coarser as the magnitude grows). */
+export function formatEnrichment(ratio: number | null | undefined): string {
+  if (ratio == null) return '—';
+  if (ratio >= 100) return String(Math.round(ratio));
+  if (ratio >= 10) return ratio.toFixed(0);
+  return ratio.toFixed(1);
+}
+
+/** Color band: strongly enriched (success) / moderate (warning) / not enriched. */
+export function enrichmentVariant(ratio: number | null | undefined): EnrichmentVariant {
+  if (ratio == null) return 'secondary';
+  if (ratio >= 5) return 'success';
+  if (ratio >= 1) return 'warning';
+  return 'secondary';
+}
+
+/** Tooltip combining ratio, NPMI, and the underlying counts. */
+export function enrichmentTooltip(item: EnrichmentRowLike): string {
+  const parts: string[] = [];
+  if (item.enrichment_ratio != null) {
+    parts.push(`Enrichment: ${item.enrichment_ratio.toFixed(2)}× more NDD co-mentions than expected`);
+  }
+  if (item.npmi != null) parts.push(`NPMI: ${item.npmi.toFixed(3)} (range −1..1)`);
+  if (item.observed != null && item.background_count != null) {
+    parts.push(`${item.observed} of ${item.background_count} total publications`);
+  }
+  return parts.join(' • ');
+}
+
+/** FDR significance stars (Benjamini-Hochberg q-value thresholds). */
+export function fdrStars(q: number | null | undefined): string {
+  if (q == null) return '';
+  if (q < 0.001) return '***';
+  if (q < 0.01) return '**';
+  if (q < 0.05) return '*';
+  return '';
+}
+
+/** CSS class pairing significance with weight/color (never color-alone). */
+export function fdrClass(q: number | null | undefined): string {
+  if (q == null) return 'text-muted';
+  return q < 0.05 ? 'fw-bold text-success' : 'text-muted';
+}
+
+/** Tooltip describing the FDR q-value and its significance. */
+export function fdrTooltip(q: number | null | undefined): string {
+  if (q == null) return 'No FDR computed';
+  const sig = q < 0.05 ? 'significant' : 'not significant';
+  const display = q < 0.001 ? q.toExponential(1) : q.toFixed(3);
+  return `BH-adjusted q = ${display} (${sig} at q < 0.05)`;
+}

--- a/db/C_Rcommands_set-table-connections.R
+++ b/db/C_Rcommands_set-table-connections.R
@@ -765,6 +765,30 @@ dbClearResult(rs)
 
 
 ############################################
+## create pubtator_gene_enrichment_view
+## Mirrors db/migrations/027_add_pubtator_gene_enrichment.sql; keep in sync.
+rs <- dbSendQuery(sysndd_db, "CREATE OR REPLACE VIEW `sysndd_db`.`pubtator_gene_enrichment_view` AS
+    SELECT
+      ge.gene_symbol AS gene_symbol,
+      ge.hgnc_id AS hgnc_id,
+      ge.observed AS observed,
+      ge.background_count AS background_count,
+      ge.enrichment_ratio AS enrichment_ratio,
+      ge.npmi AS npmi,
+      ge.fisher_p AS fisher_p,
+      ge.fdr_bh AS fdr_bh,
+      cs.ndd_corpus_size AS ndd_corpus_size,
+      cs.total_corpus_size AS total_corpus_size,
+      cs.total_is_fallback AS total_is_fallback,
+      cs.created_at AS enrichment_refreshed_at
+    FROM `sysndd_db`.`pubtator_gene_enrichment` ge
+    JOIN `sysndd_db`.`pubtator_corpus_stats` cs
+      ON ge.corpus_stats_id = cs.corpus_stats_id
+     AND cs.is_current = 1;")
+dbClearResult(rs)
+
+
+############################################
 ## close database connection
 rm_con()
 ############################################

--- a/db/migrations/027_add_pubtator_gene_enrichment.sql
+++ b/db/migrations/027_add_pubtator_gene_enrichment.sql
@@ -1,0 +1,108 @@
+-- Migration 027: PubtatorNDD gene-count enrichment normalization
+--
+-- GitHub issue #175: the gene-prioritization table ranks genes by RAW
+-- publication co-occurrence with NDD terms, which conflates true NDD relevance
+-- with research-popularity bias. Heavily-studied genes (TP53, APP, MAPT, APOE)
+-- surface in the top 10 with no specific NDD role (~40% top-10 false positives).
+-- Normalizing a gene's NDD co-occurrence count by its TOTAL PubTator
+-- publication count separates true NDD genes (0.1-0.6% NDD/Total) from
+-- popularity noise (0.001-0.01%) by ~two orders of magnitude.
+--
+-- This migration adds the durable storage for that normalization layer:
+--
+--   * pubtator_corpus_stats     -- one row per refresh snapshot, recording the
+--                                  NDD corpus size and total corpus size used,
+--                                  with exactly one is_current = 1 row.
+--   * pubtator_gene_enrichment  -- per-gene observed/background counts plus the
+--                                  computed metrics (enrichment ratio, NPMI,
+--                                  Fisher p-value, BH-FDR q-value).
+--   * pubtator_gene_enrichment_view -- read view used by the API to join the
+--                                  current metrics onto the gene view.
+--
+-- Counts are collected by the durable async worker job
+-- `pubtator_enrichment_refresh` (network egress to PubTator); the web API never
+-- computes these on a public request. Metric math lives in
+-- api/functions/pubtator-enrichment-metrics.R (pure, unit-tested).
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS + CREATE OR REPLACE VIEW.
+
+-- ---------------------------------------------------------------------------
+-- Corpus-level snapshot. is_current_slot is a generated column giving a
+-- partial-unique guarantee: at most one row may be the current snapshot.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `pubtator_corpus_stats` (
+  `corpus_stats_id` INT NOT NULL AUTO_INCREMENT,
+  `ndd_corpus_size` INT NOT NULL,
+  `total_corpus_size` BIGINT NOT NULL,
+  `total_is_fallback` TINYINT NOT NULL DEFAULT 0,
+  `genes_scored` INT NOT NULL DEFAULT 0,
+  `refreshed_by` INT DEFAULT NULL,
+  `is_current` TINYINT NOT NULL DEFAULT 0,
+  `created_at` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `is_current_slot` TINYINT
+      GENERATED ALWAYS AS (CASE WHEN `is_current` = 1 THEN 1 ELSE NULL END) STORED,
+  PRIMARY KEY (`corpus_stats_id`),
+  UNIQUE KEY `idx_pubtator_corpus_stats_current` (`is_current_slot`),
+  KEY `idx_pubtator_corpus_stats_created` (`created_at`),
+  CONSTRAINT `fk_pubtator_corpus_stats_refreshed_by`
+      FOREIGN KEY (`refreshed_by`) REFERENCES `user` (`user_id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ---------------------------------------------------------------------------
+-- Per-gene normalized metrics for the current snapshot.
+--   observed         -- NDD-corpus publications mentioning the gene
+--   background_count -- total PubTator publications mentioning the gene
+--   enrichment_ratio -- observed / (ndd_corpus * background / total_corpus)
+--   npmi             -- normalized pointwise mutual information, [-1, 1]
+--   fisher_p         -- one-sided (enrichment) Fisher exact p-value
+--   fdr_bh           -- Benjamini-Hochberg adjusted q-value across all genes
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `pubtator_gene_enrichment` (
+  `gene_enrichment_id` INT NOT NULL AUTO_INCREMENT,
+  `corpus_stats_id` INT NOT NULL,
+  `hgnc_id` VARCHAR(20) DEFAULT NULL,
+  `gene_symbol` VARCHAR(64) NOT NULL,
+  `observed` INT NOT NULL,
+  `background_count` INT DEFAULT NULL,
+  `enrichment_ratio` DOUBLE DEFAULT NULL,
+  `npmi` DOUBLE DEFAULT NULL,
+  `fisher_p` DOUBLE DEFAULT NULL,
+  `fdr_bh` DOUBLE DEFAULT NULL,
+  `created_at` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  PRIMARY KEY (`gene_enrichment_id`),
+  UNIQUE KEY `idx_pubtator_gene_enrichment_symbol` (`gene_symbol`),
+  KEY `idx_pubtator_gene_enrichment_hgnc` (`hgnc_id`),
+  KEY `idx_pubtator_gene_enrichment_corpus` (`corpus_stats_id`),
+  KEY `idx_pubtator_gene_enrichment_ratio` (`enrichment_ratio`),
+  KEY `idx_pubtator_gene_enrichment_npmi` (`npmi`),
+  CONSTRAINT `fk_pubtator_gene_enrichment_corpus`
+      FOREIGN KEY (`corpus_stats_id`) REFERENCES `pubtator_corpus_stats` (`corpus_stats_id`)
+      ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ---------------------------------------------------------------------------
+-- Serving view: per-gene current metrics with the corpus context attached.
+-- The API left-joins this onto the gene listing so genes without a metric yet
+-- (e.g. before the first refresh) still appear, with NULL metric columns.
+-- Keep in sync with db/C_Rcommands_set-table-connections.R.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE
+  ALGORITHM = UNDEFINED SQL SECURITY INVOKER
+  VIEW `pubtator_gene_enrichment_view` AS
+    SELECT
+      ge.`gene_symbol` AS `gene_symbol`,
+      ge.`hgnc_id` AS `hgnc_id`,
+      ge.`observed` AS `observed`,
+      ge.`background_count` AS `background_count`,
+      ge.`enrichment_ratio` AS `enrichment_ratio`,
+      ge.`npmi` AS `npmi`,
+      ge.`fisher_p` AS `fisher_p`,
+      ge.`fdr_bh` AS `fdr_bh`,
+      cs.`ndd_corpus_size` AS `ndd_corpus_size`,
+      cs.`total_corpus_size` AS `total_corpus_size`,
+      cs.`total_is_fallback` AS `total_is_fallback`,
+      cs.`created_at` AS `enrichment_refreshed_at`
+    FROM `pubtator_gene_enrichment` ge
+    JOIN `pubtator_corpus_stats` cs
+      ON ge.`corpus_stats_id` = cs.`corpus_stats_id`
+     AND cs.`is_current` = 1;

--- a/documentation/08-development.qmd
+++ b/documentation/08-development.qmd
@@ -152,6 +152,33 @@ curl -sS 'http://localhost/api/analysis/network_edges?cluster_type=clusters&max_
 
 If the status is `missing`, `invalid`, or `error`, the frontend falls back to browser fCoSE. The frontend only uses Cytoscape `preset` when the API reports `display_layout_status = "available"` and every displayed gene node has finite artifact coordinates.
 
+### PubtatorNDD Gene-Count Enrichment Normalization
+
+The PubtatorNDD gene-prioritization table normalizes raw NDD co-occurrence counts for research-popularity bias (issue #175). The raw count conflates true NDD relevance with how heavily a gene is studied, so heavily-studied genes (TP53, APP, MAPT, APOE) surface in the top 10 with no specific NDD role. Each gene's NDD co-occurrence count is normalized by its total PubTator publication count and scored with three metrics:
+
+- **Enrichment ratio** — `observed / (ndd_corpus_size * background_count / total_corpus_size)` (fold change).
+- **NPMI** — Normalized Pointwise Mutual Information, bounded `[-1, 1]`.
+- **Fisher exact p-value** (one-sided, enrichment) + **Benjamini-Hochberg FDR** across all genes.
+
+The metric math lives in `api/functions/pubtator-enrichment-metrics.R` (pure, unit-tested in `tests/testthat/test-unit-pubtator-enrichment.R`). Background-count collection and DB persistence live in `api/functions/pubtator-enrichment-collector.R`.
+
+Collection makes one external PubTator call per gene plus two corpus-size probes, so it runs only in the durable async worker (`pubtator_enrichment_refresh` job; needs PubTator egress), never on a public request. The external fetcher uses `memoise_external_success_only()` (7-day cache, transient errors not cached). Intended cadence: monthly. Snapshots are stored in `pubtator_corpus_stats` / `pubtator_gene_enrichment` (migration `027`) with exactly one current row; the API serves them via `pubtator_gene_enrichment_view`, LEFT-joined onto the gene listing so genes without a metric yet still appear.
+
+Admins submit a refresh and read status with:
+
+```bash
+curl -sS -X POST 'http://localhost/api/publication/pubtator/enrichment/refresh' -H "Authorization: Bearer <admin-token>"
+curl -sS 'http://localhost/api/publication/pubtator/enrichment/status' | jq
+```
+
+Or, in a worker/API R session with a DB connection:
+
+```r
+async_job_service_submit(job_type = "pubtator_enrichment_refresh", request_payload = list(refresh = "all"))
+```
+
+The default gene-table sort is `-enrichment_ratio,-npmi,publication_count`; the raw NDD publication count remains sortable. Restart the worker container after changing `api/functions/pubtator-enrichment-*.R` or `api/functions/async-job-handlers.R` before testing job behavior in Docker.
+
 ## End-to-End Tests (Playwright)
 
 The Playwright suite is **local-only**, used for ad-hoc pre-PR regression sanity checks against a real API+DB stack via a Docker Compose overlay isolated from `make dev`. There is no Playwright CI workflow — the official lane (lint, type-check, vitest, R API, smoke) covers automated regression. The Playwright spec files live in `app/tests/e2e/` for manual invocation when a refactor warrants a full-flow check.

--- a/scripts/code-quality-file-size-baseline.tsv
+++ b/scripts/code-quality-file-size-baseline.tsv
@@ -4,7 +4,7 @@ api/endpoints/entity_endpoints.R	848
 api/endpoints/external_endpoints.R	607
 api/endpoints/jobs_endpoints.R	1011
 api/endpoints/llm_admin_endpoints.R	797
-api/endpoints/publication_endpoints.R	1193
+api/endpoints/publication_endpoints.R	1234
 api/endpoints/re_review_endpoints.R	777
 api/endpoints/review_endpoints.R	634
 api/endpoints/statistics_endpoints.R	782
@@ -31,7 +31,7 @@ app/src/components/analyses/AnalysesCurationUpset.vue	748
 app/src/components/analyses/AnalysesPhenotypeClusters.vue	728
 app/src/components/analyses/NetworkVisualization.vue	1242
 app/src/components/analyses/PublicationsNDDTable.vue	1059
-app/src/components/analyses/PubtatorNDDGenes.vue	1148
+app/src/components/analyses/PubtatorNDDGenes.vue	1163
 app/src/components/analyses/PubtatorNDDTable.vue	945
 app/src/components/forms/BatchCriteriaForm.vue	747
 app/src/components/gene/GeneStructurePlotWithVariants.vue	1306
@@ -63,4 +63,4 @@ app/src/views/curate/ManageReReview.vue	1573
 app/src/views/curate/ModifyEntity.vue	762
 app/src/views/pages/EntityView.vue	811
 db/11_Rcommands_sysndd_db_table_database_comparisons.R	638
-db/C_Rcommands_set-table-connections.R	769
+db/C_Rcommands_set-table-connections.R	793


### PR DESCRIPTION
## Summary

Normalizes the PubtatorNDD gene-prioritization ranking for **research-popularity bias** (issue #175). The table ranked genes by **raw** publication co-occurrence with NDD terms, which conflates true NDD relevance with how heavily a gene is studied — TP53, APP, MAPT, APOE surfaced in the top 10 with no specific NDD role (~40% top-10 false-positive rate). Normalizing a gene's NDD co-occurrence count by its **total** PubTator publication count separates true NDD genes (0.1–0.6% NDD/Total) from popularity noise (0.001–0.01%) by ~two orders of magnitude.

This PR delivers Phases 1–3. **Phase 4 (the composite 0–5 star "NDD Association Confidence" score) is deferred to a follow-up.**

## Statistical approach (sources cited)

For each gene I build a fixed 2×2 contingency (gene∩NDD, gene∩¬NDD, ¬gene∩NDD, ¬gene∩¬NDD) over the whole PubTator corpus and compute three complementary, defensible metrics:

- **Enrichment ratio** = `observed / (ndd_corpus_size * background_count / total_corpus_size)` — fold change vs. independence (over-representation analysis).
- **NPMI** = `PMI / -log p(x,y)`, bounded `[-1, 1]` (Bouma 2009): `+1` always co-occur, `0` independence, `-1` never co-occur. Inherently normalizes for both gene popularity and corpus size. Edge cases handled: `observed == 0 → -1`; always-co-occur `→ +1`.
- **Fisher exact p-value** (one-sided, `alternative = "greater"` → tests enrichment) via base R `stats::fisher.test()`, then **Benjamini-Hochberg FDR** across all genes via `stats::p.adjust(method = "BH")` (NA-tolerant).

References (per the issue): Bouma (2009) NPMI; Pletscher-Frankild et al. (2015) *DISEASES* (Methods); Groth et al. (2020) *CoCoScore* (Bioinformatics); Stoeger et al. (2018) ignored-genes (PLOS Biology).

The metric math lives in `api/functions/pubtator-enrichment-metrics.R` — pure, no I/O, fully unit-tested.

### GRIN2B-vs-TP53 separation (asserted by tests)

Using the issue's worked counts (NDD corpus 13,459), the tests assert that under **both** enrichment-ratio and NPMI ranking, the true NDD genes (GRIN2B, SCN1A, MECP2) all rank strictly above the popularity noise (TP53, APP, ALB), and that GRIN2B's enrichment ratio is **>100×** TP53's. NPMI tests also confirm `observed == 0 → -1`, always-co-occur `→ +1`, and ≈0 at independence.

## Migration + new tables/columns (`027_add_pubtator_gene_enrichment.sql`)

- `pubtator_corpus_stats` — one row per refresh snapshot (`ndd_corpus_size`, `total_corpus_size`, `total_is_fallback`, `genes_scored`); generated `is_current_slot` gives a partial-unique guarantee so **exactly one** snapshot is current.
- `pubtator_gene_enrichment` — per gene: `observed`, `background_count`, `enrichment_ratio`, `npmi`, `fisher_p`, `fdr_bh` (FK → corpus_stats, cascade).
- `pubtator_gene_enrichment_view` — serving view over the current snapshot. Mirrored into `db/C_Rcommands_set-table-connections.R` per the docs contract. Manifest bumped to `027` (count 28).

## Async job (background collection — never on a public request)

- New durable System B job **`pubtator_enrichment_refresh`** registered in `async_job_handler_registry`. It runs in the worker (needs PubTator egress), fetches each gene's total count + the NDD/total corpus sizes, computes metrics, and persists a new current snapshot atomically.
- The external fetcher uses **`memoise_external_success_only()`** (7-day cache) so transient `list(error = TRUE, …)` failures are never cached. `DBI::dbBind` params are `unname()`d. Intended cadence: **monthly**.
- Submitted via `POST /api/publication/pubtator/enrichment/refresh` (Administrator) → 202 (409 if already running). Status via `GET /api/publication/pubtator/enrichment/status`.

## Frontend changes

- Typed client (`app/src/api/publication.ts`): `PubtatorGeneRow` gains the metric fields; adds `refreshPubtatorEnrichment()` / `getPubtatorEnrichmentStatus()`.
- `PubtatorNDDGenes.vue`: new **Background Pubs**, **Enrichment** (color-coded badge), and **FDR** (significance stars) columns; **default sort changed** to `-enrichment_ratio,-npmi,publication_count` (raw NDD count still sortable); export + help popover updated. Color is always paired with label/icon/tooltip per the visual guide.
- Formatting helpers + field factory extracted to `pubtatorEnrichmentDisplay.ts` (keeps the component under the size ratchet; independently unit-tested).
- An "enrichment chart mode" / volcano plot is **noted as follow-up** (not in this PR).

## Tests

- **R** (`test-unit-pubtator-enrichment.R`, 51 assertions): metric math incl. zero/edge cases, GRIN2B-vs-TP53 separation, BH ordering/NA-tolerance, corpus-size + background collection with a **mocked fetcher** (stubs the direct helper — no network), and the endpoint helpers (status + refresh-submit 202/409). Manifest tests updated.
- **Frontend**: `pubtatorEnrichmentDisplay.spec.ts` (formatting/bands/fields) + updated `PubtatorNDDGenes.spec.ts` (new default sort, enrichment column rendering, enriched export headers).
- Green locally: `lintr` (0), `type-check`, `eslint` (0 errors), `vitest` (311 analyses+api tests), `verify-msw-against-openapi`, `check-migration-prefixes`, `code-quality-audit`.

## Needs CI / worker confirmation

I did **not** start the shared Docker stack. The following need a DB-backed + worker run (CI / maintainer): migration `027` applying on a live DB; the `pubtator_enrichment_refresh` worker job end-to-end against the real PubTator API (corpus-size probe via `*`, per-gene `@GENE_<SYMBOL>` counts); and the `/pubtator/genes` LEFT-join + new endpoints against a populated DB. Remember to **restart the worker container** so it picks up the new function files.

## Deferred

- **Phase 4** — composite 0–5 star "NDD Association Confidence" score combining NPMI + Fisher + enrichment (DISEASES-style). Follow-up.
- Optional enrichment chart mode / volcano plot in `PubtatorNDDStats`. Follow-up.

Closes #175
