### PR TITLE
docs(deploy): design + safe skeleton for CSR/cert automation (#25)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,15 @@
 app/docker/nginx/cert.pem
 app/docker/nginx/key.pem
 
+# TLS certificate renewal (issue #25): real site-specific config + any
+# accidentally-local key/CSR output must never be committed. Only the
+# *.example template is tracked.
+scripts/cert/cert-renewal.conf
+scripts/cert/*.key.pem
+scripts/cert/*.csr.pem
+scripts/cert/*.crt
+scripts/cert/*.pem
+
 # testing files
 TESTING.md
 

--- a/.planning/decisions/2026-06-11-tls-certificate-renewal-automation.md
+++ b/.planning/decisions/2026-06-11-tls-certificate-renewal-automation.md
@@ -1,0 +1,217 @@
+# ADR: TLS Certificate Renewal Automation
+
+**Date:** 2026-06-11
+**Status:** Proposed (design + safe skeleton; live implementation deferred)
+**Refs:** #25
+
+## Context
+
+GitHub issue #25 asks us to automate the yearly TLS certificate lifecycle for
+the public SysNDD site. Today the renewal is fully manual:
+
+1. An operator generates a CSR (and private key) by hand once a year.
+2. The CSR is emailed to a signing authority.
+3. Some days/weeks later the signed certificate is emailed back.
+4. An operator installs the new key/cert and restarts the server.
+
+This is slow and bottlenecked on the availability of the specific people who
+know how to run step 1 and who hold the mailbox for steps 2–3.
+
+### What the repository tells us about how TLS is served
+
+Two TLS topologies exist in the codebase, reflecting how the deployment has
+evolved:
+
+- **Legacy standalone nginx TLS** — `app/docker/nginx/prod.conf` terminates TLS
+  on `:443` for `sysndd.org` / `www.sysndd.org`, reading
+  `ssl_certificate /etc/nginx/certificates/cert.pem` and
+  `ssl_certificate_key /etc/nginx/certificates/key.pem`. `.gitignore` already
+  excludes `app/docker/nginx/cert.pem` and `app/docker/nginx/key.pem`. This is
+  the deployment the issue's manual workflow was written for: a hand-made CSR is
+  emailed out, the returned `cert.pem`/`key.pem` are dropped into the nginx
+  certificates mount, and nginx is reloaded. **`prod.conf` is not referenced by
+  the current `app/Dockerfile` or any `docker-compose*.yml`** — it is retained
+  config from the earlier nginx-terminates-TLS era.
+- **Current Traefik stack** — `docker-compose.yml` runs Traefik `v3.7` with a
+  single `web` entrypoint on `:80` only. There is **no `websecure`/`:443`
+  entrypoint, no ACME resolver, and no certificate mount** in the application
+  Compose stack. The public host is `sysndd.dbmr.unibe.ch` (University of Bern,
+  DBMR). `documentation/09-deployment.qmd` says only "Use HTTPS in production"
+  with no in-stack TLS detail. The practical implication: **TLS is terminated by
+  an upstream / institutional reverse proxy in front of this Compose stack**, and
+  the institutional CA at Uni Bern is exactly the kind of authority that issues
+  via portal/email rather than ACME.
+
+So the renewal target is: produce a key + CSR, get it signed by the
+institutional authority, and land the signed certificate wherever the active
+TLS terminator reads it (the nginx `cert.pem`/`key.pem` mount in the legacy
+topology, or the upstream institutional terminator's certificate store in the
+current topology), then reload that terminator.
+
+### Constraints that make this a design + skeleton, not a full automation
+
+- The signing step is an **external** authority reached (per the issue) by
+  **email**. It cannot be fully automated or end-to-end tested inside this repo
+  without the authority's interface and real secrets.
+- Generating/installing real keys is **security-sensitive and
+  environment-specific**. Auto-running live key/cert operations from CI or a
+  shared agent is unacceptable.
+- Therefore the deliverable is a thorough design plus a **dry-run-by-default,
+  parameterized** CSR-generation skeleton with clearly-marked operator TODO
+  hooks for the deployment-specific submit/install/reload steps. No real keys,
+  CSRs, or certificates are generated or committed.
+
+## Options
+
+### Option A — ACME / Let's Encrypt auto-renewal via Traefik (preferred *if* a public CA is acceptable)
+
+Add a `websecure` (`:443`) entrypoint and a Let's Encrypt ACME resolver
+(TLS-ALPN-01 or HTTP-01 challenge) to the Traefik stack. Traefik then obtains
+and renews certificates automatically; there is **no CSR, no email, no yearly
+human step, and no server restart** (Traefik hot-reloads its own certs).
+
+```yaml
+# Sketch only — not wired into docker-compose.yml in this change.
+command:
+  - "--entryPoints.websecure.address=:443"
+  - "--certificatesresolvers.le.acme.tlschallenge=true"
+  - "--certificatesresolvers.le.acme.email=ops@example.org"
+  - "--certificatesresolvers.le.acme.storage=/letsencrypt/acme.json"
+# app/api routers: entrypoints=websecure + tls.certresolver=le
+# ports: add "443:443"; volume: a persisted acme.json (chmod 600)
+```
+
+- **Pros:** Eliminates the manual process entirely; 90-day certs auto-renew;
+  no private key ever leaves the host; battle-tested; zero-downtime reload.
+- **Cons / preconditions:** Requires (1) a **public CA** to be acceptable to the
+  institution for this hostname, (2) inbound `:443` (and `:80` for HTTP-01)
+  reachable from the internet for the ACME challenge, and (3) that an upstream
+  institutional proxy is **not** already terminating TLS for
+  `sysndd.dbmr.unibe.ch` (if it is, ACME must move to that proxy, not this
+  stack). Given the `*.unibe.ch` institutional hostname and the issue's
+  "signing authority + email" framing, a public CA is likely **not** the
+  accepted path for this host — but this must be confirmed with the institution,
+  because if it is acceptable it makes the whole issue disappear.
+
+### Option B — Scripted CSR generation + submission + install for an institutional CA (the path this skeleton implements)
+
+Keep the institutional CA but remove the human bottleneck from the mechanical
+parts. A small, config-driven script generates the key + CSR reproducibly
+(Option B is what `scripts/cert/generate-csr.sh` skeletons). The submit step is
+the only genuinely manual/CA-specific part and is left as an operator TODO hook
+(portal upload, CA API call, or templated email), because the authority's
+interface is not in this repo. Install + reload are also TODO hooks because they
+depend on which terminator is active.
+
+- **Pros:** Works with any institutional/internal CA; reproducible CSRs;
+  removes "which person knows the openssl incantation" risk; dry-run-safe;
+  documented runbook; easy to schedule.
+- **Cons:** The submit/receive round-trip with an email-based CA cannot be fully
+  automated without the CA's interface; still needs an operator to shepherd the
+  signed cert back. A scheduled reminder + pre-generated CSR is the realistic
+  win.
+
+## Decision / Recommendation
+
+1. **First, ask the institution whether a public-CA ACME certificate is
+   acceptable for `sysndd.dbmr.unibe.ch` (Option A).** If yes, implement Option
+   A — it is strictly simpler and fully eliminates issue #25. The follow-up work
+   is then a Traefik `:443` + ACME wiring change (or moving ACME to the upstream
+   proxy), not the CSR script.
+2. **If a public CA is not acceptable (most likely, given the institutional host
+   and the email-based signing authority described in the issue), adopt Option
+   B.** Use the safe `scripts/cert/generate-csr.sh` skeleton for reproducible
+   CSR generation, and have an operator wire the submit/install/reload TODO
+   hooks to the Uni Bern authority's actual interface.
+
+This ADR + the skeleton deliver Option B's safe foundation now and document
+Option A as the preferred outcome if the institution allows it. **No live
+certificate operations and no key material are committed in this change.**
+
+## Yearly schedule mechanism
+
+Whichever option is chosen, the cadence is automated outside the app stack:
+
+- **Option A:** No schedule needed — Traefik renews ACME certs automatically
+  (~30 days before expiry).
+- **Option B:** A host `cron` entry or a `systemd` timer runs the CSR generator
+  on a yearly cadence (e.g. ~6 weeks before expiry to allow round-trip slack)
+  and **notifies an operator** (email/Slack) that a fresh CSR is ready to submit.
+  Do **not** put cron inside the nginx app container (the repo already forbids
+  this for SEO refresh in `09-deployment.qmd`). Example crontab line:
+
+  ```cron
+  # 06:00 on Oct 1 each year — generate the renewal CSR and email the operator.
+  0 6 1 10 * /opt/sysndd/scripts/cert/generate-csr.sh --apply \
+    --out-dir /etc/sysndd/certs >> /var/log/sysndd-cert-renew.log 2>&1
+  ```
+
+  An expiry-driven check (`openssl x509 -checkend`) can replace the fixed date so
+  generation triggers from the *current* cert's `notAfter` rather than a guessed
+  month.
+
+## Where keys/certs live
+
+- **Private key + CSR output:** an operator-managed directory **outside the git
+  tree**, default `CERT_OUT_DIR=/etc/sysndd/certs`. The skeleton hard-refuses to
+  write inside the repository working tree.
+- **Active certificate/key for the terminator:**
+  - Legacy nginx topology: `cert.pem` / `key.pem` mounted at
+    `/etc/nginx/certificates/` (already gitignored under
+    `app/docker/nginx/`).
+  - Current/upstream topology: the institutional proxy's certificate store
+    (operator-specific; outside this repo).
+  - Option A (ACME): Traefik's persisted `acme.json` (chmod 600), never a repo
+    path.
+
+## How the server picks up the new cert (reload vs restart)
+
+- **nginx:** `nginx -s reload` (or `docker compose exec <proxy> nginx -s reload`)
+  re-reads `cert.pem`/`key.pem` **without dropping connections** — prefer reload
+  over a full container restart.
+- **Traefik file-provider:** dynamic certificate files **hot-reload
+  automatically** on change; no restart.
+- **Traefik ACME (Option A):** fully automatic; nothing to do.
+
+The original issue's "restart the server" step becomes a graceful **reload** in
+all modern paths.
+
+## Security considerations
+
+- **Never commit key material.** Keys/CSRs are written only to `CERT_OUT_DIR`
+  outside the repo; the skeleton refuses repo-internal paths;
+  `scripts/cert/cert-renewal.conf` (real, site-specific config) is gitignored
+  (only `cert-renewal.conf.example` is tracked, and it holds no secrets).
+- **Filesystem permissions:** private keys are written under `umask 077` and
+  `chmod 600`; the ACME store (`acme.json`) must also be `0600`.
+- **Secrets handling:** CA credentials/tokens (if the CA exposes an API) live in
+  the operator's `.env`/secret store, never in the repo. The config file holds
+  only non-secret subject metadata.
+- **No secret logging:** the script logs the CSR path (safe to share) and never
+  prints the private key.
+- **Reduced blast radius:** automating CSR generation removes ad-hoc "copy this
+  openssl command from a wiki" steps that invite mistakes.
+
+## Rollback plan
+
+- Always retain the **previous** `cert.pem`/`key.pem` (and ACME store) as `.bak`
+  before installing a new pair. The install TODO hook documents this.
+- If the new certificate fails validation or breaks TLS after reload, restore
+  the `.bak` pair and reload again — this is fast and connection-preserving.
+- Verify before and after with:
+  ```bash
+  echo | openssl s_client -connect sysndd.dbmr.unibe.ch:443 \
+    -servername sysndd.dbmr.unibe.ch 2>/dev/null | openssl x509 -noout -dates
+  ```
+- The newly generated key/CSR are inert until an operator installs the signed
+  cert, so generation itself carries no production risk.
+
+## Out of scope for this change
+
+- Wiring `:443`/ACME into `docker-compose.yml` (Option A implementation).
+- Implementing the CA-specific submit transport, the signed-cert install, and
+  the proxy reload (the three operator TODO hooks in the skeleton).
+- Any live key/cert/CSR generation.
+
+These are the recommended follow-up once the institution answers the Option A
+question and the operator confirms the active TLS terminator.

--- a/documentation/09-deployment.qmd
+++ b/documentation/09-deployment.qmd
@@ -154,7 +154,76 @@ Add `mcp-auth` through the deployment's chosen authentication middleware before 
 - Run NDDScore updates from the administrator `/ManageNDDScore` page: **Check Zenodo**, **Download & validate**, then **Import & activate latest release**. The worker needs outbound egress to Zenodo. The previous active release keeps serving until the new release validates and activates successfully. All imported releases are retained for history; there is no automatic pruning. On failure, inspect the release `import_status` and `last_error_message` in the admin view or database.
 - Configure the default NDDScore Zenodo source in the production `.env` file. `NDDSCORE_ZENODO_RECORD_ID` defaults to `20258027`, and `NDDSCORE_ZENODO_API_BASE_URL` defaults to `https://zenodo.org/api/records`. The API and worker containers both receive these variables; if they are missing, `api/config.yml` provides the same defaults.
 - `publication.publication_date_source` records how each `Publication_date` was derived (`pubmed`, `pubmed_partial`, `medline_date`, `unknown`). New ingestions set it automatically. After deploying the migration, run the one-time operator backfill with PubMed egress: `Rscript db/updates/backfill_publication_dates.R --dry-run --limit=25` for a small rehearsal, `Rscript db/updates/backfill_publication_dates.R --dry-run` to preview the full run, then `Rscript db/updates/backfill_publication_dates.R --apply` to update historical rows. The script is dry-run by default, uses an advisory lock, limits PubMed fallback requests with `NCBI_REQUEST_DELAY_SECONDS`, skips unresolved IDs, and commits writes in batches controlled by `BACKFILL_UPDATE_BATCH_SIZE`.
-- Use HTTPS in production.
+- Use HTTPS in production. See **TLS Certificate Renewal** below for the yearly certificate workflow and the dry-run-safe CSR helper.
+
+## TLS Certificate Renewal
+
+> Design rationale and the full decision record live in `.planning/decisions/2026-06-11-tls-certificate-renewal-automation.md` (issue #25). This section is the operator runbook.
+
+### How TLS is served today
+
+The application Compose stack (`docker-compose.yml`) runs Traefik on the `web` (`:80`) entrypoint only; it has **no `:443` entrypoint and no ACME resolver**, so HTTPS for the public host `sysndd.dbmr.unibe.ch` is terminated by an **upstream institutional reverse proxy**. A legacy standalone nginx TLS config also exists (`app/docker/nginx/prod.conf`, terminating `:443` from a `cert.pem`/`key.pem` mount at `/etc/nginx/certificates/`); it is retained but not wired into the current stack. Confirm which terminator is active in your deployment before installing a new certificate.
+
+### Two paths
+
+**Option A — ACME / Let's Encrypt (preferred if a public CA is acceptable).** If the institution allows a public CA for this host, add a `:443` entrypoint plus an ACME resolver to Traefik (or to the upstream proxy). Traefik then issues and auto-renews certificates with **no CSR, no email, and no restart** — this eliminates the manual yearly process entirely. Confirm public-CA acceptability and inbound `:80`/`:443` reachability for the ACME challenge first.
+
+**Option B — scripted CSR for an institutional CA (current default).** Keep the institutional/internal CA but remove the manual openssl step. Use the helper to produce a reproducible key + CSR, submit it to the authority, install the returned certificate, and reload the terminator.
+
+### CSR helper (`scripts/cert/generate-csr.sh`)
+
+The helper is **dry-run by default** and **refuses to write key material inside the repository tree**. Configure it via `scripts/cert/cert-renewal.conf` (copied from `cert-renewal.conf.example`; the real config and any local key/CSR output are gitignored) or `CERT_*` environment variables.
+
+```bash
+# 1. Configure (one-time): copy the example and edit subject/SAN/output dir.
+cp scripts/cert/cert-renewal.conf.example scripts/cert/cert-renewal.conf
+$EDITOR scripts/cert/cert-renewal.conf      # CERT_OUT_DIR must be OUTSIDE the repo
+
+# 2. Inspect resolved config and the exact openssl command (writes nothing).
+scripts/cert/generate-csr.sh --print-config
+scripts/cert/generate-csr.sh                # DRY-RUN: prints the openssl command
+
+# 3. Generate the real key + CSR (the only live operation in this helper).
+scripts/cert/generate-csr.sh --apply --out-dir /etc/sysndd/certs
+```
+
+The private key is written under `umask 077` + `chmod 600`; the CSR is safe to share with the signing authority.
+
+### Remaining operator steps (TODO hooks — CA-/deployment-specific)
+
+The helper intentionally does **not** submit, install, or reload — those depend on your CA and active terminator. It prints guidance for each:
+
+1. **Submit** the CSR to the authority (portal upload, CA API, or email).
+2. **Install** the returned certificate (+ intermediate chain). Validate it matches the key — these two MD5s must be identical:
+   ```bash
+   openssl x509 -noout -modulus -in cert.pem | openssl md5
+   openssl rsa  -noout -modulus -in key.pem  | openssl md5
+   ```
+   Keep the previous `cert.pem`/`key.pem` as `.bak` for rollback, then place the new pair at the active terminator's mount.
+3. **Reload** the terminator without dropping connections:
+   - nginx: `docker compose exec <proxy> nginx -s reload`
+   - Traefik file-provider: dynamic cert files hot-reload automatically on change.
+   Verify afterward:
+   ```bash
+   echo | openssl s_client -connect sysndd.dbmr.unibe.ch:443 \
+     -servername sysndd.dbmr.unibe.ch 2>/dev/null | openssl x509 -noout -dates
+   ```
+
+### Yearly schedule
+
+Run the generator on a yearly cadence from host `cron` or a `systemd` timer (never inside the nginx app container) and notify an operator that a fresh CSR is ready to submit. Allow round-trip slack (e.g. ~6 weeks before expiry):
+
+```cron
+# 06:00 on Oct 1 each year — generate the renewal CSR and log the result.
+0 6 1 10 * /opt/sysndd/scripts/cert/generate-csr.sh --apply \
+  --out-dir /etc/sysndd/certs >> /var/log/sysndd-cert-renew.log 2>&1
+```
+
+For ACME (Option A) no schedule is needed; Traefik renews automatically.
+
+### Rollback
+
+The generated key/CSR are inert until a signed certificate is installed, so generation carries no production risk. If a freshly installed certificate breaks TLS, restore the `.bak` `cert.pem`/`key.pem` and reload again — fast and connection-preserving.
 
 ## SEO Prerender Operations
 

--- a/scripts/cert/cert-renewal.conf.example
+++ b/scripts/cert/cert-renewal.conf.example
@@ -1,0 +1,47 @@
+# cert-renewal.conf.example
+#
+# Example operator configuration for scripts/cert/generate-csr.sh.
+#
+# HOW TO USE
+#   cp scripts/cert/cert-renewal.conf.example scripts/cert/cert-renewal.conf
+#   # edit the values below, then run a dry-run first:
+#   scripts/cert/generate-csr.sh --print-config
+#   scripts/cert/generate-csr.sh           # dry-run, prints the openssl command
+#   scripts/cert/generate-csr.sh --apply   # generate key + CSR for real
+#
+# SECURITY
+#   * This file contains NO secret material — only certificate subject metadata.
+#   * The generated PRIVATE KEY is the secret and is written to CERT_OUT_DIR,
+#     which MUST be an operator-managed path OUTSIDE this repository.
+#   * scripts/cert/cert-renewal.conf (without .example) is gitignored so a real,
+#     site-specific config never lands in version control. Keep it that way.
+#
+# Every value below can also be supplied as an environment variable of the same
+# name; environment values override this file, and --out-dir overrides both.
+
+# --- Identity (subject) ---------------------------------------------------
+# Primary hostname (Common Name). Must match the public site hostname.
+CERT_COMMON_NAME="sysndd.dbmr.unibe.ch"
+
+# Subject Alternative Names: space- or comma-separated DNS names. The Common
+# Name is always added automatically, so only list ADDITIONAL names here.
+# Example for an apex + www deployment: "sysndd.org www.sysndd.org"
+CERT_SAN="sysndd.dbmr.unibe.ch"
+
+# --- Organisation metadata (for the CSR subject) --------------------------
+CERT_COUNTRY="CH"
+CERT_STATE="Bern"
+CERT_LOCALITY="Bern"
+CERT_ORG="Universitaet Bern"
+CERT_ORG_UNIT="DBMR"
+# Optional contact email embedded in the subject. Leave empty to omit.
+CERT_EMAIL=""
+
+# --- Key parameters -------------------------------------------------------
+# RSA key size in bits: one of 2048, 3072, 4096.
+CERT_KEY_BITS="4096"
+
+# --- Output location (MUST be outside the repo) ---------------------------
+# Operator-managed directory where the private key + CSR are written. The
+# script refuses to write anywhere inside the git working tree.
+CERT_OUT_DIR="/etc/sysndd/certs"

--- a/scripts/cert/generate-csr.sh
+++ b/scripts/cert/generate-csr.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+#
+# generate-csr.sh
+#
+# SAFE, dry-run-by-default helper that builds the openssl command to generate a
+# TLS private key + Certificate Signing Request (CSR) for the SysNDD frontend.
+#
+# This is the FIRST step of the yearly certificate renewal workflow described in
+# `.planning/decisions/2026-06-11-tls-certificate-renewal-automation.md` and the
+# operator runbook in `documentation/09-deployment.qmd`. It deliberately does NOT
+# submit the CSR to a CA, install a signed certificate, or reload the proxy.
+# Those steps are CA-/deployment-specific and are left as clearly-marked TODO
+# hooks at the end of this file.
+#
+# Safety properties:
+#   * Dry-run is the DEFAULT. Without --apply the script prints the openssl
+#     command(s) it WOULD run and exits 0 without touching any key material.
+#   * It refuses to write key/CSR material inside the git working tree.
+#   * It never logs the private key and creates keys with 0600 permissions.
+#   * Subject and SAN are config-/env-driven; nothing is hard-coded as a secret.
+#
+# Usage:
+#   scripts/cert/generate-csr.sh [--config FILE] [--out-dir DIR] [--apply]
+#                                [--force] [--print-config] [-h|--help]
+#
+# Configuration precedence (low -> high):
+#   1. Built-in defaults (below)
+#   2. Config file (default: scripts/cert/cert-renewal.conf; or --config FILE)
+#   3. Environment variables (CERT_* — see cert-renewal.conf.example)
+#   4. CLI flags (--out-dir)
+#
+# Exit codes:
+#   0  success (dry-run printed, or --apply generated key + CSR)
+#   1  usage / validation error
+#   2  openssl missing or generation failed (only reachable with --apply)
+#
+# Refs:
+#   - GitHub issue #25 (automate CSR creation + certificate signing)
+#   - .planning/decisions/2026-06-11-tls-certificate-renewal-automation.md
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Resolve paths
+# ---------------------------------------------------------------------------
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT="${CERT_REPO_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+# ---------------------------------------------------------------------------
+# Built-in defaults (override via config file / env / flags).
+# These match the public SysNDD deployment but carry NO secret material.
+# ---------------------------------------------------------------------------
+DEFAULT_CONFIG_FILE="$SCRIPT_DIR/cert-renewal.conf"
+
+CERT_COMMON_NAME="${CERT_COMMON_NAME:-sysndd.dbmr.unibe.ch}"
+CERT_SAN="${CERT_SAN:-sysndd.dbmr.unibe.ch}"
+CERT_COUNTRY="${CERT_COUNTRY:-CH}"
+CERT_STATE="${CERT_STATE:-Bern}"
+CERT_LOCALITY="${CERT_LOCALITY:-Bern}"
+CERT_ORG="${CERT_ORG:-Universitaet Bern}"
+CERT_ORG_UNIT="${CERT_ORG_UNIT:-DBMR}"
+CERT_EMAIL="${CERT_EMAIL:-}"
+CERT_KEY_BITS="${CERT_KEY_BITS:-4096}"
+# Output directory MUST live outside the repository tree. The default points at
+# an operator-managed, gitignored location; never a path inside REPO_ROOT.
+CERT_OUT_DIR="${CERT_OUT_DIR:-/etc/sysndd/certs}"
+
+# ---------------------------------------------------------------------------
+# CLI state
+# ---------------------------------------------------------------------------
+APPLY=0
+FORCE=0
+PRINT_CONFIG=0
+CONFIG_FILE="$DEFAULT_CONFIG_FILE"
+CLI_OUT_DIR=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+log()  { printf '%s\n' "$*"; }
+warn() { printf 'WARN: %s\n' "$*" >&2; }
+die()  { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+usage() {
+  sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# Build an RFC 4514-style subject string for `openssl req -subj`.
+# Pure function of the CERT_* values; no side effects. Emits to stdout so it can
+# be unit-tested in isolation. Empty optional components are omitted.
+#
+# Globals read: CERT_COUNTRY CERT_STATE CERT_LOCALITY CERT_ORG CERT_ORG_UNIT
+#               CERT_COMMON_NAME CERT_EMAIL
+build_subject() {
+  local subject=""
+  [ -n "${CERT_COUNTRY:-}" ]     && subject+="/C=${CERT_COUNTRY}"
+  [ -n "${CERT_STATE:-}" ]       && subject+="/ST=${CERT_STATE}"
+  [ -n "${CERT_LOCALITY:-}" ]    && subject+="/L=${CERT_LOCALITY}"
+  [ -n "${CERT_ORG:-}" ]         && subject+="/O=${CERT_ORG}"
+  [ -n "${CERT_ORG_UNIT:-}" ]    && subject+="/OU=${CERT_ORG_UNIT}"
+  [ -n "${CERT_COMMON_NAME:-}" ] && subject+="/CN=${CERT_COMMON_NAME}"
+  [ -n "${CERT_EMAIL:-}" ]       && subject+="/emailAddress=${CERT_EMAIL}"
+  printf '%s' "$subject"
+}
+
+# Build the comma-separated SAN extension value (subjectAltName) from CERT_SAN,
+# which is a space- and/or comma-separated list of DNS names. The CN is always
+# included so legacy verifiers that ignore SAN still match. Pure function.
+#
+# Globals read: CERT_SAN CERT_COMMON_NAME
+build_san() {
+  local raw="${CERT_SAN:-} ${CERT_COMMON_NAME:-}"
+  local name out=""
+  # Normalise commas to spaces, then de-duplicate while preserving order.
+  for name in ${raw//,/ }; do
+    [ -n "$name" ] || continue
+    case ",$out," in
+      *",DNS:$name,"*) continue ;;
+    esac
+    [ -n "$out" ] && out+=","
+    out+="DNS:$name"
+  done
+  printf '%s' "$out"
+}
+
+# Build the openssl arg vector (one arg per line) that generates key + CSR in a
+# single invocation. Pure function of the resolved config + paths; prints the
+# args so the dry-run path and the unit test can both inspect them without ever
+# executing openssl.
+#
+# Args: $1 = key path, $2 = csr path, $3 = subject, $4 = san value
+build_openssl_args() {
+  local key_path="$1" csr_path="$2" subject="$3" san="$4"
+  printf '%s\n' \
+    "req" \
+    "-new" \
+    "-newkey" "rsa:${CERT_KEY_BITS}" \
+    "-nodes" \
+    "-keyout" "$key_path" \
+    "-out" "$csr_path" \
+    "-subj" "$subject" \
+    "-addext" "subjectAltName=${san}"
+}
+
+# Render an argv (passed on stdin, one arg per line) as a copy-pasteable,
+# shell-quoted command line for dry-run display. Pure function.
+render_command() {
+  local rendered="openssl"
+  local arg
+  while IFS= read -r arg; do
+    rendered+=" $(printf '%q' "$arg")"
+  done
+  printf '%s\n' "$rendered"
+}
+
+# Reject output directories that live inside the repository working tree so we
+# never write key material that could be committed. Reads REPO_ROOT.
+assert_out_dir_outside_repo() {
+  local out_dir="$1" abs
+  # Normalise without requiring the directory to exist yet.
+  abs=$(cd "$(dirname "$out_dir")" 2>/dev/null && printf '%s/%s' "$(pwd)" "$(basename "$out_dir")") \
+    || abs="$out_dir"
+  case "$abs/" in
+    "$REPO_ROOT"/*)
+      die "refusing to write key/CSR inside the repo tree: $abs
+       Set CERT_OUT_DIR (or --out-dir) to an operator-managed path outside $REPO_ROOT." ;;
+  esac
+}
+
+load_config_file() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  # Config files are operator-owned shell fragments of KEY=value assignments.
+  # shellcheck source=/dev/null
+  . "$file"
+}
+
+parse_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --config)        CONFIG_FILE="${2:-}"; shift 2 ;;
+      --config=*)      CONFIG_FILE="${1#*=}"; shift ;;
+      --out-dir)       CLI_OUT_DIR="${2:-}"; shift 2 ;;
+      --out-dir=*)     CLI_OUT_DIR="${1#*=}"; shift ;;
+      --apply)         APPLY=1; shift ;;
+      --force)         FORCE=1; shift ;;
+      --print-config)  PRINT_CONFIG=1; shift ;;
+      -h|--help)       usage; exit 0 ;;
+      *)               die "unknown argument: $1 (try --help)" ;;
+    esac
+  done
+}
+
+print_resolved_config() {
+  log "Resolved configuration (no secrets):"
+  log "  CERT_COMMON_NAME = $CERT_COMMON_NAME"
+  log "  CERT_SAN         = $(build_san)"
+  log "  subject          = $(build_subject)"
+  log "  CERT_KEY_BITS    = $CERT_KEY_BITS"
+  log "  CERT_OUT_DIR     = $CERT_OUT_DIR"
+  log "  config file      = ${CONFIG_FILE} ($([ -f "$CONFIG_FILE" ] && echo present || echo absent))"
+}
+
+# ---------------------------------------------------------------------------
+# TODO hooks — deployment-/CA-specific. Intentionally NOT implemented here.
+# Each prints guidance under dry-run and refuses to proceed silently under
+# --apply until an operator wires up the real transport for their authority.
+# ---------------------------------------------------------------------------
+submit_csr_to_ca() {
+  local csr_path="$1"
+  cat >&2 <<EOF
+TODO(#25): submit_csr_to_ca is not implemented.
+  CSR ready for submission: $csr_path
+  Wire up ONE of the following for your certificate authority:
+    - ACME (preferred if a public CA is acceptable): let Traefik or certbot
+      handle issuance/renewal automatically — no manual CSR needed.
+    - Institutional CA: submit $csr_path via the authority's portal/API/email,
+      then place the returned chain at CERT_OUT_DIR/cert.pem.
+  See .planning/decisions/2026-06-11-tls-certificate-renewal-automation.md.
+EOF
+}
+
+install_signed_cert() {
+  cat >&2 <<EOF
+TODO(#25): install_signed_cert is not implemented.
+  After receiving the signed certificate (+ intermediate chain):
+    1. Validate it matches the generated key (the two MD5s must be identical):
+         openssl x509 -noout -modulus -in cert.pem | openssl md5
+         openssl rsa  -noout -modulus -in key.pem  | openssl md5
+    2. Atomically place cert.pem (+ chain) and key.pem at the proxy's mount.
+    3. Keep the PREVIOUS cert/key as .bak for rollback.
+EOF
+}
+
+reload_proxy() {
+  cat >&2 <<EOF
+TODO(#25): reload_proxy is not implemented.
+  Reload TLS without dropping connections, e.g.:
+    - nginx:   docker compose exec <proxy> nginx -s reload
+    - Traefik file-provider: certs hot-reload automatically on file change.
+  Verify post-reload:
+    echo | openssl s_client -connect ${CERT_COMMON_NAME}:443 \\
+      -servername ${CERT_COMMON_NAME} 2>/dev/null | openssl x509 -noout -dates
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+  parse_args "$@"
+
+  load_config_file "$CONFIG_FILE"
+  # CLI --out-dir overrides config/env for the output directory.
+  CERT_OUT_DIR="${CLI_OUT_DIR:-$CERT_OUT_DIR}"
+
+  if [ "$PRINT_CONFIG" -eq 1 ]; then
+    print_resolved_config
+    exit 0
+  fi
+
+  [ -n "$CERT_COMMON_NAME" ] || die "CERT_COMMON_NAME must not be empty."
+  case "$CERT_KEY_BITS" in
+    2048|3072|4096) ;;
+    *) die "CERT_KEY_BITS must be one of 2048, 3072, 4096 (got: $CERT_KEY_BITS)." ;;
+  esac
+
+  assert_out_dir_outside_repo "$CERT_OUT_DIR"
+
+  local stamp key_path csr_path subject san
+  stamp=$(date +%Y%m%d)
+  key_path="$CERT_OUT_DIR/${CERT_COMMON_NAME}.${stamp}.key.pem"
+  csr_path="$CERT_OUT_DIR/${CERT_COMMON_NAME}.${stamp}.csr.pem"
+  subject=$(build_subject)
+  san=$(build_san)
+
+  local args rendered
+  args=$(build_openssl_args "$key_path" "$csr_path" "$subject" "$san")
+  rendered=$(printf '%s\n' "$args" | render_command)
+
+  if [ "$APPLY" -eq 0 ]; then
+    log "DRY-RUN (default): no key or CSR was generated."
+    log ""
+    print_resolved_config
+    log ""
+    log "Would create:"
+    log "  key: $key_path  (mode 0600)"
+    log "  csr: $csr_path"
+    log ""
+    log "Would run:"
+    log "  $rendered"
+    log ""
+    log "Re-run with --apply to generate the key + CSR for real."
+    log "Subsequent steps (submit / install / reload) are operator TODO hooks:"
+    submit_csr_to_ca "$csr_path"
+    exit 0
+  fi
+
+  # --- live path (--apply) -------------------------------------------------
+  command -v openssl >/dev/null 2>&1 || { printf 'ERROR: openssl not found on PATH.\n' >&2; exit 2; }
+
+  if [ -e "$key_path" ] && [ "$FORCE" -eq 0 ]; then
+    die "key already exists: $key_path (use --force to overwrite)."
+  fi
+
+  mkdir -p "$CERT_OUT_DIR"
+  # Tighten umask so the freshly written private key is not group/other readable.
+  (
+    umask 077
+    log "Generating key + CSR (this is the only live operation)..."
+    # Re-build argv as a bash array so paths/subjects with spaces survive.
+    local -a argv=()
+    while IFS= read -r line; do argv+=("$line"); done <<< "$args"
+    openssl "${argv[@]}" || { printf 'ERROR: openssl generation failed.\n' >&2; exit 2; }
+  )
+  chmod 600 "$key_path" 2>/dev/null || warn "could not chmod 600 $key_path"
+
+  log "Generated:"
+  log "  key: $key_path (KEEP SECRET; never commit)"
+  log "  csr: $csr_path (safe to send to the signing authority)"
+  log ""
+  log "Next operator steps (not automated — see runbook):"
+  submit_csr_to_ca "$csr_path"
+  install_signed_cert
+  reload_proxy
+}
+
+# Allow sourcing for unit tests without executing main().
+if [ "${CERT_SKIP_MAIN:-0}" != "1" ]; then
+  main "$@"
+fi

--- a/scripts/tests/test-generate-csr.sh
+++ b/scripts/tests/test-generate-csr.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Bash harness for scripts/cert/generate-csr.sh.
+#
+# Tests the PURE logic (subject/SAN/argv/command building) and the dry-run +
+# safety guards WITHOUT ever invoking live openssl key generation. The target
+# script is sourced with CERT_SKIP_MAIN=1 so main() does not run on source.
+
+set -u
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+CSR_SCRIPT="$REPO_ROOT/scripts/cert/generate-csr.sh"
+
+PASS=0
+FAIL=0
+
+assert_equal() {
+  local expected="$1" actual="$2" label="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    printf 'FAIL: %s\n  expected: %s\n  actual:   %s\n' "$label" "$expected" "$actual" >&2
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  case "$haystack" in
+    *"$needle"*) PASS=$((PASS + 1)) ;;
+    *)
+      FAIL=$((FAIL + 1))
+      printf 'FAIL: %s\n  expected to contain: %s\n  in: %s\n' "$label" "$needle" "$haystack" >&2
+      ;;
+  esac
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  case "$haystack" in
+    *"$needle"*)
+      FAIL=$((FAIL + 1))
+      printf 'FAIL: %s\n  expected NOT to contain: %s\n  in: %s\n' "$label" "$needle" "$haystack" >&2
+      ;;
+    *) PASS=$((PASS + 1)) ;;
+  esac
+}
+
+# Source the script's pure functions without executing main().
+# shellcheck source=/dev/null
+CERT_SKIP_MAIN=1 . "$CSR_SCRIPT"
+
+# --- build_subject -------------------------------------------------------
+test_build_subject_full() {
+  local got
+  CERT_COUNTRY="CH" CERT_STATE="Bern" CERT_LOCALITY="Bern" \
+    CERT_ORG="Universitaet Bern" CERT_ORG_UNIT="DBMR" \
+    CERT_COMMON_NAME="sysndd.dbmr.unibe.ch" CERT_EMAIL="" \
+    got=$(build_subject)
+  assert_equal "/C=CH/ST=Bern/L=Bern/O=Universitaet Bern/OU=DBMR/CN=sysndd.dbmr.unibe.ch" \
+    "$got" "build_subject emits ordered RFC4514 subject and omits empty email"
+}
+
+test_build_subject_includes_email_when_set() {
+  local got
+  CERT_COUNTRY="CH" CERT_STATE="" CERT_LOCALITY="" CERT_ORG="" CERT_ORG_UNIT="" \
+    CERT_COMMON_NAME="example.org" CERT_EMAIL="ops@example.org" \
+    got=$(build_subject)
+  assert_equal "/C=CH/CN=example.org/emailAddress=ops@example.org" \
+    "$got" "build_subject includes email and omits empty components"
+}
+
+# --- build_san -----------------------------------------------------------
+test_build_san_adds_cn_and_dedupes() {
+  local got
+  CERT_SAN="a.example.org, b.example.org" CERT_COMMON_NAME="a.example.org" \
+    got=$(build_san)
+  assert_equal "DNS:a.example.org,DNS:b.example.org" \
+    "$got" "build_san normalises commas, dedupes, and folds in the CN"
+}
+
+test_build_san_space_separated() {
+  local got
+  CERT_SAN="sysndd.org www.sysndd.org" CERT_COMMON_NAME="sysndd.org" \
+    got=$(build_san)
+  assert_equal "DNS:sysndd.org,DNS:www.sysndd.org" \
+    "$got" "build_san handles space-separated SAN lists"
+}
+
+# --- build_openssl_args / render_command ---------------------------------
+test_openssl_args_shape() {
+  local args
+  CERT_KEY_BITS="4096" args=$(build_openssl_args \
+    "/etc/sysndd/certs/k.pem" "/etc/sysndd/certs/c.pem" \
+    "/CN=sysndd.dbmr.unibe.ch" "DNS:sysndd.dbmr.unibe.ch")
+  assert_contains "$args" "rsa:4096" "openssl args carry the configured key size"
+  assert_contains "$args" "-nodes" "openssl args use -nodes (no passphrase prompt in automation)"
+  assert_contains "$args" "subjectAltName=DNS:sysndd.dbmr.unibe.ch" "openssl args carry the SAN extension"
+  assert_contains "$args" "/etc/sysndd/certs/k.pem" "openssl args carry the key output path"
+}
+
+test_render_command_quotes_spaces() {
+  local args rendered
+  args=$(build_openssl_args "/tmp/k.pem" "/tmp/c.pem" "/O=Universitaet Bern/CN=x" "DNS:x")
+  rendered=$(printf '%s\n' "$args" | render_command)
+  assert_contains "$rendered" "openssl req -new" "rendered command starts with openssl req -new"
+  # printf '%q' shell-escapes the embedded space so the command stays paste-safe.
+  assert_contains "$rendered" 'Universitaet\ Bern' "rendered command escapes the space in the subject for paste-safety"
+}
+
+# --- assert_out_dir_outside_repo (safety guard) --------------------------
+test_rejects_out_dir_inside_repo() {
+  local out
+  out=$( (assert_out_dir_outside_repo "$REPO_ROOT/scripts/cert/secrets") 2>&1 ) && rc=0 || rc=$?
+  assert_equal 1 "$rc" "writing inside the repo tree is rejected"
+  assert_contains "$out" "refusing to write" "rejection explains why"
+}
+
+test_accepts_out_dir_outside_repo() {
+  local rc
+  (assert_out_dir_outside_repo "/etc/sysndd/certs") >/dev/null 2>&1 && rc=0 || rc=$?
+  assert_equal 0 "$rc" "an out-dir outside the repo is accepted"
+}
+
+# --- end-to-end dry-run (no openssl execution, no files written) ---------
+test_dry_run_prints_command_and_writes_nothing() {
+  local out tmp
+  tmp=$(mktemp -d)
+  out=$(
+    CERT_SKIP_MAIN=0 CERT_OUT_DIR="$tmp/certs" \
+      bash "$CSR_SCRIPT" --config /nonexistent-config 2>&1
+  )
+  assert_contains "$out" "DRY-RUN" "default run is a dry-run"
+  assert_contains "$out" "openssl req -new" "dry-run prints the openssl command it would run"
+  assert_contains "$out" "TODO(#25)" "dry-run surfaces the operator submit TODO hook"
+  # The dry-run must not create the output directory or any key material.
+  if [ -e "$tmp/certs" ]; then
+    FAIL=$((FAIL + 1))
+    printf 'FAIL: dry-run created output dir %s\n' "$tmp/certs" >&2
+  else
+    PASS=$((PASS + 1))
+  fi
+  rm -rf "$tmp"
+}
+
+test_print_config_exits_clean() {
+  local out rc
+  out=$(CERT_SKIP_MAIN=0 bash "$CSR_SCRIPT" --config /nonexistent --print-config 2>&1) && rc=0 || rc=$?
+  assert_equal 0 "$rc" "--print-config exits 0"
+  assert_contains "$out" "Resolved configuration" "--print-config shows resolved config"
+  assert_not_contains "$out" "BEGIN" "--print-config never prints key material"
+}
+
+printf '==> Running generate-csr harness\n\n'
+
+test_build_subject_full
+test_build_subject_includes_email_when_set
+test_build_san_adds_cn_and_dedupes
+test_build_san_space_separated
+test_openssl_args_shape
+test_render_command_quotes_spaces
+test_rejects_out_dir_inside_repo
+test_accepts_out_dir_outside_repo
+test_dry_run_prints_command_and_writes_nothing
+test_print_config_exits_clean
+
+if [ "$FAIL" -gt 0 ]; then
+  printf '\n%d failed, %d passed\n' "$FAIL" "$PASS" >&2
+  exit 1
+fi
+
+printf '\nAll generate-csr harness tests passed (%d assertions).\n' "$PASS"


### PR DESCRIPTION
## Summary

Addresses #25 (automate yearly CSR creation + certificate signing) with a **design + safe skeleton** deliverable. The signing step involves an **external CA reached by email**, so it cannot be fully automated or end-to-end tested in this repo without the authority's interface and real secrets. This PR delivers the design, a dry-run-safe CSR generator, a runbook, and tests — **no real keys/CSRs/certs are generated or committed**, and live cert operations are left as clearly-marked operator TODO hooks.

> This is a design+skeleton PR; it does **not** auto-close #25. A follow-up implementation issue is recommended (wire the chosen option's submit/install/reload, or ACME).

## Investigation: how TLS is served today

- The application Compose stack (`docker-compose.yml`) runs Traefik on the `web` (`:80`) entrypoint **only** — no `:443` entrypoint, no ACME resolver, no cert mount. The public host is `sysndd.dbmr.unibe.ch` (Uni Bern DBMR). TLS is therefore terminated by an **upstream institutional reverse proxy**.
- A **legacy standalone nginx TLS config** (`app/docker/nginx/prod.conf`) terminating `:443` from a `cert.pem`/`key.pem` mount at `/etc/nginx/certificates/` is retained but **not wired into the current stack** (it's from the earlier nginx-terminates-TLS era; `.gitignore` already excludes those `.pem` files).
- The institutional CA + email-based signing matches the manual process #25 describes.

## Two options (full rationale in the ADR)

**Option A — ACME / Let's Encrypt via Traefik (preferred *if* a public CA is acceptable).** Add a `:443` entrypoint + ACME resolver; Traefik then issues and auto-renews certs with **no CSR, no email, no restart**. Eliminates the manual process entirely. Preconditions: the institution accepts a public CA for this host, inbound `:80`/`:443` reachable for the challenge, and an upstream proxy isn't already terminating TLS (if it is, ACME moves there).

**Option B — scripted CSR for an institutional CA (this skeleton).** Keep the institutional CA but remove the human bottleneck from CSR generation. The submit step stays operator-driven because the CA's interface isn't in this repo.

### Recommendation

1. **First confirm with the institution whether a public-CA ACME cert is acceptable for `sysndd.dbmr.unibe.ch`.** If yes → implement Option A; it makes #25 disappear.
2. **If not (likely, given the institutional host + email signing) → adopt Option B** using the skeleton in this PR.

## What the skeleton does (and its dry-run safety)

`scripts/cert/generate-csr.sh`:
- **Dry-run by default** — without `--apply` it prints the exact `openssl` command and the resolved config, and **writes nothing**.
- **Refuses to write key/CSR material inside the repo tree** (guards `CERT_OUT_DIR`).
- Config/env-driven subject + multi-SAN (RFC 4514 subject, `subjectAltName`), `umask 077` + `chmod 600` keys, **never logs the private key**.
- Submit / install / reload are **clearly-marked operator TODO hooks** (printed under dry-run and `--apply`).
- `scripts/cert/cert-renewal.conf.example` — non-secret config template (real `cert-renewal.conf` + any local key/CSR are gitignored).
- `scripts/tests/test-generate-csr.sh` — pure-logic + dry-run + safety-guard harness (20 assertions, **no live openssl**).
- `.planning/decisions/2026-06-11-tls-certificate-renewal-automation.md` — the ADR.
- `documentation/09-deployment.qmd` — operator runbook (TLS Certificate Renewal): current topology, both options, helper usage, the 3 manual steps, yearly cron/systemd cadence, rollback.

## What remains operator-/CA-specific

- The CA submit transport (portal/API/email).
- Installing the signed cert (+ chain) at the active terminator and reloading it.
- Choosing Option A vs B (pending the institution's public-CA answer).
- Wiring `:443`/ACME into `docker-compose.yml` if Option A is chosen.

## Verification

- `bash -n` on both scripts: pass.
- `scripts/tests/test-generate-csr.sh`: 20/20 assertions pass.
- `scripts/code-quality-audit.sh`: OK (all new files well under the 600-line ceiling).
- Confirmed no key material anywhere in the tree; `.gitignore` blocks real config + `*.key.pem`/`*.csr.pem`/`*.crt`/`*.pem` under `scripts/cert/`.
- Did **not** run live openssl key generation and did **not** start the Docker stack.

Refs #25
