### PR TITLE
feat(analysis-snapshot): complete #347 provenance contract (input_hash, payload_hash, record_counts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **Public analysis snapshot responses now expose full provenance lineage.** The `meta.snapshot` block returned by public REST and MCP analysis reads now includes `input_hash`, `payload_hash`, and `record_counts` alongside the existing `snapshot_id`, `schema_version`, `generated_at`, and `source_data_version` fields, completing the W3C-PROV / FAIR output contract from issue #347 so clients can audit lineage and completeness without a second query.
 
 ## [0.19.1] — 2026-05-15
 

--- a/api/services/analysis-snapshot-service.R
+++ b/api/services/analysis-snapshot-service.R
@@ -331,9 +331,45 @@ service_analysis_snapshot_meta <- function(snapshot) {
       ),
       source_data_version = service_analysis_snapshot_json_scalar(
         service_analysis_snapshot_scalar_value(row$source_data_version)
-      )
+      ),
+      # Lineage hashes (W3C-PROV / FAIR provenance per issue #347 output
+      # contract): input_hash binds the snapshot to its supported parameter set
+      # plus the public source-data version; payload_hash binds it to the
+      # materialized result. record_counts exposes the stored row counts so
+      # callers can audit completeness without a second query. All come from the
+      # public-ready manifest row already selected by analysis_snapshot_get_public().
+      input_hash = service_analysis_snapshot_json_scalar(
+        service_analysis_snapshot_column_value(row, "input_hash")
+      ),
+      payload_hash = service_analysis_snapshot_json_scalar(
+        service_analysis_snapshot_column_value(row, "payload_hash")
+      ),
+      record_counts = service_analysis_snapshot_record_counts(row)
     )
   )
