### PR TITLE
fix(ontology): repoint VariO links to a working source and make base configurable (#98)

### DIFF
--- a/app/.env
+++ b/app/.env
@@ -6,3 +6,8 @@
 #
 # Vite exposes variables with VITE_ prefix to the client
 # Do NOT put secrets here - they will be visible in browser
+
+# Optional: override the VariO (Variation Ontology) term-browser base URL.
+# When unset, the app uses the verified EBI OLS4 default (issue #98). Append-only
+# base; the term IRI is added by the app. Example:
+# VITE_VARIO_BASE_URL="https://www.ebi.ac.uk/ols4/ontologies/vario/classes?iri="

--- a/app/src/assets/js/constants/ontology_links.spec.ts
+++ b/app/src/assets/js/constants/ontology_links.spec.ts
@@ -1,0 +1,57 @@
+// ontology_links.spec.ts
+//
+// Issue #98 — VariO links must be built from a configurable base (not the dead
+// aber-owl.net fragment URL) and must encode the stored `VariO:NNNN` id as an
+// OBO PURL IRI the EBI OLS4 term browser understands.
+
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+const OLS4_BASE = 'https://www.ebi.ac.uk/ols4/ontologies/vario/classes?iri=';
+const VARIO_0001_IRI = encodeURIComponent('http://purl.obolibrary.org/obo/VariO_0001');
+
+describe('ontology_links — varioTermUrl', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('builds an EBI OLS4 term link with the OBO PURL IRI for a VariO:NNNN id', async () => {
+    const { varioTermUrl, VARIO_BASE_URL } = await import('./ontology_links');
+
+    // Default base is the verified OLS4 endpoint, not the old aber-owl.net URL.
+    expect(VARIO_BASE_URL).toBe(OLS4_BASE);
+    expect(VARIO_BASE_URL).not.toContain('aber-owl.net');
+
+    const url = varioTermUrl('VariO:0001');
+    expect(url).toBe(`${OLS4_BASE}${VARIO_0001_IRI}`);
+    // Colon -> underscore in the OBO local id; full IRI is percent-encoded.
+    expect(url).toContain('VariO_0001');
+    expect(url).not.toContain('VariO:0001');
+    expect(url.startsWith('https://')).toBe(true);
+  });
+
+  it('handles any VariO id consistently', async () => {
+    const { varioTermUrl } = await import('./ontology_links');
+    expect(varioTermUrl('VariO:0133')).toBe(
+      `${OLS4_BASE}${encodeURIComponent('http://purl.obolibrary.org/obo/VariO_0133')}`
+    );
+  });
+
+  it('returns an empty string for blank, null, or malformed ids', async () => {
+    const { varioTermUrl } = await import('./ontology_links');
+    expect(varioTermUrl('')).toBe('');
+    expect(varioTermUrl(null)).toBe('');
+    expect(varioTermUrl(undefined)).toBe('');
+    expect(varioTermUrl('not an id')).toBe('');
+    expect(varioTermUrl('VariO0001')).toBe('');
+  });
+
+  it('respects the VITE_VARIO_BASE_URL deploy-time override', async () => {
+    vi.stubEnv('VITE_VARIO_BASE_URL', 'https://example.org/vario/term?iri=');
+    vi.resetModules();
+    const { varioTermUrl, VARIO_BASE_URL } = await import('./ontology_links');
+
+    expect(VARIO_BASE_URL).toBe('https://example.org/vario/term?iri=');
+    expect(varioTermUrl('VariO:0001')).toBe(`https://example.org/vario/term?iri=${VARIO_0001_IRI}`);
+  });
+});

