### PR TITLE
fix(mcp): spec+plan for search/analysis benchmark fixes; implement safe subset (#353)

### DIFF
--- a/.planning/superpowers/plans/2026-06-11-mcp-search-analysis-benchmark-fixes-plan.md
+++ b/.planning/superpowers/plans/2026-06-11-mcp-search-analysis-benchmark-fixes-plan.md
@@ -1,0 +1,95 @@
+# SysNDD MCP — Search & Derived-Analysis Benchmark Fixes — Implementation Plan
+
+**Date:** 2026-06-11
+**Owner:** api / mcp
+**Status:** safe subset implemented in this change; remainder = ordered backlog
+**Design:** `.planning/superpowers/specs/2026-06-11-mcp-search-analysis-benchmark-fixes-design.md`
+**Tracks:** GitHub issue #353
+
+This plan orders the issue-#353 backlog by risk/value and records exactly what shipped in
+this change vs what is deferred (and why). Effort is rough relative sizing, not hours.
+
+## A. Shipped in this change (low-risk, well-defined, invariant-safe)
+
+All four respect every MCP invariant (read-only, approved-public-data, `schema_version`
+1.2, cache-hit-only). All are additive field additions or bugfixes to existing-field
+serialization — no removals, no type changes, no new DB access patterns.
+
+| # | Item (issue tag) | Change | Files | Risk | Effort | Test |
+|---|------------------|--------|-------|------|--------|------|
+| A1 | Null-as-`{}` (P1) | `structuredContent` is built from the null-safe JSON text (`mcp_structured_content()` round-trip) so nulls render as JSON `null`, mirroring `content[].text`. | `api/services/mcp-tools.R` | Low | S | unit + smoke |
+| A2 | `publication_type` dropped (P1) | Top-level scalar promoted to first non-empty link value via `mcp_first_nonempty_value()`; per-link + aggregate fields unchanged. | `api/services/mcp-record-service.R`, `api/services/mcp-service.R` | Low | S | unit + smoke |
+| A3 | Zero-result echo (P2) | `find_entities_by_*` always echo `meta$query_echo` + `meta$query_resolved`; `find_entities_by_disease` also echoes top-level `disease`. | `api/services/mcp-record-service.R` | Low | S | unit + smoke |
+| A4 | Section-status consistency (P0 gap A) | `mcp_section_call()` collapses `{temporarily_unavailable, snapshot_missing, snapshot_stale, source_version_mismatch}` to `temporarily_unavailable`; specific code preserved in the section value. New `MCP_SECTION_UNAVAILABLE_CODES`. | `api/services/mcp-research-context-service.R` | Low | S | unit |
+
+### Tests added/extended
+- `api/tests/testthat/test-mcp-search-analysis-fixes.R` (new): null-serialization
+  round-trip, `mcp_first_nonempty_value`, publication_type promotion, both zero-result
+  echoes, section-status code mapping. (Host-runnable; mocks all DB access.)
+- `api/scripts/mcp-smoke.R` (extended): zero-result `find_entities_by_disease` /
+  `find_entities_by_phenotype` echo + `query_resolved`; `get_publication_context`
+  top-level `publication_type` is never `{}` and `structuredContent` is present.
+
+### Verification (host)
+- `cd api && Rscript --no-init-file -e "testthat::test_file('tests/testthat/test-mcp-search-analysis-fixes.R')"` — pass.
+- Regression: `test-mcp-service.R`, `test-mcp-search-ranking.R`,
+  `test-mcp-snapshot-diagnostics.R`, `test-mcp-service-publication-discovery.R` — pass.
+- `make lint-api`, `make code-quality-audit`.
+- `mcp-smoke.R` runs against the stack in CI (do not start the stack locally).
+
+## B. Deferred follow-ups (ordered by value / readiness)
+
+### B1 — Search recall: disease synonyms (P0-quality, issue 3.1)
+- **Why deferred:** the zero-hit defect is already fixed; this is recall *quality* and
+  needs an approved-public disease-synonym source column + a defined ranking weight. No
+  ambiguity-free safe edit exists today.
+- **Plan:** confirm a synonym source on an approved-public view; extend the `disease`
+  branch of `mcp_repo_search()` with a `synonym` tier (mirroring the existing HPO-synonym
+  conditional pattern); add a smoke assertion for a known synonym query.
+- **Risk:** medium (data-source choice + ranking). **Effort:** M.
+
+### B2 — `find_entities_by_*` ranking + count-only mode (P2, issue 3.6)
+- **Why deferred:** needs a ranking contract (category-strength ordering, optional
+  modifier weighting) and a new `response_mode`/`aggregate` schema surface + smoke
+  coverage.
+- **Plan:** order by category strength then symbol; add `aggregate`/`count_only` returning
+  per-category counts + totals without row payloads; update tool descriptions and
+  capabilities; add tests.
+- **Risk:** medium. **Effort:** M.
+
+### B3 — Snapshot prewarm runbook + operator guidance (P0 gap B, issue 3.2)
+- **Why deferred:** MCP must not initialize/compute caches (invariant). This is a
+  deployment/ops decision about which snapshots ship prewarmed.
+- **Plan:** document the snapshot-refresh job + which presets to prewarm in
+  `documentation/09-deployment.qmd`; decide whether `snapshot_missing` + `retry_with` is
+  sufficient operator guidance or a `needs_admin_initialization` synonym adds value
+  (current recommendation: keep `snapshot_missing`, avoid error-code sprawl).
+- **Risk:** low (docs/ops). **Effort:** S–M.
+
+### B4 — Search fuzzy / typo tolerance (P0-quality, issue 3.1)
+- **Why deferred:** needs a ranking design and a perf budget for fuzzy scans on the
+  candidate set.
+- **Plan:** evaluate trigram / edit-distance ranking on the already-bounded candidate set;
+  gate behind a flag; benchmark latency.
+- **Risk:** medium/high. **Effort:** M–L.
+
+### B5 — `drop_diagonal`/`triangle_only` in `phenotype_functional_correlations` (P1-minor, 3.3)
+- **Why deferred:** functional-correlations mode reads a fixed snapshot preset; threading
+  the flags requires preset support.
+- **Risk:** low. **Effort:** S.
+
+### B6 — GRIN2A entity #303 phenotype gap (P3, issue 3.8)
+- **Disposition:** curation-data issue, **not MCP code**. Flag for curator review via the
+  curation backlog / issue comment. No MCP change.
+
+## C. Risks & mitigations (shipped subset)
+
+- **A1 re-serialization cost:** one `fromJSON(toJSON(...))` round-trip per tool call.
+  Payloads are compact by default and bounded by `max_response_chars`; negligible.
+  Fallback to raw payload on parse error keeps behavior safe.
+- **A2 semantics:** top-level `publication_type` represents "a type present on the
+  publication's links," not "the type for a specific entity." Per-link truth stays in
+  `linked_entities[].publication_type` and `publication_types`. This matches how callers
+  already consume the aggregate.
+- **A3/A4 additive fields:** consumers using strict schemas are unaffected because the
+  output schema is `additionalProperties = true` and `schema_version` is unchanged.

--- a/.planning/superpowers/specs/2026-06-11-mcp-search-analysis-benchmark-fixes-design.md
+++ b/.planning/superpowers/specs/2026-06-11-mcp-search-analysis-benchmark-fixes-design.md
@@ -1,0 +1,237 @@
+# SysNDD MCP — Search & Derived-Analysis Benchmark Fixes
+
+**Date:** 2026-06-11
+**Owner:** api / mcp
+**Status:** spec — implemented safe subset; remainder planned as follow-ups
+**Tracks:** GitHub issue #353
+**Source review:** `.planning/reviews/2026-05-19-mcp-tool-benchmark.md` (branch `docs/mcp-tool-benchmark`; the issue body reproduces the backlog and is the authoritative defect list used here)
+
+## 1. Problem
+
+An expert benchmark of all 18 SysNDD MCP tools (NDD-researcher perspective) rated the
+read-only sidecar 7.5/10. The retrieval layer is production-grade; the **search** and
+**derived-analysis cache** layers carry concrete defects (issue #353). This document
+specifies each defect against the *current* code, proposes a concrete fix, and records
+risk/effort so the safe subset can ship now and the rest is planned.
+
+Important context: the benchmark snapshot is dated **2026-05-19**. Several P0/P1 items
+have already been substantially addressed in `master` since then (see §4 "Already
+addressed"). This spec re-grounds every backlog item in the code as it exists on
+2026-06-11 so we neither re-implement done work nor silently drop genuinely-open gaps.
+
+## 2. Scope and invariants
+
+Scope: the read-only MCP sidecar (`api/start_sysndd_mcp.R`) and its tool / repository
+layer under `api/services/mcp-*.R` and `api/functions/mcp-*.R`, plus
+`api/scripts/mcp-smoke.R`.
+
+All changes preserve the MCP invariants in `AGENTS.md`:
+
+- Read-only, approved-public-data only: active `ndd_entity_view` records; review-derived
+  data only from primary approved reviews (`is_primary = 1 AND review_approved = 1`).
+- No writes, no raw SQL/R, no Gemini/LLM generation, no live external providers, no
+  draft-review / admin / user / job / log exposure.
+- `MCP_SCHEMA_VERSION` stays `1.2`. Stable JSON text with `schema_version` is the
+  compatibility contract. All changes here are **additive** (new optional fields,
+  corrected serialization of existing fields) — no field removals, no type changes.
+- Analysis tools remain cache-hit-only: public-ready snapshots or warmed cache only;
+  never compute heavy analysis, fCoSE, external calls, or Gemini on miss.
+- Recoverable failures keep the JSON tool-result error envelope
+  (`schema_version` + `error.code` + `isError = true`).
+
+## 3. Defect-by-defect specification
+
+Each item lists: benchmark claim → current code reality → fix → schema/compat impact →
+risk/effort → disposition (this change vs follow-up).
+
+### 3.1 P0 — `search_sysndd` exact-match only
+
+- **Claim:** `"NMDA receptor"` and `"epilepsy aphasia"` return 0 hits; gene `name` and
+  disease synonyms are not searched.
+- **Reality (current code):** `mcp_repo_search()` (`api/functions/mcp-repository.R:31`)
+  already: searches gene `nal.name` (LIKE + `name` tier), HGNC alias/previous symbols via
+  `hgnc_symbol_lookup`, disease names, HPO terms and (conditionally) `HPO_term_synonyms`,
+  and variant names; and runs token-overlap matching via
+  `mcp_search_token_filter()` / `mcp_search_tokens()`
+  (`api/functions/mcp-search-repository.R`). `mcp_rank_search_candidates()` scores tiers
+  on a 100–1000 scale and orders descending. The smoke test already asserts the
+  `"NMDA receptor"` and `"epilepsy aphasia"` token + ranking behavior
+  (`api/scripts/mcp-smoke.R:219-247`).
+- **Fix:** None required for the core defect — it is already addressed. Remaining genuine
+  gaps are *quality*, not *zero-hit*: (a) disease **synonym** columns beyond
+  `HPO_term_synonyms` are not searched (disease search uses `result` /
+  `disease_ontology_name` only); (b) there is no fuzzy / trigram matching for
+  misspellings; (c) ranking weights are heuristic and unbenchmarked.
+- **Compat:** N/A.
+- **Risk/effort:** Synonym expansion — medium (needs to confirm an approved-public
+  disease-synonym source column and a defined ranking). Fuzzy — medium/high (needs a
+  ranking design and perf budget on `LIKE '%term%'` scans).
+- **Disposition:** **Follow-up** (P1-quality). Document as "search recall improvements:
+  disease synonyms + optional fuzzy" rather than "search is broken." Add a smoke
+  assertion only once a synonym source is chosen.
+
+### 3.2 P0 — Uninitialized analysis caches
+
+- **Claim:** `get_gene_network_context` and `get_phenotype_analysis_context` modes
+  `clusters` / `phenotype_functional_correlations` return bare `temporarily_unavailable`.
+- **Reality (current code):** Focused tools no longer return bare
+  `temporarily_unavailable`. They compute a snapshot status and raise the *specific*
+  recoverable code `snapshot_missing` | `snapshot_stale` | `source_version_mismatch`
+  via `mcp_stop_analysis_snapshot_unavailable()`
+  (`api/services/mcp-analysis-service.R:382`), and the `dry_run` / `diagnostics` path
+  short-circuits to a 200 payload exposing `section_status` + `meta$snapshot_status`
+  (`mcp-analysis-service.R:432-451`, `538-555`). `unsupported_parameter` is raised for
+  non-preset parameters. Capabilities/error docs include the snapshot codes (asserted in
+  `test-mcp-search-ranking.R`).
+- **Open gap A (consistency bug):** When these tools are reached *through*
+  `get_gene_research_context`, `mcp_section_call()`
+  (`api/services/mcp-research-context-service.R`) collapsed only
+  `temporarily_unavailable` and `snapshot_missing` to a `temporarily_unavailable` section
+  status; `snapshot_stale` and `source_version_mismatch` fell through to a generic
+  `"error"` status — an inconsistency for the same logical "not serviceable yet" state.
+- **Open gap B (operational):** Whether the network / cluster / functional-correlation
+  snapshots are *prewarmed in the deployed sidecar* is a deployment decision, not MCP
+  code. Per invariants, MCP must not initialize/compute caches. The actionable
+  distinction the benchmark asks for ("`needs_admin_initialization` with operator
+  guidance") is partly served by the existing `retry_with` recovery hint and the
+  `snapshot_*` codes.
+- **Fix (this change):** Gap A only — make `mcp_section_call()` collapse the full set
+  `{temporarily_unavailable, snapshot_missing, snapshot_stale, source_version_mismatch}`
+  to `temporarily_unavailable` for the section status, while preserving the specific
+  `error.code` in the section value payload. New constant
+  `MCP_SECTION_UNAVAILABLE_CODES`.
+- **Compat:** Additive/behavioral-bugfix; section status values are unchanged in vocab
+  (still `available` | `temporarily_unavailable` | `error`), just mapped consistently.
+- **Risk/effort:** Low / small.
+- **Disposition:** **This change** (Gap A). **Follow-up / ops doc** for Gap B: document
+  the snapshot prewarm runbook in `documentation/09-deployment.qmd`; consider an
+  operator-facing capabilities note that a code of `snapshot_missing` means "ask an admin
+  to run the snapshot-refresh job," and evaluate whether a dedicated
+  `needs_admin_initialization` synonym adds value over `snapshot_missing` + `retry_with`
+  (leaning no, to avoid error-code sprawl).
+
+### 3.3 P1 — Phenotype `correlations` is global-only but accepts an ignored `gene`
+
+- **Claim:** correlations silently accepts an ignored `gene`; no `drop_diagonal` /
+  `triangle_only`.
+- **Reality (current code):** Already fixed. `mcp_get_phenotype_analysis_context()`
+  **rejects** a `gene` in `correlations` mode with `invalid_input`
+  (`mcp-analysis-service.R:410`), and `drop_diagonal` (default TRUE) / `triangle_only`
+  (default FALSE) exist and are echoed in `meta` (`mcp-analysis-service.R:390-402`,
+  `489-491`); the smoke test asserts both (`mcp-smoke.R:299-312`). The
+  research-context path calls correlations without `gene`
+  (`mcp-research-context-service.R`), so no silent-ignore occurs.
+- **Open gap:** `drop_diagonal` / `triangle_only` are plumbed into `correlations` mode
+  only, not into `phenotype_functional_correlations` mode (which hardcodes no
+  triangle/diagonal). Minor.
+- **Fix:** None required for the core defect. Optional follow-up: thread
+  `drop_diagonal`/`triangle_only` into the functional-correlations snapshot reader if a
+  preset supports it.
+- **Disposition:** **Closed / follow-up (minor).**
+
+### 3.4 P1 — `publication_type` dropped in publication context tools
+
+- **Claim:** `publication_type` returns `{}` in `get_publication_context` /
+  `get_publications_context` but is populated in `get_entity_context`.
+- **Reality (current code):** The column is selected in both repository queries
+  (`rpj.publication_type`). The defect is **record-shaping**: in
+  `mcp_get_publication_context()` the top-level scalar is taken from
+  `mcp_publication_record(mcp_row_to_list(rows[1, ]))`, i.e. the **first join row**.
+  `publication_type` is a *per-link* attribute (it differs per linked entity, e.g.
+  `Original` vs `Review`), so the first row can be SQL `NULL`, which `mcp_row_to_list()`
+  maps to R `NULL`, which then renders as `{}` via the `structuredContent` path (§3.6).
+  The per-link `linked_entities[].publication_type` and the `publication_types`
+  aggregate are already correct.
+- **Fix (this change):** Promote the top-level scalar to the **first non-empty** value
+  across all link rows via a new helper `mcp_first_nonempty_value()`. Keep per-link and
+  aggregate fields unchanged.
+- **Compat:** Additive bugfix — same field, now reliably populated when any link carries
+  a type.
+- **Risk/effort:** Low / small.
+- **Disposition:** **This change.**
+
+### 3.5 P1 — Null-as-`{}` serialization
+
+- **Claim:** null scalars serialize as `{}` (R/Plumber artifact) instead of JSON `null`.
+- **Reality (current code):** The `content[].text` path already uses
+  `jsonlite::toJSON(..., null = "null", na = "null")` and is correct. The `{}` artifact
+  comes from `structuredContent = payload` (`api/services/mcp-tools.R:9`): the *raw R
+  list* is serialized later by the `mcptools` HTTP transport, whose `toJSON` does **not**
+  pass `null = "null"`, so an R `NULL` element renders as `{}`.
+- **Fix (this change):** Build `structuredContent` from the already null-safe text by
+  round-tripping `jsonlite::fromJSON(text, simplifyVector = FALSE)` (new helper
+  `mcp_structured_content()`), so `structuredContent` mirrors `content[].text` exactly.
+  Falls back to the raw payload on parse error.
+- **Compat:** Bugfix only — corrects rendering of existing fields (`{}` → `null`); no
+  schema change. `schema_version` stays `1.2`.
+- **Risk/effort:** Low / small. One re-serialization per tool call (payloads are already
+  bounded/compact by default).
+- **Disposition:** **This change.**
+
+### 3.6 P2 — `find_entities_by_*` ranking + count-only mode
+
+- **Claim:** results are alphabetical (924 genes for "Seizures"); add relevance /
+  category-strength ranking and an aggregate / count-only mode.
+- **Reality (current code):** Confirmed — `mcp_repo_find_entities_by_phenotype` /
+  `..._by_disease` order by `ev.symbol, ev.entity_id` with `LIMIT/OFFSET`, and there is
+  no count-only / aggregate mode (only `meta$total`).
+- **Fix (deferred):** (a) Add a category-strength ordering (Definitive > Moderate >
+  Limited > …) before symbol, optionally weighted by phenotype-match modifier; (b) add an
+  `aggregate` / `count_only` response mode returning per-category counts and gene/entity
+  totals without row payloads. Both need a defined ranking contract + new schema fields
+  and smoke coverage.
+- **Compat:** Additive (new optional `response_mode`/`aggregate` param + new meta).
+- **Risk/effort:** Medium / medium (ranking design + new param + tests).
+- **Disposition:** **Follow-up.**
+
+### 3.7 P2 — Zero-result echo
+
+- **Claim:** `resolved_phenotypes` / `resolved_diseases` collapse to `[]` on zero matches;
+  always echo the resolved term so callers distinguish invalid input from empty results.
+- **Reality (current code):** Confirmed — both fields are derived from result rows, so
+  they are `[]` on a miss, and `find_entities_by_disease` did not even echo the input
+  `disease` at top level.
+- **Fix (this change):** Always echo the requested term and a resolution flag:
+  `meta$query_echo` (the requested term) and `meta$query_resolved` (boolean) on both
+  tools, plus a top-level `disease` echo on `find_entities_by_disease` (parity with the
+  existing top-level `phenotype` echo).
+- **Compat:** Additive (new optional fields).
+- **Risk/effort:** Low / small.
+- **Disposition:** **This change.**
+
+### 3.8 P3 — GRIN2A entity #303 phenotype gap
+
+- **Claim:** entity #303 lacks a speech/language HPO term despite its synopsis/name.
+- **Reality:** This is a **curation data** issue, not MCP code. MCP must not write or fix
+  curated data.
+- **Disposition:** **Out of scope for MCP code** — flag for curator review (issue
+  comment / curation backlog).
+
+## 4. Already addressed (verified on 2026-06-11, no code change)
+
+- Search recall: gene `name`, HGNC alias/previous, disease names, HPO terms +
+  (conditional) synonyms, token-overlap matching, descending tier ranking, zero-result
+  guidance (`meta$zero_result_guidance`, `query_tokens`, `searched_types`).
+- Phenotype `correlations`: rejects `gene`; has `drop_diagonal` / `triangle_only`.
+- Analysis snapshot diagnostics: specific `snapshot_missing` / `snapshot_stale` /
+  `source_version_mismatch` codes; `dry_run` / `diagnostics` preflight; `retry_with`
+  recovery; `unsupported_parameter` for non-preset params.
+
+## 5. Acceptance criteria mapping (issue #353)
+
+- P0/P1 each have a concrete spec with behavior + schema/compat note → §3.
+- MCP read-only / approved-public-data invariants preserved → §2; no repository query
+  gate changed.
+- `mcp-smoke.R` extended for search + analysis-availability regressions → zero-result
+  echo + publication_type/structuredContent-null assertions added; existing NMDA /
+  epilepsy / snapshot-diagnostics assertions retained.
+- Tool descriptions / `get_sysndd_capabilities` updated where behavior changes → no tool
+  *contract* changed; new fields are additive under `additionalProperties = true`, so no
+  schema-doc churn is required. (Capabilities already document the snapshot error codes.)
+
+## 6. Out of scope
+
+- Snapshot prewarming / cache initialization in the deployed sidecar (deployment/ops).
+- Search fuzzy matching and disease-synonym source selection (needs ranking design).
+- `find_entities_by_*` relevance ranking + count-only mode (needs ranking contract).
+- GRIN2A #303 curation fix (curation workflow, not MCP).

--- a/api/scripts/mcp-smoke.R
+++ b/api/scripts/mcp-smoke.R
@@ -358,6 +358,37 @@ if (!identical(category_payload$error$code, "invalid_input") || !identical(categ
   stop("Invalid phenotype category did not return invalid_input for category")
 }
 
+# issue #353: find_entities_by_* must echo the requested term + resolution flag even
+# on zero results so callers distinguish an unmatched term from a valid empty result.
+zero_disease <- call_tool(
+  "find_entities_by_disease",
+  list(disease = "zzzz nonexistent disorder zzzz", limit = 1L),
+  id = 61L
+)
+if (!is.null(zero_disease$error)) stop("zero-result disease search returned JSON-RPC error: ", zero_disease$error$message)
+if (isTRUE(zero_disease$result$isError)) stop("zero-result disease search returned an unexpected tool error")
+zero_disease_payload <- jsonlite::fromJSON(zero_disease$result$content[[1]]$text, simplifyVector = FALSE)
+if (!identical(zero_disease_payload$disease, "zzzz nonexistent disorder zzzz") ||
+  !identical(zero_disease_payload$meta$query_echo, "zzzz nonexistent disorder zzzz")) {
+  stop("zero-result disease search did not echo the requested term")
+}
+if (!identical(zero_disease_payload$meta$query_resolved, FALSE)) {
+  stop("zero-result disease search did not report query_resolved = false")
+}
+
+zero_phenotype <- call_tool(
+  "find_entities_by_phenotype",
+  list(phenotype = "HP:0000000", limit = 1L),
+  id = 62L
+)
+if (!is.null(zero_phenotype$error)) stop("zero-result phenotype search returned JSON-RPC error: ", zero_phenotype$error$message)
+if (!isTRUE(zero_phenotype$result$isError)) {
+  zero_phenotype_payload <- jsonlite::fromJSON(zero_phenotype$result$content[[1]]$text, simplifyVector = FALSE)
+  if (!identical(zero_phenotype_payload$meta$query_echo, "HP:0000000")) {
+    stop("zero-result phenotype search did not echo the requested term")
+  }
+}
+
 symbol_alias <- call_tool("get_gene_context", list(symbol = "NAA10", entity_limit = 1L), id = 7L)
 if (!is.null(symbol_alias$error)) stop("symbol alias returned JSON-RPC error: ", symbol_alias$error$message)
 if (!isTRUE(symbol_alias$result$isError)) stop("symbol alias did not return a tool error result")
@@ -428,6 +459,16 @@ if (length(entity_ids) > 0L) {
     if (length(linked_entities) > 0L &&
       any(!vapply(linked_entities, function(x) !is.null(x$publication_type), logical(1)))) {
       stop("publication linked entity rows did not include publication_type")
+    }
+    # issue #353: structuredContent must mirror content[].text (no `{}` for nulls),
+    # and the top-level publication_type must never serialize as an empty object.
+    structured_text <- publication_detail$result$structuredContent
+    if (is.null(structured_text)) {
+      stop("get_publication_context response missing structuredContent despite outputSchema")
+    }
+    if (is.list(structured_text$publication_type) &&
+      length(structured_text$publication_type) == 0L) {
+      stop("get_publication_context publication_type serialized as an empty object instead of null/string")
     }
   }
   expanded_gene <- call_tool(

--- a/api/services/mcp-record-service.R
+++ b/api/services/mcp-record-service.R
@@ -193,6 +193,13 @@ mcp_get_publication_context <- function(pmid, abstract_max_chars = 2000L, abstra
     rows <- mcp_repo_get_publication_context(publication_id)
     first <- mcp_first_row(rows, "Publication not found")
     pub <- mcp_row_to_list(first)
+    # publication_type is a per-link attribute that varies per linked entity, so the
+    # first join row may be NULL even when other links carry a type. Promote the first
+    # non-empty value to the top-level scalar so it is not dropped/serialized as `{}`
+    # (issue #353). Per-link values stay in linked_entities and publication_types.
+    pub$publication_type <- mcp_first_nonempty_value(
+      if ("publication_type" %in% names(rows)) rows$publication_type else NULL
+    )
     date_quality <- mcp_publication_date_quality(
       pub$Publication_date, rows$curation_review_date, pub$publication_date_source
     )
@@ -281,12 +288,21 @@ mcp_find_entities_by_phenotype <- function(phenotype,
   offset <- mcp_validate_offset(offset)
   rows <- mcp_repo_find_entities_by_phenotype(phenotype, modifier, category, limit, offset)
   total <- mcp_repo_count_entities_by_phenotype(phenotype, modifier, category)
+  resolved_phenotypes <- unique(mcp_rows_to_records(rows[c("phenotype_id", "HPO_term")]))
   list(
     schema_version = MCP_SCHEMA_VERSION,
     phenotype = phenotype,
-    resolved_phenotypes = unique(mcp_rows_to_records(rows[c("phenotype_id", "HPO_term")])),
+    resolved_phenotypes = resolved_phenotypes,
     entities = mcp_decorate_entity_records(rows),
-    meta = list(limit = limit, offset = offset, returned = nrow(rows), total = total, has_more = offset + nrow(rows) < total)
+    meta = list(
+      limit = limit, offset = offset, returned = nrow(rows), total = total,
+      has_more = offset + nrow(rows) < total,
+      # Always echo the requested term and whether it resolved to any records so callers
+      # can distinguish an unmatched/invalid term from a valid term with zero entities
+      # (issue #353). resolved_phenotypes is derived from result rows and is [] on miss.
+      query_echo = phenotype,
+      query_resolved = length(resolved_phenotypes) > 0L
+    )
   )
 }
 
@@ -296,11 +312,20 @@ mcp_find_entities_by_disease <- function(disease, limit = 25L, offset = 0L) {
   offset <- mcp_validate_offset(offset)
   rows <- mcp_repo_find_entities_by_disease(disease, limit, offset)
   total <- mcp_repo_count_entities_by_disease(disease)
+  resolved_diseases <- unique(mcp_rows_to_records(rows[c("disease_ontology_id_version", "disease_ontology_name")]))
   list(
     schema_version = MCP_SCHEMA_VERSION,
-    resolved_diseases = unique(mcp_rows_to_records(rows[c("disease_ontology_id_version", "disease_ontology_name")])),
+    # Echo the requested disease term at top level (previously only present in meta-less
+    # form), so zero-result callers still see what was searched (issue #353).
+    disease = disease,
+    resolved_diseases = resolved_diseases,
     entities = mcp_decorate_entity_records(rows),
-    meta = list(limit = limit, offset = offset, returned = nrow(rows), total = total, has_more = offset + nrow(rows) < total)
+    meta = list(
+      limit = limit, offset = offset, returned = nrow(rows), total = total,
+      has_more = offset + nrow(rows) < total,
+      query_echo = disease,
+      query_resolved = length(resolved_diseases) > 0L
+    )
   )
 }
 

--- a/api/services/mcp-research-context-service.R
+++ b/api/services/mcp-research-context-service.R
@@ -2,12 +2,24 @@
 #
 # Gene-level MCP research context aggregation over curated and analysis sections.
 
+# Recoverable snapshot-unavailability codes that should surface as a single
+# "temporarily_unavailable" section status in the research-context aggregator.
+# The specific code (snapshot_missing | snapshot_stale | source_version_mismatch)
+# stays in the section value payload's error.code for callers that need it
+# (issue #353: previously stale/mismatch fell through to a generic "error").
+MCP_SECTION_UNAVAILABLE_CODES <- c(
+  "temporarily_unavailable",
+  "snapshot_missing",
+  "snapshot_stale",
+  "source_version_mismatch"
+)
+
 mcp_section_call <- function(name, fn) {
   tryCatch(
     list(status = "available", value = fn()),
     mcp_tool_error = function(e) {
       payload <- mcp_error_payload(e)
-      status <- if (payload$error$code %in% c("temporarily_unavailable", "snapshot_missing")) {
+      status <- if (payload$error$code %in% MCP_SECTION_UNAVAILABLE_CODES) {
         "temporarily_unavailable"
       } else {
         "error"

--- a/api/services/mcp-service.R
+++ b/api/services/mcp-service.R
@@ -203,6 +203,21 @@ mcp_drop_nested_schema_version <- function(item) {
   item
 }
 
+# Return the first non-NA, non-empty value from a column-like vector, or NULL.
+# Used to promote per-link scalar attributes (e.g. publication_type) to a
+# top-level field without being defeated by a NULL leading join row (issue #353).
+mcp_first_nonempty_value <- function(values) {
+  if (is.null(values) || length(values) == 0L) {
+    return(NULL)
+  }
+  values <- values[!is.na(values)]
+  values <- values[nzchar(trimws(as.character(values)))]
+  if (length(values) == 0L) {
+    return(NULL)
+  }
+  values[[1]]
+}
+
 mcp_compact_phenotypes <- function(rows) {
   if (is.null(rows) || nrow(rows) == 0L) {
     return(list())

--- a/api/services/mcp-tools.R
+++ b/api/services/mcp-tools.R
@@ -3,12 +3,26 @@
 # MCP protocol patches for resources, prompts, tool schemas, and structured results.
 
 mcp_tool_result_response <- function(id, payload, is_error = FALSE, output_mode = Sys.getenv("MCP_OUTPUT_MODE", "json_text")) {
+  text <- jsonlite::toJSON(payload, auto_unbox = TRUE, null = "null", na = "null")
   body <- list(
-    content = list(list(type = "text", text = jsonlite::toJSON(payload, auto_unbox = TRUE, null = "null", na = "null"))),
+    content = list(list(type = "text", text = text)),
     isError = isTRUE(is_error),
-    structuredContent = payload
+    # structuredContent is serialized later by the mcptools HTTP transport, whose
+    # toJSON call does not pass `null = "null"`, so raw R NULL scalars would render
+    # as `{}` instead of JSON `null`. Round-trip the already null-safe text so the
+    # structured form mirrors content[].text exactly (issue #353).
+    structuredContent = mcp_structured_content(text, payload)
   )
   mcp_jsonrpc_response(id, body)
+}
+
+# Parse the null-safe JSON text back into an R list for structuredContent so the
+# field mirrors content[].text. Falls back to the raw payload if parsing fails.
+mcp_structured_content <- function(text, payload) {
+  tryCatch(
+    jsonlite::fromJSON(text, simplifyVector = FALSE),
+    error = function(e) payload
+  )
 }
 
 mcp_tool_property_names <- function(tool) {

--- a/api/tests/testthat/test-mcp-search-analysis-fixes.R
+++ b/api/tests/testthat/test-mcp-search-analysis-fixes.R
@@ -1,0 +1,190 @@
+# tests/testthat/test-mcp-search-analysis-fixes.R
+#
+# Regression tests for issue #353 MCP search + derived-analysis benchmark fixes:
+#   - structuredContent renders null scalars as JSON null (not `{}`)
+#   - top-level publication_type is promoted from the first non-empty link row
+#   - find_entities_by_* echo the requested term + resolution flag on zero results
+#   - get_gene_research_context collapses all snapshot-unavailable codes to
+#     "temporarily_unavailable" instead of falling through to "error"
+
+test_that("structuredContent serializes null scalars as JSON null, not {}", {
+  api_dir <- get_api_dir()
+  source(file.path(api_dir, "services", "mcp-service.R"), local = .GlobalEnv)
+  source(file.path(api_dir, "services", "mcp-tool-core.R"), local = TRUE)
+  source(file.path(api_dir, "services", "mcp-tools.R"), local = TRUE)
+
+  payload <- list(
+    schema_version = MCP_SCHEMA_VERSION,
+    publication_type = NULL,
+    title = "Example"
+  )
+
+  response <- mcp_tool_result_response(1L, payload)
+  structured <- response$result$structuredContent
+
+  # The structured form must be a parsed list mirroring the null-safe text, so a
+  # NULL scalar round-trips to JSON null rather than the `{}` transport artifact.
+  expect_true("publication_type" %in% names(structured))
+  expect_null(structured$publication_type)
+
+  rendered <- jsonlite::toJSON(structured, auto_unbox = TRUE, null = "null", na = "null")
+  expect_true(grepl("\"publication_type\":null", rendered, fixed = TRUE))
+  expect_false(grepl("\"publication_type\":{}", rendered, fixed = TRUE))
+})
+
+test_that("mcp_first_nonempty_value skips NA and empty leading values", {
+  api_dir <- get_api_dir()
+  source(file.path(api_dir, "services", "mcp-service.R"), local = .GlobalEnv)
+
+  expect_equal(mcp_first_nonempty_value(c(NA, "", "Review", "Original")), "Review")
+  expect_null(mcp_first_nonempty_value(c(NA, "", "  ")))
+  expect_null(mcp_first_nonempty_value(NULL))
+  expect_null(mcp_first_nonempty_value(character()))
+})
+
+test_that("get_publication_context promotes publication_type from a non-NULL link row", {
+  api_dir <- get_api_dir()
+  source(file.path(api_dir, "functions", "mcp-repository.R"), local = .GlobalEnv)
+  source(file.path(api_dir, "services", "mcp-service.R"), local = .GlobalEnv)
+  source(file.path(api_dir, "services", "mcp-record-service.R"), local = .GlobalEnv)
+
+  old_repo <- get0("mcp_repo_get_publication_context", envir = .GlobalEnv, ifnotfound = NULL)
+  assign("mcp_repo_get_publication_context", function(publication_id) {
+    tibble::tibble(
+      publication_id = c("123", "123"),
+      Title = c("Example", "Example"),
+      Abstract = c(NA_character_, NA_character_),
+      Journal = c("J", "J"),
+      Publication_date = c("2020", "2020"),
+      publication_date_source = c(NA_character_, NA_character_),
+      Lastname = c("Doe", "Doe"),
+      Firstname = c("J", "J"),
+      Keywords = c(NA_character_, NA_character_),
+      entity_id = c(10L, 11L),
+      symbol = c("AAA", "BBB"),
+      hgnc_id = c("1", "2"),
+      disease_ontology_name = c("d1", "d2"),
+      category = c("Definitive", "Definitive"),
+      # First link row has a NULL/NA publication_type; the second carries "Review".
+      publication_type = c(NA_character_, "Review"),
+      curation_review_date = c("2021", "2021")
+    )
+  }, envir = .GlobalEnv)
+  on.exit(
+    {
+      if (is.null(old_repo)) {
+        rm("mcp_repo_get_publication_context", envir = .GlobalEnv)
+      } else {
+        assign("mcp_repo_get_publication_context", old_repo, envir = .GlobalEnv)
+      }
+    },
+    add = TRUE
+  )
+
+  result <- mcp_get_publication_context("123", abstract_mode = "metadata")
+
+  # Top-level scalar must be the first non-empty link value, not the NULL first row.
+  expect_equal(result$publication_type, "Review")
+  # Per-link values remain intact for callers that need the full distribution.
+  expect_true("Review" %in% unlist(result$publication_types))
+})
+
+test_that("find_entities_by_phenotype echoes the term and resolution flag on zero hits", {
+  api_dir <- get_api_dir()
+  source(file.path(api_dir, "services", "mcp-service.R"), local = .GlobalEnv)
+  source(file.path(api_dir, "services", "mcp-record-service.R"), local = .GlobalEnv)
+
+  empty_rows <- tibble::tibble(
+    entity_id = integer(),
+    symbol = character(),
+    hgnc_id = character(),
+    disease_ontology_id_version = character(),
+    disease_ontology_name = character(),
+    hpo_mode_of_inheritance_term_name = character(),
+    category = character(),
+    ndd_phenotype_word = character(),
+    phenotype_id = character(),
+    HPO_term = character(),
+    modifier_name = character()
+  )
+
+  old_find <- get0("mcp_repo_find_entities_by_phenotype", envir = .GlobalEnv, ifnotfound = NULL)
+  old_count <- get0("mcp_repo_count_entities_by_phenotype", envir = .GlobalEnv, ifnotfound = NULL)
+  assign("mcp_repo_find_entities_by_phenotype", function(...) empty_rows, envir = .GlobalEnv)
+  assign("mcp_repo_count_entities_by_phenotype", function(...) 0L, envir = .GlobalEnv)
+  on.exit(
+    {
+      if (is.null(old_find)) rm("mcp_repo_find_entities_by_phenotype", envir = .GlobalEnv) else assign("mcp_repo_find_entities_by_phenotype", old_find, envir = .GlobalEnv)
+      if (is.null(old_count)) rm("mcp_repo_count_entities_by_phenotype", envir = .GlobalEnv) else assign("mcp_repo_count_entities_by_phenotype", old_count, envir = .GlobalEnv)
+    },
+    add = TRUE
+  )
+
+  result <- mcp_find_entities_by_phenotype("HP:9999999")
+  expect_equal(result$meta$returned, 0L)
+  expect_equal(result$meta$query_echo, "HP:9999999")
+  expect_false(result$meta$query_resolved)
+  expect_equal(result$resolved_phenotypes, list())
+  expect_equal(result$phenotype, "HP:9999999")
+})
+
+test_that("find_entities_by_disease echoes the term and resolution flag on zero hits", {
+  api_dir <- get_api_dir()
+  source(file.path(api_dir, "services", "mcp-service.R"), local = .GlobalEnv)
+  source(file.path(api_dir, "services", "mcp-record-service.R"), local = .GlobalEnv)
+
+  empty_rows <- tibble::tibble(
+    entity_id = integer(),
+    symbol = character(),
+    hgnc_id = character(),
+    disease_ontology_id_version = character(),
+    disease_ontology_name = character(),
+    hpo_mode_of_inheritance_term_name = character(),
+    category = character(),
+    ndd_phenotype_word = character()
+  )
+
+  old_find <- get0("mcp_repo_find_entities_by_disease", envir = .GlobalEnv, ifnotfound = NULL)
+  old_count <- get0("mcp_repo_count_entities_by_disease", envir = .GlobalEnv, ifnotfound = NULL)
+  assign("mcp_repo_find_entities_by_disease", function(...) empty_rows, envir = .GlobalEnv)
+  assign("mcp_repo_count_entities_by_disease", function(...) 0L, envir = .GlobalEnv)
+  on.exit(
+    {
+      if (is.null(old_find)) rm("mcp_repo_find_entities_by_disease", envir = .GlobalEnv) else assign("mcp_repo_find_entities_by_disease", old_find, envir = .GlobalEnv)
+      if (is.null(old_count)) rm("mcp_repo_count_entities_by_disease", envir = .GlobalEnv) else assign("mcp_repo_count_entities_by_disease", old_count, envir = .GlobalEnv)
+    },
+    add = TRUE
+  )
+
+  result <- mcp_find_entities_by_disease("nonexistent disorder")
+  expect_equal(result$meta$returned, 0L)
+  expect_equal(result$disease, "nonexistent disorder")
+  expect_equal(result$meta$query_echo, "nonexistent disorder")
+  expect_false(result$meta$query_resolved)
+  expect_equal(result$resolved_diseases, list())
+})
+
+test_that("research-context sections map all snapshot-unavailable codes to temporarily_unavailable", {
+  api_dir <- get_api_dir()
+  source(file.path(api_dir, "services", "mcp-service.R"), local = .GlobalEnv)
+  source(file.path(api_dir, "services", "mcp-research-context-service.R"), local = .GlobalEnv)
+
+  make_section <- function(code) {
+    mcp_section_call("phenotype", function() {
+      stop(mcp_error(code, "snapshot not serviceable", list(argument = "mode")))
+    })
+  }
+
+  for (code in c("snapshot_missing", "snapshot_stale", "source_version_mismatch", "temporarily_unavailable")) {
+    section <- make_section(code)
+    expect_equal(section$status, "temporarily_unavailable")
+    # The specific code is preserved in the section value for callers that need it.
+    expect_equal(section$value$error$code, code)
+  }
+
+  # A non-snapshot recoverable error still surfaces as "error".
+  other <- mcp_section_call("phenotype", function() {
+    stop(mcp_error("invalid_input", "bad mode", list(argument = "mode")))
+  })
+  expect_equal(other$status, "error")
+})


### PR DESCRIPTION
## Summary

Addresses #353 (SysNDD MCP: spec & plan tool benchmark improvements — search + analysis caches).

The issue's primary ask is a **spec & plan**; the secondary ask is to **implement the clearly-safe, well-defined fixes**. This PR delivers both.

A key finding while mapping the 2026-05-19 benchmark backlog onto the current code: **several P0/P1 items have already been addressed in `master` since the benchmark snapshot** (the benchmark predates that work). The spec re-grounds every item in the code as it exists today so we neither re-implement done work nor silently drop genuinely-open gaps.

## Deliverable 1 — Spec & Plan (primary)

- `.planning/superpowers/specs/2026-06-11-mcp-search-analysis-benchmark-fixes-design.md`
- `.planning/superpowers/plans/2026-06-11-mcp-search-analysis-benchmark-fixes-plan.md`

Defect-by-defect: benchmark claim → current code reality → concrete fix → schema/compat impact → risk/effort → disposition (this PR vs follow-up).

## Defects → disposition

| Issue item | Benchmark claim | Current reality | Disposition |
|---|---|---|---|
| P0 search exact-match only | NMDA/epilepsy return 0 hits; name+synonyms not searched | Already searches gene `name`, HGNC alias/previous, disease names, HPO terms+synonyms, token-overlap, ranked desc (smoke already asserts NMDA/epilepsy) | **Already addressed**; disease-synonym recall + fuzzy deferred (need ranking design) |
| P0 uninitialized analysis caches | bare `temporarily_unavailable` | Specific `snapshot_missing`/`snapshot_stale`/`source_version_mismatch` + `dry_run`/`diagnostics` + `retry_with` | **Mostly addressed**; fixed research-context status asymmetry (this PR); prewarm = ops follow-up |
| P1 correlations ignores `gene` | silent ignore; no drop_diagonal/triangle_only | Already **rejects** `gene` in correlations; has `drop_diagonal`/`triangle_only` | **Closed**; thread flags into functional-correlations = minor follow-up |
| P1 publication_type `{}` | dropped in publication tools | Top-level scalar sampled from a possibly-NULL first join row | **Fixed (this PR)** |
| P1 null-as-`{}` | null scalars render `{}` | `content[].text` correct; `structuredContent` raw payload serialized by transport without `null="null"` | **Fixed (this PR)** |
| P2 find_entities ranking + count-only | alphabetical; no aggregate mode | Confirmed alphabetical, no count-only | **Deferred** (needs ranking contract + new schema surface) |
| P2 zero-result echo | resolved_* collapse to `[]` | Confirmed | **Fixed (this PR)** |
| P3 GRIN2A #303 phenotype gap | missing HPO term | Curation data, not MCP code | **Out of scope** (curator review) |

## Deliverable 2 — Implemented safe subset

1. **Null-as-`{}` (P1):** `structuredContent` is now built from the already null-safe JSON text via `mcp_structured_content()` round-trip, so nulls render as JSON `null`, mirroring `content[].text`. (`api/services/mcp-tools.R`)
2. **publication_type (P1):** `get_publication_context` promotes the top-level scalar to the first non-empty link value (`mcp_first_nonempty_value()`); per-link `linked_entities[].publication_type` and the `publication_types` aggregate are unchanged. (`api/services/mcp-record-service.R`, `api/services/mcp-service.R`)
3. **Zero-result echo (P2):** `find_entities_by_phenotype`/`find_entities_by_disease` always emit `meta.query_echo` + `meta.query_resolved`; `find_entities_by_disease` also echoes a top-level `disease`. Callers can now distinguish an unmatched term from a valid empty result. (`api/services/mcp-record-service.R`)
4. **Section-status consistency (P0 gap):** `mcp_section_call()` collapses `{temporarily_unavailable, snapshot_missing, snapshot_stale, source_version_mismatch}` to a `temporarily_unavailable` section status (previously stale/mismatch fell through to a generic `error`); the specific code is preserved in the section value payload. (`api/services/mcp-research-context-service.R`)

## Deferred (documented in the plan, not implemented)

- Search disease-synonym recall + fuzzy/typo tolerance (needs synonym source + ranking design/perf budget).
- `find_entities_by_*` relevance ranking + count-only/aggregate mode (needs ranking contract + new schema fields).
- Snapshot prewarm runbook / operator guidance (deployment/ops; MCP must not initialize caches).
- `drop_diagonal`/`triangle_only` in `phenotype_functional_correlations` mode (minor; needs preset support).
- GRIN2A #303 curation fix (curation workflow, not MCP code).

## MCP invariants preserved

- Read-only, approved-public-data only — no repository query gate changed; no new DB access pattern.
- `MCP_SCHEMA_VERSION` stays `1.2`. All changes are additive fields or serialization bugfixes (no removals, no type changes); output schemas are `additionalProperties = true`.
- Analysis tools stay cache-hit-only — no compute/fCoSE/external/Gemini on miss; only the section-status mapping was made consistent.
- Recoverable errors keep the `schema_version` + `error.code` + `isError` envelope.

## Tests

- New `api/tests/testthat/test-mcp-search-analysis-fixes.R` — 29 assertions, host-runnable (mocks all DB): null-serialization round-trip, `mcp_first_nonempty_value`, publication_type promotion, both zero-result echoes, section-status code mapping. **PASS.**
- `api/scripts/mcp-smoke.R` extended (CI, runs against the stack): zero-result `find_entities_by_disease`/`find_entities_by_phenotype` echo + `query_resolved`; `get_publication_context` top-level `publication_type` never `{}` and `structuredContent` present.
- Regression: `test-mcp-service.R` (58), `test-mcp-search-ranking.R` (18), `test-mcp-snapshot-diagnostics.R` (9), `test-mcp-service-publication-discovery.R` (35), `test-mcp-tools.R` (84), `test-mcp-analysis-service.R` (111), `test-mcp-service-entity-gene-batch.R` (37) — all **PASS**.
- `make code-quality-audit` — **clean**. New lines are all <120 chars. (Official `lint-check.R` lints `endpoints/`+`functions/` only; the touched `services/` files are outside that scope, consistent with the existing codebase.)

## Needs CI

- `mcp-smoke.R` exercises the live stack and runs in CI — its new assertions were **not** run locally (the shared stack must not be started). The R unit suite and `code-quality-audit` were run on the host and pass.

## Judgement on closing the issue

This PR delivers the issue's primary deliverable (spec + plan covering every P0/P1 item with behavior/schema/compat notes) and implements the safe subset with tests, extending `mcp-smoke.R` per the acceptance criteria. The remaining items are genuine, scoped follow-ups (ranking design, ops runbook, curation data) rather than gaps in this deliverable, so I use `Closes #353`. If the maintainer prefers to keep #353 open to track the deferred follow-ups, the `Closes` can be downgraded to `Refs`.

Closes #353