+}
+
+# Safe single-row column accessor that tolerates manifests missing optional
+# columns without emitting tibble "unknown column" warnings.
+service_analysis_snapshot_column_value <- function(row, name, default = NULL) {
+  if (!name %in% names(row)) {
+    return(default)
+  }
+  service_analysis_snapshot_scalar_value(row[[name]], default)
+}
+
+service_analysis_snapshot_record_counts <- function(row) {
+  if (!"row_counts_json" %in% names(row)) {
+    return(NULL)
+  }
+  counts <- service_analysis_snapshot_parse_json_object(row$row_counts_json[[1]])
+  # network_metadata is generated metadata, not a row count; keep the
+  # record_counts block scoped to the materialized payload tables.
+  counts$network_metadata <- NULL
+  if (length(counts) == 0L) {
+    return(NULL)
+  }
+  counts
 }
 
 service_analysis_snapshot_parse_json_object <- function(value) {

--- a/api/tests/testthat/test-unit-analysis-snapshot-provenance.R
+++ b/api/tests/testthat/test-unit-analysis-snapshot-provenance.R
@@ -1,0 +1,102 @@
+# Regression guard for issue #347: public analysis snapshot responses must
+# surface the W3C-PROV / FAIR provenance fields named in the issue output
+# contract (snapshot_id, schema_version, generated_at, source_versions,
+# input_hash, record_counts, parameters) directly from the public-ready
+# manifest row, without any heavy compute or extra DB round trip.
+
+analysis_snapshot_provenance_test_wd <- getwd()
+setwd(get_api_dir())
+withr::defer(setwd(analysis_snapshot_provenance_test_wd), testthat::teardown_env())
+
+analysis_snapshot_provenance_fake_snapshot <- function(row_counts_json) {
+  list(
+    manifest = tibble::tibble(
+      snapshot_id = 42,
+      analysis_type = "gene_network_edges",
+      parameter_hash = "param-hash",
+      schema_version = "1.0",
+      data_class = "curated_derived_analysis",
+      generated_at = as.POSIXct("2026-05-30 12:00:00", tz = "UTC"),
+      stale_after = as.POSIXct("2026-06-06 12:00:00", tz = "UTC"),
+      source_data_version = "source-v1",
+      parameters_json = "{\"cluster_type\":\"clusters\",\"min_confidence\":400,\"max_edges\":10000}",
+      algorithm_name = "clusters",
+      input_hash = "input-hash",
+      payload_hash = "payload-hash",
+      row_counts_json = row_counts_json
+    ),
+    network_nodes = tibble::tibble(),
+    network_edges = tibble::tibble(),
+    clusters = tibble::tibble(),
+    cluster_members = tibble::tibble(),
+    correlations = tibble::tibble()
+  )
+}
+
+test_that("snapshot meta surfaces lineage hashes and record counts from the manifest", {
+  source(file.path("services", "analysis-snapshot-service.R"), local = TRUE)
+
+  snapshot <- analysis_snapshot_provenance_fake_snapshot(
+    row_counts_json = "{\"nodes\":2,\"edges\":1,\"network_metadata\":{\"min_confidence\":400}}"
+  )
+
+  meta <- service_analysis_snapshot_meta(snapshot)$snapshot
+
+  # Issue #347 output-contract fields are all present and load-bearing.
+  expect_equal(as.character(meta$snapshot_id), "42")
+  expect_equal(as.character(meta$schema_version), "1.0")
+  expect_equal(as.character(meta$data_class), "curated_derived_analysis")
+  expect_equal(as.character(meta$source_data_version), "source-v1")
+  expect_equal(as.character(meta$input_hash), "input-hash")
+  expect_equal(as.character(meta$payload_hash), "payload-hash")
+  expect_false(is.null(meta$generated_at))
+
+  # record_counts reflects the materialized payload tables only; the generated
+  # network_metadata block is excluded so the block stays a true row-count map.
+  expect_equal(meta$record_counts$nodes, 2L)
+  expect_equal(meta$record_counts$edges, 1L)
+  expect_null(meta$record_counts$network_metadata)
+})
+
+test_that("snapshot meta record_counts is null when no row counts were stored", {
+  source(file.path("services", "analysis-snapshot-service.R"), local = TRUE)
+
+  snapshot <- analysis_snapshot_provenance_fake_snapshot(row_counts_json = NA_character_)
+  meta <- service_analysis_snapshot_meta(snapshot)$snapshot
+
+  expect_null(meta$record_counts)
+})
+
+test_that("snapshot meta record_counts is null when only generated metadata is stored", {
+  source(file.path("services", "analysis-snapshot-service.R"), local = TRUE)
+
+  snapshot <- analysis_snapshot_provenance_fake_snapshot(
+    row_counts_json = "{\"network_metadata\":{\"min_confidence\":400}}"
+  )
+  meta <- service_analysis_snapshot_meta(snapshot)$snapshot
+
+  expect_null(meta$record_counts)
+})
+
+test_that("snapshot meta tolerates manifests missing the optional lineage columns", {
+  source(file.path("services", "analysis-snapshot-service.R"), local = TRUE)
+
+  snapshot <- list(
+    manifest = tibble::tibble(
+      snapshot_id = 7,
+      analysis_type = "phenotype_clusters",
+      parameter_hash = "p",
+      schema_version = "1.0",
+      data_class = "curated_derived_analysis",
+      generated_at = as.POSIXct("2026-05-30 12:00:00", tz = "UTC"),
+      stale_after = as.POSIXct(NA),
+      source_data_version = "source-v1"
+    )
+  )
+
+  meta <- service_analysis_snapshot_meta(snapshot)$snapshot
+  expect_null(meta$input_hash)
+  expect_null(meta$payload_hash)
+  expect_null(meta$record_counts)
+  expect_equal(as.character(meta$snapshot_id), "7")
+})

--- a/documentation/09-deployment.qmd
+++ b/documentation/09-deployment.qmd
@@ -75,6 +75,8 @@ Snapshot status meanings:
 - `snapshot_stale`: an active snapshot exists but is past `stale_after`; public REST and MCP analysis reads report it unavailable until the preset is refreshed.
 - `source_version_mismatch`: the stored source data version no longer matches the cheap current source version; public REST and MCP analysis reads report it unavailable until the preset is refreshed.
 
+Available snapshot responses carry a `meta.snapshot` provenance block sourced from the public-ready manifest row: `snapshot_id`, `analysis_type`, `parameter_hash`, `schema_version`, `data_class`, `generated_at`, `stale_after`, `source_data_version`, `input_hash`, `payload_hash`, and `record_counts`. `input_hash` binds the snapshot to its supported parameter set plus the public source-data version; `payload_hash` binds it to the materialized result; `record_counts` reports the stored payload row counts (it excludes generated network metadata). These fields let operators and downstream clients audit lineage and completeness without a second query.
+
 ### Gemini model configuration
 
 The effective Gemini model resolves in this order: `GEMINI_MODEL`, `api/config.yml` key `gemini_model`, then the SysNDD default `gemini-3.5-flash`. The admin LLM configuration endpoint reports the source, default model, validity, and any warning so operators can see when an environment override is active.


### PR DESCRIPTION
## Summary

Issue #347 asked to **persist public derived analysis snapshots in the DB** so MCP/API can serve durable public-ready data and report meaningful diagnostics, replacing dependence on ephemeral file-cache keys.

**Verification finding: the snapshot subsystem requested by #347 is already implemented on `master`.** This PR closes the one remaining gap against the issue's W3C-PROV / FAIR **"Output contract"** example field list, adds a regression guard, and documents the contract.

## Evidence: #347 acceptance criteria → existing code

| Acceptance criterion | Where it is satisfied |
| --- | --- |
| DB-backed versioned snapshot model w/ manifest + payload tables | `db/migrations/024_add_public_analysis_snapshots.sql` — `analysis_snapshot_manifest` + `analysis_snapshot_network_node/edge`, `analysis_snapshot_cluster/_member`, `analysis_snapshot_correlation` |
| One public-ready row per `(analysis_type, parameter_hash)` | Migration 024 generated column `public_ready_slot` + `UNIQUE KEY idx_analysis_snapshot_public_ready`; `analysis_snapshot_activate()` atomic supersede/activate in `analysis-snapshot-repository.R` |
| Manifest provenance: source versions, input hashes, data class, schema version, status, public readiness, algorithm, parameters | Migration 024 columns + `analysis_snapshot_create_manifest()` / `analysis_snapshot_refresh()` (`analysis-snapshot-builder.R`) |
| Populated only by approved API/admin/worker paths | `analysis_snapshot_refresh` durable async job (`async-job-analysis-snapshot-handlers.R`, registered in `async_job_handler_registry`); approved-public input gate `analysis_snapshot_approved_gene_ids()` (`ndd_phenotype = 1` from `ndd_entity_view`) |
| MCP reads only approved public-ready snapshots; never computes/writes | `mcp-analysis-repository.R` (`mcp_analysis_repo_get_public_snapshot` + bounded shapers) and `mcp-analysis-cache-repository.R` (`mcp_analysis_repo_public_snapshot_status`, bounded SELECTs) |
| Network & phenotype tools use bounded SELECTs against public-ready snapshots | `analysis_snapshot_get_public()` reads by `snapshot_id`; MCP/API shapers in `analysis-snapshot-service.R` |
| Missing/stale snapshots → recoverable result w/ diagnostics + operator recovery hints | `snapshot_missing` / `snapshot_stale` / `source_version_mismatch` / `unsupported_parameter` via `analysis_snapshot_status_code()`, `service_analysis_snapshot_read()`, and MCP `mcp_stop_analysis_snapshot_unavailable()` with `recovery.retry_with` |
| `data_class = curated_derived_analysis`, `not_evidence_tier = true`, not curated evidence | `mcp_analysis_provenance()` in `mcp-analysis-shaping.R` |
| Token efficiency (compact, `max_response_chars="auto"`, dry-run, budget, dropped-summary) | `mcp_analysis_response_budget()`, `mcp_analysis_finalize_budget()`, dry-run paths in `mcp-analysis-service.R` |
| Migration / repository / service / MCP / smoke tests | `test-unit-analysis-snapshot-migration.R`, `test-unit-analysis-snapshot-repository.R`, `test-endpoint-analysis-snapshot-read.R`, `test-mcp-analysis-service.R`, `test-mcp-snapshot-diagnostics.R`, `api/scripts/mcp-smoke.R` |
| MCP never computes heavy analysis on miss (AGENTS.md invariant) | Documented + enforced; cache-hit-only reads |

## The one gap this PR closes

The issue's "Output contract" lists `snapshot_id`, `schema_version`, `generated_at`, `source_versions`, **`input_hash`**, **`record_counts`**, and `parameters` as the provenance fields a snapshot response should expose. The surfaced `meta.snapshot` block (`service_analysis_snapshot_meta()`) already returned `snapshot_id`, `schema_version`, `data_class`, `generated_at`, `stale_after`, `source_data_version`, and `parameter_hash`, but **omitted `input_hash`, `payload_hash`, and `record_counts`** — even though those values are already stored on the public-ready manifest row that `analysis_snapshot_get_public()` selects with `SELECT *`.

### Changes
- `api/services/analysis-snapshot-service.R`: `service_analysis_snapshot_meta()` now emits `input_hash`, `payload_hash`, and `record_counts`. `record_counts` is parsed from `row_counts_json` with the generated `network_metadata` block excluded so it stays a true row-count map. Added a safe single-row column accessor so partial manifests do not emit tibble "unknown column" warnings.
- `api/tests/testthat/test-unit-analysis-snapshot-provenance.R`: new regression guard (16 assertions) — lineage hashes surface from the manifest, `record_counts` strips `network_metadata`, empty/absent counts degrade to null, and missing optional columns degrade to null without compute or extra queries.
- `documentation/09-deployment.qmd`: documents the `meta.snapshot` provenance block.
- `CHANGELOG.md`: Unreleased entry.

No request-path compute, external calls, fCoSE layouts, or Gemini are introduced; reads remain bounded SELECTs against public-ready snapshots only (AGENTS.md invariant preserved).

## Tests (host-run, pure logic)

```
test-unit-analysis-snapshot-provenance  PASS 16
test-endpoint-analysis-snapshot-read    PASS 39
test-mcp-analysis-service               PASS 111
test-unit-analysis-snapshot-presets     PASS 13
test-unit-analysis-snapshot-migration   PASS 11
test-unit-analysis-snapshot-repository  PASS 36
test-mcp-snapshot-diagnostics           PASS 9
```

`make code-quality-audit` clean; changed file + new test lint-clean (the two `line_length_linter` notes on lines 323-324 are pre-existing in `master`, untouched here). DB-backed integration tests run in CI.

Closes #347