--- a/app/src/assets/js/constants/ontology_links.ts
+++ b/app/src/assets/js/constants/ontology_links.ts
@@ -1,0 +1,78 @@
+// ontology_links.ts
+//
+// Central, configurable base URLs for external ontology term browsers, plus
+// pure helpers that build a term-detail link from a SysNDD ontology id.
+//
+// Why this module exists (issue #98):
+//   The VariO (Variation Ontology) link in the entity view was hardcoded to an
+//   `aber-owl.net` fragment URL that no longer reliably resolves to a term page.
+//   Per the issue, ontology base links should live in one configurable place so
+//   they can be repointed without touching component logic.
+//
+// Scope note: this module ONLY governs how a stored ontology id (e.g.
+// `VariO:0001`) is turned into an outbound link. It does NOT migrate or
+// reinterpret curated `vario_id` values — changing the underlying ontology of a
+// curated variant record is a curation decision and is deliberately out of
+// scope here. See documentation/12-ontology-link-config.md.
+
+/**
+ * Override hook for the VariO term-browser base URL.
+ *
+ * Set `VITE_VARIO_BASE_URL` in the appropriate `app/.env*` file to repoint VariO
+ * links at deploy time without a code change. When unset, the verified default
+ * below is used.
+ */
+const VARIO_BASE_URL_OVERRIDE = import.meta.env.VITE_VARIO_BASE_URL;
+
+/**
+ * Default external term-browser base URLs for ontologies linked from SysNDD.
+ *
+ * VARIO points at EBI OLS4, which (verified 2026-06) serves live VariO term
+ * pages, e.g. https://www.ebi.ac.uk/ols4/ontologies/vario/classes?iri=...VariO_0001
+ * resolves to the real "variation" term. The OBO PURL / OntoBee / Bioregistry
+ * routes 404 for this orphaned ontology, and the previous aber-owl.net fragment
+ * URL was an insecure (http://) SPA fragment link, so OLS4 is the canonical
+ * working target.
+ *
+ * `as const` enables literal type inference for consumers.
+ */
+const ONTOLOGY_LINK_BASES = {
+  /**
+   * EBI OLS4 VariO term-browser base. The numeric id (`VariO:0001`) is appended
+   * as an OBO PURL IRI by {@link varioTermUrl}.
+   */
+  VARIO: 'https://www.ebi.ac.uk/ols4/ontologies/vario/classes?iri=',
+} as const;
+
+/** Resolved VariO base URL: deploy-time override wins, else the verified default. */
+export const VARIO_BASE_URL: string =
+  (typeof VARIO_BASE_URL_OVERRIDE === 'string' && VARIO_BASE_URL_OVERRIDE.trim()) ||
+  ONTOLOGY_LINK_BASES.VARIO;
+
+/** OBO PURL prefix VariO terms dereference through. */
+const OBO_PURL_PREFIX = 'http://purl.obolibrary.org/obo/';
+
+/**
+ * Build an external term-browser URL for a VariO id.
+ *
+ * Accepts the SysNDD-stored form `VariO:NNNN` (the `variation_ontology_list`
+ * primary-key format) and converts it to the OBO PURL IRI that OLS4 expects.
+ * Returns an empty string for blank/invalid ids so callers can suppress the
+ * link rather than emit a broken one.
+ *
+ * @example
+ *   varioTermUrl('VariO:0001')
+ *   // 'https://www.ebi.ac.uk/ols4/ontologies/vario/classes?iri=http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FVariO_0001'
+ */
+export function varioTermUrl(varioId: unknown): string {
+  const id = varioId == null ? '' : String(varioId).trim();
+  // Expect the `VariO:NNNN` (or generic `PREFIX:NNNN`) shape; bail on anything else.
+  if (!/^[A-Za-z]+:\w+$/.test(id)) {
+    return '';
+  }
+  const oboLocalId = id.replace(':', '_');
+  const iri = encodeURIComponent(`${OBO_PURL_PREFIX}${oboLocalId}`);
+  return `${VARIO_BASE_URL}${iri}`;
+}
+
+export default ONTOLOGY_LINK_BASES;

