### PR TITLE
feat(re-review): add refusal action for complex entries (#54)

### DIFF
--- a/api/bootstrap/load_modules.R
+++ b/api/bootstrap/load_modules.R
@@ -152,6 +152,7 @@ bootstrap_load_modules <- function() {
     "services/review-service.R",
     "services/approval-service.R",
     "services/re-review-service.R",
+    "services/re-review-refusal-service.R",
     "services/seo-service.R",
     "services/analysis-snapshot-service.R",
     "services/mcp-service.R",

--- a/api/endpoints/re_review_endpoints.R
+++ b/api/endpoints/re_review_endpoints.R
@@ -72,6 +72,62 @@ function(req, res, re_review_id) {
 }
 
 
+#* Refuse / decline a Re-Review Entry (needs specialist)
+#*
+#* Reviewer+ declines a complex / out-of-scope item (issue #54). Sets
+#* re_review_refused = 1 with the optional body reason, refusing user, and
+#* timestamp; the item leaves the reviewer queue and curator approve queue and
+#* surfaces in the curator "refused" view. Curated status/review unchanged.
+#* The optional reason is body-only: `{ "reason": "..." }`, never a query string.
+#*
+#* @tag re_review
+#* @serializer json list(na="string")
+#*
+#* @put refuse/<re_review_id>
+function(req, res, re_review_id) {
+  require_role(req, res, "Reviewer")
+
+  re_review_id <- as.integer(re_review_id)
+  if (is.na(re_review_id)) {
+    stop_for_bad_request("re_review_id must be an integer")
+  }
+
+  result <- refuse_re_review_entity(
+    re_review_entity_id = re_review_id,
+    user_id = req$user_id,
+    reason = req$argsBody$reason,
+    pool = pool
+  )
+  stop_for_rereview_result_error(result)
+
+  list(message = result$message, entry = result$entry)
+}
+
+
+#* Clear a Re-Review refusal (curator triage)
+#*
+#* Curator+ reverses a refusal so the item re-enters the normal re-review flow
+#* (issue #54). 200 on success, problem+json 404 when the item is not found.
+#*
+#* @tag re_review
+#* @serializer json list(na="string")
+#*
+#* @put refuse/clear/<re_review_id>
+function(req, res, re_review_id) {
+  require_role(req, res, "Curator")
+
+  re_review_id <- as.integer(re_review_id)
+  if (is.na(re_review_id)) {
+    stop_for_bad_request("re_review_id must be an integer")
+  }
+
+  result <- clear_re_review_refusal(re_review_entity_id = re_review_id, pool = pool)
+  stop_for_rereview_result_error(result)
+
+  list(message = result$message, entry = result$entry)
+}
+
+
 #* Approve a Re-Review Entry
 #*
 #* Allows (Administrator, Curator) to approve a re-review entry.
@@ -128,9 +184,12 @@ function(req, res, re_review_id, status_ok = FALSE, review_ok = FALSE) {
 #* Returns the re-review overview table for the authenticated user.
 #*
 #* # `Details`
-#* The function filters the re-review data based on the provided `filter` and
-#* `curate` parameters. Admin/Curators can see curated or uncurated sets.
-#* Reviewers see only unsubmitted sets assigned to them.
+#* The function filters the re-review data based on the provided `filter`,
+#* `curate`, and `refused` parameters. Admin/Curators can see curated or
+#* uncurated sets. Reviewers see only unsubmitted, non-refused sets assigned to
+#* them. When `refused = TRUE` (Curator+), the table lists items a re-reviewer
+#* declined for specialist attention (issue #54) — these are excluded from both
+#* the reviewer queue and the curator approve queue.
 #* Supports cursor pagination for large re-review lists.
 #*
 #* # `Return`
@@ -141,6 +200,7 @@ function(req, res, re_review_id, status_ok = FALSE, review_ok = FALSE) {
 #*
 #* @param filter Condition for the re-review data.
 #* @param curate Boolean indicating whether to see curated or not.
+#* @param refused Boolean. When TRUE (Curator+), list refused items only.
 #* @param page_after Cursor after which entries are shown (default: 0)
 #* @param page_size Page size in cursor pagination (default: "all")
 #*
@@ -149,12 +209,15 @@ function(req,
          res,
          filter = "equals(re_review_approved,0)",
          curate = FALSE,
+         refused = FALSE,
          page_after = 0,
          page_size = "all") {
   curate <- as.logical(curate)
+  refused <- as.logical(refused)
 
-  # Curate mode requires Curator+, non-curate requires Reviewer+
-  if (curate) {
+  # Refused mode is a curator surface; otherwise curate -> Curator+,
+  # plain reviewer queue -> Reviewer+.
+  if (curate || refused) {
     require_role(req, res, "Curator")
   } else {
     require_role(req, res, "Reviewer")
@@ -167,17 +230,21 @@ function(req,
     tbl("re_review_entity_connect") %>%
     filter(re_review_approved == 0) %>%
     {
-      if (curate) {
-        filter(., re_review_submitted == 1)
+      if (refused) {
+        # Curator surface: refused / needs-specialist items only.
+        filter(., re_review_refused == 1)
+      } else if (curate) {
+        filter(., re_review_submitted == 1, re_review_refused == 0)
       } else {
-        filter(., re_review_submitted == 0)
+        # Reviewer queue: hide refused items so they leave the active queue.
+        filter(., re_review_submitted == 0, re_review_refused == 0)
       }
     }
 
   re_review_assignment <- pool %>%
     tbl("re_review_assignment") %>%
     {
-      if (!curate) {
+      if (!curate && !refused) {
         filter(., user_id == user)
       } else {
         .
@@ -226,6 +293,13 @@ function(req,
   # provided so we don't collect the full 6-table join just to drop most rows
   # in R. Falls back to the legacy collect-then-filter path on translation
   # errors. No fspec contract on this endpoint, so unconditional pushdown is safe.
+  refused_user_collected <- pool %>%
+    tbl("user") %>%
+    select(
+      re_review_refused_user_id = user_id,
+      re_review_refused_user_name = user_name
+    )
+
   re_review_user_list_lazy <- re_review_entity_connect %>%
     inner_join(re_review_assignment, by = c("re_review_batch")) %>%
     select(
@@ -235,9 +309,14 @@ function(req,
       re_review_status_saved,
       re_review_submitted,
       re_review_approved,
+      re_review_refused,
+      re_review_refusal_comment,
+      re_review_refused_user_id,
+      re_review_refused_date,
       status_id,
       review_id
     ) %>%
+    left_join(refused_user_collected, by = c("re_review_refused_user_id")) %>%
     inner_join(ndd_entity_view, by = c("entity_id")) %>%
     select(-category_id, -category) %>%
     inner_join(ndd_entity_status_category, by = c("status_id")) %>%

--- a/api/functions/migration-manifest.R
+++ b/api/functions/migration-manifest.R
@@ -2,8 +2,8 @@
 #
 # Strict migration manifest validation for startup/readiness.
 
-EXPECTED_LATEST_MIGRATION <- "026_add_entity_last_update.sql"
-EXPECTED_MIGRATION_COUNT <- 27L
+EXPECTED_LATEST_MIGRATION <- "029_add_rereview_refusal.sql"
+EXPECTED_MIGRATION_COUNT <- 28L
 
 #' Validate the migration manifest for strict startup/readiness checks
 #'

--- a/api/services/re-review-refusal-service.R
+++ b/api/services/re-review-refusal-service.R
@@ -1,0 +1,176 @@
+# Re-Review Refusal Service for SysNDD API
+#
+# Issue #54: a re-reviewer can DECLINE/REFUSE a re-review item that is too
+# complex or out of scope, flagging it for specialist/curator attention
+# instead of forcing a review.
+#
+# Refusal is a distinct state (re_review_refused = 1), NOT "approved" and NOT
+# "rejected". A refused item:
+#   - leaves the refusing reviewer's active queue,
+#   - leaves the curator approve queue,
+#   - surfaces in the curator "refused / needs specialist" view.
+#
+# It never alters the curated SysNDD status or review classification.
+#
+# Extracted into its own file (rather than growing the ~930-line
+# re-review-service.R) per the AGENTS.md file-size guidance.
+
+#' Map a refusal-service result status to a classed RFC 9457 error
+#'
+#' Endpoints call this to translate a non-200 service result into the
+#' appropriate `stop_for_*` classed error so the mounted error handler emits
+#' problem+json. Only `error_400/401/403/404/500` classes exist, so the 409
+#' "already refused" case maps to a 400 with a clear message. No-op on 200.
+#'
+#' @param result List returned by the refusal service (`status`, `message`).
+#' @keywords internal
+stop_for_rereview_result_error <- function(result) {
+  if (result$status == 200) {
+    return(invisible(NULL))
+  }
+  if (result$status == 404) {
+    stop_for_not_found(result$message)
+  }
+  # 400 and 409 (already refused) both surface as a 400 bad request.
+  stop_for_bad_request(result$message)
+}
+
+#' Record a re-review refusal for a single re-review item
+#'
+#' Marks the `re_review_entity_connect` row as refused, recording the
+#' optional reason, the refusing user, and the timestamp. Refusing clears
+#' `re_review_submitted` so the item cannot also sit in the approve queue.
+#'
+#' @param re_review_entity_id Integer id of the re_review_entity_connect row.
+#' @param user_id Integer id of the refusing re-reviewer (req$user_id).
+#' @param reason Optional free-text reason (trimmed; capped at 1000 chars).
+#' @param pool Database connection pool (or transaction connection).
+#' @return List with status, message, and entry (re_review_entity_id).
+#'   status 404 when the row does not exist, 409 when already refused.
+#'
+#' @examples
+#' \dontrun{
+#' refuse_re_review_entity(42L, user_id = 7L, reason = "Needs specialist", pool)
+#' }
+#'
+#' @export
+refuse_re_review_entity <- function(re_review_entity_id, user_id, reason = NULL, pool) {
+  re_review_entity_id <- as.integer(re_review_entity_id)
+  user_id <- as.integer(user_id)
+
+  if (is.na(re_review_entity_id)) {
+    return(list(status = 400, message = "re_review_entity_id must be an integer"))
+  }
+  if (is.na(user_id)) {
+    return(list(status = 400, message = "A valid user_id is required to record a refusal"))
+  }
+
+  # Normalize the optional reason: trim, NULL out empties, cap to column width.
+  reason <- if (is.null(reason)) NA_character_ else trimws(as.character(reason)[1])
+  if (!is.na(reason) && !nzchar(reason)) {
+    reason <- NA_character_
+  }
+  if (!is.na(reason) && nchar(reason) > 1000L) {
+    reason <- substr(reason, 1L, 1000L)
+  }
+
+  existing <- db_execute_query(
+    "SELECT re_review_entity_id, re_review_refused, re_review_approved
+     FROM re_review_entity_connect
+     WHERE re_review_entity_id = ?",
+    list(re_review_entity_id),
+    conn = pool
+  )
+
+  if (nrow(existing) == 0) {
+    logger::log_warn("Re-review refusal failed: item not found",
+      re_review_entity_id = re_review_entity_id
+    )
+    return(list(status = 404, message = "Re-review item not found"))
+  }
+
+  if (isTRUE(as.integer(existing$re_review_refused[1]) == 1L)) {
+    logger::log_warn("Re-review refusal skipped: already refused",
+      re_review_entity_id = re_review_entity_id
+    )
+    return(list(status = 409, message = "Re-review item is already marked as refused"))
+  }
+
+  # IMPORTANT: unname() the params for the anonymous ? placeholders.
+  db_execute_statement(
+    "UPDATE re_review_entity_connect
+        SET re_review_refused = 1,
+            re_review_refusal_comment = ?,
+            re_review_refused_user_id = ?,
+            re_review_refused_date = UTC_TIMESTAMP(),
+            re_review_submitted = 0
+      WHERE re_review_entity_id = ?",
+    unname(list(
+      if (is.na(reason)) NA else reason,
+      user_id,
+      re_review_entity_id
+    )),
+    conn = pool
+  )
+
+  logger::log_info("Re-review item refused",
+    re_review_entity_id = re_review_entity_id,
+    refused_by = user_id,
+    has_reason = !is.na(reason)
+  )
+
+  list(
+    status = 200,
+    message = "Re-review item refused and flagged for specialist attention",
+    entry = list(re_review_entity_id = re_review_entity_id)
+  )
+}
+
+
+#' Clear a re-review refusal (curator/admin action)
+#'
+#' Reverses a refusal so the item can re-enter the normal re-review flow.
+#' Intended for curators triaging the "refused / needs specialist" surface.
+#'
+#' @param re_review_entity_id Integer id of the re_review_entity_connect row.
+#' @param pool Database connection pool (or transaction connection).
+#' @return List with status, message, and entry (re_review_entity_id).
+#'   status 404 when the row does not exist.
+#'
+#' @export
+clear_re_review_refusal <- function(re_review_entity_id, pool) {
+  re_review_entity_id <- as.integer(re_review_entity_id)
+
+  if (is.na(re_review_entity_id)) {
+    return(list(status = 400, message = "re_review_entity_id must be an integer"))
+  }
+
+  existing <- db_execute_query(
+    "SELECT re_review_entity_id FROM re_review_entity_connect WHERE re_review_entity_id = ?",
+    list(re_review_entity_id),
+    conn = pool
+  )
+
+  if (nrow(existing) == 0) {
+    return(list(status = 404, message = "Re-review item not found"))
+  }
+
+  db_execute_statement(
+    "UPDATE re_review_entity_connect
+        SET re_review_refused = 0,
+            re_review_refusal_comment = NULL,
+            re_review_refused_user_id = NULL,
+            re_review_refused_date = NULL
+      WHERE re_review_entity_id = ?",
+    list(re_review_entity_id),
+    conn = pool
+  )
+
+  logger::log_info("Re-review refusal cleared", re_review_entity_id = re_review_entity_id)
+
+  list(
+    status = 200,
+    message = "Re-review refusal cleared",
+    entry = list(re_review_entity_id = re_review_entity_id)
+  )
+}

--- a/api/tests/testthat/test-re-review-refusal-service.R
+++ b/api/tests/testthat/test-re-review-refusal-service.R
@@ -1,0 +1,213 @@
+# tests/testthat/test-re-review-refusal-service.R
+#
+# Unit tests for re-review-refusal-service.R (issue #54).
+#
+# Strategy mirrors test-re-review-service.R: replace db_execute_query and
+# db_execute_statement in .GlobalEnv so the refusal logic runs without a live
+# database. We assert the recorded SQL + params (refusal flag, reason capping,
+# user/timestamp, submitted reset) and the status-code branches.
+
+source_api_file("functions/db-helpers.R", local = FALSE, envir = .GlobalEnv)
+if (!requireNamespace("logger", quietly = TRUE)) {
+  stop("logger package not available — cannot run re-review-refusal-service tests")
+}
+source_api_file("services/re-review-refusal-service.R", local = FALSE, envir = .GlobalEnv)
+
+make_mock_conn <- function() structure(list(), class = "MockPool")
+
+# Install query + statement mocks in .GlobalEnv; restore on exit.
+with_refusal_mock <- function(query_fn, statement_fn, expr) {
+  orig_q <- if (exists("db_execute_query", envir = .GlobalEnv)) {
+    get("db_execute_query", envir = .GlobalEnv)
+  } else {
+    NULL
+  }
+  orig_s <- if (exists("db_execute_statement", envir = .GlobalEnv)) {
+    get("db_execute_statement", envir = .GlobalEnv)
+  } else {
+    NULL
+  }
+
+  assign("db_execute_query", query_fn, envir = .GlobalEnv)
+  assign("db_execute_statement", statement_fn, envir = .GlobalEnv)
+
+  on.exit({
+    if (is.null(orig_q)) rm("db_execute_query", envir = .GlobalEnv) else assign("db_execute_query", orig_q, envir = .GlobalEnv)
+    if (is.null(orig_s)) rm("db_execute_statement", envir = .GlobalEnv) else assign("db_execute_statement", orig_s, envir = .GlobalEnv)
+  }, add = TRUE)
+
+  force(expr)
+}
+
+# SELECT result for an existing, not-yet-refused row.
+existing_not_refused <- function() {
+  tibble::tibble(
+    re_review_entity_id = 42L,
+    re_review_refused = 0L,
+    re_review_approved = 0L
+  )
+}
+
+context("re-review-refusal-service: refuse_re_review_entity (issue #54)")
+
+test_that("refuse service functions are defined", {
+  expect_true(exists("refuse_re_review_entity", mode = "function"))
+  expect_true(exists("clear_re_review_refusal", mode = "function"))
+})
+
+test_that("refusal records flag, reason, user, timestamp and resets submitted", {
+  captured <- list()
+  query_fn <- function(sql, params = list(), conn = NULL) existing_not_refused()
+  statement_fn <- function(sql, params = list(), conn = NULL) {
+    captured$sql <<- sql
+    captured$params <<- params
+    1L
+  }
+
+  with_refusal_mock(query_fn, statement_fn, {
+    result <- refuse_re_review_entity(
+      re_review_entity_id = 42L,
+      user_id = 7L,
+      reason = "  Too complex; needs specialist  ",
+      pool = make_mock_conn()
+    )
+  })
+
+  expect_equal(result$status, 200L)
+  expect_equal(result$entry$re_review_entity_id, 42L)
+
+  # UPDATE must set the refusal flag, reason, user, date and reset submitted.
+  expect_match(captured$sql, "re_review_refused = 1", fixed = TRUE)
+  expect_match(captured$sql, "re_review_refusal_comment = ?", fixed = TRUE)
+  expect_match(captured$sql, "re_review_refused_user_id = ?", fixed = TRUE)
+  expect_match(captured$sql, "re_review_refused_date = UTC_TIMESTAMP()", fixed = TRUE)
+  expect_match(captured$sql, "re_review_submitted = 0", fixed = TRUE)
+
+  # Params: trimmed reason, user_id, re_review_entity_id (unnamed for ? binding).
+  expect_null(names(captured$params))
+  expect_equal(captured$params[[1]], "Too complex; needs specialist")
+  expect_equal(captured$params[[2]], 7L)
+  expect_equal(captured$params[[3]], 42L)
+})
+
+test_that("empty / whitespace reason is stored as NA (NULL reason column)", {
+  captured <- list()
+  query_fn <- function(sql, params = list(), conn = NULL) existing_not_refused()
+  statement_fn <- function(sql, params = list(), conn = NULL) {
+    captured$params <<- params
+    1L
+  }
+
+  with_refusal_mock(query_fn, statement_fn, {
+    result <- refuse_re_review_entity(42L, user_id = 7L, reason = "   ", pool = make_mock_conn())
+  })
+
+  expect_equal(result$status, 200L)
+  expect_true(is.na(captured$params[[1]]))
+})
+
+test_that("reason is capped at 1000 characters", {
+  captured <- list()
+  long_reason <- paste(rep("x", 1500L), collapse = "")
+  query_fn <- function(sql, params = list(), conn = NULL) existing_not_refused()
+  statement_fn <- function(sql, params = list(), conn = NULL) {
+    captured$params <<- params
+    1L
+  }
+
+  with_refusal_mock(query_fn, statement_fn, {
+    refuse_re_review_entity(42L, user_id = 7L, reason = long_reason, pool = make_mock_conn())
+  })
+
+  expect_equal(nchar(captured$params[[1]]), 1000L)
+})
+
+test_that("refusal returns 404 when the item does not exist", {
+  query_fn <- function(sql, params = list(), conn = NULL) tibble::tibble()
+  statement_fn <- function(sql, params = list(), conn = NULL) {
+    stop("statement must not run when item is missing")
+  }
+
+  with_refusal_mock(query_fn, statement_fn, {
+    result <- refuse_re_review_entity(999L, user_id = 7L, reason = NULL, pool = make_mock_conn())
+  })
+
+  expect_equal(result$status, 404L)
+})
+
+test_that("refusal returns 409 when already refused (no UPDATE issued)", {
+  statement_called <- FALSE
+  query_fn <- function(sql, params = list(), conn = NULL) {
+    tibble::tibble(
+      re_review_entity_id = 42L,
+      re_review_refused = 1L,
+      re_review_approved = 0L
+    )
+  }
+  statement_fn <- function(sql, params = list(), conn = NULL) {
+    statement_called <<- TRUE
+    1L
+  }
+
+  with_refusal_mock(query_fn, statement_fn, {
+    result <- refuse_re_review_entity(42L, user_id = 7L, reason = "again", pool = make_mock_conn())
+  })
+
+  expect_equal(result$status, 409L)
+  expect_false(statement_called)
+})
+
+test_that("refusal validates the re_review_entity_id and user_id", {
+  with_refusal_mock(
+    function(...) existing_not_refused(),
+    function(...) 1L,
+    {
+      # as.integer() on non-numeric text warns "NAs introduced by coercion";
+      # that NA path is exactly what we assert returns a 400.
+      bad_id <- suppressWarnings(
+        refuse_re_review_entity("not-an-int", user_id = 7L, pool = make_mock_conn())
+      )
+      bad_user <- suppressWarnings(
+        refuse_re_review_entity(42L, user_id = "nope", pool = make_mock_conn())
+      )
+    }
+  )
+  expect_equal(bad_id$status, 400L)
+  expect_equal(bad_user$status, 400L)
+})
+
+context("re-review-refusal-service: clear_re_review_refusal")
+
+test_that("clearing a refusal nulls the flag/reason/user/date", {
+  captured <- list()
+  query_fn <- function(sql, params = list(), conn = NULL) {
+    tibble::tibble(re_review_entity_id = 42L)
+  }
+  statement_fn <- function(sql, params = list(), conn = NULL) {
+    captured$sql <<- sql
+    1L
+  }
+
+  with_refusal_mock(query_fn, statement_fn, {
+    result <- clear_re_review_refusal(42L, pool = make_mock_conn())
+  })
+
+  expect_equal(result$status, 200L)
+  expect_match(captured$sql, "re_review_refused = 0", fixed = TRUE)
+  expect_match(captured$sql, "re_review_refusal_comment = NULL", fixed = TRUE)
+  expect_match(captured$sql, "re_review_refused_user_id = NULL", fixed = TRUE)
+  expect_match(captured$sql, "re_review_refused_date = NULL", fixed = TRUE)
+})
+
+test_that("clearing a refusal returns 404 when the item does not exist", {
+  query_fn <- function(sql, params = list(), conn = NULL) tibble::tibble()
+  statement_fn <- function(sql, params = list(), conn = NULL) {
+    stop("statement must not run when item is missing")
+  }
+
+  with_refusal_mock(query_fn, statement_fn, {
+    result <- clear_re_review_refusal(999L, pool = make_mock_conn())
+  })
+
+  expect_equal(result$status, 404L)
+})

--- a/api/tests/testthat/test-unit-analysis-snapshot-migration.R
+++ b/api/tests/testthat/test-unit-analysis-snapshot-migration.R
@@ -5,8 +5,8 @@ withr::defer(setwd(analysis_snapshot_test_wd), testthat::teardown_env())
 test_that("migration manifest tracks the latest migration", {
   source(file.path("functions", "migration-manifest.R"), local = TRUE)
 
-  expect_equal(EXPECTED_LATEST_MIGRATION, "026_add_entity_last_update.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 27L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "029_add_rereview_refusal.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 28L)
 })
 
 test_that("public analysis snapshot migration enforces scoped public-ready uniqueness", {

--- a/api/tests/testthat/test-unit-core-views-manifest.R
+++ b/api/tests/testthat/test-unit-core-views-manifest.R
@@ -9,16 +9,16 @@
 source_api_file("functions/migration-manifest.R", local = FALSE)
 source_api_file("functions/migration-runner.R", local = FALSE)
 
-test_that("manifest expects migration 026 as latest", {
-  expect_equal(EXPECTED_LATEST_MIGRATION, "026_add_entity_last_update.sql")
-  expect_gte(EXPECTED_MIGRATION_COUNT, 27L)
+test_that("manifest expects migration 029 as latest", {
+  expect_equal(EXPECTED_LATEST_MIGRATION, "029_add_rereview_refusal.sql")
+  expect_gte(EXPECTED_MIGRATION_COUNT, 28L)
 })
 
 test_that("migration manifest validates against db/migrations", {
   migrations_dir <- file.path(get_api_dir(), "..", "db", "migrations")
   res <- validate_migration_manifest(migrations_dir = migrations_dir)
   expect_true(res$ok)
-  expect_identical(res$latest, "026_add_entity_last_update.sql")
+  expect_identical(res$latest, "029_add_rereview_refusal.sql")
 })
 
 test_that("migration 026 adds a last_update column derived from curation dates", {

--- a/api/tests/testthat/test-unit-migration-runner.R
+++ b/api/tests/testthat/test-unit-migration-runner.R
@@ -243,8 +243,8 @@ describe("validate_migration_manifest", {
     migrations_dir <- file.path(api_dir, "..", "db", "migrations")
     result <- validate_migration_manifest(migrations_dir)
     expect_true(result$ok)
-    expect_equal(result$expected_latest, "026_add_entity_last_update.sql")
-    expect_true(result$count >= 27L)
+    expect_equal(result$expected_latest, "029_add_rereview_refusal.sql")
+    expect_true(result$count >= 28L)
   })
 })
 

--- a/app/src/api/re_review.spec.ts
+++ b/app/src/api/re_review.spec.ts
@@ -8,6 +8,8 @@ import { http, HttpResponse } from 'msw';
 import {
   submitReReview,
   unsubmitReReview,
+  refuseReReview,
+  clearReReviewRefusal,
   approveReReview,
   getReReviewTable,
   applyForReReviewBatch,
@@ -55,6 +57,60 @@ describe('api/re_review — unsubmitReReview', () => {
 
     await unsubmitReReview(7);
     expect(observedPath).toBe('/api/re_review/unsubmit/7');
+  });
+});
+
+describe('api/re_review — refuseReReview (issue #54)', () => {
+  it('PUTs the optional reason as a body, not a query string', async () => {
+    let observedPath: string | null = null;
+    let observedQuery: string | null = null;
+    let receivedBody: unknown = null;
+    server.use(
+      http.put('/api/re_review/refuse/:id', async ({ request }) => {
+        const url = new URL(request.url);
+        observedPath = url.pathname;
+        observedQuery = url.search;
+        receivedBody = await request.json();
+        return HttpResponse.json({ message: 'refused' });
+      })
+    );
+
+    const res = await refuseReReview(42, { reason: 'Needs specialist' });
+    expect(observedPath).toBe('/api/re_review/refuse/42');
+    expect(observedQuery).toBe('');
+    expect((receivedBody as { reason?: string }).reason).toBe('Needs specialist');
+    expect(res.message).toBe('refused');
+  });
+
+  it('throws an API error on 404 (item not found)', async () => {
+    server.use(
+      http.put('/api/re_review/refuse/:id', () =>
+        HttpResponse.json({ detail: 'Re-review item not found' }, { status: 404 })
+      )
+    );
+
+    let caught: unknown;
+    try {
+      await refuseReReview(999, { reason: 'x' });
+    } catch (err) {
+      caught = err;
+    }
+    expect(isApiError(caught)).toBe(true);
+  });
+});
+
+describe('api/re_review — clearReReviewRefusal (issue #54)', () => {
+  it('PUTs `/api/re_review/refuse/clear/:id`', async () => {
+    let observedPath: string | null = null;
+    server.use(
+      http.put('/api/re_review/refuse/clear/:id', ({ request }) => {
+        observedPath = new URL(request.url).pathname;
+        return HttpResponse.json({ message: 'cleared' });
+      })
+    );
+
+    await clearReReviewRefusal(42);
+    expect(observedPath).toBe('/api/re_review/refuse/clear/42');
   });
 });
 

--- a/app/src/api/re_review.ts
+++ b/app/src/api/re_review.ts
@@ -27,6 +27,16 @@ export interface ApproveReReviewParams {
   review_ok?: boolean;
 }
 
+/** Optional reason recorded when a re-reviewer declines an item (issue #54). */
+export interface RefuseReReviewRequest {
+  reason?: string | null;
+}
+
+export interface RefuseReReviewResponse {
+  message: string;
+  entry?: { re_review_entity_id: number };
+}
+
 export interface ApproveReReviewResponse {
   message: string;
 }
@@ -34,6 +44,8 @@ export interface ApproveReReviewResponse {
 export interface ReReviewTableParams {
   filter?: string;
   curate?: boolean;
+  /** Curator+ only. When true, list refused / needs-specialist items (issue #54). */
+  refused?: boolean;
   page_after?: string | number;
   page_size?: string;
 }
@@ -185,6 +197,40 @@ export async function unsubmitReReview(
 ): Promise<unknown> {
   const path = `/api/re_review/unsubmit/${encodeURIComponent(String(re_review_id))}`;
   return apiClient.put<unknown>(path, undefined, config);
+}
+
+/**
+ * PUT /api/re_review/refuse/<re_review_id>
+ * Mirrors api/endpoints/re_review_endpoints.R (handler `@put refuse/<re_review_id>`).
+ *
+ * Reviewer+ only. Declines a re-review item that is too complex / out of scope
+ * (issue #54), flagging it for specialist/curator attention. The optional
+ * reason is sent body-only (auth-sensitive/free-text inputs are never put on
+ * the query string). Throws AxiosError on non-2xx (404 not found, 400 already
+ * refused).
+ */
+export async function refuseReReview(
+  re_review_id: number | string,
+  body: RefuseReReviewRequest = {},
+  config?: AxiosRequestConfig
+): Promise<RefuseReReviewResponse> {
+  const path = `/api/re_review/refuse/${encodeURIComponent(String(re_review_id))}`;
+  return apiClient.put<RefuseReReviewResponse, RefuseReReviewRequest>(path, body, config);
+}
+
+/**
+ * PUT /api/re_review/refuse/clear/<re_review_id>
+ * Mirrors api/endpoints/re_review_endpoints.R (handler `@put refuse/clear/<re_review_id>`).
+ *
+ * Curator+ only. Reverses a refusal so the item re-enters the normal re-review
+ * flow. Throws AxiosError on non-2xx (404 not found).
+ */
+export async function clearReReviewRefusal(
+  re_review_id: number | string,
+  config?: AxiosRequestConfig
+): Promise<RefuseReReviewResponse> {
+  const path = `/api/re_review/refuse/clear/${encodeURIComponent(String(re_review_id))}`;
+  return apiClient.put<RefuseReReviewResponse>(path, undefined, config);
 }
 
 /**

--- a/app/src/test-utils/mocks/handlers.ts
+++ b/app/src/test-utils/mocks/handlers.ts
@@ -715,6 +715,20 @@ export const handlers = [
   // Returns the `{links, meta, data}` cursor envelope.
   http.get('/api/re_review/table', () => HttpResponse.json(reReviewTableOk)),
 
+  // OpenAPI: PUT /api/re_review/refuse/<re_review_id>
+  // api/endpoints/re_review_endpoints.R @put refuse/<re_review_id>
+  // Issue #54: a re-reviewer declines an item for specialist attention.
+  http.put('/api/re_review/refuse/:id', () =>
+    HttpResponse.json({ message: 'Re-review item refused and flagged for specialist attention' })
+  ),
+
+  // OpenAPI: PUT /api/re_review/refuse/clear/<re_review_id>
+  // api/endpoints/re_review_endpoints.R @put refuse/clear/<re_review_id>
+  // Issue #54: a curator clears a refusal so the item re-enters the queue.
+  http.put('/api/re_review/refuse/clear/:id', () =>
+    HttpResponse.json({ message: 'Re-review refusal cleared' })
+  ),
+
   // ---------------------------------------------------------------------------
   // ManageAnnotations.vue aux endpoints (non-B1, onMounted + action handlers)
   // ---------------------------------------------------------------------------

--- a/app/src/views/curate/ManageReReview.spec.ts
+++ b/app/src/views/curate/ManageReReview.spec.ts
@@ -175,6 +175,9 @@ const mountManageReReview = async (): Promise<VueWrapper> => {
         BatchCriteriaForm: { template: '<div />' },
         AriaLiveRegion: { template: '<div />' },
         IconLegend: { template: '<div />' },
+        // Issue #54: refused-items surface owns its own data load; stub it so
+        // this spec doesn't also drive its table render.
+        RefusedReReviewPanel: { template: '<div data-testid="refused-panel" />' },
       },
     },
   });

--- a/app/src/views/curate/ManageReReview.vue
+++ b/app/src/views/curate/ManageReReview.vue
@@ -412,6 +412,13 @@
               </GenericTable>
             </div>
           </TableShell>
+
+          <!-- Refused / needs-specialist surface (issue #54). Self-contained
+               panel so this view does not grow past its size budget. -->
+          <RefusedReReviewPanel
+            class="re-review-section--refused"
+            @cleared="loadReReviewTableData"
+          />
         </div>
       </BContainer>
 
@@ -519,6 +526,7 @@ import GenericTable from '@/components/small/GenericTable.vue';
 import TableSearchInput from '@/components/small/TableSearchInput.vue';
 import TablePaginationControls from '@/components/small/TablePaginationControls.vue';
 import ManualEntityAssignmentPanel from '@/views/curate/components/ManualEntityAssignmentPanel.vue';
+import RefusedReReviewPanel from '@/views/curate/components/RefusedReReviewPanel.vue';
 import { filterReReviewBatches, sortReReviewBatches } from '@/views/curate/utils/reReviewFilters';
 import {
   assignReReviewBatch,
@@ -547,6 +555,7 @@ export default {
     TableSearchInput,
     TablePaginationControls,
     ManualEntityAssignmentPanel,
+    RefusedReReviewPanel,
   },
   setup() {
     const { makeToast } = useToast();

--- a/app/src/views/curate/components/RefusedReReviewPanel.spec.ts
+++ b/app/src/views/curate/components/RefusedReReviewPanel.spec.ts
@@ -1,0 +1,99 @@
+// app/src/views/curate/components/RefusedReReviewPanel.spec.ts
+//
+// Component spec for the curator "refused / needs specialist" surface
+// (issue #54). Verifies it loads refused items via the typed re_review client
+// (GET /api/re_review/table?refused=true) and clears a refusal via
+// PUT /api/re_review/refuse/clear/:id.
+
+import { describe, it, expect, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { http, HttpResponse } from 'msw';
+
+// The panel calls useToast() in setup(); stub the composables barrel so the
+// component mounts without a BApp/registry provider.
+vi.mock('@/composables', () => ({
+  useToast: () => ({ makeToast: vi.fn() }),
+}));
+
+import RefusedReReviewPanel from './RefusedReReviewPanel.vue';
+import { server } from '@/test-utils/mocks/server';
+
+const refusedRow = {
+  re_review_entity_id: 701,
+  entity_id: 501,
+  symbol: 'ARID1B',
+  disease_ontology_name: 'ARID1B-related disorder',
+  re_review_refused: 1,
+  re_review_refusal_comment: 'Complex inheritance; needs specialist',
+  re_review_refused_user_name: 'reviewer_b',
+  re_review_refused_date: '2026-06-11 10:00:00',
+};
+
+function mountPanel() {
+  return mount(RefusedReReviewPanel, {
+    global: {
+      directives: { 'b-tooltip': {} },
+      stubs: {
+        TableShell: { template: '<section><slot name="actions" /><slot /></section>' },
+        GenericTable: {
+          name: 'GenericTable',
+          props: ['items', 'fields'],
+          template: `
+            <table><tbody>
+              <tr v-for="item in items" :key="item.re_review_entity_id">
+                <td><slot name="cell-entity_id" :row="item" /></td>
+                <td><slot name="cell-re_review_refusal_comment" :row="item" /></td>
+                <td><slot name="cell-re_review_refused_user_name" :row="item" /></td>
+                <td><slot name="cell-re_review_refused_date" :row="item" /></td>
+                <td><slot name="cell-actions" :row="item" /></td>
+              </tr>
+            </tbody></table>`,
+        },
+        BButton: { template: '<button><slot /></button>' },
+        BBadge: { template: '<span><slot /></span>' },
+        BSpinner: { template: '<span role="status" />' },
+      },
+    },
+  });
+}
+
+describe('RefusedReReviewPanel (issue #54)', () => {
+  it('loads refused items via GET /api/re_review/table?refused=true', async () => {
+    let observedQuery: URLSearchParams | null = null;
+    server.use(
+      http.get('/api/re_review/table', ({ request }) => {
+        observedQuery = new URL(request.url).searchParams;
+        return HttpResponse.json({ data: [refusedRow] });
+      })
+    );
+
+    const wrapper = mountPanel();
+    await flushPromises();
+
+    const q = observedQuery as unknown as URLSearchParams;
+    expect(q.get('refused')).toBe('true');
+    expect(q.get('curate')).toBe('true');
+    expect(wrapper.text()).toContain('Complex inheritance; needs specialist');
+    expect(wrapper.text()).toContain('reviewer_b');
+  });
+
+  it('clears a refusal via PUT /api/re_review/refuse/clear/:id and emits "cleared"', async () => {
+    let clearedPath: string | null = null;
+    server.use(
+      http.get('/api/re_review/table', () => HttpResponse.json({ data: [refusedRow] })),
+      http.put('/api/re_review/refuse/clear/:id', ({ request }) => {
+        clearedPath = new URL(request.url).pathname;
+        return HttpResponse.json({ message: 'cleared' });
+      })
+    );
+
+    const wrapper = mountPanel();
+    await flushPromises();
+
+    await wrapper.find('button[aria-label="Clear refusal for sysndd:501"]').trigger('click');
+    await flushPromises();
+
+    expect(clearedPath).toBe('/api/re_review/refuse/clear/701');
+    expect(wrapper.emitted('cleared')).toBeTruthy();
+  });
+});

--- a/app/src/views/curate/components/RefusedReReviewPanel.vue
+++ b/app/src/views/curate/components/RefusedReReviewPanel.vue
@@ -1,0 +1,177 @@
+<!-- src/views/curate/components/RefusedReReviewPanel.vue -->
+<!--
+  Curator surface for re-review items a re-reviewer declined / refused for
+  specialist attention (issue #54).
+
+  Self-contained: owns its own data load via the typed re_review client
+  (`getReReviewTable({ refused: true, curate: true })`) and the "clear refusal"
+  mutation (`clearReReviewRefusal`). Lives in its own component so
+  `ManageReReview.vue` (already over the file-size soft ceiling) does not grow.
+-->
+<template>
+  <TableShell
+    title="Refused / needs specialist"
+    :meta="`${rows.length} flagged`"
+    description="Entities a re-reviewer declined as too complex or out of scope. Reassign to a specialist or clear the refusal to return them to the queue."
+  >
+    <template #actions>
+      <BButton
+        size="sm"
+        variant="outline-secondary"
+        class="refused-icon-button"
+        :disabled="loading"
+        aria-label="Refresh refused re-review items"
+        @click="loadRefused"
+      >
+        <BSpinner v-if="loading" small />
+        <i v-else class="bi bi-arrow-clockwise" aria-hidden="true" />
+      </BButton>
+    </template>
+
+    <div class="position-relative refused-table-wrap">
+      <div v-if="!loading && rows.length === 0" class="text-center py-4">
+        <i class="bi bi-flag fs-1 text-muted" aria-hidden="true" />
+        <p class="text-muted mt-2 mb-0">No refused items.</p>
+      </div>
+
+      <GenericTable
+        v-else
+        :items="rows"
+        :fields="fields"
+        :is-busy="loading"
+        :stacked-mode="false"
+      >
+        <template #cell-entity_id="{ row }">
+          <span class="font-monospace">sysndd:{{ row.entity_id }}</span>
+        </template>
+
+        <template #cell-re_review_refusal_comment="{ row }">
+          <span v-if="row.re_review_refusal_comment" class="refused-reason">
+            {{ row.re_review_refusal_comment }}
+          </span>
+          <span v-else class="text-muted">—</span>
+        </template>
+
+        <template #cell-re_review_refused_user_name="{ row }">
+          <BBadge variant="warning">
+            {{ row.re_review_refused_user_name || 'Unknown' }}
+          </BBadge>
+        </template>
+
+        <template #cell-re_review_refused_date="{ row }">
+          <span class="small text-muted">
+            {{ row.re_review_refused_date ? String(row.re_review_refused_date).substring(0, 10) : '—' }}
+          </span>
+        </template>
+
+        <template #cell-actions="{ row }">
+          <BButton
+            size="sm"
+            variant="outline-primary"
+            :disabled="clearingId === row.re_review_entity_id"
+            :aria-label="`Clear refusal for sysndd:${row.entity_id}`"
+            @click="handleClear(row)"
+          >
+            <BSpinner v-if="clearingId === row.re_review_entity_id" small />
+            <template v-else>
+              <i class="bi bi-arrow-counterclockwise me-1" aria-hidden="true" />
+              Return to queue
+            </template>
+          </BButton>
+        </template>
+      </GenericTable>
+    </div>
+  </TableShell>
+</template>
+
+<script>
+import TableShell from '@/components/table/TableShell.vue';
+import GenericTable from '@/components/small/GenericTable.vue';
+import { useToast } from '@/composables';
+import { getReReviewTable, clearReReviewRefusal } from '@/api/re_review';
+
+export default {
+  name: 'RefusedReReviewPanel',
+  components: { TableShell, GenericTable },
+  emits: ['cleared'],
+  setup() {
+    const { makeToast } = useToast();
+    return { makeToast };
+  },
+  data() {
+    return {
+      rows: [],
+      loading: false,
+      clearingId: null,
+      fields: [
+        { key: 'entity_id', label: 'Entity', class: 'text-start' },
+        { key: 'symbol', label: 'Gene', class: 'text-start' },
+        { key: 'disease_ontology_name', label: 'Disease', class: 'text-start' },
+        { key: 're_review_refused_user_name', label: 'Refused by', class: 'text-start' },
+        { key: 're_review_refusal_comment', label: 'Reason', class: 'text-start' },
+        { key: 're_review_refused_date', label: 'Date', class: 'text-start' },
+        { key: 'actions', label: 'Actions', class: 'text-center' },
+      ],
+    };
+  },
+  mounted() {
+    this.loadRefused();
+  },
+  methods: {
+    async loadRefused() {
+      this.loading = true;
+      try {
+        const payload = await getReReviewTable({ refused: true, curate: true });
+        this.rows = Array.isArray(payload) ? payload : (payload?.data ?? []);
+      } catch (e) {
+        this.makeToast(e, 'Error', 'danger');
+        this.rows = [];
+      } finally {
+        this.loading = false;
+      }
+    },
+    async handleClear(row) {
+      this.clearingId = row.re_review_entity_id;
+      try {
+        await clearReReviewRefusal(row.re_review_entity_id);
+        this.makeToast('Refusal cleared; entity returned to the re-review queue', 'Success', 'success');
+        this.$emit('cleared', row);
+        await this.loadRefused();
+      } catch (e) {
+        this.makeToast(e, 'Error', 'danger');
+      } finally {
+        this.clearingId = null;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.refused-icon-button {
+  display: inline-grid;
+  width: 2rem;
+  min-width: 2rem;
+  height: 2rem;
+  padding: 0;
+  place-items: center;
+}
+
+.refused-table-wrap {
+  padding: 0.75rem;
+}
+
+.refused-reason {
+  display: inline-block;
+  max-width: min(28rem, 100%);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
+}
+
+.font-monospace {
+  font-family: SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.9em;
+}
+</style>

--- a/app/src/views/review/Review.spec.ts
+++ b/app/src/views/review/Review.spec.ts
@@ -757,6 +757,51 @@ describe('Review.vue — classification wizard (functional)', () => {
     expect(vm.categoryFilter).toBe('Definitive');
     expect(vm.userFilter).toBe('alice_admin');
   });
+
+  // Issue #54: refusing a re-review item PUTs to /refuse/:id with a body
+  // reason, then resets the refuse modal so the next entity opens clean.
+  it('refuses a re-review item via /api/re_review/refuse/:id with the body reason', async () => {
+    const axiosMock = await getSharedAxiosMock();
+    wireHappyPathResponses(axiosMock);
+    axiosMock.put.mockResolvedValue({ data: { message: 'refused' } });
+
+    const wrapper = await mountReview();
+    const vm = wrapper.vm as unknown as ReviewVm & {
+      reviewModals: {
+        refuseModal: { id: string; title: string };
+        entity: { value: Array<{ entity_id: number }> };
+        refuse_reason: { value: string };
+      };
+      refuse_reason: string;
+      infoRefuse: (item: ReReviewRow) => void;
+      handleRefuseOk: () => Promise<void>;
+    };
+    await flushPromises();
+
+    vm.infoRefuse(sampleRow);
+    await flushPromises();
+
+    expect(vm.reviewModals.entity.value).toHaveLength(1);
+    expect(vm.reviewModals.refuseModal.title).toBe('sysndd:501');
+
+    // User types a reason, then confirms.
+    vm.reviewModals.refuse_reason.value = 'Too complex; needs specialist';
+    await flushPromises();
+
+    await vm.handleRefuseOk();
+    await flushPromises();
+
+    const refuseCall = axiosMock.put.mock.calls.find(
+      (c: unknown[]) => (c[0] as string) === `/api/re_review/refuse/${sampleRow.re_review_entity_id}`
+    );
+    expect(refuseCall).toBeDefined();
+    expect((refuseCall as [string, { reason?: string }])[1].reason).toBe(
+      'Too complex; needs specialist'
+    );
+
+    // Reason is reset for the next entity.
+    expect(vm.reviewModals.refuse_reason.value).toBe('');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/app/src/views/review/Review.vue
+++ b/app/src/views/review/Review.vue
@@ -44,6 +44,7 @@
         @info-status="infoStatus"
         @info-submit="infoSubmit"
         @info-approve="infoApprove"
+        @info-refuse="infoRefuse"
         @filtered="onFiltered"
         @update:filter="filter = $event"
         @update:category-filter="categoryFilter = $event"
@@ -95,6 +96,14 @@
         @ok="handleSubmitOk"
       />
 
+      <RefuseConfirmModal
+        ref="refuseModalRef"
+        :modal-descriptor="refuseModal"
+        :reason="refuse_reason"
+        @ok="handleRefuseOk"
+        @update:reason="refuse_reason = $event"
+      />
+
       <ApproveDecisionModal
         ref="approveModalRef"
         :modal-descriptor="approveModal"
@@ -130,6 +139,7 @@ import ReviewQueueTable from './components/ReviewQueueTable.vue';
 import ReviewEditModal from './components/ReviewEditModal.vue';
 import StatusEditModal from './components/StatusEditModal.vue';
 import SubmitConfirmModal from './components/SubmitConfirmModal.vue';
+import RefuseConfirmModal from './components/RefuseConfirmModal.vue';
 import ApproveDecisionModal from './components/ApproveDecisionModal.vue';
 
 // Import the utilities file
@@ -214,6 +224,7 @@ export default {
     ReviewEditModal,
     StatusEditModal,
     SubmitConfirmModal,
+    RefuseConfirmModal,
     ApproveDecisionModal,
   },
   setup() {
@@ -333,9 +344,11 @@ export default {
       statusModal: modals.statusModal,
       submitModal: modals.submitModal,
       approveModal: modals.approveModal,
+      refuseModal: modals.refuseModal,
       entity: modals.entity,
       review_approved: modals.review_approved,
       status_approved: modals.status_approved,
+      refuse_reason: modals.refuse_reason,
       reviewModals: modals,
 
       // useReviewActions handle (used by the on*/handle* methods)
@@ -404,6 +417,10 @@ export default {
       this.reviewModals.openApprove(item);
       this.$refs.approveModalRef?.show();
     },
+    infoRefuse(item) {
+      this.reviewModals.openRefuse(item);
+      this.$refs.refuseModalRef?.show();
+    },
 
     // ---- Wizard form submissions (BModal @ok wiring) -----------------------
 
@@ -450,6 +467,20 @@ export default {
       });
       this.reviewModals.resetApproveModal();
       await this.loadReReviewData();
+    },
+    async handleRefuseOk() {
+      const ok = await this.reviewActions.refuseEntity(
+        this.entity[0].re_review_entity_id,
+        this.refuse_reason
+      );
+      if (ok) {
+        this.makeToast('Re-review refused and flagged for specialist', 'Success', 'success');
+        this.announce('Re-review refused and flagged for specialist');
+        this.reviewModals.resetRefuseModal();
+        await this.loadReReviewData();
+      } else {
+        this.announce('Failed to refuse re-review', 'assertive');
+      }
     },
     async handleUnsetSubmission() {
       await this.reviewActions.unsubmitEntity(this.entity[0].re_review_entity_id);
@@ -500,6 +531,7 @@ export default {
         [this.reviewModal.id]: this.$refs.reviewModalRef,
         [this.statusModal.id]: this.$refs.statusModalRef,
         [this.submitModal.id]: this.$refs.submitModalRef,
+        [this.refuseModal.id]: this.$refs.refuseModalRef,
         [this.approveModal.id]: this.$refs.approveModalRef,
       };
       refMap[id]?.hide();

--- a/app/src/views/review/components/RefuseConfirmModal.vue
+++ b/app/src/views/review/components/RefuseConfirmModal.vue
@@ -1,0 +1,100 @@
+<!-- views/review/components/RefuseConfirmModal.vue -->
+<!--
+  Refuse / decline-confirmation modal for the re-review queue (issue #54).
+
+  A re-reviewer uses this to DECLINE a particularly complex or out-of-scope
+  entry, flagging it for specialist / curator attention instead of forcing a
+  review. The optional reason is captured here and emitted on `@ok`; the parent
+  owns the modal id (`refuse-modal`) and the mutation that fires
+  `PUT /api/re_review/refuse/:id`.
+
+  Refusal is a "needs specialist" flag, not a destructive delete, so it uses
+  the warning variant and is visually separated from the success/submit action.
+-->
+<template>
+  <BModal
+    :id="modalDescriptor.id"
+    :ref="modalDescriptor.id"
+    centered
+    ok-title="Refuse (needs specialist)"
+    ok-variant="warning"
+    cancel-variant="outline-secondary"
+    no-close-on-esc
+    no-close-on-backdrop
+    header-class="border-bottom-0 pb-0"
+    footer-class="border-top-0 pt-0"
+    @ok="$emit('ok')"
+  >
+    <template #title>
+      <div class="d-flex align-items-center">
+        <i class="bi bi-flag-fill me-2 text-warning" aria-hidden="true" />
+        <span class="fw-semibold">Refuse re-review</span>
+      </div>
+    </template>
+
+    <div class="py-2">
+      <div class="text-center mb-3">
+        <span
+          class="d-inline-flex align-items-center justify-content-center rounded-circle bg-warning-subtle text-warning"
+          style="width: 64px; height: 64px; font-size: 1.5rem"
+        >
+          <i class="bi bi-flag" aria-hidden="true" />
+        </span>
+      </div>
+      <p class="mb-2 text-center">
+        Decline the re-review of entity
+        <BBadge variant="primary" class="fs-6 ms-1">
+          {{ modalDescriptor.title }}
+        </BBadge>
+      </p>
+      <p class="text-muted small text-center mb-3">
+        Use this for entries that are too complex or out of scope. The item
+        leaves your queue and is flagged for specialist / curator attention. It
+        will not change the curated classification.
+      </p>
+
+      <BFormGroup
+        label="Reason (optional)"
+        label-for="refuse-reason-input"
+        description="Briefly explain why this entry needs specialist attention."
+      >
+        <BFormTextarea
+          id="refuse-reason-input"
+          :model-value="reason"
+          placeholder="e.g. Complex inheritance / outside my expertise"
+          rows="3"
+          max-rows="6"
+          maxlength="1000"
+          aria-label="Optional reason for refusing this re-review"
+          @update:model-value="$emit('update:reason', $event)"
+        />
+      </BFormGroup>
+    </div>
+  </BModal>
+</template>
+
+<script>
+export default {
+  name: 'RefuseConfirmModal',
+  props: {
+    modalDescriptor: {
+      type: Object,
+      required: true,
+      validator: (value) => typeof value?.id === 'string' && typeof value?.title === 'string',
+    },
+    reason: {
+      type: String,
+      default: '',
+    },
+  },
+  emits: ['ok', 'update:reason'],
+  methods: {
+    show() {
+      this.$refs[this.modalDescriptor.id]?.show();
+    },
+    hide() {
+      this.$refs[this.modalDescriptor.id]?.hide();
+    },
+  },
+};
+</script>

--- a/app/src/views/review/components/ReviewQueueTable.vue
+++ b/app/src/views/review/components/ReviewQueueTable.vue
@@ -213,6 +213,21 @@
           <i class="bi bi-send-check" aria-hidden="true" />
         </BButton>
 
+        <!-- Refuse / decline (needs specialist) — issue #54. Visually separated
+             from the success Submit action; warning, not destructive. -->
+        <BButton
+          v-if="!curationSelected"
+          v-b-tooltip.hover.top
+          size="sm"
+          class="ms-2 btn-xs"
+          variant="outline-warning"
+          title="Refuse / decline (needs specialist)"
+          :aria-label="`Refuse re-review for sysndd:${row.item.entity_id}`"
+          @click="$emit('info-refuse', row.item, row.index, $event.target)"
+        >
+          <i class="bi bi-flag" aria-hidden="true" />
+        </BButton>
+
         <BButton
           v-if="curationSelected"
           v-b-tooltip.hover.right
@@ -387,6 +402,7 @@ export default {
     'info-status',
     'info-submit',
     'info-approve',
+    'info-refuse',
     'filtered',
     'update:filter',
     'update:categoryFilter',

--- a/app/src/views/review/composables/__tests__/useReviewActions.spec.ts
+++ b/app/src/views/review/composables/__tests__/useReviewActions.spec.ts
@@ -155,6 +155,57 @@ describe('useReviewActions', () => {
     });
   });
 
+  describe('refuseEntity', () => {
+    it('PUTs `/api/re_review/refuse/:id` with a body reason and resolves true', async () => {
+      const axios = await getAxiosMock();
+      axios.put.mockResolvedValueOnce({ data: { message: 'refused' } });
+
+      const a = useReviewActions();
+      const promise = a.refuseEntity(701, '  Too complex  ');
+      expect(a.mutating.value).toBe(true);
+      const result = await promise;
+      await flushPromises();
+
+      expect(result).toBe(true);
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/re_review/refuse/701',
+        { reason: 'Too complex' },
+        undefined
+      );
+      expect(a.mutating.value).toBe(false);
+    });
+
+    it('sends reason=null when blank/whitespace-only', async () => {
+      const axios = await getAxiosMock();
+      axios.put.mockResolvedValueOnce({ data: { message: 'refused' } });
+
+      const a = useReviewActions();
+      await a.refuseEntity(701, '   ');
+      await flushPromises();
+
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/re_review/refuse/701',
+        { reason: null },
+        undefined
+      );
+    });
+
+    it('routes errors through onError and resolves false', async () => {
+      const axios = await getAxiosMock();
+      const err = new Error('409 already refused');
+      axios.put.mockRejectedValueOnce(err);
+
+      const onError = vi.fn();
+      const a = useReviewActions({ onError });
+      const result = await a.refuseEntity(701, 'x');
+      await flushPromises();
+
+      expect(onError).toHaveBeenCalledWith(err);
+      expect(result).toBe(false);
+      expect(a.mutating.value).toBe(false);
+    });
+  });
+
   describe('applyForBatch', () => {
     it('GETs `/api/re_review/batch/apply`', async () => {
       const axios = await getAxiosMock();

--- a/app/src/views/review/composables/useReviewActions.ts
+++ b/app/src/views/review/composables/useReviewActions.ts
@@ -3,21 +3,23 @@
 // W6 of v11.1 finish-hardening — re-review mutation composable for
 // `Review.vue`.
 //
-// Owns the four `/api/re_review/*` mutations:
+// Owns the `/api/re_review/*` mutations:
 //   - `submitReReviewEntity(id)`        → `PUT /api/re_review/submit`
 //   - `approveEntity(id, params)`       → `PUT /api/re_review/approve/:id`
 //   - `unsubmitEntity(id)`              → `PUT /api/re_review/unsubmit/:id`
+//   - `refuseEntity(id, reason)`        → `PUT /api/re_review/refuse/:id`
 //   - `applyForBatch()`                 → `GET /api/re_review/batch/apply`
 //
 // Does NOT own the wizard's form submissions — those stay in the
 // `useReviewForm` / `useStatusForm` composables. Those have their own
 // loading/saving state. This composable only exposes a single `mutating`
-// flag covering the four re-review-level mutations.
+// flag covering the re-review-level mutations.
 
 import { ref, type Ref } from 'vue';
 import {
   applyForReReviewBatch,
   approveReReview,
+  refuseReReview,
   submitReReview,
   unsubmitReReview,
 } from '@/api/re_review';
@@ -37,7 +39,7 @@ export interface UseReviewActionsOptions {
 }
 
 export interface UseReviewActions {
-  /** True while any of the four mutations is in flight. */
+  /** True while any mutation is in flight. */
   mutating: Ref<boolean>;
 
   /** PUT /api/re_review/submit with submit_json. */
@@ -48,6 +50,13 @@ export interface UseReviewActions {
 
   /** PUT /api/re_review/unsubmit/:id. */
   unsubmitEntity: (re_review_entity_id: number | string) => Promise<void>;
+
+  /**
+   * PUT /api/re_review/refuse/:id with an optional reason (issue #54).
+   * Resolves true on success and false when the mutation was reported as
+   * failed, so the caller can keep the confirm modal open on failure.
+   */
+  refuseEntity: (re_review_entity_id: number | string, reason?: string | null) => Promise<boolean>;
 
   /** GET /api/re_review/batch/apply (email send). */
   applyForBatch: () => Promise<void>;
@@ -109,6 +118,23 @@ export function useReviewActions(options: UseReviewActionsOptions = {}): UseRevi
     }
   }
 
+  async function refuseEntity(
+    re_review_entity_id: number | string,
+    reason?: string | null
+  ): Promise<boolean> {
+    mutating.value = true;
+    try {
+      const trimmed = typeof reason === 'string' ? reason.trim() : '';
+      await refuseReReview(re_review_entity_id, { reason: trimmed.length ? trimmed : null });
+      return true;
+    } catch (err) {
+      reportError(err);
+      return false;
+    } finally {
+      mutating.value = false;
+    }
+  }
+
   async function applyForBatch(): Promise<void> {
     mutating.value = true;
     try {
@@ -125,6 +151,7 @@ export function useReviewActions(options: UseReviewActionsOptions = {}): UseRevi
     submitReReviewEntity,
     approveEntity,
     unsubmitEntity,
+    refuseEntity,
     applyForBatch,
   };
 }

--- a/app/src/views/review/composables/useReviewModals.ts
+++ b/app/src/views/review/composables/useReviewModals.ts
@@ -34,19 +34,25 @@ export interface UseReviewModals {
   statusModal: ModalDescriptor;
   submitModal: ModalDescriptor;
   approveModal: ModalDescriptor;
+  refuseModal: ModalDescriptor;
 
-  /** Single-element queue Approve/Submit confirm handlers read on `@ok`. */
+  /** Single-element queue Approve/Submit/Refuse confirm handlers read on `@ok`. */
   entity: Ref<ModalTargetRow[]>;
 
   status_approved: Ref<boolean>;
   review_approved: Ref<boolean>;
 
+  /** Optional reason captured in the refuse-confirm modal (issue #54). */
+  refuse_reason: Ref<string>;
+
   setReviewTarget: (row: ModalTargetRow) => void;
   setStatusTarget: (row: ModalTargetRow) => void;
   openSubmit: (row: ModalTargetRow) => void;
   openApprove: (row: ModalTargetRow) => void;
+  openRefuse: (row: ModalTargetRow) => void;
 
   resetApproveModal: () => void;
+  resetRefuseModal: () => void;
   clearTarget: () => void;
 }
 
@@ -63,10 +69,12 @@ export function useReviewModals(): UseReviewModals {
   const statusModal = reactive(makeDescriptor('status-modal'));
   const submitModal = reactive(makeDescriptor('submit-modal'));
   const approveModal = reactive(makeDescriptor('approve-modal'));
+  const refuseModal = reactive(makeDescriptor('refuse-modal'));
 
   const entity = ref<ModalTargetRow[]>([]);
   const status_approved = ref(false);
   const review_approved = ref(false);
+  const refuse_reason = ref('');
 
   function setReviewTarget(row: ModalTargetRow): void {
     reviewModal.title = `sysndd:${row.entity_id}`;
@@ -86,9 +94,19 @@ export function useReviewModals(): UseReviewModals {
     entity.value = [row];
   }
 
+  function openRefuse(row: ModalTargetRow): void {
+    refuseModal.title = `sysndd:${row.entity_id}`;
+    refuse_reason.value = '';
+    entity.value = [row];
+  }
+
   function resetApproveModal(): void {
     status_approved.value = false;
     review_approved.value = false;
+  }
+
+  function resetRefuseModal(): void {
+    refuse_reason.value = '';
   }
 
   function clearTarget(): void {
@@ -100,14 +118,18 @@ export function useReviewModals(): UseReviewModals {
     statusModal,
     submitModal,
     approveModal,
+    refuseModal,
     entity,
     status_approved,
     review_approved,
+    refuse_reason,
     setReviewTarget,
     setStatusTarget,
     openSubmit,
     openApprove,
+    openRefuse,
     resetApproveModal,
+    resetRefuseModal,
     clearTarget,
   };
 }

--- a/db/migrations/029_add_rereview_refusal.sql
+++ b/db/migrations/029_add_rereview_refusal.sql
@@ -1,0 +1,100 @@
+-- Migration 029: Add re-reviewer refusal state to re_review_entity_connect
+--
+-- Issue #54: let a re-reviewer DECLINE/REFUSE a re-review item on a
+-- particularly complex or out-of-scope entry, flagging it for specialist /
+-- curator attention instead of forcing a review.
+--
+-- Refusal is a distinct state, NOT "approved" and NOT "rejected":
+--   * re_review_refused        -- 1 when the re-reviewer declined the item
+--   * re_review_refusal_comment -- optional free-text reason the reviewer gives
+--   * re_review_refused_user_id -- the re-reviewer who declined (FK -> user)
+--   * re_review_refused_date    -- when the refusal was recorded (UTC)
+--
+-- A refused item leaves the reviewer's active queue and the curator approve
+-- queue, and surfaces in a dedicated "refused / needs specialist" curator
+-- view (re_review table endpoint `refused` mode). It never changes the
+-- curated SysNDD status or review classification.
+--
+-- Idempotent: a stored procedure guards each ADD COLUMN / ADD FOREIGN KEY so
+-- re-running the migration is safe (mirrors migration 002's pattern).
+
+DELIMITER //
+
+CREATE PROCEDURE IF NOT EXISTS migrate_029_rereview_refusal()
+BEGIN
+    -- re_review_refused flag
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 're_review_entity_connect'
+          AND COLUMN_NAME = 're_review_refused'
+    ) THEN
+        ALTER TABLE re_review_entity_connect
+            ADD COLUMN re_review_refused TINYINT NOT NULL DEFAULT 0
+            AFTER re_review_approved;
+    END IF;
+
+    -- re_review_refusal_comment (optional reviewer-supplied reason)
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 're_review_entity_connect'
+          AND COLUMN_NAME = 're_review_refusal_comment'
+    ) THEN
+        ALTER TABLE re_review_entity_connect
+            ADD COLUMN re_review_refusal_comment VARCHAR(1000) NULL DEFAULT NULL
+            AFTER re_review_refused;
+    END IF;
+
+    -- re_review_refused_user_id (who declined)
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 're_review_entity_connect'
+          AND COLUMN_NAME = 're_review_refused_user_id'
+    ) THEN
+        ALTER TABLE re_review_entity_connect
+            ADD COLUMN re_review_refused_user_id INT NULL DEFAULT NULL
+            AFTER re_review_refusal_comment;
+    END IF;
+
+    -- re_review_refused_date (when declined)
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 're_review_entity_connect'
+          AND COLUMN_NAME = 're_review_refused_date'
+    ) THEN
+        ALTER TABLE re_review_entity_connect
+            ADD COLUMN re_review_refused_date DATETIME NULL DEFAULT NULL
+            AFTER re_review_refused_user_id;
+    END IF;
+
+    -- Index the flag for the curator "refused" surface query.
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 're_review_entity_connect'
+          AND INDEX_NAME = 'idx_re_review_refused'
+    ) THEN
+        ALTER TABLE re_review_entity_connect
+            ADD INDEX idx_re_review_refused (re_review_refused);
+    END IF;
+
+    -- Foreign key on the refusing user (named so we can guard re-runs).
+    IF NOT EXISTS (
+        SELECT 1 FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+        WHERE TABLE_SCHEMA = DATABASE()
+          AND TABLE_NAME = 're_review_entity_connect'
+          AND CONSTRAINT_NAME = 're_review_entity_connect_refused_user_fk'
+          AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+    ) THEN
+        ALTER TABLE re_review_entity_connect
+            ADD CONSTRAINT re_review_entity_connect_refused_user_fk
+            FOREIGN KEY (re_review_refused_user_id) REFERENCES user (user_id);
+    END IF;
+END //
+
+CALL migrate_029_rereview_refusal() //
+
+DROP PROCEDURE IF EXISTS migrate_029_rereview_refusal //

--- a/db/migrations/README.md
+++ b/db/migrations/README.md
@@ -99,7 +99,11 @@ codifies the four core views (`ndd_entity_view`, `users_view`,
 previously missing from migrations, ensuring a pristine DB boots fully, and
 `026_add_entity_last_update.sql` which adds a derived `last_update` freshness
 column to `ndd_entity_view` (GREATEST of entry date, approved status date, and
-primary-approved review date).
+primary-approved review date), and `029_add_rereview_refusal.sql` which adds the
+re-reviewer refusal state to `re_review_entity_connect`
+(`re_review_refused` flag plus `re_review_refusal_comment`,
+`re_review_refused_user_id`, and `re_review_refused_date`) so a re-reviewer can
+decline a complex / out-of-scope item for specialist attention (issue #54).
 
 ## 4. Adding a new migration
 

--- a/documentation/06-re-review-instructions.qmd
+++ b/documentation/06-re-review-instructions.qmd
@@ -174,7 +174,25 @@ After clicking this button, the entity disappears from your list. You can then p
 <br/>
 <br/>
 
+### Refusing a re-review (needs specialist)
+
+Some entries are too complex or fall outside your area of expertise. Instead of forcing a review, you can **decline / refuse** the entry so it is flagged for specialist or curator attention. Use the flag button (`Refuse / decline (needs specialist)`) in the action column of your re-review queue.
+
+A confirmation window lets you add an optional short reason (for example, "complex inheritance / outside my expertise"). After you confirm:
+
+- the entry leaves your active queue, so you can continue with the rest of your batch; and
+- it is recorded as **refused** — a distinct state that is neither "approved" nor "rejected" and that does **not** change the curated SysNDD classification.
+
+Refusing is reversible by a curator (see below); if you refuse an entry by mistake, ask a curator to return it to the queue.
+
+<br/>
+<br/>
+
 ## Re-review curation
+
+### Handling refused entries
+
+The "Manage Re-review" page shows a **Refused / needs specialist** panel listing every entry a re-reviewer declined, together with the optional reason, who refused it, and when. From there a curator can reassign the entry to a specialist or click **Return to queue** to clear the refusal so the entry re-enters the normal re-review flow. Clearing a refusal does not change any curated status or review.
 
 ### Definitive association status
 

--- a/scripts/code-quality-file-size-baseline.tsv
+++ b/scripts/code-quality-file-size-baseline.tsv
@@ -5,7 +5,7 @@ api/endpoints/external_endpoints.R	607
 api/endpoints/jobs_endpoints.R	1011
 api/endpoints/llm_admin_endpoints.R	797
 api/endpoints/publication_endpoints.R	1193
-api/endpoints/re_review_endpoints.R	777
+api/endpoints/re_review_endpoints.R	856
 api/endpoints/review_endpoints.R	634
 api/endpoints/statistics_endpoints.R	782
 api/endpoints/user_endpoints.R	1128
@@ -59,7 +59,7 @@ app/src/views/admin/ManageUser.vue	675
 app/src/views/curate/ApproveReview.vue	841
 app/src/views/curate/ApproveUser.vue	842
 app/src/views/curate/CreateEntity.vue	637
-app/src/views/curate/ManageReReview.vue	1573
+app/src/views/curate/ManageReReview.vue	1579
 app/src/views/curate/ModifyEntity.vue	762
 app/src/views/pages/EntityView.vue	811
 db/11_Rcommands_sysndd_db_table_database_comparisons.R	638


### PR DESCRIPTION
## Summary

Resolves #54. Re-reviewers can now **decline / refuse** a re-review item that is too complex or out of scope, flagging it for specialist/curator attention instead of being forced to review it. This is a distinct, reversible state — separate from the "Skip double review" curator toggle in `FormWizard.vue`, which is an unrelated feature.

## State model

New columns on `re_review_entity_connect` (migration `029_add_rereview_refusal.sql`):

| column | purpose |
| --- | --- |
| `re_review_refused` `TINYINT DEFAULT 0` | the refusal flag |
| `re_review_refusal_comment` `VARCHAR(1000)` | optional reviewer-supplied reason |
| `re_review_refused_user_id` `INT` (FK → `user`) | who declined |
| `re_review_refused_date` `DATETIME` | when (UTC) |

`re_review_refused = 1` is a **distinct state** — not `approved`, not `rejected`. A refused item:
- leaves the refusing reviewer's active queue (the queue filters `re_review_submitted = 0 AND re_review_refused = 0`);
- leaves the curator approve queue (`re_review_submitted = 1 AND re_review_refused = 0`);
- surfaces in a dedicated curator **"Refused / needs specialist"** view (`refused = 1`).

It **never** changes the curated SysNDD status or review classification. The migration is idempotent (guarded stored procedure, mirrors migration 002).

## API

New service `api/services/re-review-refusal-service.R` (kept out of the already-large `re-review-service.R`):
- `refuse_re_review_entity()` — records the flag, trimmed/≤1000-char reason, refusing user, UTC timestamp, and resets `re_review_submitted`.
- `clear_re_review_refusal()` — reverses a refusal (curator triage).
- `stop_for_rereview_result_error()` — maps service status → classed RFC 9457 error.

New endpoints in `api/endpoints/re_review_endpoints.R` (mounted via `mount_endpoint()`, classed errors only):
- `PUT /api/re_review/refuse/<re_review_id>` — Reviewer+. Optional reason is **body-only** (`{ "reason": "..." }`), never a query string. 404 not found / 400 already-refused as `application/problem+json`.
- `PUT /api/re_review/refuse/clear/<re_review_id>` — Curator+.
- `GET /api/re_review/table` gains a `refused` (Curator+) mode and now excludes refused items from the reviewer and curator queues; carries the refusal columns + refusing-user name for the curator surface.

(409 "already refused" maps to a 400 because only `error_400/401/403/404/500` classes exist per the repo's error contract.)

## Frontend

- Typed client `refuseReReview()` / `clearReReviewRefusal()` in `app/src/api/re_review.ts` (no raw axios in components).
- `useReviewActions.refuseEntity()` + `useReviewModals` refuse-modal state.
- **"Refuse / decline (needs specialist)"** flag button in the re-review queue (`ReviewQueueTable.vue`), visually separated from the success Submit action (warning, not destructive — per the visual design guide), with a confirm modal (`RefuseConfirmModal.vue`) and optional reason textarea.
- **Where refused items surface for curators:** new `RefusedReReviewPanel.vue` mounted in `ManageReReview.vue` — lists refused entries with reason / who / when and a **"Return to queue"** (clear) action. Self-contained so `ManageReReview.vue` (already over the size budget) barely grows.

## Tests

- **R:** `test-re-review-refusal-service.R` (27 assertions: flag/reason/user/timestamp recorded, submitted reset, reason trim + 1000-char cap, 404/409/400 branches, clear). Full fast gate green locally: `FAIL 0 | PASS 3486`.
- **TS:** `refuseReReview`/`clearReReviewRefusal` client (body-not-query, 404), `useReviewActions.refuseEntity`, `Review.vue` refuse flow, `RefusedReReviewPanel` load + clear. MSW handlers added and the MSW↔OpenAPI drift check passes.
- Updated migration-manifest tests (`026`→`029`, count `27`→`28`).

## Migration

`029_add_rereview_refusal.sql`. `EXPECTED_LATEST_MIGRATION` / count bumped to `029` / `28`. In-flight PRs use 027/028 — **renumber on merge collision**.

## Verified locally

`make code-quality-audit` (clean), `npm run type-check` (clean), `npm run lint` (0 errors), `make test-api-fast` (0 fail), R lint on changed files, `verify-msw-against-openapi.sh` (59 OK). DB-writing integration tests skip without a DB and will run in CI. Docs updated: `documentation/06-re-review-instructions.qmd` and `db/migrations/README.md`.

## Notes for CI

- DB-backed/integration runs (e.g. `test-integration-rereview-sync.R`) skipped locally — rely on CI with the test DB.
- No Playwright spec added (E2E lane is local-only/ad-hoc per repo convention).

Closes #54
