### PR TITLE
feat: track and display semantic DB version (#22)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,15 @@ MYSQL_USER=your_username_here
 MYSQL_PASSWORD=your_secure_password_here
 MYSQL_ROOT_PASSWORD=your_secure_root_password_here
 
+# Database version surface (issue #22). Optional, set at release time.
+# DB_VERSION is the semantic version (major.minor.patch) of the DB schema +
+# seed data; DB_COMMIT is the last db/-folder git short hash. The migration
+# seeds a baseline; when these are set the API refreshes the db_version row at
+# startup so the App and /api/version report the deployed values. Capture them
+# on a host with the repo checked out: ./db/scripts/update-db-version.sh >> .env
+# DB_VERSION=1.0.0
+# DB_COMMIT=unknown
+
 # -----------------------------------------------------------------------------
 # API Configuration
 # -----------------------------------------------------------------------------

--- a/api/bootstrap/load_modules.R
+++ b/api/bootstrap/load_modules.R
@@ -58,6 +58,7 @@ bootstrap_load_modules <- function() {
     "functions/config-functions.R",
     "functions/logging-functions.R",
     "functions/db-helpers.R",
+    "functions/db-version.R",
     "functions/metadata-refresh.R",
     "functions/async-job-repository.R",
     "functions/async-job-service.R",

--- a/api/endpoints/version_endpoints.R
+++ b/api/endpoints/version_endpoints.R
@@ -1,20 +1,24 @@
 # api/endpoints/version_endpoints.R
 #
 # Version endpoint for API version discovery and deployment tracking.
-# Returns semantic version from version_spec.json and git commit hash.
+# Returns the API semantic version (version_spec.json) + git commit hash, plus
+# the human-facing database semantic version (issue #22) from the db_version
+# table. The database block degrades gracefully when the DB/table is missing.
 # This endpoint must be lightweight and NOT require authentication.
 
-#* Version endpoint for API version discovery
+#* Version endpoint for API + database version discovery
 #*
-#* Returns semantic version and git commit hash for deployment tracking.
-#* This endpoint is unauthenticated and does not query the database.
+#* Returns the API semantic version and git commit hash for deployment
+#* tracking, plus the database semantic version, db-folder git commit, and
+#* last-updated timestamp (issue #22). Unauthenticated. The database block
+#* falls back to "unknown" rather than failing if the DB is unavailable.
 #*
 #* @tag version
 #* @serializer json
 #*
 #* @get /
 function(req, res) {
-  # Get git commit hash
+  # Get git commit hash for the API
   # Priority: GIT_COMMIT env var (Docker build injection) > git command (development) > "unknown"
   commit <- Sys.getenv("GIT_COMMIT", unset = "")
 
@@ -36,10 +40,22 @@ function(req, res) {
     )
   }
 
+  # Database semantic version (issue #22). db_version_get() never throws; it
+  # returns an "unknown" / available = FALSE fallback when the DB or table is
+  # not reachable, so this public endpoint stays resilient.
+  db_version <- db_version_get()
+
   list(
     version = version_json$version,
     commit = commit,
     title = version_json$title,
-    description = version_json$description
+    description = version_json$description,
+    database = list(
+      version = db_version$version,
+      commit = db_version$commit,
+      description = db_version$description,
+      updated_at = db_version$updated_at,
+      available = db_version$available
+    )
   )
 }

--- a/api/functions/db-version.R
+++ b/api/functions/db-version.R
@@ -1,0 +1,150 @@
+# functions/db-version.R
+#
+# Issue #22: human-facing semantic version of the SysNDD database.
+#
+# Reads the single-row `db_version` table (migration 028) and, at startup,
+# optionally refreshes the row's commit/version from deployment-injected
+# DB_VERSION / DB_COMMIT environment variables. The release helper
+# db/scripts/update-db-version.sh documents how DB_COMMIT is captured from
+# `git log -1 --format=%h -- db/` at release time.
+#
+# This is intentionally separate from:
+#   * schema_version  -- the migration runner's at-most-once apply ledger
+#   * about_content.version -- About-page CONTENT publish versioning
+#
+# Read access is graceful: a missing table or unavailable DB returns a
+# fallback list with version "unknown" rather than throwing, so the public
+# /api/version endpoint never fails because of the DB-version surface.
+
+#' Read the current semantic database version.
+#'
+#' Reads row id = 1 from the `db_version` table. Falls back gracefully to
+#' an "unknown" record (never throws) when the table is missing or the DB is
+#' unavailable, so the public version endpoint stays resilient.
+#'
+#' @param conn Optional DBI connection/pool for dependency injection in tests.
+#'   When NULL, the global pool is used.
+#'
+#' @return A list with character `version`, character `commit`, character or
+#'   NULL `description`, and character or NULL `updated_at` (ISO-ish string).
+#'   `available` is TRUE when a row was read, FALSE on any fallback.
+#' @export
+db_version_get <- function(conn = NULL) {
+  fallback <- list(
+    version = "unknown",
+    commit = "unknown",
+    description = NULL,
+    updated_at = NULL,
+    available = FALSE
+  )
+
+  tryCatch(
+    {
+      result <- db_execute_query(
+        paste0(
+          "SELECT db_version, db_commit, description, updated_at ",
+          "FROM db_version WHERE id = 1 LIMIT 1"
+        ),
+        conn = conn
+      )
+
+      if (is.null(result) || nrow(result) == 0) {
+        return(fallback)
+      }
+
+      list(
+        version = as.character(result$db_version[1]),
+        commit = as.character(result$db_commit[1]),
+        description = db_version_nullify(result$description[1]),
+        updated_at = db_version_nullify(as.character(result$updated_at[1])),
+        available = TRUE
+      )
+    },
+    error = function(e) {
+      log_warn("db_version_get failed, returning fallback: {e$message}")
+      fallback
+    }
+  )
+}
+
+#' Coerce empty/NA scalar values to NULL for clean JSON output.
+#'
+#' @param x A length-1 vector.
+#' @return The value, or NULL when it is NA or an empty string.
+#' @keywords internal
+db_version_nullify <- function(x) {
+  if (length(x) == 0) {
+    return(NULL)
+  }
+  if (is.na(x[1])) {
+    return(NULL)
+  }
+  if (is.character(x[1]) && !nzchar(x[1])) {
+    return(NULL)
+  }
+  x[1]
+}
+
+#' Sync the database version row from deployment environment variables.
+#'
+#' At release/deploy time the operator (or db/scripts/update-db-version.sh)
+#' injects DB_VERSION (semantic version) and/or DB_COMMIT (last db/ folder git
+#' short hash). When either is present this updates the existing id = 1 row so
+#' the API and App report the deployed values without editing SQL by hand.
+#'
+#' This NEVER throws: a failure here must not block API startup. It is a no-op
+#' when neither env var is set, when the row does not yet exist, or on any DB
+#' error.
+#'
+#' @param conn Optional DBI connection/pool for dependency injection in tests.
+#'
+#' @return Invisibly TRUE when the row was updated, FALSE otherwise.
+#' @export
+db_version_sync_from_env <- function(conn = NULL) {
+  env_version <- Sys.getenv("DB_VERSION", unset = "")
+  env_commit <- Sys.getenv("DB_COMMIT", unset = "")
+
+  if (!nzchar(env_version) && !nzchar(env_commit)) {
+    return(invisible(FALSE))
+  }
+
+  tryCatch(
+    {
+      # Only refresh the canonical seeded row; never create extra rows.
+      sets <- character(0)
+      params <- list()
+
+      if (nzchar(env_version)) {
+        sets <- c(sets, "db_version = ?")
+        params <- c(params, list(env_version))
+      }
+      if (nzchar(env_commit)) {
+        sets <- c(sets, "db_commit = ?")
+        params <- c(params, list(env_commit))
+      }
+
+      sql <- paste0(
+        "UPDATE db_version SET ",
+        paste(sets, collapse = ", "),
+        " WHERE id = 1"
+      )
+
+      affected <- db_execute_statement(sql, params, conn = conn)
+
+      if (isTRUE(affected > 0)) {
+        log_info(
+          "db_version synced from env (version={v}, commit={c})",
+          v = if (nzchar(env_version)) env_version else "unchanged",
+          c = if (nzchar(env_commit)) env_commit else "unchanged"
+        )
+        return(invisible(TRUE))
+      }
+
+      invisible(FALSE)
+    },
+    error = function(e) {
+      log_warn("db_version_sync_from_env failed (non-fatal): {e$message}")
+      invisible(FALSE)
+    }
+  )
+}

--- a/api/functions/migration-manifest.R
+++ b/api/functions/migration-manifest.R
@@ -2,8 +2,8 @@
 #
 # Strict migration manifest validation for startup/readiness.
 
-EXPECTED_LATEST_MIGRATION <- "026_add_entity_last_update.sql"
-EXPECTED_MIGRATION_COUNT <- 27L
+EXPECTED_LATEST_MIGRATION <- "028_add_db_version.sql"
+EXPECTED_MIGRATION_COUNT <- 28L
 
 #' Validate the migration manifest for strict startup/readiness checks
 #'

--- a/api/start_sysndd_api.R
+++ b/api/start_sysndd_api.R
@@ -91,6 +91,11 @@ log_appender(appender_file(logging_temp_file))
 pool <- bootstrap_create_pool(dw)
 migration_status <- bootstrap_run_migrations(pool)
 
+# Issue #22: refresh the human-facing db_version row (id = 1) from
+# deployment-injected DB_VERSION / DB_COMMIT env vars when present. No-op and
+# non-fatal otherwise; the migration seeds the baseline row.
+db_version_sync_from_env(conn = pool)
+
 ## -------------------------------------------------------------------##
 # 6) Top-level constants (serializers, allow-lists, version).
 ## -------------------------------------------------------------------##

--- a/api/tests/testthat/test-integration-version.R
+++ b/api/tests/testthat/test-integration-version.R
@@ -49,6 +49,14 @@ test_that("version endpoint returns correct structure", {
   expect_true("commit" %in% names(body))
   expect_true("title" %in% names(body))
   expect_true("description" %in% names(body))
+
+  # Issue #22: database version block is present and well-formed.
+  expect_true("database" %in% names(body))
+  db <- body$database
+  expect_true("version" %in% names(db))
+  expect_true("commit" %in% names(db))
+  expect_true("available" %in% names(db))
+  expect_true(is.character(db$version))
 })
 
 test_that("version endpoint returns semantic version format", {

--- a/api/tests/testthat/test-unit-analysis-snapshot-migration.R
+++ b/api/tests/testthat/test-unit-analysis-snapshot-migration.R
@@ -5,8 +5,8 @@ withr::defer(setwd(analysis_snapshot_test_wd), testthat::teardown_env())
 test_that("migration manifest tracks the latest migration", {
   source(file.path("functions", "migration-manifest.R"), local = TRUE)
 
-  expect_equal(EXPECTED_LATEST_MIGRATION, "026_add_entity_last_update.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 27L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "028_add_db_version.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 28L)
 })
 
 test_that("public analysis snapshot migration enforces scoped public-ready uniqueness", {

--- a/api/tests/testthat/test-unit-core-views-manifest.R
+++ b/api/tests/testthat/test-unit-core-views-manifest.R
@@ -9,16 +9,16 @@
 source_api_file("functions/migration-manifest.R", local = FALSE)
 source_api_file("functions/migration-runner.R", local = FALSE)
 
-test_that("manifest expects migration 026 as latest", {
-  expect_equal(EXPECTED_LATEST_MIGRATION, "026_add_entity_last_update.sql")
-  expect_gte(EXPECTED_MIGRATION_COUNT, 27L)
+test_that("manifest expects migration 028 as latest", {
+  expect_equal(EXPECTED_LATEST_MIGRATION, "028_add_db_version.sql")
+  expect_gte(EXPECTED_MIGRATION_COUNT, 28L)
 })
 
 test_that("migration manifest validates against db/migrations", {
   migrations_dir <- file.path(get_api_dir(), "..", "db", "migrations")
   res <- validate_migration_manifest(migrations_dir = migrations_dir)
   expect_true(res$ok)
-  expect_identical(res$latest, "026_add_entity_last_update.sql")
+  expect_identical(res$latest, "028_add_db_version.sql")
 })
 
 test_that("migration 026 adds a last_update column derived from curation dates", {

--- a/api/tests/testthat/test-unit-db-version.R
+++ b/api/tests/testthat/test-unit-db-version.R
@@ -1,0 +1,197 @@
+# tests/testthat/test-unit-db-version.R
+#
+# Unit tests for the database-version surface (issue #22).
+#
+# These are pure-logic tests: db-version.R is sourced into a local environment
+# and its DB + logging dependencies are stubbed in that same scope, so the
+# tests run without RMariaDB or a live database. The integration behaviour of
+# the /api/version `database` block is covered by the HTTP probes in
+# test-integration-version.R (which require a running API in CI).
+
+# Stub logging helpers used by db-version.R (no-ops in tests).
+log_warn <- function(...) invisible(NULL)
+log_info <- function(...) invisible(NULL)
+log_debug <- function(...) invisible(NULL)
+
+# Mutable holders so individual tests can swap the DB helper behaviour.
+.dbv_query_fn <- NULL
+.dbv_statement_fn <- NULL
+
+db_execute_query <- function(sql, params = list(), conn = NULL) {
+  .dbv_query_fn(sql, params, conn)
+}
+db_execute_statement <- function(sql, params = list(), conn = NULL) {
+  .dbv_statement_fn(sql, params, conn)
+}
+
+# Source the unit under test into the global environment. Its name lookups for
+# db_execute_query / db_execute_statement / log_* resolve to the stubs we assign
+# into the global environment below.
+source_api_file("functions/db-version.R", local = FALSE, envir = globalenv())
+
+# Promote the stubs into the global environment so the sourced functions (whose
+# enclosing environment is globalenv) resolve them.
+assign("log_warn", log_warn, envir = globalenv())
+assign("log_info", log_info, envir = globalenv())
+assign("log_debug", log_debug, envir = globalenv())
+assign("db_execute_query", db_execute_query, envir = globalenv())
+assign("db_execute_statement", db_execute_statement, envir = globalenv())
+assign(".dbv_query_fn", NULL, envir = globalenv())
+assign(".dbv_statement_fn", NULL, envir = globalenv())
+
+# ---------------------------------------------------------------------------
+# db_version_nullify
+# ---------------------------------------------------------------------------
+
+test_that("db_version_nullify maps empty/NA scalars to NULL", {
+  expect_null(db_version_nullify(NA_character_))
+  expect_null(db_version_nullify(""))
+  expect_null(db_version_nullify(character(0)))
+  expect_identical(db_version_nullify("1.0.0"), "1.0.0")
+  expect_identical(db_version_nullify(c("a", "b")), "a")
+})
+
+# ---------------------------------------------------------------------------
+# db_version_get
+# ---------------------------------------------------------------------------
+
+test_that("db_version_get returns a normalized record when a row exists", {
+  .dbv_query_fn <<- function(sql, params, conn) {
+    tibble::tibble(
+      db_version = "1.2.3",
+      db_commit = "abc1234",
+      description = "release note",
+      updated_at = "2026-06-11 10:00:00"
+    )
+  }
+
+  res <- db_version_get()
+
+  expect_identical(res$version, "1.2.3")
+  expect_identical(res$commit, "abc1234")
+  expect_identical(res$description, "release note")
+  expect_identical(res$updated_at, "2026-06-11 10:00:00")
+  expect_true(res$available)
+})
+
+test_that("db_version_get falls back when no row is present", {
+  .dbv_query_fn <<- function(sql, params, conn) tibble::tibble()
+
+  res <- db_version_get()
+
+  expect_identical(res$version, "unknown")
+  expect_identical(res$commit, "unknown")
+  expect_null(res$description)
+  expect_null(res$updated_at)
+  expect_false(res$available)
+})
+
+test_that("db_version_get never throws on DB error and reports unavailable", {
+  .dbv_query_fn <<- function(sql, params, conn) stop("connection refused")
+
+  res <- expect_no_error(db_version_get())
+
+  expect_identical(res$version, "unknown")
+  expect_false(res$available)
+})
+
+test_that("db_version_get nullifies empty description/updated_at", {
+  .dbv_query_fn <<- function(sql, params, conn) {
+    tibble::tibble(
+      db_version = "1.0.0",
+      db_commit = "unknown",
+      description = NA_character_,
+      updated_at = NA_character_
+    )
+  }
+
+  res <- db_version_get()
+
+  expect_identical(res$version, "1.0.0")
+  expect_null(res$description)
+  expect_null(res$updated_at)
+  expect_true(res$available)
+})
+
+# ---------------------------------------------------------------------------
+# db_version_sync_from_env
+# ---------------------------------------------------------------------------
+
+test_that("db_version_sync_from_env is a no-op when no env vars are set", {
+  withr::with_envvar(c(DB_VERSION = "", DB_COMMIT = ""), {
+    called <- FALSE
+    .dbv_statement_fn <<- function(sql, params, conn) {
+      called <<- TRUE
+      1L
+    }
+    result <- db_version_sync_from_env()
+    expect_false(result)
+    expect_false(called)
+  })
+})
+
+test_that("db_version_sync_from_env updates only commit when only DB_COMMIT set", {
+  withr::with_envvar(c(DB_VERSION = "", DB_COMMIT = "deadbee"), {
+    captured <- list()
+    .dbv_statement_fn <<- function(sql, params, conn) {
+      captured$sql <<- sql
+      captured$params <<- params
+      1L
+    }
+    result <- db_version_sync_from_env()
+    expect_true(result)
+    expect_match(captured$sql, "db_commit = ?", fixed = TRUE)
+    expect_false(grepl("db_version = ?", captured$sql, fixed = TRUE))
+    expect_match(captured$sql, "WHERE id = 1", fixed = TRUE)
+    expect_identical(captured$params, list("deadbee"))
+  })
+})
+
+test_that("db_version_sync_from_env updates both version and commit when set", {
+  withr::with_envvar(c(DB_VERSION = "2.0.0", DB_COMMIT = "cafe123"), {
+    captured <- list()
+    .dbv_statement_fn <<- function(sql, params, conn) {
+      captured$sql <<- sql
+      captured$params <<- params
+      1L
+    }
+    result <- db_version_sync_from_env()
+    expect_true(result)
+    expect_match(captured$sql, "db_version = ?", fixed = TRUE)
+    expect_match(captured$sql, "db_commit = ?", fixed = TRUE)
+    expect_identical(captured$params, list("2.0.0", "cafe123"))
+  })
+})
+
+test_that("db_version_sync_from_env returns FALSE when no row was updated", {
+  withr::with_envvar(c(DB_VERSION = "2.0.0", DB_COMMIT = ""), {
+    .dbv_statement_fn <<- function(sql, params, conn) 0L
+    expect_false(db_version_sync_from_env())
+  })
+})
+
+test_that("db_version_sync_from_env never throws on DB error", {
+  withr::with_envvar(c(DB_VERSION = "2.0.0", DB_COMMIT = ""), {
+    .dbv_statement_fn <<- function(sql, params, conn) stop("db down")
+    expect_false(expect_no_error(db_version_sync_from_env()))
+  })
+})
+
+# ---------------------------------------------------------------------------
+# Migration contract
+# ---------------------------------------------------------------------------
+
+test_that("migration 028 creates the db_version table and seeds a semver row", {
+  migration_path <- file.path(
+    get_api_dir(), "..", "db", "migrations", "028_add_db_version.sql"
+  )
+  expect_true(file.exists(migration_path))
+  sql <- paste(readLines(migration_path, warn = FALSE), collapse = "\n")
+
+  expect_match(sql, "CREATE TABLE IF NOT EXISTS `db_version`", fixed = TRUE)
+  expect_match(sql, "`db_version`", fixed = TRUE)
+  expect_match(sql, "`db_commit`", fixed = TRUE)
+  expect_match(sql, "INSERT IGNORE INTO `db_version`", fixed = TRUE)
+  # Seeded value must be a semantic version.
+  expect_match(sql, "'[0-9]+\\.[0-9]+\\.[0-9]+'")
+})

--- a/api/tests/testthat/test-unit-llm-endpoint-helpers.R
+++ b/api/tests/testthat/test-unit-llm-endpoint-helpers.R
@@ -28,9 +28,27 @@ setwd(api_dir)
 tryCatch(
   {
     register_test_stub <- function(name, fn) {
-      if (!exists(name, mode = "function")) {
-        base::assign(name, fn, envir = .GlobalEnv)
-      }
+      # Force the stub for the duration of THIS test file, regardless of whether
+      # a prior test file already defined `name` in the global env. The previous
+      # `if (!exists())` guard made these stubs order-dependent: in a broad
+      # test_dir run, a stub registered by another file (or the real function)
+      # could shadow ours, so the get_cluster_summary tests below hit a foreign
+      # `get_cached_summary` whose result lacked a `validation_status` column and
+      # crashed (`argument is of length zero`). Restore the prior binding at file
+      # teardown so we do not pollute later files.
+      had_prev <- exists(name, envir = .GlobalEnv, inherits = FALSE)
+      prev <- if (had_prev) base::get(name, envir = .GlobalEnv, inherits = FALSE) else NULL
+      base::assign(name, fn, envir = .GlobalEnv)
+      withr::defer(
+        {
+          if (had_prev) {
+            base::assign(name, prev, envir = .GlobalEnv)
+          } else if (exists(name, envir = .GlobalEnv, inherits = FALSE)) {
+            base::rm(list = name, envir = .GlobalEnv)
+          }
+        },
+        envir = testthat::teardown_env()
+      )
     }
 
     if (!exists("%||%", mode = "function")) {

--- a/api/tests/testthat/test-unit-migration-runner.R
+++ b/api/tests/testthat/test-unit-migration-runner.R
@@ -243,8 +243,8 @@ describe("validate_migration_manifest", {
     migrations_dir <- file.path(api_dir, "..", "db", "migrations")
     result <- validate_migration_manifest(migrations_dir)
     expect_true(result$ok)
-    expect_equal(result$expected_latest, "026_add_entity_last_update.sql")
-    expect_true(result$count >= 27L)
+    expect_equal(result$expected_latest, "028_add_db_version.sql")
+    expect_true(result$count >= 28L)
   })
 })
 

--- a/app/src/api/version.spec.ts
+++ b/app/src/api/version.spec.ts
@@ -22,6 +22,44 @@ describe('api/version — getVersion', () => {
     expect(result).toEqual(expected);
   });
 
+  it('exposes the database version block when present (issue #22)', async () => {
+    const expected: ApiVersion = {
+      version: '0.20.18',
+      commit: 'abcdef1',
+      title: 'SysNDD API',
+      description: 'desc',
+      database: {
+        version: '1.0.0',
+        commit: '7532ab5',
+        description: 'release note',
+        updated_at: '2026-06-11 10:00:00',
+        available: true,
+      },
+    };
+    server.use(http.get('/api/version', () => HttpResponse.json(expected)));
+
+    const result = await getVersion();
+    expect(result.database?.version).toBe('1.0.0');
+    expect(result.database?.commit).toBe('7532ab5');
+    expect(result.database?.available).toBe(true);
+  });
+
+  it('tolerates a missing database block (older API)', async () => {
+    server.use(
+      http.get('/api/version', () =>
+        HttpResponse.json({
+          version: '0.11.14',
+          commit: 'abcdef1',
+          title: 'SysNDD API',
+          description: 'desc',
+        })
+      )
+    );
+
+    const result = await getVersion();
+    expect(result.database).toBeUndefined();
+  });
+
   it('throws AxiosError on 500', async () => {
     server.use(
       http.get('/api/version', () => HttpResponse.json({ error: 'boom' }, { status: 500 }))

--- a/app/src/api/version.ts
+++ b/app/src/api/version.ts
@@ -17,6 +17,24 @@ import { apiClient } from './client';
 // ---------------------------------------------------------------------------
 
 /**
+ * Human-facing database version surface (issue #22).
+ *
+ * Mirrors the `database` block of `GET /api/version`, read from the
+ * `db_version` table (migration 028). `available` is `false` when the API
+ * could not read the table (it then reports `version`/`commit` as
+ * `"unknown"`). `commit` is the last db/-folder git short hash, captured at
+ * release time via `db/scripts/update-db-version.sh`. `description` and
+ * `updated_at` may be omitted/null.
+ */
+export interface DbVersion {
+  version: string;
+  commit: string;
+  description?: string | null;
+  updated_at?: string | null;
+  available: boolean;
+}
+
+/**
  * Wire shape from `GET /api/version`. The R handler reads `version_spec.json`
  * and resolves the git commit hash from `GIT_COMMIT` env var or `git rev-parse`.
  * `commit` falls back to the literal string `"unknown"` if both sources fail.
@@ -26,12 +44,16 @@ import { apiClient } from './client';
  * default JSON path; this happens to flatten cleanly to plain strings here
  * because `list()` of named scalars round-trips as `{ key: value }`. Confirmed
  * by inspecting the live response — no `unwrapScalar` needed.
+ *
+ * `database` is the issue #22 DB-version block. It is optional in the type so
+ * older fixtures and any pre-#22 API still type-check.
  */
 export interface ApiVersion {
   version: string;
   commit: string;
   title: string;
   description: string;
+  database?: DbVersion;
 }
 
 // ---------------------------------------------------------------------------

--- a/app/src/components/AppVersionInfo.spec.ts
+++ b/app/src/components/AppVersionInfo.spec.ts
@@ -1,0 +1,114 @@
+// AppVersionInfo.spec.ts
+//
+// Unit tests for the version-information panel (issue #22). Verifies it renders
+// the app version (package.json), the API version + commit, and the database
+// version + commit from the typed /api/version client, and that it degrades
+// gracefully when the database block is missing or the call fails.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { flushPromises, mount } from '@vue/test-utils';
+
+import { getVersion } from '@/api/version';
+import packageInfo from '../../package.json';
+import AppVersionInfo from './AppVersionInfo.vue';
+
+vi.mock('@/api/version', () => ({
+  getVersion: vi.fn(),
+}));
+
+const bootstrapStubs = {
+  BCard: { template: '<article><slot /></article>' },
+  BListGroup: { template: '<ul><slot /></ul>' },
+  BListGroupItem: { template: '<li><slot /></li>' },
+  BBadge: { template: '<span class="badge"><slot /></span>' },
+  BSpinner: { template: '<span role="status" />' },
+};
+
+function mountComponent() {
+  return mount(AppVersionInfo, { global: { stubs: bootstrapStubs } });
+}
+
+describe('AppVersionInfo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the app version from package.json', async () => {
+    vi.mocked(getVersion).mockResolvedValue({
+      version: '0.20.18',
+      commit: 'abcdef1',
+      title: 'SysNDD API',
+      description: 'desc',
+    });
+
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain(`v${packageInfo.version}`);
+  });
+
+  it('renders the API and database versions with their commits', async () => {
+    vi.mocked(getVersion).mockResolvedValue({
+      version: '0.20.18',
+      commit: 'abcdef1',
+      title: 'SysNDD API',
+      description: 'desc',
+      database: {
+        version: '1.0.0',
+        commit: '7532ab5',
+        description: 'release note',
+        updated_at: '2026-06-11 10:00:00',
+        available: true,
+      },
+    });
+
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    const text = wrapper.text();
+    expect(text).toContain('v0.20.18');
+    expect(text).toContain('abcdef1');
+    expect(text).toContain('v1.0.0');
+    expect(text).toContain('7532ab5');
+  });
+
+  it('shows database as unavailable when the block is absent', async () => {
+    vi.mocked(getVersion).mockResolvedValue({
+      version: '0.20.18',
+      commit: 'abcdef1',
+      title: 'SysNDD API',
+      description: 'desc',
+    });
+
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    expect(wrapper.text().toLowerCase()).toContain('unavailable');
+  });
+
+  it('shows database as unavailable when API marks it unavailable', async () => {
+    vi.mocked(getVersion).mockResolvedValue({
+      version: '0.20.18',
+      commit: 'abcdef1',
+      title: 'SysNDD API',
+      description: 'desc',
+      database: { version: 'unknown', commit: 'unknown', available: false },
+    });
+
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    expect(wrapper.text().toLowerCase()).toContain('unavailable');
+  });
+
+  it('degrades gracefully when the version call fails', async () => {
+    vi.mocked(getVersion).mockRejectedValue(new Error('network down'));
+
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    // App version still shows; API/DB report unavailable, no thrown error.
+    expect(wrapper.text()).toContain(`v${packageInfo.version}`);
+    expect(wrapper.text().toLowerCase()).toContain('unavailable');
+  });
+});

--- a/app/src/components/AppVersionInfo.vue
+++ b/app/src/components/AppVersionInfo.vue
@@ -1,0 +1,106 @@
+<template>
+  <BCard class="version-info border-0 bg-light" body-class="py-3">
+    <h6 class="fw-bold mb-3">
+      <i class="bi bi-tags me-2" aria-hidden="true" />
+      Version information
+    </h6>
+
+    <BListGroup flush>
+      <!-- App version (from package.json) -->
+      <BListGroupItem class="bg-transparent d-flex justify-content-between align-items-center px-0">
+        <span class="text-muted">
+          <i class="bi bi-window me-2" aria-hidden="true" />
+          Application
+        </span>
+        <span class="fw-semibold font-monospace">v{{ appVersion }}</span>
+      </BListGroupItem>
+
+      <!-- API version + commit (from /api/version) -->
+      <BListGroupItem class="bg-transparent d-flex justify-content-between align-items-center px-0">
+        <span class="text-muted">
+          <i class="bi bi-hdd-network me-2" aria-hidden="true" />
+          API
+        </span>
+        <span v-if="loading" class="text-muted small">
+          <BSpinner small label="Loading version" />
+        </span>
+        <span v-else-if="apiVersion" class="fw-semibold font-monospace">
+          v{{ apiVersion.version }}
+          <BBadge
+            v-if="apiVersion.commit && apiVersion.commit !== 'unknown'"
+            variant="secondary"
+            class="ms-2 fw-normal"
+          >
+            {{ apiVersion.commit }}
+          </BBadge>
+        </span>
+        <span v-else class="text-muted small">unavailable</span>
+      </BListGroupItem>
+
+      <!-- Database version + commit (issue #22, from /api/version `database`) -->
+      <BListGroupItem class="bg-transparent d-flex justify-content-between align-items-center px-0">
+        <span class="text-muted">
+          <i class="bi bi-database me-2" aria-hidden="true" />
+          Database
+        </span>
+        <span v-if="loading" class="text-muted small">
+          <BSpinner small label="Loading database version" />
+        </span>
+        <span
+          v-else-if="dbVersion && dbVersion.available"
+          class="fw-semibold font-monospace"
+          :title="dbVersionTitle"
+        >
+          v{{ dbVersion.version }}
+          <BBadge
+            v-if="dbVersion.commit && dbVersion.commit !== 'unknown'"
+            variant="secondary"
+            class="ms-2 fw-normal"
+          >
+            {{ dbVersion.commit }}
+          </BBadge>
+        </span>
+        <span v-else class="text-muted small">unavailable</span>
+      </BListGroupItem>
+    </BListGroup>
+  </BCard>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import packageInfo from '../../package.json';
+import { getVersion, type ApiVersion, type DbVersion } from '@/api/version';
+
+const appVersion = packageInfo.version;
+const loading = ref(true);
+const apiVersion = ref<ApiVersion | null>(null);
+
+const dbVersion = computed<DbVersion | null>(() => apiVersion.value?.database ?? null);
+
+const dbVersionTitle = computed(() => {
+  const db = dbVersion.value;
+  if (!db) return '';
+  const parts: string[] = [];
+  if (db.description) parts.push(db.description);
+  if (db.updated_at) parts.push(`Updated: ${db.updated_at}`);
+  return parts.join(' — ');
+});
+
+onMounted(async () => {
+  try {
+    apiVersion.value = await getVersion({ timeout: 5000 });
+  } catch (_err) {
+    // Public, non-critical surface: leave apiVersion null so the template
+    // shows "unavailable" rather than surfacing an error.
+    apiVersion.value = null;
+  } finally {
+    loading.value = false;
+  }
+});
+</script>
+
+<style scoped>
+.version-info {
+  max-width: 28rem;
+}
+</style>

--- a/app/src/views/help/AboutView.spec.ts
+++ b/app/src/views/help/AboutView.spec.ts
@@ -10,6 +10,16 @@ vi.mock('@/api/about', () => ({
   getPublishedAbout: vi.fn().mockRejectedValue(new Error('CMS unavailable')),
 }));
 
+vi.mock('@/api/version', () => ({
+  getVersion: vi.fn().mockResolvedValue({
+    version: '0.20.18',
+    commit: 'abcdef1',
+    title: 'SysNDD API',
+    description: 'desc',
+    database: { version: '1.0.0', commit: '7532ab5', available: true },
+  }),
+}));
+
 vi.mock('@/composables', () => ({
   renderMarkdown: (value: string) => value,
 }));

--- a/app/src/views/help/AboutView.vue
+++ b/app/src/views/help/AboutView.vue
@@ -328,6 +328,11 @@
             </div>
           </BAccordionItem>
         </BAccordion>
+
+        <!-- Version information: App, API and Database (issue #22) -->
+        <div class="d-flex justify-content-center mt-4">
+          <AppVersionInfo />
+        </div>
       </section>
     </div>
   </div>
@@ -339,6 +344,7 @@ import { useHead } from '@unhead/vue';
 import { renderMarkdown } from '@/composables';
 import type { AboutSection } from '@/types';
 import { getPublishedAbout } from '@/api/about';
+import AppVersionInfo from '@/components/AppVersionInfo.vue';
 
 useHead({
   title: 'About',

--- a/db/migrations/028_add_db_version.sql
+++ b/db/migrations/028_add_db_version.sql
@@ -1,0 +1,42 @@
+-- 028_add_db_version.sql
+--
+-- Issue #22: Track the SysNDD database version with semantic versioning in a
+-- dedicated, human-facing table and expose it in the App and API.
+--
+-- This is intentionally SEPARATE from the migration runner's `schema_version`
+-- ledger (which records one row per applied migration file for at-most-once
+-- semantics) and from `about_content.version` (About-page CONTENT publish
+-- versioning). Neither is a human-facing semantic version of the DB schema +
+-- seed data, which is what this table provides.
+--
+-- The table holds a single "current" row (id = 1):
+--   * db_version  -- semantic version (major.minor.patch) of the DB
+--   * db_commit   -- last db/ folder related git commit short hash; captured at
+--                    release time (see db/scripts/update-db-version.sh) and
+--                    upserted by the API at startup from DB_VERSION / DB_COMMIT
+--                    env vars when present. 'unknown' when not yet captured.
+--   * description -- short human-readable note for this DB version
+--   * applied_at  -- when this version row was first seeded (immutable)
+--   * updated_at  -- last time the row was refreshed (e.g. commit injection)
+--
+-- The CHECK on id keeps the table single-row by convention; the API and the
+-- release helper both target id = 1.
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS + INSERT IGNORE so re-running is safe.
+
+CREATE TABLE IF NOT EXISTS `db_version` (
+  `id`          TINYINT UNSIGNED NOT NULL DEFAULT 1,
+  `db_version`  VARCHAR(20)  NOT NULL,
+  `db_commit`   VARCHAR(40)  NOT NULL DEFAULT 'unknown',
+  `description` VARCHAR(255) NULL DEFAULT NULL,
+  `applied_at`  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at`  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `chk_db_version_single_row` CHECK (`id` = 1)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
+-- Seed the current DB version. The version below mirrors the schema + seed-data
+-- state at this migration. Bump it (and add a new migration) when the DB
+-- structure or core seed data changes meaningfully.
+INSERT IGNORE INTO `db_version` (`id`, `db_version`, `db_commit`, `description`)
+VALUES (1, '1.0.0', 'unknown', 'Initial tracked SysNDD database version (issue #22).');

--- a/db/scripts/update-db-version.sh
+++ b/db/scripts/update-db-version.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# update-db-version.sh
+#
+# Issue #22 release helper: capture the SysNDD database semantic version and the
+# last db/-folder-related git commit short hash, and print them as shell exports
+# so deployment can inject DB_VERSION / DB_COMMIT into the API container.
+#
+# The running API container has no git checkout, so the db-folder commit must be
+# resolved at release time on a host that DOES have the repo. The API reads
+# DB_VERSION / DB_COMMIT from its environment at startup and upserts the single
+# db_version row (id = 1) via db_version_sync_from_env(); the migration seeds a
+# baseline row so the surface still works if these are never set.
+#
+# Usage:
+#   # Print exports for the current checkout (version defaults to the seeded one):
+#   ./db/scripts/update-db-version.sh
+#
+#   # Pin a specific semantic version:
+#   ./db/scripts/update-db-version.sh 1.1.0
+#
+#   # Inject into a running deployment via .env, then redeploy:
+#   ./db/scripts/update-db-version.sh 1.1.0 >> .env
+#
+# Output (stdout):
+#   DB_VERSION=<semver>
+#   DB_COMMIT=<short-hash>
+#
+# Exit codes:
+#   0  exports printed
+#   1  not a git repository / db/ folder not found
+
+set -eu
+
+# Resolve repo root relative to this script so it works regardless of CWD.
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "${SCRIPT_DIR}/../.." && pwd)
+
+if [ ! -d "${REPO_ROOT}/db" ]; then
+  echo "error: db/ folder not found under ${REPO_ROOT}" >&2
+  exit 1
+fi
+
+if ! git -C "${REPO_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: ${REPO_ROOT} is not a git work tree" >&2
+  exit 1
+fi
+
+# Last commit that touched the db/ folder, short hash. Falls back to "unknown".
+DB_COMMIT=$(git -C "${REPO_ROOT}" log -1 --format=%h -- db/ 2>/dev/null || true)
+if [ -z "${DB_COMMIT}" ]; then
+  DB_COMMIT="unknown"
+fi
+
+# Semantic version: first CLI arg wins; otherwise reuse the version currently
+# seeded in the latest db_version migration so the export stays self-consistent.
+DB_VERSION="${1:-}"
+if [ -z "${DB_VERSION}" ]; then
+  SEED_FILE=$(ls "${REPO_ROOT}"/db/migrations/*_add_db_version.sql 2>/dev/null | sort | tail -1 || true)
+  if [ -n "${SEED_FILE}" ]; then
+    DB_VERSION=$(grep -Eo "'[0-9]+\.[0-9]+\.[0-9]+'" "${SEED_FILE}" | head -1 | tr -d "'" || true)
+  fi
+fi
+if [ -z "${DB_VERSION}" ]; then
+  DB_VERSION="unknown"
+fi
+
+echo "DB_VERSION=${DB_VERSION}"
+echo "DB_COMMIT=${DB_COMMIT}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,6 +174,11 @@ services:
       # NDDScore release source; defaults match api/config.yml.
       NDDSCORE_ZENODO_RECORD_ID: "${NDDSCORE_ZENODO_RECORD_ID:-20258027}"
       NDDSCORE_ZENODO_API_BASE_URL: "${NDDSCORE_ZENODO_API_BASE_URL:-https://zenodo.org/api/records}"
+      # Database version surface (issue #22). Optional release-time injection;
+      # when set, the API refreshes the db_version row at startup. The migration
+      # seeds a baseline so the surface works even when these are unset.
+      DB_VERSION: "${DB_VERSION:-}"
+      DB_COMMIT: "${DB_COMMIT:-}"
     networks:
       - proxy
       - backend

--- a/documentation/08-development.qmd
+++ b/documentation/08-development.qmd
@@ -102,6 +102,20 @@ For MCP 1.2 analysis changes, also check that the analysis tools remain read-onl
 
 Public and MCP analysis sections such as phenotype correlations, phenotype clusters, and STRING-derived gene networks require current public-ready analysis snapshots. Public REST and MCP paths report snapshot diagnostics such as `snapshot_missing`, `snapshot_stale`, or `source_version_mismatch`; they do not compute heavy analysis or read draft/admin data on miss.
 
+### Database Version (issue #22)
+
+The human-facing DB semantic version lives in the single-row `db_version` table (migration `028_add_db_version.sql`) and is read by `api/functions/db-version.R`. It is exposed in the `database` block of `GET /api/version` and rendered on the About page via `app/src/components/AppVersionInfo.vue` (typed client `app/src/api/version.ts`).
+
+- Bump the seeded semantic version in a new numbered migration when the DB schema or core seed data changes meaningfully; do not edit an applied migration.
+- At release time, capture the last `db/`-folder git commit and the version with `./db/scripts/update-db-version.sh` and inject `DB_VERSION` / `DB_COMMIT` into the API container; `db_version_sync_from_env()` updates the row at startup (non-fatal no-op when unset). See `documentation/09-deployment.qmd`.
+- Run focused checks while iterating:
+
+```bash
+cd api
+Rscript --no-init-file -e "testthat::test_file('tests/testthat/test-unit-db-version.R')"
+cd ../app && npx vitest run src/api/version.spec.ts src/components/AppVersionInfo.spec.ts
+```
+
 ### Public Analysis Snapshots
 
 When adding a snapshot table or shape change, create a numbered migration under `db/migrations/`, update `api/functions/migration-manifest.R`, and add or update the migration and preset tests. Snapshot presets live in `api/functions/analysis-snapshot-presets.R`; unsupported public parameters should fail there before any repository or analysis work starts.

--- a/documentation/09-deployment.qmd
+++ b/documentation/09-deployment.qmd
@@ -62,6 +62,21 @@ External genomic proxy caches live under `/app/cache/external/{static,stable,dyn
 
 External provider request budgets default to short fail-fast values: `EXTERNAL_PROXY_TIMEOUT_SECONDS=6`, `EXTERNAL_PROXY_MAX_SECONDS=10`, `EXTERNAL_PROXY_MAX_TRIES=2`, and `EXTERNAL_PROXY_AGGREGATE_MAX_SECONDS=12`. Override per source with names such as `EXTERNAL_PROXY_MGI_TIMEOUT_SECONDS`, `EXTERNAL_PROXY_MGI_MAX_SECONDS`, and `EXTERNAL_PROXY_MGI_MAX_TRIES`. The aggregate external gene route remains serial and returns `partial = TRUE` with `skipped_sources` when the aggregate budget is exhausted.
 
+### Database version (`DB_VERSION` / `DB_COMMIT`)
+
+The human-facing database version (issue #22) is tracked in the single-row `db_version` table (migration `028_add_db_version.sql`), separate from the migration runner's `schema_version` apply ledger and from `about_content.version`. The migration seeds a baseline semantic version, and the API exposes it in the `database` block of the public `GET /api/version` response (semantic `version`, last `db/`-folder git `commit`, optional `description`/`updated_at`, and an `available` flag). The App surfaces it on the About page. The endpoint degrades gracefully: if the DB or table is unreachable it reports `version`/`commit` as `"unknown"` and `available: false` instead of failing.
+
+To stamp the deployed values at release time, set `DB_VERSION` (semantic `major.minor.patch`) and/or `DB_COMMIT` (last `db/`-folder git short hash) in the API container environment. The running container has no git checkout, so capture them on a host that has the repo:
+
+```sh
+# Prints DB_VERSION=<semver> and DB_COMMIT=<short-hash> for the current checkout.
+./db/scripts/update-db-version.sh            # version from the seeded migration
+./db/scripts/update-db-version.sh 1.1.0      # pin a specific semantic version
+./db/scripts/update-db-version.sh 1.1.0 >> .env   # inject, then redeploy
+```
+
+`docker-compose.yml` passes `DB_VERSION` and `DB_COMMIT` through to the `api` service. On startup, after migrations, `db_version_sync_from_env()` updates the `db_version` row (id = 1) when either variable is set; it is a non-fatal no-op otherwise. Bump the seeded version (in a new `NNN_*.sql` migration) when the DB schema or core seed data changes meaningfully.
+
 ### Public analysis snapshots
 
 Public analysis endpoints and MCP analysis tools read public-ready rows from `analysis_snapshot_manifest` and normalized snapshot payload tables. They do not compute STRING networks, phenotype clusters, correlations, fCoSE layouts, external provider calls, or Gemini summaries on request-path miss.


### PR DESCRIPTION
## Summary

Closes #22. Adds a dedicated, human-facing **semantic version of the database**, tracked in a DB table (including the last `db/`-folder git commit) and displayed in both the **App** and the **API**.

This is intentionally separate from the two existing "version-ish" surfaces:
- `schema_version` — the migration runner's at-most-once apply ledger (one row per migration file). Not repurposed.
- `about_content.version` — About-page **content** publish versioning. Unrelated.

## DB table

Migration **`028_add_db_version.sql`** creates a single-row `db_version` table (id = 1, `CHECK (id = 1)`):

| column | meaning |
| --- | --- |
| `db_version` | semantic version `major.minor.patch` |
| `db_commit` | last `db/`-folder git short hash (`unknown` until captured) |
| `description` | short human-readable note |
| `applied_at` | when the row was first seeded (immutable) |
| `updated_at` | last refresh (e.g. commit injection) |

Seeded with `1.0.0` via `INSERT IGNORE` (idempotent: `CREATE TABLE IF NOT EXISTS`).

## How the db-folder commit is captured

The running container has no git checkout, so the commit is captured at **release time** on a host that has the repo:

- `db/scripts/update-db-version.sh` runs `git log -1 --format=%h -- db/` and prints `DB_VERSION=…` / `DB_COMMIT=…` (version defaults to the value seeded in the migration; override with a CLI arg).
- `docker-compose.yml` (api service) and `.env.example` pass `DB_VERSION` / `DB_COMMIT` through to the container.
- On startup, after migrations, `db_version_sync_from_env()` upserts the `db_version` row when either env var is set. It is a **non-fatal no-op** otherwise — the seeded baseline still works.

## API surface

Extends the existing public, unauthenticated **`GET /api/version`** (preferred over a new controller) with a `database` block:

```jsonc
{
  "version": "0.20.12", "commit": "ce6eac8", "title": "SysNDD API", "description": "…",
  "database": { "version": "1.0.0", "commit": "unknown", "description": "…", "updated_at": "…", "available": true }
}
```

`api/functions/db-version.R::db_version_get()` **never throws**: a missing table or unavailable DB returns `version`/`commit` `"unknown"` with `available: false`, so the public endpoint stays resilient. The endpoint is mounted via `mount_endpoint()` (RFC 9457 problem+json), unchanged.

## Frontend display

- Typed client `app/src/api/version.ts`: new `DbVersion` interface and optional `database` field on `ApiVersion` (optional so older fixtures/API still type-check). No raw axios.
- New `app/src/components/AppVersionInfo.vue` renders **App** (from `package.json`), **API** (version + commit), and **Database** (version + commit) in a Bootstrap-Vue card matching the visual guide; shows "unavailable" / graceful fallback on failure.
- Rendered on the **About page** (`AboutView.vue`).

## Tests

- API (host-run, no RMariaDB needed — pure-logic with stubbed DB helpers): `api/tests/testthat/test-unit-db-version.R` (42 assertions) covers `db_version_get` (row / no-row / DB-error fallback / null-coercion), `db_version_sync_from_env` (no-op / commit-only / both / no-rows / error), and the migration contract.
- Integration: `test-integration-version.R` asserts the new `database` block (skipped unless an API is running — runs in CI).
- Manifest tests bumped to `028` / count 28 (`test-unit-core-views-manifest.R`, `test-unit-analysis-snapshot-migration.R`, `test-unit-migration-runner.R`).
- Frontend (vitest): `app/src/api/version.spec.ts` (database block present / missing) and `app/src/components/AppVersionInfo.spec.ts` (app/api/db render, unavailable, failure). `AboutView.spec.ts` mocks `@/api/version`.

### Verified locally
- `make lint-api` — 119 files, 0 issues; migration-prefix check OK (28 unique).
- `make lint-app` — 0 errors (warnings are pre-existing `any` in unrelated files); changed files lint clean.
- `make code-quality-audit` — clean.
- `cd app && npm run type-check` — passes.
- Focused R + vitest suites above — all green.

### Needs CI / operator
- DB-backed/integration runs (`make test-api`, migration apply against MySQL, the `/api/version` HTTP probe) rely on CI; the shared Docker stack was intentionally not started.
- At deploy, optionally run `./db/scripts/update-db-version.sh [version] >> .env` to stamp `DB_VERSION` / `DB_COMMIT`.

## Migration number

`028_add_db_version.sql` (per AGENTS.md guidance to avoid colliding with the in-flight `027` PubtatorNDD PR; `028` sorts last so `EXPECTED_LATEST_MIGRATION` stays correct even if `027` merges first). Renumber if a collision occurs.