--- a/app/src/env.d.ts
+++ b/app/src/env.d.ts
@@ -3,6 +3,10 @@
 interface ImportMetaEnv {
   readonly VITE_API_URL: string;
   readonly VITE_BASE_URL?: string;
+  // Optional deploy-time override for the VariO ontology term-browser base URL.
+  // Falls back to the verified EBI OLS4 default when unset. See issue #98 and
+  // app/src/assets/js/constants/ontology_links.ts.
+  readonly VITE_VARIO_BASE_URL?: string;
   readonly BASE_URL: string;
   readonly MODE: string;
   readonly DEV: boolean;

--- a/app/src/views/pages/EntityView.vue
+++ b/app/src/views/pages/EntityView.vue
@@ -284,6 +284,7 @@ import { useEntityPhenotypes } from '@/composables/useEntityPhenotypes';
 import { useEntityVariation } from '@/composables/useEntityVariation';
 import { useGeneRecord } from '@/composables/useGeneRecord';
 import { returnToFromRoute } from '@/utils/returnNavigation';
+import { varioTermUrl } from '@/assets/js/constants/ontology_links';
 
 const route = useRoute();
 const router = useRouter();
@@ -427,12 +428,11 @@ function hpoUrl(phenotype: EntityRowMap): string {
   return `https://hpo.jax.org/app/browse/term/${asString(phenotype.phenotype_id)}`;
 }
 
+// VariO links are built from the configurable EBI OLS4 base (the previous
+// aber-owl.net target no longer reliably resolves to a term page). The base is
+// overridable via VITE_VARIO_BASE_URL — see assets/js/constants/ontology_links.ts.
 function varioUrl(variant: EntityRowMap): string {
-  return (
-    'http://aber-owl.net/ontology/VARIO/#/Browse/%3Chttp%3A%2F%2Fpurl.obolibrary.org%2Fobo%2F' +
-    asString(variant.vario_id).replace(':', '_') +
-    '%3E'
-  );
+  return varioTermUrl(variant.vario_id);
 }
 
 function termTitle(item: EntityRowMap, idKey: string): string {

--- a/app/src/views/pages/__tests__/EntityView.spec.ts
+++ b/app/src/views/pages/__tests__/EntityView.spec.ts
@@ -481,6 +481,17 @@ describe('EntityView (v11.3 W3)', () => {
     expect(w.get('[data-testid="variation-chip-VariO:0133"]').attributes('data-tooltip')).toBe(
       'variable | VariO:0133'
     );
+    // Issue #98: VariO chip links to the configurable EBI OLS4 term browser
+    // (not the dead aber-owl.net fragment URL), with the id encoded as an OBO
+    // PURL IRI (VariO:0133 -> VariO_0133).
+    const varioHref = w
+      .get('[data-testid="variation-chip-VariO:0133"]')
+      .attributes('href') as string;
+    expect(varioHref.startsWith('https://www.ebi.ac.uk/ols4/ontologies/vario/classes?iri=')).toBe(
+      true
+    );
+    expect(varioHref).toContain(encodeURIComponent('http://purl.obolibrary.org/obo/VariO_0133'));
+    expect(varioHref).not.toContain('aber-owl.net');
     w.unmount();
   });
 

--- a/db/data/ontology-migrations/vario-to-replacement.mapping.template.csv
+++ b/db/data/ontology-migrations/vario-to-replacement.mapping.template.csv
@@ -1,0 +1,23 @@
+# VariO -> replacement-ontology mapping TEMPLATE (issue #98)
+#
+# This is a SCAFFOLD, not an applied migration. It exists so a future
+# CURATOR-APPROVED migration off the orphaned VariO ontology has a defined,
+# reviewable shape. Filling and applying it changes the meaning of curated
+# variant records and MUST be reviewed/signed off by curators (see
+# documentation/12-ontology-link-config.md). Nothing reads this file today.
+#
+# Columns:
+#   vario_id        Existing SysNDD VariO id (variation_ontology_list PK), e.g. VariO:0001
+#   vario_name      Existing curated label, for reviewer context
+#   new_ontology    Target ontology prefix (e.g. SO for Sequence Ontology)
+#   new_id          Proposed replacement term id (e.g. SO:0001583), blank if none
+#   new_name        Proposed replacement label, blank if none
+#   mapping_status  one of: exact | broad | narrow | related | no_equivalent
+#   reviewed_by     Curator initials/handle once reviewed (blank until reviewed)
+#   notes           Free-text rationale / caveats
+#
+# Rows below are ILLUSTRATIVE EXAMPLES ONLY — delete before real use.
+vario_id,vario_name,new_ontology,new_id,new_name,mapping_status,reviewed_by,notes
+VariO:0001,variation,SO,,,no_equivalent,,"Root 'variation' term; SO has no direct top-level equivalent — curator decision needed"
+VariO:0002,variation affecting protein,SO,,,related,,"Effect-level term; SO describes feature types, not effects — likely needs SO + a separate consequence vocabulary"
+VariO:0133,protein truncation,SO,SO:0001906,feature_truncation,broad,,"SysNDD-local id (not in published VARIO); SO:0001906 is broader — confirm with curators"

--- a/documentation/12-ontology-link-config.md
+++ b/documentation/12-ontology-link-config.md
@@ -1,0 +1,128 @@
+# Ontology link configuration and the VariO replacement path
+
+This note documents (1) how external ontology term links are built in the
+frontend, (2) the fix applied for the broken VariO links (issue #98), and (3)
+the **deferred, curator-gated** path for replacing VariO with a different
+ontology. It is a developer/operator reference, not a public book chapter.
+
+## Background: the VariO broken-link bug (#98)
+
+SysNDD curates variant effect/consequence terms in the `variation_ontology_list`
+table, keyed by a `vario_id` in the `VariO:NNNN` form (Variation Ontology,
+VariO). The entity detail page rendered each term as an outbound link to an
+external term browser.
+
+The original link was hardcoded in `app/src/views/pages/EntityView.vue` to an
+`aber-owl.net` fragment URL:
+
+```
+http://aber-owl.net/ontology/VARIO/#/Browse/%3Chttp%3A%2F%2Fpurl.obolibrary.org%2Fobo%2FVariO_0001%3E
+```
+
+VariO is an **orphaned** OBO ontology. Its OBO PURL, OntoBee, and Bioregistry
+routes no longer resolve to term pages, and the aber-owl link used insecure
+`http://` plus a brittle SPA fragment. The links were effectively broken for
+users.
+
+## The fix (this PR): configurable base + verified working target
+
+The bug is purely a link-construction problem, so the fix is frontend-only and
+introduces **no database change**.
+
+- New module `app/src/assets/js/constants/ontology_links.ts` centralizes the
+  VariO term-browser base URL and exposes a pure `varioTermUrl(varioId)` helper
+  that converts the stored `VariO:NNNN` id to the OBO PURL IRI the browser
+  expects (`VariO:0001` -> `http://purl.obolibrary.org/obo/VariO_0001`,
+  percent-encoded).
+- `EntityView.vue`'s `varioUrl()` now delegates to that helper instead of the
+  hardcoded string.
+- The base is overridable at deploy time via the `VITE_VARIO_BASE_URL`
+  environment variable (typed in `app/src/env.d.ts`, documented in `app/.env`).
+  When unset, the verified default is used.
+
+### Verified working target: EBI OLS4
+
+Despite the issue's premise that VariO is "no longer in OLS", the EBI **OLS4**
+service does currently serve live VariO term pages. Verified 2026-06:
+
+- `GET https://www.ebi.ac.uk/ols4/api/ontologies/vario` -> HTTP 200
+- `GET https://www.ebi.ac.uk/ols4/api/ontologies/vario/terms?iri=http://purl.obolibrary.org/obo/VariO_0001`
+  -> HTTP 200, returns the real term: label `variation`, definition
+  "Alteration in biological macromolecule.", `obo_id: VariO:0001`.
+- `VariO_0002` likewise resolves to `variation affecting protein`.
+- UI term page
+  `https://www.ebi.ac.uk/ols4/ontologies/vario/classes?iri=<encoded-IRI>`
+  -> HTTP 200.
+
+Default base used by the app:
+
+```
+https://www.ebi.ac.uk/ols4/ontologies/vario/classes?iri=
+```
+
+Candidates that were checked and rejected: OBO PURL / OntoBee / Bioregistry all
+404 for VariO terms; BioPortal bot-blocks and its REST API requires an API key;
+variationontology.org is live but hosts no term browser of its own.
+
+### Important caveat: SysNDD-local VariO ids
+
+Some `vario_id` values in `variation_ontology_list` are SysNDD-internal and are
+**not** present in the published VARIO ontology (e.g. `VariO:0133`, used in test
+fixtures, returns 404 from OLS4). Those links will still 404 at OLS4 because the
+term genuinely does not exist upstream. This is a data-curation gap, not a
+link-construction bug, and is part of why a real ontology migration (below) must
+be a deliberate, curator-reviewed exercise rather than an automatic rewrite.
+
+## Deferred: replacing VariO with another ontology (curator decision)
+
+The issue also proposes migrating curated `vario_id` / `vario_name` values to a
+replacement ontology (e.g. Sequence Ontology, SO). **This is intentionally NOT
+done in this PR.** Rewriting `vario_id` changes the *meaning* of curated variant
+records — it is a curation decision with scientific consequences, and it must be
+reviewed and signed off by curators, not performed autonomously by a bug-fix.
+
+When a future curator-approved migration happens, the recommended shape is:
+
+1. **Choose the replacement ontology and pin a version.** Sequence Ontology (SO)
+   is the issue's suggested target and is well maintained in OLS4
+   (`https://www.ebi.ac.uk/ols4/ontologies/so`). Note SO describes *sequence
+   feature/variant types*; VariO additionally covers *effect/consequence and
+   mechanism* at DNA/RNA/protein level. The mappings will not all be 1:1.
+
+2. **Build a reviewed mapping table** `vario_id -> {new_id, new_name, status}`
+   where `status` is one of `exact`, `broad`, `narrow`, `related`, or
+   `no_equivalent`. This must be produced and reviewed by curators. SysNDD-local
+   VariO ids (no upstream term) will frequently land in `no_equivalent` and need
+   an explicit curation decision. A mapping scaffold lives at
+   `db/data/ontology-migrations/vario-to-replacement.mapping.template.csv`.
+
+3. **Add a new ontology list table** (e.g. `variant_ontology_list`) and a
+   *compatibility/back-mapping* column rather than destructively overwriting
+   `variation_ontology_list`, so historical curated records and their
+   provenance remain intact and auditable. This mirrors the existing
+   ontology-update safeguard pattern (keep superseded rows as `is_active = 0`
+   compatibility rows so foreign keys stay valid).
+
+4. **Migrate via a normal versioned migration** in `db/migrations/`, applied at
+   API startup by the migration runner, only after the mapping table is approved.
+   Keep the old ids/links resolvable (or clearly marked legacy) for any term
+   that has no equivalent.
+
+5. **Make the new ontology's link base configurable too**, following the same
+   `ontology_links.ts` + `VITE_*` pattern added here.
+
+Until that curator-approved migration lands, the current fix keeps existing
+VariO ids pointing at the best working external browser (EBI OLS4) and makes the
+base trivially repointable without a code change.
+
+## Where things live
+
+- Link helper + base: `app/src/assets/js/constants/ontology_links.ts`
+- Consumer: `app/src/views/pages/EntityView.vue` (`varioUrl`)
+- Env override: `VITE_VARIO_BASE_URL` (`app/src/env.d.ts`, `app/.env`)
+- Tests: `app/src/assets/js/constants/ontology_links.spec.ts` and the VariO-link
+  assertion in `app/src/views/pages/__tests__/EntityView.spec.ts`
+- Curated VariO data: `variation_ontology_list` (see
+  `db/migrations/000_initialize_base_schema.sql`)
+- Migration scaffold:
+  `db/data/ontology-migrations/vario-to-replacement.mapping.template.csv`


### PR DESCRIPTION
## Summary

Fixes the broken VariO (Variation Ontology) term links in the entity view (#98), scoped to the **safe, reversible** part of the issue. The curated-data migration to a replacement ontology is **deliberately deferred** because it is a curation decision (see below).

VariO is an orphaned OBO ontology. The entity page hardcoded each term link to an insecure `http://aber-owl.net/...` fragment URL, and the usual OBO routes (OBO PURL, OntoBee, Bioregistry) now **404** for VariO terms — so the links were broken.

## What changed (frontend-only, no DB migration)

- **New** `app/src/assets/js/constants/ontology_links.ts` — a central, configurable home for the VariO term-browser base URL plus a pure `varioTermUrl(varioId)` helper. It converts the SysNDD-stored `VariO:NNNN` id to the OBO PURL IRI the browser expects (`VariO:0001` → `http://purl.obolibrary.org/obo/VariO_0001`, percent-encoded). Returns `''` for blank/malformed ids so callers don't emit broken links.
- `EntityView.vue` `varioUrl()` now delegates to that helper (removed the inline hardcoded URL).
- **Configurable base:** overridable at deploy time via `VITE_VARIO_BASE_URL` (typed in `app/src/env.d.ts`, documented in `app/.env`) — matches the existing `import.meta.env.VITE_*` pattern. When unset, the verified default is used.

## Verified working link target: EBI OLS4

Despite the issue's premise that VariO is "no longer in OLS", **OLS4 currently does serve live VariO term pages.** Verified 2026-06:

| Check | Result |
|---|---|
| `GET https://www.ebi.ac.uk/ols4/api/ontologies/vario` | HTTP 200 |
| `GET .../ontologies/vario/terms?iri=...VariO_0001` | HTTP 200 — label **"variation"**, def *"Alteration in biological macromolecule."*, `obo_id: VariO:0001` (stable across 3 calls) |
| `...VariO_0002` | HTTP 200 — **"variation affecting protein"** |
| UI term page `https://www.ebi.ac.uk/ols4/ontologies/vario/classes?iri=<encoded IRI>` | HTTP 200 |

Default base now used by the app:
```
https://www.ebi.ac.uk/ols4/ontologies/vario/classes?iri=
```

Candidates checked and rejected: OBO PURL / OntoBee / Bioregistry → 404 for VariO terms; BioPortal bot-blocks `curl`/WebFetch and its REST API needs an API key; variationontology.org is live but hosts no term browser of its own.

**Caveat (data gap, not a link bug):** some `vario_id` values are SysNDD-internal and are not in the published VARIO ontology (e.g. `VariO:0133`, used in fixtures, 404s upstream). Those will still 404 at OLS4 because the term genuinely doesn't exist. This is part of why a real ontology migration must be curator-reviewed, not an automatic rewrite.

## Deferred (needs curator sign-off): migrating curated data to a replacement ontology

The issue also asks to replace `vario_id`/`vario_name` with a new ontology (e.g. Sequence Ontology) and migrate data. **Not done here on purpose** — rewriting `vario_id` changes the *meaning* of curated variant records (a scientific/curation decision) and must be reviewed and approved by curators, not performed by a bug-fix.

Provided instead (no data changes):
- **Design note:** `documentation/12-ontology-link-config.md` — documents the link config, the fix, and a step-by-step curator-gated migration path (pin a target + version; build a reviewed `vario_id → {new_id, status}` mapping; add a *new* ontology table + compatibility/back-mapping rather than destructive overwrite, mirroring the existing ontology-update safeguard; apply via a normal versioned `db/migrations/` migration only after the mapping is approved; make the new base configurable the same way).
- **Mapping scaffold:** `db/data/ontology-migrations/vario-to-replacement.mapping.template.csv` (template only; nothing reads it). Notes that SO describes *feature/variant types* while VariO also covers *effect/consequence/mechanism*, so mappings are not all 1:1.

## Tests

- New `app/src/assets/js/constants/ontology_links.spec.ts` — default base is OLS4 (not aber-owl), correct `VariO:NNNN → VariO_NNNN` OBO PURL IRI encoding, blank/null/malformed → `''`, and `VITE_VARIO_BASE_URL` override.
- Extended `app/src/views/pages/__tests__/EntityView.spec.ts` — the rendered VariO chip's `href` uses the OLS4 base + encoded OBO IRI and contains no `aber-owl.net`.

Local checks (all green):
- `npx vitest run` on the 5 VariO-touching specs → **29 passed**
- `npm run type-check` (vue-tsc) → clean
- `eslint` on changed files → clean
- `make code-quality-audit` (file-size ratchet) → clean

## What needs CI

Standard frontend lane: lint, type-check, vitest. No API/R changes, no DB migration, no Docker stack started locally (per instructions). Backend is untouched.

## Judgement on closing #98

Referencing rather than auto-closing #98. This PR fully fixes the **broken-link bug** but the issue additionally scopes a curator-gated **data migration** to a replacement ontology, which is intentionally deferred. Leaving #98 open to track that migration (with the path documented here).

Refs #98