### PR TITLE
chore(db): config-ize and document db creation scripts; add master runner (#33)

### DIFF
--- a/db/.gitignore
+++ b/db/.gitignore
@@ -1,9 +1,18 @@
 # R files
 .Rhistory
 
-# config files
+# config files (real credentials / source overrides — never commit)
 sysndd_db.yml
+config/sysndd_db.yml
+config/db_sources.yml
 initial_users.csv
 
-# omim files
+# omim files (account-specific download links embed a secret token)
 omim_links.txt
+data/omim_links/
+
+# SysID reproducible snapshot (large, operator-generated artifact)
+data/sysid/
+
+# generated outputs
+results/

--- a/db/.lintr
+++ b/db/.lintr
@@ -1,0 +1,21 @@
+linters: linters_with_defaults(
+    # Codebase mixes %>% and |>
+    pipe_consistency_linter = NULL,
+    # 120-char lines (matches api/.lintr); URLs/SQL are often long
+    line_length_linter = line_length_linter(120L),
+    # Allow explicit returns
+    return_linter = NULL,
+    # Allow SCREAMING_SNAKE_CASE constants and longer object names
+    object_name_linter = NULL,
+    object_length_linter = NULL,
+    # NSE / sourced-into-global symbols confuse usage analysis
+    object_usage_linter = NULL,
+    # File-path header comments and roxygen examples trip this
+    commented_code_linter = NULL,
+    # styler handles formatting
+    indentation_linter = NULL
+  )
+exclusions: list(
+    "data/", "results/", "migrations/", "fixtures/", "updates/"
+  )
+encoding: "UTF-8"

--- a/db/01_Rcommands_sysndd_db_table_hgnc_non_alt_loci_set.R
+++ b/db/01_Rcommands_sysndd_db_table_hgnc_non_alt_loci_set.R
@@ -8,19 +8,17 @@ library(config)     ## needed to read config file
 
 
 ############################################
-## define relative script path
-project_topic <- "sysndd"
-project_name <- "R"
-
-## read configs
-config_vars_proj <- config::get(file = Sys.getenv("CONFIG_FILE"),
-    config = project_topic)
-
-## set working directory
-setwd(paste0(config_vars_proj$projectsdir, project_name))
-
-## set global options
-options(scipen = 999)
+## SysNDD data-prep bootstrap (issue #33): locate db/config, then db_bootstrap()
+## sets SYSNDD_DB_DIR, anchors CWD to db/, sources db_sysid_source.R, sets db_src.
+.f <- tryCatch(sys.frame(1)$ofile, error = function(e) NULL)
+if (is.null(.f)) .f <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+.cfg <- if (nzchar(Sys.getenv("SYSNDD_DB_DIR"))) {
+  file.path(Sys.getenv("SYSNDD_DB_DIR"), "config")
+} else {
+  file.path(dirname(normalizePath(.f[1])), "config")
+}
+source(file.path(.cfg, "db_config.R"))
+config_vars_proj <- db_bootstrap()
 ############################################
 
 
@@ -95,8 +93,8 @@ gene_coordinates_from_ensembl <- function(ensembl_id, reference = "hg19") {
 ############################################
 ## download HGNC file
 file_date <- strftime(as.POSIXlt(Sys.time(), "UTC", "%Y-%m-%dT%H:%M:%S"), "%Y-%m-%d")
-hgnc_link <- "http://ftp.ebi.ac.uk/pub/databases/genenames/hgnc/tsv/non_alt_loci_set.txt"
-hgnc_file <- "data/non_alt_loci_set.txt"
+hgnc_link <- db_source_url("hgnc_non_alt_loci_set", db_src)
+hgnc_file <- db_data_path("non_alt_loci_set.txt", create_dir = TRUE)
 download.file(hgnc_link, hgnc_file, mode = "wb")
 ############################################
 
@@ -104,7 +102,7 @@ download.file(hgnc_link, hgnc_file, mode = "wb")
 
 ############################################
 ## load STRINGdb database
-string_db <- STRINGdb$new( version="11.5", species=9606, score_threshold=200, input_directory="data/")
+string_db <- STRINGdb$new( version="11.5", species=9606, score_threshold=200, input_directory=db_data_path())
 ############################################
 
 
@@ -161,5 +159,5 @@ non_alt_loci_set_coordinates <- non_alt_loci_set_string %>%
 ############################################
 ## export table as csv with date of creation
 creation_date <- strftime(as.POSIXlt(Sys.time(), "UTC", "%Y-%m-%dT%H:%M:%S"), "%Y-%m-%d")
-write_csv(non_alt_loci_set_coordinates, file = paste0("results/non_alt_loci_set.",creation_date,".csv"))
+write_csv(non_alt_loci_set_coordinates, file = db_results_path(paste0("non_alt_loci_set.", creation_date, ".csv")))
 ############################################

--- a/db/02_Rcommands_sysndd_db_table_disease_ontology_set.R
+++ b/db/02_Rcommands_sysndd_db_table_disease_ontology_set.R
@@ -7,19 +7,17 @@ library(config)     ## needed to read config file
 
 
 ############################################
-## define relative script path
-project_topic <- "sysndd"
-project_name <- "R"
-
-## read configs
-config_vars_proj <- config::get(file = Sys.getenv("CONFIG_FILE"),
-    config = project_topic)
-
-## set working directory
-setwd(paste0(config_vars_proj$projectsdir, project_name))
-
-## set global options
-options(scipen = 999)
+## SysNDD data-prep bootstrap (issue #33): locate db/config, then db_bootstrap()
+## sets SYSNDD_DB_DIR, anchors CWD to db/, sources db_sysid_source.R, sets db_src.
+.f <- tryCatch(sys.frame(1)$ofile, error = function(e) NULL)
+if (is.null(.f)) .f <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+.cfg <- if (nzchar(Sys.getenv("SYSNDD_DB_DIR"))) {
+  file.path(Sys.getenv("SYSNDD_DB_DIR"), "config")
+} else {
+  file.path(dirname(normalizePath(.f[1])), "config")
+}
+source(file.path(.cfg, "db_config.R"))
+config_vars_proj <- db_bootstrap()
 ############################################
 
 
@@ -27,7 +25,7 @@ options(scipen = 999)
 ## define functions
 
 hgnc_id_from_prevsymbol <- function(symbol_input)  {
-  symbol_request <- fromJSON(paste0("http://rest.genenames.org/search/prev_symbol/", symbol_input))
+  symbol_request <- fromJSON(db_genenames_search_url("prev_symbol", symbol_input, db_src))
 
   hgnc_id_from_symbol <- as_tibble(symbol_request$response$docs)
   
@@ -42,7 +40,7 @@ hgnc_id_from_prevsymbol <- function(symbol_input)  {
 }
 
 hgnc_id_from_aliassymbol <- function(symbol_input)  {
-  symbol_request <- fromJSON(paste0("http://rest.genenames.org/search/alias_symbol/", symbol_input))
+  symbol_request <- fromJSON(db_genenames_search_url("alias_symbol", symbol_input, db_src))
 
   hgnc_id_from_symbol <- as_tibble(symbol_request$response$docs)
   
@@ -59,7 +57,7 @@ hgnc_id_from_aliassymbol <- function(symbol_input)  {
 hgnc_id_from_symbol <- function(symbol_tibble) {
   symbol_list_tibble <- as_tibble(symbol_tibble) %>% select(symbol = value) %>% mutate(symbol = toupper(symbol))
   
-  symbol_request <- fromJSON(paste0("http://rest.genenames.org/search/symbol/", str_c(symbol_list_tibble$symbol, collapse = "+OR+")))
+  symbol_request <- fromJSON(db_genenames_search_url("symbol", str_c(symbol_list_tibble$symbol, collapse = "+OR+"), db_src))
 
   hgnc_id_from_symbol <- as_tibble(symbol_request$response$docs)
   
@@ -107,7 +105,7 @@ hgnc_id_from_symbol_grouped <- function(input_tibble, request_max = 150) {
 ## to do: make this recursive and independent of global variable
 
 HPO_name_from_term <- function(term_input_id) {
-  hpo_term_response <- fromJSON(paste0("https://hpo.jax.org/api/hpo/term/", URLencode(term_input_id, reserved=T)))
+  hpo_term_response <- fromJSON(db_hpo_term_url(term_input_id, db_src))
   hpo_term_name <- as_tibble(hpo_term_response$details$name) %>%
   select(hpo_mode_of_inheritance_term_name = value)
 
@@ -116,7 +114,7 @@ HPO_name_from_term <- function(term_input_id) {
 
 
 HPO_definition_from_term <- function(term_input_id) {
-  hpo_term_response <- fromJSON(paste0("https://hpo.jax.org/api/hpo/term/", URLencode(term_input_id, reserved=T)))
+  hpo_term_response <- fromJSON(db_hpo_term_url(term_input_id, db_src))
   hpo_term_definition <- as_tibble(hpo_term_response$details$definition) %>%
   select(hpo_mode_of_inheritance_term_definition = value)
 
@@ -125,7 +123,7 @@ HPO_definition_from_term <- function(term_input_id) {
 
 
 HPO_children_count_from_term <- function(term_input_id) {
-  hpo_term_response <- fromJSON(paste0("https://hpo.jax.org/api/hpo/term/", URLencode(term_input_id, reserved=T)))
+  hpo_term_response <- fromJSON(db_hpo_term_url(term_input_id, db_src))
   hpo_term_children_count <- as_tibble(hpo_term_response$relations$children)
 
   return(length(hpo_term_children_count))
@@ -133,7 +131,7 @@ HPO_children_count_from_term <- function(term_input_id) {
 
 
 HPO_children_from_term <- function(term_input_id) {
-  hpo_term_response <- fromJSON(paste0("https://hpo.jax.org/api/hpo/term/", URLencode(term_input_id, reserved=T)))
+  hpo_term_response <- fromJSON(db_hpo_term_url(term_input_id, db_src))
   hpo_term_children <- as_tibble(hpo_term_response$relations$children)
 
   return(hpo_term_children)
@@ -162,7 +160,7 @@ HPO_all_children_from_term <- function(term_input) {
 
 oxo_mapping_from_ontology_id <- function(ontology_id)  {
 
-  url <- paste0("https://www.ebi.ac.uk/spot/oxo/api/mappings?fromId=", ontology_id)
+  url <- db_oxo_mappings_url(ontology_id, db_src)
   
   # try again while error
   # implemented in April 2023 because of

--- a/db/03_Rcommands_sysndd_db_table_mode_of_inheritance_list.R
+++ b/db/03_Rcommands_sysndd_db_table_mode_of_inheritance_list.R
@@ -7,19 +7,17 @@ library(config)     ## needed to read config file
 
 
 ############################################
-## define relative script path
-project_topic <- "sysndd"
-project_name <- "R"
-
-## read configs
-config_vars_proj <- config::get(file = Sys.getenv("CONFIG_FILE"),
-    config = project_topic)
-
-## set working directory
-setwd(paste0(config_vars_proj$projectsdir, project_name))
-
-## set global options
-options(scipen = 999)
+## SysNDD data-prep bootstrap (issue #33): locate db/config, then db_bootstrap()
+## sets SYSNDD_DB_DIR, anchors CWD to db/, sources db_sysid_source.R, sets db_src.
+.f <- tryCatch(sys.frame(1)$ofile, error = function(e) NULL)
+if (is.null(.f)) .f <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+.cfg <- if (nzchar(Sys.getenv("SYSNDD_DB_DIR"))) {
+  file.path(Sys.getenv("SYSNDD_DB_DIR"), "config")
+} else {
+  file.path(dirname(normalizePath(.f[1])), "config")
+}
+source(file.path(.cfg, "db_config.R"))
+config_vars_proj <- db_bootstrap()
 ############################################
 
 
@@ -29,7 +27,7 @@ options(scipen = 999)
 ## to do: make this recursive and independent of global variable
 
 HPO_name_from_term <- function(term_input_id) {
-  hpo_term_response <- fromJSON(paste0("https://hpo.jax.org/api/hpo/term/", URLencode(term_input_id, reserved=T)))
+  hpo_term_response <- fromJSON(db_hpo_term_url(term_input_id, db_src))
   hpo_term_name <- as_tibble(hpo_term_response$details$name) %>%
   select(hpo_mode_of_inheritance_term_name = value)
 
@@ -38,7 +36,7 @@ HPO_name_from_term <- function(term_input_id) {
 
 
 HPO_definition_from_term <- function(term_input_id) {
-  hpo_term_response <- fromJSON(paste0("https://hpo.jax.org/api/hpo/term/", URLencode(term_input_id, reserved=T)))
+  hpo_term_response <- fromJSON(db_hpo_term_url(term_input_id, db_src))
   hpo_term_definition <- as_tibble(hpo_term_response$details$definition) %>%
   select(hpo_mode_of_inheritance_term_definition = value)
 
@@ -47,7 +45,7 @@ HPO_definition_from_term <- function(term_input_id) {
 
 
 HPO_children_count_from_term <- function(term_input_id) {
-  hpo_term_response <- fromJSON(paste0("https://hpo.jax.org/api/hpo/term/", URLencode(term_input_id, reserved=T)))
+  hpo_term_response <- fromJSON(db_hpo_term_url(term_input_id, db_src))
   hpo_term_children_count <- as_tibble(hpo_term_response$relations$children)
 
   return(length(hpo_term_children_count))
@@ -55,7 +53,7 @@ HPO_children_count_from_term <- function(term_input_id) {
 
 
 HPO_children_from_term <- function(term_input_id) {
-  hpo_term_response <- fromJSON(paste0("https://hpo.jax.org/api/hpo/term/", URLencode(term_input_id, reserved=T)))
+  hpo_term_response <- fromJSON(db_hpo_term_url(term_input_id, db_src))
   hpo_term_children <- as_tibble(hpo_term_response$relations$children)
 
   return(hpo_term_children)

--- a/db/04_Rcommands_sysndd_db_table_ndd_entity.R
+++ b/db/04_Rcommands_sysndd_db_table_ndd_entity.R
@@ -12,19 +12,17 @@ library(config)     ## needed to read config file
 
 
 ############################################
-## define relative script path
-project_topic <- "sysndd"
-project_name <- "R"
-
-## read configs
-config_vars_proj <- config::get(file = Sys.getenv("CONFIG_FILE"),
-    config = project_topic)
-
-## set working directory
-setwd(paste0(config_vars_proj$projectsdir, project_name))
-
-## set global options
-options(scipen = 999)
+## SysNDD data-prep bootstrap (issue #33): locate db/config, then db_bootstrap()
+## sets SYSNDD_DB_DIR, anchors CWD to db/, sources db_sysid_source.R, sets db_src.
+.f <- tryCatch(sys.frame(1)$ofile, error = function(e) NULL)
+if (is.null(.f)) .f <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+.cfg <- if (nzchar(Sys.getenv("SYSNDD_DB_DIR"))) {
+  file.path(Sys.getenv("SYSNDD_DB_DIR"), "config")
+} else {
+  file.path(dirname(normalizePath(.f[1])), "config")
+}
+source(file.path(.cfg, "db_config.R"))
+config_vars_proj <- db_bootstrap()
 ############################################
 
 
@@ -32,7 +30,7 @@ options(scipen = 999)
 ## define functions
 
 hgnc_id_from_prevsymbol <- function(symbol_input)  {
-  symbol_request <- fromJSON(paste0("http://rest.genenames.org/search/prev_symbol/", symbol_input))
+  symbol_request <- fromJSON(db_genenames_search_url("prev_symbol", symbol_input, db_src))
 
   hgnc_id_from_symbol <- as_tibble(symbol_request$response$docs)
   
@@ -47,7 +45,7 @@ hgnc_id_from_prevsymbol <- function(symbol_input)  {
 }
 
 hgnc_id_from_aliassymbol <- function(symbol_input)  {
-  symbol_request <- fromJSON(paste0("http://rest.genenames.org/search/alias_symbol/", symbol_input))
+  symbol_request <- fromJSON(db_genenames_search_url("alias_symbol", symbol_input, db_src))
 
   hgnc_id_from_symbol <- as_tibble(symbol_request$response$docs)
   
@@ -64,7 +62,7 @@ hgnc_id_from_aliassymbol <- function(symbol_input)  {
 hgnc_id_from_symbol <- function(symbol_tibble) {
   symbol_list_tibble <- as_tibble(symbol_tibble) %>% select(symbol = value) %>% mutate(symbol = toupper(symbol))
   
-  symbol_request <- fromJSON(paste0("http://rest.genenames.org/search/symbol/", str_c(symbol_list_tibble$symbol, collapse = "+OR+")))
+  symbol_request <- fromJSON(db_genenames_search_url("symbol", str_c(symbol_list_tibble$symbol, collapse = "+OR+"), db_src))
 
   hgnc_id_from_symbol <- as_tibble(symbol_request$response$docs)
   
@@ -86,7 +84,7 @@ symbol_from_hgnc_id <- function(hgnc_id_tibble) {
     select(hgnc_id = value) %>%
     mutate(hgnc_id = as.integer(hgnc_id))
   
-  hgnc_id_request <- fromJSON(paste0("http://rest.genenames.org/search/hgnc_id/", str_c(hgnc_id_list_tibble$hgnc_id, collapse = "+OR+")))
+  hgnc_id_request <- fromJSON(db_genenames_search_url("hgnc_id", str_c(hgnc_id_list_tibble$hgnc_id, collapse = "+OR+"), db_src))
 
   hgnc_id_from_hgnc_id <- as_tibble(hgnc_id_request$response$docs)
   
@@ -135,7 +133,7 @@ hgnc_id_from_symbol_grouped <- function(input_tibble, request_max = 150) {
 ## to do: make this recursive and independent of global variable
 
 HPO_name_from_term <- function(term_input_id) {
-  hpo_term_response <- fromJSON(paste0("https://hpo.jax.org/api/hpo/term/", URLencode(term_input_id, reserved=T)))
+  hpo_term_response <- fromJSON(db_hpo_term_url(term_input_id, db_src))
   hpo_term_name <- as_tibble(hpo_term_response$details$name) %>%
   select(hpo_mode_of_inheritance_term_name = value)
 
@@ -144,7 +142,7 @@ HPO_name_from_term <- function(term_input_id) {
 
 
 HPO_definition_from_term <- function(term_input_id) {
-  hpo_term_response <- fromJSON(paste0("https://hpo.jax.org/api/hpo/term/", URLencode(term_input_id, reserved=T)))
+  hpo_term_response <- fromJSON(db_hpo_term_url(term_input_id, db_src))
   hpo_term_definition <- as_tibble(hpo_term_response$details$definition) %>%
   select(hpo_mode_of_inheritance_term_definition = value)
 
@@ -153,7 +151,7 @@ HPO_definition_from_term <- function(term_input_id) {
 
 
 HPO_children_count_from_term <- function(term_input_id) {
-  hpo_term_response <- fromJSON(paste0("https://hpo.jax.org/api/hpo/term/", URLencode(term_input_id, reserved=T)))
+  hpo_term_response <- fromJSON(db_hpo_term_url(term_input_id, db_src))
   hpo_term_children_count <- as_tibble(hpo_term_response$relations$children)
 
   return(length(hpo_term_children_count))
@@ -161,7 +159,7 @@ HPO_children_count_from_term <- function(term_input_id) {
 
 
 HPO_children_from_term <- function(term_input_id) {
-  hpo_term_response <- fromJSON(paste0("https://hpo.jax.org/api/hpo/term/", URLencode(term_input_id, reserved=T)))
+  hpo_term_response <- fromJSON(db_hpo_term_url(term_input_id, db_src))
   hpo_term_children <- as_tibble(hpo_term_response$relations$children)
 
   return(hpo_term_children)
@@ -190,28 +188,35 @@ HPO_all_children_from_term <- function(term_input) {
 
 
 ############################################
-##connect to online sysid database
-## make ssh connection
-cmd <- paste0('ssh::ssh_tunnel(ssh::ssh_connect(host = "',
-  config_vars_proj$host_sysid,
-  ', passwd = "',
-  config_vars_proj$passwd_sysid,
-  '"), port = ',
-  config_vars_proj$port_sysid_local,
-  ', target = "',
-  config_vars_proj$server_sysid_local,
-  ':',
-  config_vars_proj$port_sysid_local,
-  '")')
+## connect to the SysID source (issue #33: reproducible import)
+## db_sysid_source_mode() selects "sqlite" (a local, reproducible snapshot —
+## recommended) or "mysql" (the legacy upstream SysID DB over an SSH tunnel).
+## See db/config/db_sysid_source.R and db/README.md "Reproducible SysID import".
+sysid_mode <- db_sysid_source_mode(config_vars_proj)
 
-pid <- sys::r_background(
-    std_out = FALSE,
-    std_err = FALSE,
-    args = c("-e", cmd)
-)
+if (sysid_mode == "mysql") {
+  ## legacy path: open an SSH tunnel to the upstream SysID MySQL instance.
+  cmd <- paste0('ssh::ssh_tunnel(ssh::ssh_connect(host = "',
+    config_vars_proj$host_sysid,
+    ', passwd = "',
+    config_vars_proj$passwd_sysid,
+    '"), port = ',
+    config_vars_proj$port_sysid_local,
+    ', target = "',
+    config_vars_proj$server_sysid_local,
+    ':',
+    config_vars_proj$port_sysid_local,
+    '")')
 
-## connect to the database
-sysid_db <- dbConnect(RMariaDB::MariaDB(), dbname = config_vars_proj$dbname_sysid, user = config_vars_proj$user_sysid, password = config_vars_proj$password_sysid, server = config_vars_proj$server_sysid_local, port = config_vars_proj$port_sysid_local)
+  pid <- sys::r_background(
+      std_out = FALSE,
+      std_err = FALSE,
+      args = c("-e", cmd)
+  )
+}
+
+## open a source-agnostic connection (SQLite snapshot or tunnelled MySQL)
+sysid_db <- db_sysid_connect(config_vars_proj, mode = sysid_mode)
 ############################################
 
 

--- a/db/05_Rcommands_sysndd_db_table_ndd_entity_review.R
+++ b/db/05_Rcommands_sysndd_db_table_ndd_entity_review.R
@@ -11,45 +11,50 @@ library(config)     ## needed to read config file
 
 
 ############################################
-## define relative script path
-project_topic <- "sysndd"
-project_name <- "R"
-
-## read configs
-config_vars_proj <- config::get(file = Sys.getenv("CONFIG_FILE"),
-    config = project_topic)
-
-## set working directory
-setwd(paste0(config_vars_proj$projectsdir, project_name))
-
-## set global options
-options(scipen = 999)
+## SysNDD data-prep bootstrap (issue #33): locate db/config, then db_bootstrap()
+## sets SYSNDD_DB_DIR, anchors CWD to db/, sources db_sysid_source.R, sets db_src.
+.f <- tryCatch(sys.frame(1)$ofile, error = function(e) NULL)
+if (is.null(.f)) .f <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+.cfg <- if (nzchar(Sys.getenv("SYSNDD_DB_DIR"))) {
+  file.path(Sys.getenv("SYSNDD_DB_DIR"), "config")
+} else {
+  file.path(dirname(normalizePath(.f[1])), "config")
+}
+source(file.path(.cfg, "db_config.R"))
+config_vars_proj <- db_bootstrap()
 ############################################
 
 
 ############################################
-##connect to online sysid database
-## make ssh connection
-cmd <- paste0('ssh::ssh_tunnel(ssh::ssh_connect(host = "',
-  config_vars_proj$host_sysid,
-  ', passwd = "',
-  config_vars_proj$passwd_sysid,
-  '"), port = ',
-  config_vars_proj$port_sysid_local,
-  ', target = "',
-  config_vars_proj$server_sysid_local,
-  ':',
-  config_vars_proj$port_sysid_local,
-  '")')
+## connect to the SysID source (issue #33: reproducible import)
+## db_sysid_source_mode() selects "sqlite" (a local, reproducible snapshot —
+## recommended) or "mysql" (the legacy upstream SysID DB over an SSH tunnel).
+## See db/config/db_sysid_source.R and db/README.md "Reproducible SysID import".
+sysid_mode <- db_sysid_source_mode(config_vars_proj)
 
-pid <- sys::r_background(
-    std_out = FALSE,
-    std_err = FALSE,
-    args = c("-e", cmd)
-)
+if (sysid_mode == "mysql") {
+  ## legacy path: open an SSH tunnel to the upstream SysID MySQL instance.
+  cmd <- paste0('ssh::ssh_tunnel(ssh::ssh_connect(host = "',
+    config_vars_proj$host_sysid,
+    ', passwd = "',
+    config_vars_proj$passwd_sysid,
+    '"), port = ',
+    config_vars_proj$port_sysid_local,
+    ', target = "',
+    config_vars_proj$server_sysid_local,
+    ':',
+    config_vars_proj$port_sysid_local,
+    '")')
 
-## connect to the database
-sysid_db <- dbConnect(RMariaDB::MariaDB(), dbname = config_vars_proj$dbname_sysid, user = config_vars_proj$user_sysid, password = config_vars_proj$password_sysid, server = config_vars_proj$server_sysid_local, port = config_vars_proj$port_sysid_local)
+  pid <- sys::r_background(
+      std_out = FALSE,
+      std_err = FALSE,
+      args = c("-e", cmd)
+  )
+}
+
+## open a source-agnostic connection (SQLite snapshot or tunnelled MySQL)
+sysid_db <- db_sysid_connect(config_vars_proj, mode = sysid_mode)
 ############################################
 
 

--- a/db/06_Rcommands_sysndd_db_table_ndd_entity_status.R
+++ b/db/06_Rcommands_sysndd_db_table_ndd_entity_status.R
@@ -12,46 +12,51 @@ library(config)     ## needed to read config file
 
 
 ############################################
-## define relative script path
-project_topic <- "sysndd"
-project_name <- "R"
-
-## read configs
-config_vars_proj <- config::get(file = Sys.getenv("CONFIG_FILE"),
-    config = project_topic)
-
-## set working directory
-setwd(paste0(config_vars_proj$projectsdir, project_name))
-
-## set global options
-options(scipen = 999)
+## SysNDD data-prep bootstrap (issue #33): locate db/config, then db_bootstrap()
+## sets SYSNDD_DB_DIR, anchors CWD to db/, sources db_sysid_source.R, sets db_src.
+.f <- tryCatch(sys.frame(1)$ofile, error = function(e) NULL)
+if (is.null(.f)) .f <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+.cfg <- if (nzchar(Sys.getenv("SYSNDD_DB_DIR"))) {
+  file.path(Sys.getenv("SYSNDD_DB_DIR"), "config")
+} else {
+  file.path(dirname(normalizePath(.f[1])), "config")
+}
+source(file.path(.cfg, "db_config.R"))
+config_vars_proj <- db_bootstrap()
 ############################################
 
 
 
 ############################################
-##connect to online sysid database
-## make ssh connection
-cmd <- paste0('ssh::ssh_tunnel(ssh::ssh_connect(host = "',
-  config_vars_proj$host_sysid,
-  ', passwd = "',
-  config_vars_proj$passwd_sysid,
-  '"), port = ',
-  config_vars_proj$port_sysid_local,
-  ', target = "',
-  config_vars_proj$server_sysid_local,
-  ':',
-  config_vars_proj$port_sysid_local,
-  '")')
+## connect to the SysID source (issue #33: reproducible import)
+## db_sysid_source_mode() selects "sqlite" (a local, reproducible snapshot —
+## recommended) or "mysql" (the legacy upstream SysID DB over an SSH tunnel).
+## See db/config/db_sysid_source.R and db/README.md "Reproducible SysID import".
+sysid_mode <- db_sysid_source_mode(config_vars_proj)
 
-pid <- sys::r_background(
-    std_out = FALSE,
-    std_err = FALSE,
-    args = c("-e", cmd)
-)
+if (sysid_mode == "mysql") {
+  ## legacy path: open an SSH tunnel to the upstream SysID MySQL instance.
+  cmd <- paste0('ssh::ssh_tunnel(ssh::ssh_connect(host = "',
+    config_vars_proj$host_sysid,
+    ', passwd = "',
+    config_vars_proj$passwd_sysid,
+    '"), port = ',
+    config_vars_proj$port_sysid_local,
+    ', target = "',
+    config_vars_proj$server_sysid_local,
+    ':',
+    config_vars_proj$port_sysid_local,
+    '")')
 
-## connect to the database
-sysid_db <- dbConnect(RMariaDB::MariaDB(), dbname = config_vars_proj$dbname_sysid, user = config_vars_proj$user_sysid, password = config_vars_proj$password_sysid, server = config_vars_proj$server_sysid_local, port = config_vars_proj$port_sysid_local)
+  pid <- sys::r_background(
+      std_out = FALSE,
+      std_err = FALSE,
+      args = c("-e", cmd)
+  )
+}
+
+## open a source-agnostic connection (SQLite snapshot or tunnelled MySQL)
+sysid_db <- db_sysid_connect(config_vars_proj, mode = sysid_mode)
 ############################################
 
 

--- a/db/07_Rcommands_sysndd_db_table_ndd_review_phenotype_connect.R
+++ b/db/07_Rcommands_sysndd_db_table_ndd_review_phenotype_connect.R
@@ -14,46 +14,51 @@ library(config)     ## needed to read config file
 
 
 ############################################
-## define relative script path
-project_topic <- "sysndd"
-project_name <- "R"
-
-## read configs
-config_vars_proj <- config::get(file = Sys.getenv("CONFIG_FILE"),
-    config = project_topic)
-
-## set working directory
-setwd(paste0(config_vars_proj$projectsdir, project_name))
-
-## set global options
-options(scipen = 999)
+## SysNDD data-prep bootstrap (issue #33): locate db/config, then db_bootstrap()
+## sets SYSNDD_DB_DIR, anchors CWD to db/, sources db_sysid_source.R, sets db_src.
+.f <- tryCatch(sys.frame(1)$ofile, error = function(e) NULL)
+if (is.null(.f)) .f <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+.cfg <- if (nzchar(Sys.getenv("SYSNDD_DB_DIR"))) {
+  file.path(Sys.getenv("SYSNDD_DB_DIR"), "config")
+} else {
+  file.path(dirname(normalizePath(.f[1])), "config")
+}
+source(file.path(.cfg, "db_config.R"))
+config_vars_proj <- db_bootstrap()
 ############################################
 
 
 
 ############################################
-##connect to online sysid database
-## make ssh connection
-cmd <- paste0('ssh::ssh_tunnel(ssh::ssh_connect(host = "',
-  config_vars_proj$host_sysid,
-  ', passwd = "',
-  config_vars_proj$passwd_sysid,
-  '"), port = ',
-  config_vars_proj$port_sysid_local,
-  ', target = "',
-  config_vars_proj$server_sysid_local,
-  ':',
-  config_vars_proj$port_sysid_local,
-  '")')
+## connect to the SysID source (issue #33: reproducible import)
+## db_sysid_source_mode() selects "sqlite" (a local, reproducible snapshot —
+## recommended) or "mysql" (the legacy upstream SysID DB over an SSH tunnel).
+## See db/config/db_sysid_source.R and db/README.md "Reproducible SysID import".
+sysid_mode <- db_sysid_source_mode(config_vars_proj)
 
-pid <- sys::r_background(
-    std_out = FALSE,
-    std_err = FALSE,
-    args = c("-e", cmd)
-)
+if (sysid_mode == "mysql") {
+  ## legacy path: open an SSH tunnel to the upstream SysID MySQL instance.
+  cmd <- paste0('ssh::ssh_tunnel(ssh::ssh_connect(host = "',
+    config_vars_proj$host_sysid,
+    ', passwd = "',
+    config_vars_proj$passwd_sysid,
+    '"), port = ',
+    config_vars_proj$port_sysid_local,
+    ', target = "',
+    config_vars_proj$server_sysid_local,
+    ':',
+    config_vars_proj$port_sysid_local,
+    '")')
 
-## connect to the database
-sysid_db <- dbConnect(RMariaDB::MariaDB(), dbname = config_vars_proj$dbname_sysid, user = config_vars_proj$user_sysid, password = config_vars_proj$password_sysid, server = config_vars_proj$server_sysid_local, port = config_vars_proj$port_sysid_local)
+  pid <- sys::r_background(
+      std_out = FALSE,
+      std_err = FALSE,
+      args = c("-e", cmd)
+  )
+}
+
+## open a source-agnostic connection (SQLite snapshot or tunnelled MySQL)
+sysid_db <- db_sysid_connect(config_vars_proj, mode = sysid_mode)
 ############################################
 
 

--- a/db/08_Rcommands_sysndd_db_table_publication.R
+++ b/db/08_Rcommands_sysndd_db_table_publication.R
@@ -17,45 +17,50 @@ library(config)     ## needed to read config file
 
 
 ############################################
-## define relative script path
-project_topic <- "sysndd"
-project_name <- "R"
-
-## read configs
-config_vars_proj <- config::get(file = Sys.getenv("CONFIG_FILE"),
-    config = project_topic)
-
-## set working directory
-setwd(paste0(config_vars_proj$projectsdir, project_name))
-
-## set global options
-options(scipen = 999)
+## SysNDD data-prep bootstrap (issue #33): locate db/config, then db_bootstrap()
+## sets SYSNDD_DB_DIR, anchors CWD to db/, sources db_sysid_source.R, sets db_src.
+.f <- tryCatch(sys.frame(1)$ofile, error = function(e) NULL)
+if (is.null(.f)) .f <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+.cfg <- if (nzchar(Sys.getenv("SYSNDD_DB_DIR"))) {
+  file.path(Sys.getenv("SYSNDD_DB_DIR"), "config")
+} else {
+  file.path(dirname(normalizePath(.f[1])), "config")
+}
+source(file.path(.cfg, "db_config.R"))
+config_vars_proj <- db_bootstrap()
 ############################################
 
 
 ############################################
-##connect to online sysid database
-## make ssh connection
-cmd <- paste0('ssh::ssh_tunnel(ssh::ssh_connect(host = "',
-  config_vars_proj$host_sysid,
-  ', passwd = "',
-  config_vars_proj$passwd_sysid,
-  '"), port = ',
-  config_vars_proj$port_sysid_local,
-  ', target = "',
-  config_vars_proj$server_sysid_local,
-  ':',
-  config_vars_proj$port_sysid_local,
-  '")')
+## connect to the SysID source (issue #33: reproducible import)
+## db_sysid_source_mode() selects "sqlite" (a local, reproducible snapshot —
+## recommended) or "mysql" (the legacy upstream SysID DB over an SSH tunnel).
+## See db/config/db_sysid_source.R and db/README.md "Reproducible SysID import".
+sysid_mode <- db_sysid_source_mode(config_vars_proj)
 
-pid <- sys::r_background(
-    std_out = FALSE,
-    std_err = FALSE,
-    args = c("-e", cmd)
-)
+if (sysid_mode == "mysql") {
+  ## legacy path: open an SSH tunnel to the upstream SysID MySQL instance.
+  cmd <- paste0('ssh::ssh_tunnel(ssh::ssh_connect(host = "',
+    config_vars_proj$host_sysid,
+    ', passwd = "',
+    config_vars_proj$passwd_sysid,
+    '"), port = ',
+    config_vars_proj$port_sysid_local,
+    ', target = "',
+    config_vars_proj$server_sysid_local,
+    ':',
+    config_vars_proj$port_sysid_local,
+    '")')
 
-## connect to the database
-sysid_db <- dbConnect(RMariaDB::MariaDB(), dbname = config_vars_proj$dbname_sysid, user = config_vars_proj$user_sysid, password = config_vars_proj$password_sysid, server = config_vars_proj$server_sysid_local, port = config_vars_proj$port_sysid_local)
+  pid <- sys::r_background(
+      std_out = FALSE,
+      std_err = FALSE,
+      args = c("-e", cmd)
+  )
+}
+
+## open a source-agnostic connection (SQLite snapshot or tunnelled MySQL)
+sysid_db <- db_sysid_connect(config_vars_proj, mode = sysid_mode)
 ############################################
 
 
@@ -90,7 +95,7 @@ pubmed_fetch_xml <- function(pmids) {
     return("<PubmedArticleSet/>")
   }
 
-  request("https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi") %>%
+  request(db_source_url("ncbi_eutils_efetch", db_src)) %>%
     req_url_query(
       db = "pubmed",
       id = str_c(pmids, collapse = ","),
@@ -216,7 +221,7 @@ pubmed_info_from_pmid <- function(pmid_tibble, request_max = 200) {
 
 
 genereviews_from_pmid <- function(pmid_input)  {
-  url_request <- paste0("https://www.ncbi.nlm.nih.gov/books/NBK1116/?term=", pmid_input)
+  url_request <- paste0(db_source_url("ncbi_books_base", db_src), "/NBK1116/?term=", pmid_input)
   url_request = url(url_request, "rb")
 
   webpage_request <- xml2::read_html(url_request, options = c("RECOVER"))
@@ -238,7 +243,7 @@ genereviews_from_pmid <- function(pmid_input)  {
 
 
 info_from_genereviews <- function(Bookshelf_ID)  {
-  genereviews_url <- paste0("https://www.ncbi.nlm.nih.gov/books/", Bookshelf_ID)
+  genereviews_url <- paste0(db_source_url("ncbi_books_base", db_src), "/", Bookshelf_ID)
   genereviews_url = url(genereviews_url, "rb")
 
   genereviews_request <- xml2::read_html(genereviews_url, options = "RECOVER")

--- a/db/09_Rcommands_sysndd_db_table_re_review.R
+++ b/db/09_Rcommands_sysndd_db_table_re_review.R
@@ -15,19 +15,17 @@ library(config)     ## needed to read config file
 
 
 ############################################
-## define relative script path
-project_topic <- "sysndd"
-project_name <- "R"
-
-## read configs
-config_vars_proj <- config::get(file = Sys.getenv("CONFIG_FILE"),
-    config = project_topic)
-
-## set working directory
-setwd(paste0(config_vars_proj$projectsdir, project_name))
-
-## set global options
-options(scipen = 999)
+## SysNDD data-prep bootstrap (issue #33): locate db/config, then db_bootstrap()
+## sets SYSNDD_DB_DIR, anchors CWD to db/, sources db_sysid_source.R, sets db_src.
+.f <- tryCatch(sys.frame(1)$ofile, error = function(e) NULL)
+if (is.null(.f)) .f <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+.cfg <- if (nzchar(Sys.getenv("SYSNDD_DB_DIR"))) {
+  file.path(Sys.getenv("SYSNDD_DB_DIR"), "config")
+} else {
+  file.path(dirname(normalizePath(.f[1])), "config")
+}
+source(file.path(.cfg, "db_config.R"))
+config_vars_proj <- db_bootstrap()
 ############################################
 
 

--- a/db/10_Rcommands_sysndd_db_table_user.R
+++ b/db/10_Rcommands_sysndd_db_table_user.R
@@ -6,19 +6,17 @@ library(config)     ## needed to read config file
 
 
 ############################################
-## define relative script path
-project_topic <- "sysndd"
-project_name <- "R"
-
-## read configs
-config_vars_proj <- config::get(file = Sys.getenv("CONFIG_FILE"),
-    config = project_topic)
-
-## set working directory
-setwd(paste0(config_vars_proj$projectsdir, project_name))
-
-## set global options
-options(scipen = 999)
+## SysNDD data-prep bootstrap (issue #33): locate db/config, then db_bootstrap()
+## sets SYSNDD_DB_DIR, anchors CWD to db/, sources db_sysid_source.R, sets db_src.
+.f <- tryCatch(sys.frame(1)$ofile, error = function(e) NULL)
+if (is.null(.f)) .f <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+.cfg <- if (nzchar(Sys.getenv("SYSNDD_DB_DIR"))) {
+  file.path(Sys.getenv("SYSNDD_DB_DIR"), "config")
+} else {
+  file.path(dirname(normalizePath(.f[1])), "config")
+}
+source(file.path(.cfg, "db_config.R"))
+config_vars_proj <- db_bootstrap()
 ############################################
 
 

--- a/db/11_Rcommands_sysndd_db_table_database_comparisons.R
+++ b/db/11_Rcommands_sysndd_db_table_database_comparisons.R
@@ -8,19 +8,17 @@ library(config)     ## needed to read config file
 
 
 ############################################
-## define relative script path
-project_topic <- "sysndd"
-project_name <- "R"
-
-## read configs
-config_vars_proj <- config::get(file = Sys.getenv("CONFIG_FILE"),
-    config = project_topic)
-
-## set working directory
-setwd(paste0(config_vars_proj$projectsdir, project_name))
-
-## set global options
-options(scipen = 999)
+## SysNDD data-prep bootstrap (issue #33): locate db/config, then db_bootstrap()
+## sets SYSNDD_DB_DIR, anchors CWD to db/, sources db_sysid_source.R, sets db_src.
+.f <- tryCatch(sys.frame(1)$ofile, error = function(e) NULL)
+if (is.null(.f)) .f <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+.cfg <- if (nzchar(Sys.getenv("SYSNDD_DB_DIR"))) {
+  file.path(Sys.getenv("SYSNDD_DB_DIR"), "config")
+} else {
+  file.path(dirname(normalizePath(.f[1])), "config")
+}
+source(file.path(.cfg, "db_config.R"))
+config_vars_proj <- db_bootstrap()
 ############################################
 
 
@@ -30,7 +28,7 @@ options(scipen = 999)
 
 ## HGNC functions
 hgnc_id_from_prevsymbol <- function(symbol_input)  {
-  symbol_request <- fromJSON(paste0("http://rest.genenames.org/search/prev_symbol/", symbol_input))
+  symbol_request <- fromJSON(db_genenames_search_url("prev_symbol", symbol_input, db_src))
 
   hgnc_id_from_symbol <- as_tibble(symbol_request$response$docs)
   
@@ -45,7 +43,7 @@ hgnc_id_from_prevsymbol <- function(symbol_input)  {
 }
 
 hgnc_id_from_aliassymbol <- function(symbol_input)  {
-  symbol_request <- fromJSON(paste0("http://rest.genenames.org/search/alias_symbol/", symbol_input))
+  symbol_request <- fromJSON(db_genenames_search_url("alias_symbol", symbol_input, db_src))
 
   hgnc_id_from_symbol <- as_tibble(symbol_request$response$docs)
   
@@ -62,7 +60,7 @@ hgnc_id_from_aliassymbol <- function(symbol_input)  {
 hgnc_id_from_symbol <- function(symbol_tibble) {
   symbol_list_tibble <- as_tibble(symbol_tibble) %>% select(symbol = value) %>% mutate(symbol = toupper(symbol))
   
-  symbol_request <- fromJSON(paste0("http://rest.genenames.org/search/symbol/", str_c(symbol_list_tibble$symbol, collapse = "+OR+")))
+  symbol_request <- fromJSON(db_genenames_search_url("symbol", str_c(symbol_list_tibble$symbol, collapse = "+OR+"), db_src))
 
   hgnc_id_from_symbol <- as_tibble(symbol_request$response$docs)
   
@@ -111,7 +109,7 @@ symbol_from_hgnc_id <- function(hgnc_id_tibble) {
     select(hgnc_id = value) %>%
     mutate(hgnc_id = as.integer(hgnc_id))
   
-  hgnc_id_request <- fromJSON(paste0("http://rest.genenames.org/search/hgnc_id/", str_c(hgnc_id_list_tibble$hgnc_id, collapse = "+OR+")))
+  hgnc_id_request <- fromJSON(db_genenames_search_url("hgnc_id", str_c(hgnc_id_list_tibble$hgnc_id, collapse = "+OR+"), db_src))
 
   hgnc_id_from_hgnc_id <- as_tibble(hgnc_id_request$response$docs)
   
@@ -146,7 +144,7 @@ symbol_from_hgnc_id_grouped <- function(input_tibble, request_max = 150) {
 ## to do: make this recursive and independent of global variable
 
 HPO_name_from_term <- function(term_input_id) {
-  hpo_term_response <- fromJSON(paste0("https://hpo.jax.org/api/hpo/term/", URLencode(term_input_id, reserved=T)))
+  hpo_term_response <- fromJSON(db_hpo_term_url(term_input_id, db_src))
   hpo_term_name <- as_tibble(hpo_term_response$details$name) %>%
   select(hpo_mode_of_inheritance_term_name = value)
 
@@ -155,7 +153,7 @@ HPO_name_from_term <- function(term_input_id) {
 
 
 HPO_definition_from_term <- function(term_input_id) {
-  hpo_term_response <- fromJSON(paste0("https://hpo.jax.org/api/hpo/term/", URLencode(term_input_id, reserved=T)))
+  hpo_term_response <- fromJSON(db_hpo_term_url(term_input_id, db_src))
   hpo_term_definition <- as_tibble(hpo_term_response$details$definition) %>%
   select(hpo_mode_of_inheritance_term_definition = value)
 
@@ -164,7 +162,7 @@ HPO_definition_from_term <- function(term_input_id) {
 
 
 HPO_children_count_from_term <- function(term_input_id) {
-  hpo_term_response <- fromJSON(paste0("https://hpo.jax.org/api/hpo/term/", URLencode(term_input_id, reserved=T)))
+  hpo_term_response <- fromJSON(db_hpo_term_url(term_input_id, db_src))
   hpo_term_children_count <- as_tibble(hpo_term_response$relations$children)
 
   return(length(hpo_term_children_count))
@@ -172,7 +170,7 @@ HPO_children_count_from_term <- function(term_input_id) {
 
 
 HPO_children_from_term <- function(term_input_id) {
-  hpo_term_response <- fromJSON(paste0("https://hpo.jax.org/api/hpo/term/", URLencode(term_input_id, reserved=T)))
+  hpo_term_response <- fromJSON(db_hpo_term_url(term_input_id, db_src))
   hpo_term_children <- as_tibble(hpo_term_response$relations$children)
 
   return(hpo_term_children)

--- a/db/12_Rcommands_sysndd_db_table_variation_ontology_set.R
+++ b/db/12_Rcommands_sysndd_db_table_variation_ontology_set.R
@@ -8,19 +8,17 @@ library(config)     ## needed to read config file
 
 
 ############################################
-## define relative script path
-project_topic <- "sysndd"
-project_name <- "R"
-
-## read configs
-config_vars_proj <- config::get(file = Sys.getenv("CONFIG_FILE"),
-    config = project_topic)
-
-## set working directory
-setwd(paste0(config_vars_proj$projectsdir, project_name))
-
-## set global options
-options(scipen = 999)
+## SysNDD data-prep bootstrap (issue #33): locate db/config, then db_bootstrap()
+## sets SYSNDD_DB_DIR, anchors CWD to db/, sources db_sysid_source.R, sets db_src.
+.f <- tryCatch(sys.frame(1)$ofile, error = function(e) NULL)
+if (is.null(.f)) .f <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+.cfg <- if (nzchar(Sys.getenv("SYSNDD_DB_DIR"))) {
+  file.path(Sys.getenv("SYSNDD_DB_DIR"), "config")
+} else {
+  file.path(dirname(normalizePath(.f[1])), "config")
+}
+source(file.path(.cfg, "db_config.R"))
+config_vars_proj <- db_bootstrap()
 ############################################
 
 
@@ -50,7 +48,7 @@ sort_variation <- read_excel("data/lists/lists_2022-05-03.xlsx",
 ############################################
 ## download vario.obo file
 file_date <- strftime(as.POSIXlt(Sys.time(), "UTC", "%Y-%m-%dT%H:%M:%S"), "%Y-%m-%d")
-vario_link <- "http://www.variationontology.org/vario_download/vario.obo"
+vario_link <- db_source_url("vario_obo", db_src)
 vario_file <- "data/vario.obo"
 download.file(vario_link, vario_file, mode = "wb")
 ############################################

--- a/db/13_Rcommands_sysndd_db_boolean_list.R
+++ b/db/13_Rcommands_sysndd_db_boolean_list.R
@@ -6,19 +6,17 @@ library(config)     ## needed to read config file
 
 
 ############################################
-## define relative script path
-project_topic <- "sysndd"
-project_name <- "R"
-
-## read configs
-config_vars_proj <- config::get(file = Sys.getenv("CONFIG_FILE"),
-    config = project_topic)
-
-## set working directory
-setwd(paste0(config_vars_proj$projectsdir, project_name))
-
-## set global options
-options(scipen = 999)
+## SysNDD data-prep bootstrap (issue #33): locate db/config, then db_bootstrap()
+## sets SYSNDD_DB_DIR, anchors CWD to db/, sources db_sysid_source.R, sets db_src.
+.f <- tryCatch(sys.frame(1)$ofile, error = function(e) NULL)
+if (is.null(.f)) .f <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+.cfg <- if (nzchar(Sys.getenv("SYSNDD_DB_DIR"))) {
+  file.path(Sys.getenv("SYSNDD_DB_DIR"), "config")
+} else {
+  file.path(dirname(normalizePath(.f[1])), "config")
+}
+source(file.path(.cfg, "db_config.R"))
+config_vars_proj <- db_bootstrap()
 ############################################
 
 

--- a/db/14_Rcommands_sysndd_db_allowed_list.R
+++ b/db/14_Rcommands_sysndd_db_allowed_list.R
@@ -6,19 +6,17 @@ library(config)     ## needed to read config file
 
 
 ############################################
-## define relative script path
-project_topic <- "sysndd"
-project_name <- "R"
-
-## read configs
-config_vars_proj <- config::get(file = Sys.getenv("CONFIG_FILE"),
-    config = project_topic)
-
-## set working directory
-setwd(paste0(config_vars_proj$projectsdir, project_name))
-
-## set global options
-options(scipen = 999)
+## SysNDD data-prep bootstrap (issue #33): locate db/config, then db_bootstrap()
+## sets SYSNDD_DB_DIR, anchors CWD to db/, sources db_sysid_source.R, sets db_src.
+.f <- tryCatch(sys.frame(1)$ofile, error = function(e) NULL)
+if (is.null(.f)) .f <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+.cfg <- if (nzchar(Sys.getenv("SYSNDD_DB_DIR"))) {
+  file.path(Sys.getenv("SYSNDD_DB_DIR"), "config")
+} else {
+  file.path(dirname(normalizePath(.f[1])), "config")
+}
+source(file.path(.cfg, "db_config.R"))
+config_vars_proj <- db_bootstrap()
 ############################################
 
 

--- a/db/15_Rcommands_sysndd_db_logging_table.R
+++ b/db/15_Rcommands_sysndd_db_logging_table.R
@@ -8,19 +8,17 @@ library(config)     ## needed to read config file
 
 
 ############################################
-## define relative script path
-project_topic <- "sysndd"
-project_name <- "R"
-
-## read configs
-config_vars_proj <- config::get(file = Sys.getenv("CONFIG_FILE"),
-    config = project_topic)
-
-## set working directory
-setwd(paste0(config_vars_proj$projectsdir, project_name))
-
-## set global options
-options(scipen = 999)
+## SysNDD data-prep bootstrap (issue #33): locate db/config, then db_bootstrap()
+## sets SYSNDD_DB_DIR, anchors CWD to db/, sources db_sysid_source.R, sets db_src.
+.f <- tryCatch(sys.frame(1)$ofile, error = function(e) NULL)
+if (is.null(.f)) .f <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+.cfg <- if (nzchar(Sys.getenv("SYSNDD_DB_DIR"))) {
+  file.path(Sys.getenv("SYSNDD_DB_DIR"), "config")
+} else {
+  file.path(dirname(normalizePath(.f[1])), "config")
+}
+source(file.path(.cfg, "db_config.R"))
+config_vars_proj <- db_bootstrap()
 ############################################
 
 

--- a/db/16_Rcommands_sysndd_db_pubtator_cache_table.R
+++ b/db/16_Rcommands_sysndd_db_pubtator_cache_table.R
@@ -16,18 +16,17 @@ library(RMariaDB)    ## needed for MySQL data export
 library(config)      ## needed to read config file
 
 ############################################
-## define relative script path
-project_topic <- "sysndd"
-project_name <- "R"
-
-## read configs
-config_vars_proj <- config::get(file = Sys.getenv("CONFIG_FILE"), config = project_topic)
-
-## set working directory
-setwd(paste0(config_vars_proj$projectsdir, project_name))
-
-## set global options
-options(scipen = 999)
+## SysNDD data-prep bootstrap (issue #33): locate db/config, then db_bootstrap()
+## sets SYSNDD_DB_DIR, anchors CWD to db/, sources db_sysid_source.R, sets db_src.
+.f <- tryCatch(sys.frame(1)$ofile, error = function(e) NULL)
+if (is.null(.f)) .f <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+.cfg <- if (nzchar(Sys.getenv("SYSNDD_DB_DIR"))) {
+  file.path(Sys.getenv("SYSNDD_DB_DIR"), "config")
+} else {
+  file.path(dirname(normalizePath(.f[1])), "config")
+}
+source(file.path(.cfg, "db_config.R"))
+config_vars_proj <- db_bootstrap()
 
 ############################################
 ## connect to the database

--- a/db/17_Rcommands_sysndd_db_json_storage_table.R
+++ b/db/17_Rcommands_sysndd_db_json_storage_table.R
@@ -8,18 +8,17 @@ library(config)     ## needed to read config file
 
 
 ############################################
-## define relative script path
-project_topic <- "sysndd"
-project_name <- "R"
-
-## read configs
-config_vars_proj <- config::get(file = Sys.getenv("CONFIG_FILE"), config = project_topic)
-
-## set working directory
-setwd(paste0(config_vars_proj$projectsdir, project_name))
-
-## set global options
-options(scipen = 999)
+## SysNDD data-prep bootstrap (issue #33): locate db/config, then db_bootstrap()
+## sets SYSNDD_DB_DIR, anchors CWD to db/, sources db_sysid_source.R, sets db_src.
+.f <- tryCatch(sys.frame(1)$ofile, error = function(e) NULL)
+if (is.null(.f)) .f <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+.cfg <- if (nzchar(Sys.getenv("SYSNDD_DB_DIR"))) {
+  file.path(Sys.getenv("SYSNDD_DB_DIR"), "config")
+} else {
+  file.path(dirname(normalizePath(.f[1])), "config")
+}
+source(file.path(.cfg, "db_config.R"))
+config_vars_proj <- db_bootstrap()
 ############################################
 
 

--- a/db/A_Rcommands_create-database-tables.R
+++ b/db/A_Rcommands_create-database-tables.R
@@ -11,19 +11,17 @@ library(config)     ## needed to read config file
 
 
 ############################################
-## define relative script path
-project_topic <- "sysndd"
-project_name <- "R"
-
-## read configs
-config_vars_proj <- config::get(file = Sys.getenv("CONFIG_FILE"),
-    config = project_topic)
-
-## set working directory
-setwd(paste0(config_vars_proj$projectsdir, project_name))
-
-## set global options
-options(scipen = 999)
+## SysNDD data-prep bootstrap (issue #33): locate db/config, then db_bootstrap()
+## sets SYSNDD_DB_DIR, anchors CWD to db/, sources db_sysid_source.R, sets db_src.
+.f <- tryCatch(sys.frame(1)$ofile, error = function(e) NULL)
+if (is.null(.f)) .f <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+.cfg <- if (nzchar(Sys.getenv("SYSNDD_DB_DIR"))) {
+  file.path(Sys.getenv("SYSNDD_DB_DIR"), "config")
+} else {
+  file.path(dirname(normalizePath(.f[1])), "config")
+}
+source(file.path(.cfg, "db_config.R"))
+config_vars_proj <- db_bootstrap()
 ############################################
 
 

--- a/db/B_Rcommands_set-table-data-types.R
+++ b/db/B_Rcommands_set-table-data-types.R
@@ -10,19 +10,17 @@ library(config)     ## needed to read config file
 
 
 ############################################
-## define relative script path
-project_topic <- "sysndd"
-project_name <- "R"
-
-## read configs
-config_vars_proj <- config::get(file = Sys.getenv("CONFIG_FILE"),
-    config = project_topic)
-
-## set working directory
-setwd(paste0(config_vars_proj$projectsdir, project_name))
-
-## set global options
-options(scipen = 999)
+## SysNDD data-prep bootstrap (issue #33): locate db/config, then db_bootstrap()
+## sets SYSNDD_DB_DIR, anchors CWD to db/, sources db_sysid_source.R, sets db_src.
+.f <- tryCatch(sys.frame(1)$ofile, error = function(e) NULL)
+if (is.null(.f)) .f <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+.cfg <- if (nzchar(Sys.getenv("SYSNDD_DB_DIR"))) {
+  file.path(Sys.getenv("SYSNDD_DB_DIR"), "config")
+} else {
+  file.path(dirname(normalizePath(.f[1])), "config")
+}
+source(file.path(.cfg, "db_config.R"))
+config_vars_proj <- db_bootstrap()
 ############################################
 
 

--- a/db/C_Rcommands_set-table-connections.R
+++ b/db/C_Rcommands_set-table-connections.R
@@ -10,19 +10,17 @@ library(config)     ## needed to read config file
 
 
 ############################################
-## define relative script path
-project_topic <- "sysndd"
-project_name <- "R"
-
-## read configs
-config_vars_proj <- config::get(file = Sys.getenv("CONFIG_FILE"),
-    config = project_topic)
-
-## set working directory
-setwd(paste0(config_vars_proj$projectsdir, project_name))
-
-## set global options
-options(scipen = 999)
+## SysNDD data-prep bootstrap (issue #33): locate db/config, then db_bootstrap()
+## sets SYSNDD_DB_DIR, anchors CWD to db/, sources db_sysid_source.R, sets db_src.
+.f <- tryCatch(sys.frame(1)$ofile, error = function(e) NULL)
+if (is.null(.f)) .f <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+.cfg <- if (nzchar(Sys.getenv("SYSNDD_DB_DIR"))) {
+  file.path(Sys.getenv("SYSNDD_DB_DIR"), "config")
+} else {
+  file.path(dirname(normalizePath(.f[1])), "config")
+}
+source(file.path(.cfg, "db_config.R"))
+config_vars_proj <- db_bootstrap()
 ############################################
 
 

--- a/db/README.md
+++ b/db/README.md
@@ -1,8 +1,240 @@
 # SysNDD-DB <img src='../app/public/img/icons/android-chrome-192x192.png' align="right" alt="SysNDD logo" width="192" height="192" />
 
-The repository for the relation database powering SysNDD.
+The repository for the relational database powering SysNDD.
 
 We use the open-source MySQL 8.0 relational database management system (RDBMS).
 
 The design of our DB schema can be viewed in DB DESIGNER:
 [SysNDD DB schema](https://dbdesigner.page.link/3Morx9HZxzqt4R379)
+
+---
+
+## Two distinct kinds of "database scripts"
+
+This directory contains **two separate mechanisms**. Do not confuse them:
+
+| | `db/migrations/*.sql` | `db/*_Rcommands_*.R` (this README) |
+|---|---|---|
+| **What** | Versioned schema migrations | Out-of-band data-prep / DB-creation |
+| **When** | Applied automatically at **API startup** by the migration runner | Run **manually** by a maintainer to (re)build the DB content from external sources |
+| **Audience** | Every deployment | Maintainers rebuilding the dataset |
+| **Source of truth** | `db/migrations/README.md` | this file |
+
+Everything below describes the **out-of-band data-prep / DB-creation scripts**.
+
+---
+
+## What the data-prep scripts do
+
+The numbered scripts (`01..17`) each fetch / transform one logical dataset and
+write a dated CSV into `db/results/`. The lettered finalizers (`A`, `B`, `C`)
+then load those CSVs into MySQL and apply data types, keys, and views.
+
+| Step | Script | Builds / does |
+|---|---|---|
+| 01 | `01_..._hgnc_non_alt_loci_set.R` | HGNC gene set + STRING ids + gene coordinates |
+| 02 | `02_..._disease_ontology_set.R` | Disease ontology (OMIM/MONDO) cross-mapped via OxO |
+| 03 | `03_..._mode_of_inheritance_list.R` | HPO inheritance-mode terms |
+| 04 | `04_..._ndd_entity.R` | Core NDD entities (SysID import + OMIM/MONDO) |
+| 05 | `05_..._ndd_entity_review.R` | Initial review records from SysID synopses |
+| 06 | `06_..._ndd_entity_status.R` | Curated status categories from SysID groups |
+| 07 | `07_..._ndd_review_phenotype_connect.R` | Phenotype → HPO term links |
+| 08 | `08_..._publication.R` | Publication metadata (PubMed / GeneReviews) |
+| 09 | `09_..._re_review.R` | Re-review batch assignments |
+| 10 | `10_..._user.R` | Users (from an external CSV) |
+| 11 | `11_..._database_comparisons.R` | Comparison vs. external NDD databases |
+| 12 | `12_..._variation_ontology_set.R` | Variation Ontology (VariO) + links |
+| 13 | `13_..._boolean_list.R` | Boolean lookup table |
+| 14 | `14_..._allowed_list.R` | Allowed-value lists for the UI |
+| 15 | `15_..._logging_table.R` | Logging table schema |
+| 16 | `16_..._pubtator_cache_table.R` | PubTator cache tables |
+| 17 | `17_..._json_storage_table.R` | JSON storage table |
+| A | `A_Rcommands_create-database-tables.R` | Import all `results/*.csv` into MySQL |
+| B | `B_Rcommands_set-table-data-types.R` | Set column types / constraints |
+| C | `C_Rcommands_set-table-connections.R` | Set keys, foreign keys, views |
+
+> **Note on `C_Rcommands_set-table-connections.R` and views:** the core read
+> views (`ndd_entity_view`, `users_view`, ...) are also codified in
+> `db/migrations/025_create_core_views.sql` (and later migrations). If you change
+> a view definition, keep the migration and this script in sync. See `AGENTS.md`.
+
+---
+
+## Configuration (no hardcoded secrets)
+
+All credentials, the project directory, the SysID source selection, and the
+external download URLs are read from config so nothing sensitive lives in the
+scripts.
+
+1. **Credentials** — copy the template and fill in real values:
+
+   ```bash
+   cp db/config/sysndd_db.yml.example db/config/sysndd_db.yml
+   # edit db/config/sysndd_db.yml
+   ```
+
+   `db/config/sysndd_db.yml` is **gitignored**. You can also point at a
+   different file with the `CONFIG_FILE` environment variable; if neither is set,
+   the default `db/config/sysndd_db.yml` is used.
+
+2. **External source URLs** (HGNC, HPO, OxO, NCBI, genenames REST, VariO) — these
+   have sensible built-in defaults in `db/config/db_config.R`
+   (`.db_source_defaults`). Override only if you need a mirror/pinned version:
+
+   ```bash
+   cp db/config/db_sources.yml.example db/config/db_sources.yml
+   # edit db/config/db_sources.yml
+   ```
+
+3. **OMIM download links** — OMIM downloads are access-controlled and the URLs
+   embed a per-account secret token, so they are **never** hardcoded. Put your
+   authorized OMIM download links (one per line) in:
+
+   ```
+   db/data/omim_links/omim_links.txt   # gitignored
+   ```
+
+   Scripts 02 and 04 read that file at runtime.
+
+4. **Other input data** — Excel/TSV lookup files live under `db/data/` (e.g.
+   `data/lists/`, `data/phenotypes/`, `data/mondo_terms/`,
+   `data/ndd_databases_links/`). See each script header for the expected file.
+
+> **NEVER commit real credentials, tokens, or OMIM links.** Only the
+> `*.example` templates and placeholder values belong in git.
+
+---
+
+## Working-directory independence
+
+The scripts resolve the `db/` directory from their own location (via
+`db/config/db_config.R`) and anchor the working directory there, so they can be
+launched from anywhere:
+
+```bash
+# all equivalent — no need to `cd db` first
+Rscript db/01_Rcommands_sysndd_db_table_hgnc_non_alt_loci_set.R
+cd db && Rscript 01_Rcommands_sysndd_db_table_hgnc_non_alt_loci_set.R
+SYSNDD_DB_DIR=/abs/path/to/db Rscript /abs/path/to/db/01_...R
+```
+
+Resolution order for the `db/` directory: `SYSNDD_DB_DIR` env var → the running
+script's path → `here::here()/db` → current working directory.
+
+---
+
+## Running the pipeline
+
+### Master runner (recommended)
+
+`db/run_all.R` orchestrates every step in the correct order, each in its own
+fresh R subprocess, with timestamped logging and fail-fast behavior:
+
+```bash
+Rscript db/run_all.R               # run the full pipeline
+Rscript db/run_all.R --list        # list ordered steps and exit
+Rscript db/run_all.R --dry-run     # log what would run, do nothing
+Rscript db/run_all.R --only 01,02  # run only matching step prefixes
+Rscript db/run_all.R --from 04     # resume starting at step 04
+Rscript db/run_all.R --skip-finalize  # skip the A/B/C finalizers
+```
+
+If a step fails, the runner stops and prints a `--from NN` command to resume.
+
+### Running steps individually
+
+Each script is standalone and can be run on its own (e.g. to rebuild a single
+table):
+
+```bash
+Rscript db/03_Rcommands_sysndd_db_table_mode_of_inheritance_list.R
+```
+
+---
+
+## Reproducible SysID import (SQLite)
+
+The initial import (scripts 04–08) historically read two tables — `disease` and
+`human_gene_disease_connect` — from the upstream **SysID** MySQL instance over an
+SSH tunnel. That source is not reproducible for anyone outside the original
+maintainers, which blocks clean rebuilds.
+
+To make the import reproducible, the scripts can read the **same two tables from
+a local SQLite snapshot** instead. Selection is driven by config
+(`sysid_source: "sqlite" | "mysql"` in `sysndd_db.yml`); if unset, `sqlite` is
+auto-selected when a snapshot file exists.
+
+### One-time: create the snapshot (maintainer with live SysID access)
+
+```r
+# from an R session with live SysID MySQL credentials in sysndd_db.yml
+source("db/config/db_config.R")
+source("db/config/db_sysid_source.R")
+cfg <- db_load_config()
+db_sysid_export_to_sqlite(cfg)   # -> db/data/sysid/sysid_snapshot.sqlite
+```
+
+Archive the resulting `db/data/sysid/sysid_snapshot.sqlite` (it is gitignored by
+default because it can be large; commit/store it wherever your reproducibility
+policy requires). Future rebuilds then run **network-free** against the snapshot.
+
+### Subsequent rebuilds (anyone)
+
+With the snapshot present (and `sysid_source: sqlite` or unset), just run the
+pipeline — scripts 04–08 read the snapshot automatically. Requires the
+`RSQLite` R package.
+
+---
+
+## Prerequisites
+
+- R with the packages each step `library()`-loads (e.g. `tidyverse`, `DBI`,
+  `RMariaDB`, `RSQLite`, `sqlr`, `biomaRt`, `STRINGdb`, `ontologyIndex`,
+  `jsonlite`, `httr2`, `readxl`, `config`, `yaml`, `here`). Network access is
+  required for the steps that download from external sources.
+- A reachable **SysNDD target MySQL 8.0** database (credentials in
+  `db/config/sysndd_db.yml`).
+- For the SysID import: either a SysID **SQLite snapshot** (recommended) or live
+  SysID MySQL credentials.
+- Authorized **OMIM** download links in `db/data/omim_links/omim_links.txt`.
+
+---
+
+## Tests
+
+Pure helpers (path resolution, config loading, URL building, SysID source
+selection) have host-runnable unit tests in `db/tests/testthat/` (no DB/network
+needed):
+
+```bash
+Rscript --no-init-file -e "testthat::test_dir('db/tests/testthat')"
+```
+
+The data-prep scripts themselves require a DB and/or network, so they are not
+run in CI. At minimum, verify a script parses:
+
+```bash
+Rscript --no-init-file -e "invisible(parse('db/01_Rcommands_sysndd_db_table_hgnc_non_alt_loci_set.R'))"
+```
+
+---
+
+## Directory layout
+
+```
+db/
+├── 01..17_Rcommands_*.R         # per-table data-prep steps
+├── A/B/C_Rcommands_*.R          # finalizers (import, types, keys/views)
+├── run_all.R                    # master orchestration runner
+├── config/
+│   ├── db_config.R              # shared config + path + URL helpers
+│   ├── db_sysid_source.R        # SysID source abstraction (SQLite/MySQL)
+│   ├── sysndd_db.yml.example    # credentials template (copy -> sysndd_db.yml)
+│   └── db_sources.yml.example   # external-URL overrides template (optional)
+├── tests/testthat/              # host-runnable unit tests for helpers
+├── data/                        # input data (OMIM links, lists, snapshots, ...)
+├── results/                     # generated CSV outputs (gitignored)
+├── migrations/                  # runtime schema migrations (separate! see its README)
+├── fixtures/                    # test/seed fixtures
+└── updates/                     # one-off update/backfill scripts
+```

--- a/db/config/db_config.R
+++ b/db/config/db_config.R
@@ -1,0 +1,326 @@
+# db/config/db_config.R
+#
+# Shared configuration + path helpers for the out-of-band SysNDD data-prep /
+# database-creation scripts (the numbered `NN_Rcommands_*.R` files plus the
+# `A/B/C_Rcommands_*.R` finalizers).
+#
+# These scripts historically did three fragile things in every header:
+#   1. `config::get(file = Sys.getenv("CONFIG_FILE"), config = "sysndd")`
+#   2. `setwd(paste0(config_vars_proj$projectsdir, project_name))`
+#   3. inlined every external download URL as a hardcoded literal
+#
+# That made them depend on (a) an undocumented `CONFIG_FILE` env var, (b) the
+# caller's working directory, and (c) source URLs that could only be changed by
+# editing each script. This module centralizes all three concerns so the
+# scripts can be sourced from anywhere and so external sources / paths live in
+# one config file.
+#
+# IMPORTANT: this is the OUT-OF-BAND data-prep tooling. It is distinct from the
+# runtime migration runner under `db/migrations/*.sql`. Do not confuse the two.
+#
+# Pure helpers in this file are unit-tested in `db/tests/testthat/`. Functions
+# that touch the network or a live database are intentionally NOT auto-run here.
+
+# Avoid noisy scientific notation in every script that sources this helper.
+options(scipen = 999)
+
+# ---------------------------------------------------------------------------
+# Repo-root / path resolution (working-directory independent)
+# ---------------------------------------------------------------------------
+
+#' Resolve the absolute path to this `db/` directory.
+#'
+#' Resolution order (first hit wins):
+#'   1. `SYSNDD_DB_DIR` environment variable, if set and existing.
+#'   2. The directory containing this script, derived from the call stack
+#'      (`sys.frame`) when sourced, or from `commandArgs()` when run via
+#'      `Rscript`.
+#'   3. The `db/` directory under `here::here()` if the `here` package is
+#'      available (anchors on the repo root via `.git` / project markers).
+#'   4. The current working directory as a last resort.
+#'
+#' @return Absolute, normalized path to the `db/` directory.
+db_dir <- function() {
+  env_dir <- Sys.getenv("SYSNDD_DB_DIR", unset = "")
+  if (nzchar(env_dir) && dir.exists(env_dir)) {
+    return(normalizePath(env_dir, mustWork = FALSE))
+  }
+
+  script_path <- db_this_script_path()
+  if (!is.null(script_path)) {
+    candidate <- dirname(dirname(script_path)) # config/ -> db/
+    if (basename(dirname(script_path)) == "config" && dir.exists(candidate)) {
+      return(normalizePath(candidate, mustWork = FALSE))
+    }
+  }
+
+  if (requireNamespace("here", quietly = TRUE)) {
+    candidate <- file.path(here::here(), "db")
+    if (dir.exists(candidate)) {
+      return(normalizePath(candidate, mustWork = FALSE))
+    }
+  }
+
+  normalizePath(getwd(), mustWork = FALSE)
+}
+
+#' Resolve the absolute path to the repository root (parent of `db/`).
+#'
+#' @return Absolute, normalized path to the repo root.
+db_repo_root <- function() {
+  normalizePath(dirname(db_dir()), mustWork = FALSE)
+}
+
+#' Best-effort path of the currently executing/sourcing script.
+#'
+#' Works for both `source()` (reads `sys.frames()` `ofile`) and
+#' `Rscript file.R` (reads the `--file=` command argument). Returns `NULL` when
+#' neither is available (e.g. an interactive paste).
+#'
+#' @return Absolute path string, or `NULL`.
+db_this_script_path <- function() {
+  # Case 1: sourced file — walk the frame stack for an `ofile`.
+  for (frame in rev(sys.frames())) {
+    ofile <- frame$ofile
+    if (!is.null(ofile)) {
+      return(normalizePath(ofile, mustWork = FALSE))
+    }
+  }
+
+  # Case 2: Rscript — parse the `--file=` command argument.
+  cmd_args <- commandArgs(trailingOnly = FALSE)
+  file_arg <- grep("^--file=", cmd_args, value = TRUE)
+  if (length(file_arg) == 1) {
+    return(normalizePath(sub("^--file=", "", file_arg), mustWork = FALSE))
+  }
+
+  NULL
+}
+
+#' Build an absolute path under the `db/` directory.
+#'
+#' Replaces working-directory-relative literals such as `"data/foo.txt"` and
+#' `"results/bar.csv"` so scripts resolve the same paths regardless of `getwd()`.
+#'
+#' @param ... Path components passed to `file.path()`, relative to `db/`.
+#' @param create_dir Whether to create the parent directory if missing.
+#' @return Absolute, normalized path string.
+db_path <- function(..., create_dir = FALSE) {
+  path <- file.path(db_dir(), ...)
+  if (create_dir) {
+    dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)
+  }
+  normalizePath(path, mustWork = FALSE)
+}
+
+#' Absolute path under the `db/data/` input directory.
+#' @param ... Components relative to `db/data/`.
+#' @param create_dir Whether to create the parent directory if missing.
+db_data_path <- function(..., create_dir = FALSE) {
+  db_path("data", ..., create_dir = create_dir)
+}
+
+#' Absolute path under the `db/results/` output directory.
+#'
+#' The `results/` directory is created on demand because it holds generated
+#' CSVs that are not checked into the repo.
+#'
+#' @param ... Components relative to `db/results/`.
+#' @param create_dir Whether to create the parent directory if missing.
+db_results_path <- function(..., create_dir = TRUE) {
+  db_path("results", ..., create_dir = create_dir)
+}
+
+#' One-call bootstrap for the data-prep scripts.
+#'
+#' Replaces the per-script header boilerplate. It:
+#'   1. exports `SYSNDD_DB_DIR` so all path helpers (and any child processes)
+#'      resolve `db/` deterministically;
+#'   2. anchors the working directory to `db/` (so the scripts' existing
+#'      `"data/..."` / `"results/..."` relative paths resolve);
+#'   3. sources the SysID source abstraction (`db_sysid_source.R`);
+#'   4. resolves the external-source URL registry into a `db_src` variable in the
+#'      caller's environment (so URL-building scripts can use it);
+#'   5. loads and returns the credentials config.
+#'
+#' Typical script header (after a tiny finder + `source(db_config.R)`):
+#'   `config_vars_proj <- db_bootstrap()`
+#'
+#' @param config_file Optional explicit config path (see `db_load_config`).
+#' @param config Config section name (default `"sysndd"`).
+#' @param envir Environment to assign `db_src` into (default: caller).
+#' @return The loaded config list.
+db_bootstrap <- function(config_file = NULL, config = "sysndd",
+                         envir = parent.frame()) {
+  Sys.setenv(SYSNDD_DB_DIR = db_dir())
+  db_setwd_to_db_dir()
+
+  sysid_helper <- db_path("config", "db_sysid_source.R")
+  if (file.exists(sysid_helper)) {
+    sys.source(sysid_helper, envir = globalenv())
+  }
+
+  assign("db_src", db_sources(), envir = envir)
+  db_load_config(config_file = config_file, config = config)
+}
+
+#' Anchor the working directory to the `db/` directory.
+#'
+#' The legacy scripts called `setwd(paste0(projectsdir, "R"))`, which depended
+#' on an operator-specific config path. This anchors `getwd()` to the resolved
+#' `db/` directory instead, so the many existing `"data/..."` / `"results/..."`
+#' relative paths in the scripts resolve correctly no matter where the script
+#' is launched from. Call this once in each script's header (after sourcing this
+#' file). The `db/results/` directory is created if missing.
+#'
+#' @return The `db/` directory path (invisibly).
+db_setwd_to_db_dir <- function() {
+  target <- db_dir()
+  dir.create(file.path(target, "results"), recursive = TRUE, showWarnings = FALSE)
+  setwd(target)
+  invisible(target)
+}
+
+# ---------------------------------------------------------------------------
+# Config loading (database credentials + project dir)
+# ---------------------------------------------------------------------------
+
+#' Load the database/credentials config for the data-prep scripts.
+#'
+#' Mirrors the legacy
+#' `config::get(file = Sys.getenv("CONFIG_FILE"), config = "sysndd")` call but
+#' resolves a sensible default config file when `CONFIG_FILE` is unset, so the
+#' env var is no longer mandatory.
+#'
+#' Resolution order for the config file:
+#'   1. `config_file` argument, if provided.
+#'   2. `CONFIG_FILE` environment variable, if set.
+#'   3. `db/config/sysndd_db.yml` (gitignored real credentials).
+#'
+#' @param config_file Optional explicit path to a config YAML.
+#' @param config Config section name (default `"sysndd"`).
+#' @return Named list of config values.
+db_load_config <- function(config_file = NULL, config = "sysndd") {
+  if (is.null(config_file) || !nzchar(config_file)) {
+    config_file <- Sys.getenv("CONFIG_FILE", unset = "")
+  }
+  if (!nzchar(config_file)) {
+    config_file <- db_path("config", "sysndd_db.yml")
+  }
+  if (!file.exists(config_file)) {
+    stop(
+      "DB config file not found: ", config_file,
+      "\nCopy db/config/sysndd_db.yml.example to db/config/sysndd_db.yml ",
+      "and fill in real credentials, or set CONFIG_FILE.",
+      call. = FALSE
+    )
+  }
+  config::get(file = config_file, config = config)
+}
+
+# ---------------------------------------------------------------------------
+# External data-source registry (config-ized URLs)
+# ---------------------------------------------------------------------------
+
+# Built-in defaults for every external source URL the scripts touch. These are
+# public, non-secret base URLs; they live in code as a fallback so a fresh
+# checkout works without an extra config file. Operators can override any of
+# them via `db/config/db_sources.yml`.
+.db_source_defaults <- list(
+  # HGNC complete gene set (TSV) downloaded by script 01.
+  hgnc_non_alt_loci_set = "http://ftp.ebi.ac.uk/pub/databases/genenames/hgnc/tsv/non_alt_loci_set.txt",
+  # genenames.org REST search endpoints (scripts 02, 04, 11).
+  genenames_rest_base   = "http://rest.genenames.org/search",
+  # Human Phenotype Ontology term API (scripts 02, 03, 04, 11).
+  hpo_term_api_base     = "https://hpo.jax.org/api/hpo/term",
+  # EBI OxO cross-ontology mapping API (scripts 02, 04).
+  oxo_mappings_api      = "https://www.ebi.ac.uk/spot/oxo/api/mappings",
+  # NCBI E-utilities efetch endpoint (script 08).
+  ncbi_eutils_efetch    = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi",
+  # NCBI Bookshelf / GeneReviews base (script 08).
+  ncbi_books_base       = "https://www.ncbi.nlm.nih.gov/books",
+  # Variation Ontology OBO download (script 12).
+  vario_obo             = "http://www.variationontology.org/vario_download/vario.obo"
+)
+
+#' Resolve the external-source registry (defaults overlaid with config file).
+#'
+#' Reads `db/config/db_sources.yml` (if present) and overlays any keys it
+#' defines on top of `.db_source_defaults`. The config file is optional; the
+#' built-in defaults are valid public URLs.
+#'
+#' @param sources_file Optional explicit path to a sources YAML.
+#' @return Named list of source URLs.
+db_sources <- function(sources_file = NULL) {
+  if (is.null(sources_file) || !nzchar(sources_file)) {
+    sources_file <- Sys.getenv("DB_SOURCES_FILE", unset = "")
+  }
+  if (!nzchar(sources_file)) {
+    sources_file <- db_path("config", "db_sources.yml")
+  }
+
+  merged <- .db_source_defaults
+  if (file.exists(sources_file) && requireNamespace("yaml", quietly = TRUE)) {
+    overrides <- yaml::read_yaml(sources_file)
+    sources <- overrides[["sources"]]
+    if (is.null(sources)) {
+      sources <- overrides
+    }
+    for (key in names(sources)) {
+      if (nzchar(key) && !is.null(sources[[key]])) {
+        merged[[key]] <- sources[[key]]
+      }
+    }
+  }
+  merged
+}
+
+#' Look up a single external-source URL by key.
+#'
+#' @param key Source key (see names of `.db_source_defaults`).
+#' @param sources Optional pre-resolved source list (avoids re-reading config).
+#' @return URL string.
+db_source_url <- function(key, sources = db_sources()) {
+  if (!key %in% names(sources)) {
+    stop("Unknown data source key: ", key, call. = FALSE)
+  }
+  sources[[key]]
+}
+
+#' Build a genenames.org REST search URL.
+#'
+#' Example: `db_genenames_search_url("prev_symbol", "FOO")` ->
+#'   "http://rest.genenames.org/search/prev_symbol/FOO"
+#'
+#' @param field Search field (e.g. "prev_symbol", "alias_symbol", "symbol",
+#'   "hgnc_id").
+#' @param value Search value (caller is responsible for any escaping).
+#' @param sources Optional pre-resolved source list.
+#' @return URL string.
+db_genenames_search_url <- function(field, value = "", sources = db_sources()) {
+  base <- db_source_url("genenames_rest_base", sources)
+  paste0(base, "/", field, "/", value)
+}
+
+#' Build an HPO term API URL for a single term id.
+#'
+#' Reserved characters in the term id (e.g. the `:` in "HP:0000005") are
+#' URL-encoded, matching the legacy `URLencode(term, reserved = TRUE)` calls.
+#'
+#' @param term_id HPO term id (e.g. "HP:0000005").
+#' @param sources Optional pre-resolved source list.
+#' @return URL string.
+db_hpo_term_url <- function(term_id, sources = db_sources()) {
+  base <- db_source_url("hpo_term_api_base", sources)
+  paste0(base, "/", utils::URLencode(term_id, reserved = TRUE))
+}
+
+#' Build an EBI OxO mappings API URL for a `fromId`.
+#'
+#' @param from_id Source ontology id to map from.
+#' @param sources Optional pre-resolved source list.
+#' @return URL string.
+db_oxo_mappings_url <- function(from_id, sources = db_sources()) {
+  base <- db_source_url("oxo_mappings_api", sources)
+  paste0(base, "?fromId=", from_id)
+}

--- a/db/config/db_sources.yml.example
+++ b/db/config/db_sources.yml.example
@@ -1,0 +1,38 @@
+## db/config/db_sources.yml.example
+##
+## OPTIONAL override file for the external data-source URLs used by the SysNDD
+## data-prep scripts. Copy this to `db/config/db_sources.yml` ONLY if you need
+## to point a script at a mirror or a pinned upstream version. If this file is
+## absent, the built-in defaults in `db/config/db_config.R`
+## (`.db_source_defaults`) are used.
+##
+## These are public, non-secret base URLs. Do NOT put API keys or credentials
+## here — credentials belong in `db/config/sysndd_db.yml` (gitignored).
+##
+## Any key you omit falls back to its built-in default. Keys may be nested under
+## a top-level `sources:` block (shown here) or placed at the top level.
+
+sources:
+  # HGNC complete gene set (TSV) — script 01.
+  hgnc_non_alt_loci_set: "http://ftp.ebi.ac.uk/pub/databases/genenames/hgnc/tsv/non_alt_loci_set.txt"
+
+  # genenames.org REST search base — scripts 02, 04, 11.
+  # Full URLs are built as "<base>/<field>/<value>".
+  genenames_rest_base: "http://rest.genenames.org/search"
+
+  # Human Phenotype Ontology term API base — scripts 02, 03, 04, 11.
+  # Full URLs are built as "<base>/<url-encoded term id>".
+  hpo_term_api_base: "https://hpo.jax.org/api/hpo/term"
+
+  # EBI OxO cross-ontology mappings API — scripts 02, 04.
+  # Full URLs are built as "<base>?fromId=<id>".
+  oxo_mappings_api: "https://www.ebi.ac.uk/spot/oxo/api/mappings"
+
+  # NCBI E-utilities efetch endpoint — script 08.
+  ncbi_eutils_efetch: "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+
+  # NCBI Bookshelf / GeneReviews base — script 08.
+  ncbi_books_base: "https://www.ncbi.nlm.nih.gov/books"
+
+  # Variation Ontology OBO download — script 12.
+  vario_obo: "http://www.variationontology.org/vario_download/vario.obo"

--- a/db/config/db_sysid_source.R
+++ b/db/config/db_sysid_source.R
@@ -1,0 +1,168 @@
+# db/config/db_sysid_source.R
+#
+# SysID source abstraction for the initial SysNDD import.
+#
+# The original SysID import (scripts 04, 05, 06, 07, 08) reads two tables —
+# `disease` and `human_gene_disease_connect` — from the upstream SysID MySQL
+# instance over an SSH tunnel. That source is no longer reproducible by anyone
+# outside the original maintainers, which blocks a clean rebuild of the SysNDD
+# database from scratch.
+#
+# To make the initial import reproducible (GitHub issue #33), this module lets a
+# script read the same two tables from a *local SQLite snapshot* instead. The
+# snapshot is a one-time, versionable artifact an operator builds once from the
+# live SysID DB (see `db_sysid_export_to_sqlite()` and `db/README.md`), and then
+# commits / archives so future rebuilds are deterministic and network-free.
+#
+# Selection is driven by config (`sysid_source: "sqlite" | "mysql"`), defaulting
+# to SQLite when a snapshot file is present so reproducible rebuilds are the easy
+# path.
+#
+# Pure helpers (mode/path resolution) are unit-tested in db/tests/. The actual
+# DBI connections are NOT exercised on host CI because they need RSQLite /
+# RMariaDB + a real snapshot/tunnel.
+
+#' Decide which SysID source to use for the initial import.
+#'
+#' Resolution order:
+#'   1. `SYSID_SOURCE` environment variable ("sqlite" | "mysql"), if set.
+#'   2. `config$sysid_source`, if set in the loaded config.
+#'   3. "sqlite" when a snapshot file exists at the resolved snapshot path.
+#'   4. "mysql" otherwise (legacy SSH-tunnelled remote source).
+#'
+#' @param config Loaded config list (from `db_load_config()`); may be `NULL`.
+#' @return One of "sqlite" or "mysql".
+db_sysid_source_mode <- function(config = NULL) {
+  env_mode <- tolower(Sys.getenv("SYSID_SOURCE", unset = ""))
+  if (env_mode %in% c("sqlite", "mysql")) {
+    return(env_mode)
+  }
+
+  cfg_mode <- if (!is.null(config)) tolower(config$sysid_source %||% "") else ""
+  if (cfg_mode %in% c("sqlite", "mysql")) {
+    return(cfg_mode)
+  }
+
+  if (file.exists(db_sysid_sqlite_path(config))) {
+    return("sqlite")
+  }
+
+  "mysql"
+}
+
+#' Resolve the path to the local SysID SQLite snapshot.
+#'
+#' Order: `config$sysid_sqlite_path` (absolute or db/-relative), else the
+#' default `db/data/sysid/sysid_snapshot.sqlite`.
+#'
+#' @param config Loaded config list; may be `NULL`.
+#' @return Absolute, normalized path string.
+db_sysid_sqlite_path <- function(config = NULL) {
+  configured <- if (!is.null(config)) config$sysid_sqlite_path %||% "" else ""
+  if (nzchar(configured)) {
+    if (.db_is_absolute_path(configured)) {
+      return(normalizePath(configured, mustWork = FALSE))
+    }
+    return(db_path(configured))
+  }
+  db_data_path("sysid", "sysid_snapshot.sqlite")
+}
+
+#' Open a DBI connection to the configured SysID source.
+#'
+#' For "sqlite", opens the local snapshot (read-only). For "mysql", opens a
+#' connection to the SSH-tunnelled remote SysID database using the legacy config
+#' keys. Callers are responsible for closing the connection with
+#' `DBI::dbDisconnect()` (and tearing down any SSH tunnel they started).
+#'
+#' @param config Loaded config list (from `db_load_config()`).
+#' @param mode Optional explicit mode override ("sqlite" | "mysql").
+#' @return A DBI connection.
+db_sysid_connect <- function(config, mode = db_sysid_source_mode(config)) {
+  if (mode == "sqlite") {
+    if (!requireNamespace("RSQLite", quietly = TRUE)) {
+      stop("RSQLite is required to read the SysID SQLite snapshot.", call. = FALSE)
+    }
+    snapshot <- db_sysid_sqlite_path(config)
+    if (!file.exists(snapshot)) {
+      stop(
+        "SysID SQLite snapshot not found: ", snapshot,
+        "\nBuild it once with db_sysid_export_to_sqlite(), or set ",
+        "sysid_source: mysql to use the live remote source.",
+        call. = FALSE
+      )
+    }
+    return(DBI::dbConnect(RSQLite::SQLite(), dbname = snapshot, flags = RSQLite::SQLITE_RO))
+  }
+
+  if (!requireNamespace("RMariaDB", quietly = TRUE)) {
+    stop("RMariaDB is required to read the live SysID MySQL source.", call. = FALSE)
+  }
+  DBI::dbConnect(
+    RMariaDB::MariaDB(),
+    dbname = config$dbname_sysid,
+    user = config$user_sysid,
+    password = config$password_sysid,
+    host = config$server_sysid_local,
+    port = as.integer(config$port_sysid_local)
+  )
+}
+
+#' Read a SysID table from the connected source as a tibble/data.frame.
+#'
+#' Wraps the table read so call sites are source-agnostic. The two tables the
+#' initial import needs are "disease" and "human_gene_disease_connect".
+#'
+#' @param conn DBI connection from `db_sysid_connect()`.
+#' @param table Table name.
+#' @return A data.frame of the table contents.
+db_sysid_read_table <- function(conn, table) {
+  DBI::dbReadTable(conn, table)
+}
+
+#' Export the SysID source tables to a local SQLite snapshot (one-time).
+#'
+#' OPERATOR HELPER. Run this once, with `mode = "mysql"` config pointed at the
+#' live SysID DB, to produce the reproducible snapshot future rebuilds read.
+#' Commit / archive the resulting file. By default it captures the two tables
+#' the initial import consumes.
+#'
+#' @param config Loaded config list with live SysID MySQL credentials.
+#' @param sqlite_path Destination snapshot path (defaults to the resolved
+#'   snapshot path).
+#' @param tables Character vector of SysID table names to capture.
+#' @return The path to the written SQLite snapshot (invisibly).
+db_sysid_export_to_sqlite <- function(config,
+                                      sqlite_path = db_sysid_sqlite_path(config),
+                                      tables = c("disease", "human_gene_disease_connect")) {
+  if (!requireNamespace("RSQLite", quietly = TRUE)) {
+    stop("RSQLite is required to write the SysID SQLite snapshot.", call. = FALSE)
+  }
+  dir.create(dirname(sqlite_path), recursive = TRUE, showWarnings = FALSE)
+
+  src <- db_sysid_connect(config, mode = "mysql")
+  on.exit(DBI::dbDisconnect(src), add = TRUE)
+
+  dst <- DBI::dbConnect(RSQLite::SQLite(), dbname = sqlite_path)
+  on.exit(DBI::dbDisconnect(dst), add = TRUE)
+
+  for (table in tables) {
+    data <- DBI::dbReadTable(src, table)
+    DBI::dbWriteTable(dst, table, data, overwrite = TRUE)
+    message("Wrote SysID table '", table, "' (", nrow(data), " rows) to snapshot.")
+  }
+
+  message("SysID SQLite snapshot written to: ", sqlite_path)
+  invisible(sqlite_path)
+}
+
+# Minimal helpers ----------------------------------------------------------
+
+# `%||%`: return `x` unless it is NULL, otherwise `y`. (rlang provides this but
+# we avoid a hard dependency here.)
+`%||%` <- function(x, y) if (is.null(x)) y else x
+
+# Cross-platform absolute-path test (handles POSIX "/..." and Windows "C:\...").
+.db_is_absolute_path <- function(path) {
+  grepl("^(/|[A-Za-z]:[\\\\/])", path)
+}

--- a/db/config/sysndd_db.yml.example
+++ b/db/config/sysndd_db.yml.example
@@ -1,0 +1,64 @@
+## db/config/sysndd_db.yml.example
+##
+## Credentials + connection config for the OUT-OF-BAND SysNDD data-prep /
+## database-creation scripts (the `NN_Rcommands_*.R` files and the
+## `A/B/C_Rcommands_*.R` finalizers).
+##
+## Copy this file to `db/config/sysndd_db.yml` and fill in REAL values before
+## running the scripts. The real file is gitignored (see `db/.gitignore`) so
+## secrets are never committed. NOTHING in this template is a real credential.
+##
+## How it is loaded: `db/config/db_config.R::db_load_config()` reads this file
+## via the `config` package. You can also point at a different file with the
+## `CONFIG_FILE` environment variable; if neither is set this default path is
+## used.
+##
+## NOTE: this is separate from `api/config.yml` (the runtime API config). These
+## scripts only need the SysNDD target DB credentials, the (legacy) SysID source
+## credentials, and a base directory.
+
+default:
+  sysndd:
+    ## ---- Working directory / repo anchor -------------------------------
+    ## Legacy scripts did `setwd(paste0(projectsdir, "R"))`. The refactored
+    ## scripts resolve paths relative to the `db/` directory automatically
+    ## (see db_config.R), so `projectsdir` is only kept for backward compat
+    ## with any unconverted script and is otherwise unused.
+    projectsdir: "/path/to/your/projects/"
+
+    ## ---- SysNDD target database (MySQL 8.0) ----------------------------
+    dbname_sysndd: "sysndd_db"
+    user_sysndd: "your_username_here"
+    password_sysndd: "your_secure_password_here"
+    server_sysndd_local: "127.0.0.1"
+    port_sysndd_local: "3306"
+    ## Some scripts use these alternate key names for the same target DB.
+    server_sysid_sysndd: "127.0.0.1"
+    port_sysid_sysndd: "3306"
+
+    ## ---- Initial SysID import source -----------------------------------
+    ## Choose how the one-time SysID import reads its source tables:
+    ##   "sqlite" — read a local, reproducible snapshot (recommended; see
+    ##              db/README.md "Reproducible SysID import").
+    ##   "mysql"  — read the live upstream SysID DB over an SSH tunnel
+    ##              (legacy; requires the credentials below).
+    ## If unset, the scripts auto-select "sqlite" when a snapshot file exists.
+    sysid_source: "sqlite"
+    ## Path to the local SQLite snapshot (absolute, or relative to db/).
+    sysid_sqlite_path: "data/sysid/sysid_snapshot.sqlite"
+
+    ## ---- Legacy live SysID source (only needed when sysid_source: mysql) -
+    host_sysid: "sysid.example.org"
+    passwd_sysid: "your_ssh_password_here"
+    port_sysid_local: "3307"
+    server_sysid_local: "127.0.0.1"
+    dbname_sysid: "sysid_db"
+    user_sysid: "your_sysid_username_here"
+    password_sysid: "your_sysid_password_here"
+
+    ## ---- OMIM ----------------------------------------------------------
+    ## OMIM downloads are access-controlled. Do NOT hardcode the per-account
+    ## download URLs (which embed a secret token) in scripts. Instead, place
+    ## the authorized OMIM download links — one per line — in:
+    ##   db/data/omim_links/omim_links.txt   (gitignored)
+    ## The scripts read that file at runtime. See db/README.md.

--- a/db/run_all.R
+++ b/db/run_all.R
@@ -1,0 +1,197 @@
+#!/usr/bin/env Rscript
+# db/run_all.R
+#
+# MASTER orchestration script for the out-of-band SysNDD data-prep /
+# database-creation pipeline (GitHub issue #33).
+#
+# It runs the numbered table-builder scripts (01..17) followed by the database
+# finalizers (A, B, C) in the correct order, each in its own fresh R subprocess,
+# with timestamped logging and fail-fast behavior.
+#
+# WHY SUBPROCESSES: each step `library()`-loads heavy / mutually masking
+# packages (tidyverse, biomaRt, STRINGdb, RMariaDB, ssh, ...) and manages its
+# own DB connection lifecycle (e.g. `rm_con()`). Running each in a clean
+# `Rscript` process avoids cross-step namespace masking and stale connections,
+# and matches how the steps were historically run one-by-one.
+#
+# This script is OUT-OF-BAND tooling. It is NOT the runtime migration runner
+# (`db/migrations/*.sql`, applied at API startup). Do not run this against a
+# production database without understanding each step.
+#
+# Usage:
+#   Rscript db/run_all.R                 # run the full pipeline
+#   Rscript db/run_all.R --list          # list the ordered steps and exit
+#   Rscript db/run_all.R --dry-run       # log what would run, do nothing
+#   Rscript db/run_all.R --only 01,02    # run only matching step prefixes
+#   Rscript db/run_all.R --from 04       # start at step 04 (resume)
+#   Rscript db/run_all.R --skip-finalize # skip the A/B/C finalizers
+#
+# Prerequisites (see db/README.md):
+#   * R with the packages each step needs (tidyverse, DBI, RMariaDB, sqlr, ...).
+#   * db/config/sysndd_db.yml filled in (copy from .example).
+#   * Authorized OMIM links in db/data/omim_links/omim_links.txt.
+#   * A reachable SysNDD target DB and either a SysID SQLite snapshot or a live
+#     SysID source (see db/README.md "Reproducible SysID import").
+
+# The master script itself only needs base R; each step loads its own deps.
+
+# Resolve this script's directory so the pipeline is working-directory
+# independent (issue #33). We do NOT source db_config.R here to keep the
+# orchestrator dependency-free, but we use the same --file= resolution trick.
+.resolve_db_dir <- function() {
+  env_dir <- Sys.getenv("SYSNDD_DB_DIR", unset = "")
+  if (nzchar(env_dir) && dir.exists(env_dir)) {
+    return(normalizePath(env_dir, mustWork = FALSE))
+  }
+  cmd_args <- commandArgs(trailingOnly = FALSE)
+  file_arg <- grep("^--file=", cmd_args, value = TRUE)
+  if (length(file_arg) == 1) {
+    return(normalizePath(dirname(sub("^--file=", "", file_arg)), mustWork = FALSE))
+  }
+  normalizePath(getwd(), mustWork = FALSE)
+}
+
+DB_DIR <- .resolve_db_dir()
+
+# Ordered pipeline. Numbered steps build/export individual tables; the A/B/C
+# finalizers import the generated CSVs and set data types / keys / views.
+TABLE_STEPS <- c(
+  "01_Rcommands_sysndd_db_table_hgnc_non_alt_loci_set.R",
+  "02_Rcommands_sysndd_db_table_disease_ontology_set.R",
+  "03_Rcommands_sysndd_db_table_mode_of_inheritance_list.R",
+  "04_Rcommands_sysndd_db_table_ndd_entity.R",
+  "05_Rcommands_sysndd_db_table_ndd_entity_review.R",
+  "06_Rcommands_sysndd_db_table_ndd_entity_status.R",
+  "07_Rcommands_sysndd_db_table_ndd_review_phenotype_connect.R",
+  "08_Rcommands_sysndd_db_table_publication.R",
+  "09_Rcommands_sysndd_db_table_re_review.R",
+  "10_Rcommands_sysndd_db_table_user.R",
+  "11_Rcommands_sysndd_db_table_database_comparisons.R",
+  "12_Rcommands_sysndd_db_table_variation_ontology_set.R",
+  "13_Rcommands_sysndd_db_boolean_list.R",
+  "14_Rcommands_sysndd_db_allowed_list.R",
+  "15_Rcommands_sysndd_db_logging_table.R",
+  "16_Rcommands_sysndd_db_pubtator_cache_table.R",
+  "17_Rcommands_sysndd_db_json_storage_table.R"
+)
+
+FINALIZE_STEPS <- c(
+  "A_Rcommands_create-database-tables.R",
+  "B_Rcommands_set-table-data-types.R",
+  "C_Rcommands_set-table-connections.R"
+)
+
+# ---- arg parsing ---------------------------------------------------------
+
+args <- commandArgs(trailingOnly = TRUE)
+
+arg_flag <- function(name) name %in% args
+
+arg_value <- function(name) {
+  hit <- grep(paste0("^", name, "="), args, value = TRUE)
+  if (length(hit) == 1) {
+    return(sub(paste0("^", name, "="), "", hit))
+  }
+  idx <- which(args == name)
+  if (length(idx) == 1 && idx < length(args)) {
+    return(args[idx + 1])
+  }
+  NULL
+}
+
+opt_list <- arg_flag("--list")
+opt_dry_run <- arg_flag("--dry-run")
+opt_skip_finalize <- arg_flag("--skip-finalize")
+opt_only <- arg_value("--only")
+opt_from <- arg_value("--from")
+
+# ---- logging -------------------------------------------------------------
+
+log_msg <- function(...) {
+  ts <- format(Sys.time(), "%Y-%m-%d %H:%M:%S")
+  cat(sprintf("[%s] %s\n", ts, paste0(...)))
+}
+
+# ---- build the step list -------------------------------------------------
+
+steps <- TABLE_STEPS
+if (!opt_skip_finalize) {
+  steps <- c(steps, FINALIZE_STEPS)
+}
+
+if (!is.null(opt_only)) {
+  prefixes <- trimws(strsplit(opt_only, ",")[[1]])
+  steps <- steps[vapply(steps, function(s) {
+    any(startsWith(s, prefixes))
+  }, logical(1))]
+}
+
+if (!is.null(opt_from)) {
+  start_idx <- which(startsWith(steps, opt_from))
+  if (length(start_idx) >= 1) {
+    steps <- steps[seq(min(start_idx), length(steps))]
+  } else {
+    log_msg("WARNING: --from '", opt_from, "' matched no step; running all.")
+  }
+}
+
+# ---- list / validate -----------------------------------------------------
+
+if (opt_list) {
+  log_msg("Ordered pipeline steps (db dir: ", DB_DIR, "):")
+  for (i in seq_along(steps)) {
+    cat(sprintf("  %2d. %s\n", i, steps[i]))
+  }
+  quit(status = 0)
+}
+
+if (length(steps) == 0) {
+  log_msg("No steps selected. Nothing to do.")
+  quit(status = 0)
+}
+
+missing <- steps[!file.exists(file.path(DB_DIR, steps))]
+if (length(missing) > 0) {
+  log_msg("ERROR: missing step scripts: ", paste(missing, collapse = ", "))
+  quit(status = 1)
+}
+
+# ---- run -----------------------------------------------------------------
+
+r_bin <- file.path(R.home("bin"), "Rscript")
+
+log_msg("Starting SysNDD data-prep pipeline (", length(steps), " steps).")
+log_msg("DB dir: ", DB_DIR)
+if (opt_dry_run) log_msg("DRY RUN: no scripts will be executed.")
+
+pipeline_start <- Sys.time()
+
+for (i in seq_along(steps)) {
+  step <- steps[i]
+  step_path <- file.path(DB_DIR, step)
+  log_msg(sprintf("[%d/%d] >>> %s", i, length(steps), step))
+
+  if (opt_dry_run) {
+    next
+  }
+
+  step_start <- Sys.time()
+  # Propagate SYSNDD_DB_DIR so each subprocess resolves paths identically.
+  status <- system2(
+    r_bin,
+    args = c("--no-init-file", shQuote(step_path)),
+    env = paste0("SYSNDD_DB_DIR=", DB_DIR)
+  )
+  elapsed <- round(as.numeric(difftime(Sys.time(), step_start, units = "secs")), 1)
+
+  if (!identical(status, 0L)) {
+    log_msg(sprintf("FAILED (exit %s) after %ss: %s", status, elapsed, step))
+    log_msg("Pipeline aborted. Fix the step above and resume with: ",
+            "Rscript db/run_all.R --from ", substr(step, 1, 2))
+    quit(status = 1)
+  }
+  log_msg(sprintf("[%d/%d] <<< OK in %ss: %s", i, length(steps), elapsed, step))
+}
+
+total <- round(as.numeric(difftime(Sys.time(), pipeline_start, units = "secs")), 1)
+log_msg("Pipeline completed successfully in ", total, "s.")

--- a/db/tests/testthat/test-db-config-helpers.R
+++ b/db/tests/testthat/test-db-config-helpers.R
@@ -1,0 +1,172 @@
+# Unit tests for the pure helpers in db/config/db_config.R and
+# db/config/db_sysid_source.R.
+#
+# These run on host CI (no DB / no network). Run with:
+#   Rscript --no-init-file -e "testthat::test_dir('db/tests/testthat')"
+
+library(testthat)
+
+# Resolve the db/ directory from this test file's location so the tests are
+# themselves working-directory independent.
+.this_file <- normalizePath(
+  sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE)[1]),
+  mustWork = FALSE
+)
+if (is.na(.this_file) || !nzchar(.this_file) || !file.exists(.this_file)) {
+  # Fallback when sourced interactively or via test_dir(): use getwd()-anchored
+  # search for the config helper.
+  .db_dir_guess <- NULL
+  for (cand in c("db/config", "../../config", "config")) {
+    if (file.exists(file.path(cand, "db_config.R"))) {
+      .db_dir_guess <- normalizePath(dirname(cand), mustWork = FALSE)
+      break
+    }
+  }
+  stopifnot(!is.null(.db_dir_guess))
+  .db_config_dir <- file.path(.db_dir_guess, "config")
+} else {
+  # tests/testthat/<this> -> db/
+  .db_config_dir <- file.path(dirname(dirname(dirname(.this_file))), "config")
+}
+
+source(file.path(.db_config_dir, "db_config.R"))
+source(file.path(.db_config_dir, "db_sysid_source.R"))
+
+
+test_that("db_dir and db_repo_root resolve consistently", {
+  d <- db_dir()
+  expect_true(dir.exists(d))
+  expect_equal(basename(d), "db")
+  expect_equal(db_repo_root(), normalizePath(dirname(d), mustWork = FALSE))
+})
+
+test_that("SYSNDD_DB_DIR env var overrides db_dir", {
+  tmp <- normalizePath(tempfile("dbdir"), mustWork = FALSE)
+  dir.create(tmp)
+  on.exit({
+    Sys.unsetenv("SYSNDD_DB_DIR")
+    unlink(tmp, recursive = TRUE)
+  })
+  Sys.setenv(SYSNDD_DB_DIR = tmp)
+  expect_equal(db_dir(), tmp)
+})
+
+test_that("db_path / db_data_path / db_results_path build paths under db/", {
+  expect_equal(db_path("data", "x.txt"), file.path(db_dir(), "data", "x.txt"))
+  expect_equal(
+    db_data_path("omim_links", "omim_links.txt"),
+    file.path(db_dir(), "data", "omim_links", "omim_links.txt")
+  )
+  expect_equal(db_results_path("foo.csv"), file.path(db_dir(), "results", "foo.csv"))
+})
+
+test_that("db_results_path creates the parent directory", {
+  unique_sub <- paste0("test_results_", as.integer(Sys.time()))
+  target <- db_results_path(unique_sub, "out.csv")
+  on.exit(unlink(file.path(db_dir(), "results", unique_sub), recursive = TRUE))
+  expect_true(dir.exists(dirname(target)))
+})
+
+
+test_that("default external source URLs match the legacy literals", {
+  expect_equal(
+    db_source_url("hgnc_non_alt_loci_set"),
+    "http://ftp.ebi.ac.uk/pub/databases/genenames/hgnc/tsv/non_alt_loci_set.txt"
+  )
+  expect_equal(db_source_url("genenames_rest_base"), "http://rest.genenames.org/search")
+  expect_equal(db_source_url("hpo_term_api_base"), "https://hpo.jax.org/api/hpo/term")
+  expect_equal(db_source_url("oxo_mappings_api"), "https://www.ebi.ac.uk/spot/oxo/api/mappings")
+  expect_equal(
+    db_source_url("ncbi_eutils_efetch"),
+    "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+  )
+  expect_equal(db_source_url("ncbi_books_base"), "https://www.ncbi.nlm.nih.gov/books")
+  expect_equal(db_source_url("vario_obo"), "http://www.variationontology.org/vario_download/vario.obo")
+})
+
+test_that("db_source_url rejects unknown keys", {
+  expect_error(db_source_url("not_a_source"), "Unknown data source key")
+})
+
+test_that("db_sources overlays YAML overrides on defaults", {
+  tmp <- tempfile(fileext = ".yml")
+  on.exit(unlink(tmp))
+  writeLines(c("sources:", "  vario_obo: \"http://mirror.example/vario.obo\""), tmp)
+  s <- db_sources(sources_file = tmp)
+  expect_equal(s[["vario_obo"]], "http://mirror.example/vario.obo")
+  # Untouched keys keep their defaults.
+  expect_equal(s[["hpo_term_api_base"]], "https://hpo.jax.org/api/hpo/term")
+})
+
+test_that("db_sources accepts a flat (un-nested) YAML mapping", {
+  tmp <- tempfile(fileext = ".yml")
+  on.exit(unlink(tmp))
+  writeLines("hpo_term_api_base: \"https://hpo.mirror/term\"", tmp)
+  s <- db_sources(sources_file = tmp)
+  expect_equal(s[["hpo_term_api_base"]], "https://hpo.mirror/term")
+})
+
+
+test_that("db_genenames_search_url builds the legacy REST shape", {
+  expect_equal(
+    db_genenames_search_url("prev_symbol", "FOO"),
+    "http://rest.genenames.org/search/prev_symbol/FOO"
+  )
+  expect_equal(
+    db_genenames_search_url("hgnc_id", "12345"),
+    "http://rest.genenames.org/search/hgnc_id/12345"
+  )
+})
+
+test_that("db_hpo_term_url URL-encodes the term id like the legacy calls", {
+  # Legacy used URLencode(term, reserved = TRUE) -> ":" becomes "%3A".
+  expect_equal(
+    db_hpo_term_url("HP:0000005"),
+    "https://hpo.jax.org/api/hpo/term/HP%3A0000005"
+  )
+})
+
+test_that("db_oxo_mappings_url appends the fromId query parameter", {
+  expect_equal(
+    db_oxo_mappings_url("OMIM:123456"),
+    "https://www.ebi.ac.uk/spot/oxo/api/mappings?fromId=OMIM:123456"
+  )
+})
+
+
+test_that("db_sysid_source_mode honours env, then config, then snapshot", {
+  on.exit(Sys.unsetenv("SYSID_SOURCE"))
+
+  Sys.setenv(SYSID_SOURCE = "mysql")
+  expect_equal(db_sysid_source_mode(NULL), "mysql")
+  Sys.setenv(SYSID_SOURCE = "sqlite")
+  expect_equal(db_sysid_source_mode(NULL), "sqlite")
+  Sys.unsetenv("SYSID_SOURCE")
+
+  expect_equal(db_sysid_source_mode(list(sysid_source = "mysql")), "mysql")
+
+  # No env, no config, no snapshot -> mysql (legacy default).
+  expect_equal(db_sysid_source_mode(list()), "mysql")
+})
+
+test_that("db_sysid_source_mode auto-selects sqlite when a snapshot exists", {
+  snap <- tempfile(fileext = ".sqlite")
+  file.create(snap)
+  on.exit(unlink(snap))
+  expect_equal(db_sysid_source_mode(list(sysid_sqlite_path = snap)), "sqlite")
+})
+
+test_that("db_sysid_sqlite_path resolves absolute, relative, and default forms", {
+  expect_equal(
+    db_sysid_sqlite_path(list(sysid_sqlite_path = "/abs/snap.sqlite")),
+    normalizePath("/abs/snap.sqlite", mustWork = FALSE)
+  )
+  expect_equal(
+    db_sysid_sqlite_path(list(sysid_sqlite_path = "data/custom/snap.sqlite")),
+    db_path("data", "custom", "snap.sqlite")
+  )
+  expect_equal(
+    db_sysid_sqlite_path(NULL),
+    db_data_path("sysid", "sysid_snapshot.sqlite")
+  )
+})


### PR DESCRIPTION
## Summary

Addresses #33 — enhances the **out-of-band** `db/` data-prep / DB-creation scripts (the `NN_Rcommands_*.R` + `A/B/C_Rcommands_*.R` files). This is distinct from the runtime migration runner: **`db/migrations/*` and the migration manifest are untouched.**

## What changed

### 1. Config-ized hardcoded values
New `db/config/db_config.R` holds an external-source URL **registry** with built-in public defaults (overridable via optional `db/config/db_sources.yml`):

| Source | Used by |
|---|---|
| HGNC non_alt_loci_set TSV | 01 |
| genenames.org REST search | 02, 04, 11 |
| HPO term API | 02, 03, 04, 11 |
| EBI OxO mappings | 02, 04 |
| NCBI eutils efetch + Bookshelf | 08 |
| Variation Ontology OBO | 12 |

All those hardcoded URL literals are replaced with helper calls (`db_source_url`, `db_genenames_search_url`, `db_hpo_term_url`, `db_oxo_mappings_url`). OMIM download links (which embed an account secret token) stay out of code — read at runtime from gitignored `db/data/omim_links/omim_links.txt`, now documented. Credentials move to a gitignored `db/config/sysndd_db.yml` with a committed `.example` template (no real secrets).

### 2. Working-directory independence
Every script's legacy header (`config::get(Sys.getenv("CONFIG_FILE")) + setwd(paste0(projectsdir, "R"))`) is replaced with a tiny finder + `db_bootstrap()`. The bootstrap resolves `db/` from the script's own location (env var → script path → `here::here()` → cwd), anchors CWD to `db/` (so the many existing `data/`/`results/` relative paths still resolve), exports `SYSNDD_DB_DIR` for child processes, and loads config. `CONFIG_FILE` is no longer required.

### 3. Master orchestration script
`db/run_all.R` runs all steps (01→17, then A/B/C) in order, each in its own fresh R subprocess, with timestamped logging and fail-fast. Flags: `--list`, `--dry-run`, `--only 01,02`, `--from 04` (resume), `--skip-finalize`.

### 4. README + comments
`db/README.md` rewritten: the two distinct script mechanisms (migrations vs. data-prep), per-step table, config setup, working-dir model, master-runner usage, reproducible SysID import, prerequisites, tests, and directory layout. Touched scripts got concise comments.

### 5. Reproducible SysID import (SQLite) — implemented
`db/config/db_sysid_source.R` abstracts the SysID source. Scripts 04–08 now connect via `db_sysid_connect()`, which reads either a **local SQLite snapshot** (recommended, reproducible, network-free) or the legacy SSH-tunnelled remote MySQL, selected by config (`sysid_source`) with auto-detection when a snapshot exists. `db_sysid_export_to_sqlite()` lets a maintainer create the snapshot once from the live source. (The `tbl() %>% collect()` reads are source-agnostic via dbplyr.)

## Tests / verification (host-runnable, no DB/network)
- `db/tests/testthat/test-db-config-helpers.R` — 31 unit tests for path resolution, config loading, source registry/overrides, URL builders, and SysID source/path selection. All pass: `Rscript --no-init-file -e "testthat::test_dir('db/tests/testthat')"`.
- All 20 data-prep scripts + `run_all.R` parse cleanly.
- `make code-quality-audit` — clean (legacy oversized files did not grow; no new >600-line files; the header refactor extracted boilerplate into `db_bootstrap()`).
- New authored files lint clean (`db/.lintr` mirrors `api/.lintr` conventions). Note: pre-existing legacy style nits in the long data-prep scripts are unchanged; my edits net-reduced lint findings in converted files.

## Operator notes
- Copy `db/config/sysndd_db.yml.example` → `db/config/sysndd_db.yml` and fill in credentials.
- Put authorized OMIM links in `db/data/omim_links/omim_links.txt`.
- For reproducible rebuilds, create the SysID SQLite snapshot once (see README).
- The actual pipeline needs a DB + network and was **not** executed here.

## Nothing deferred from the core asks
All five issue tasks are covered (config-ize, master script, comments, README, SQLite SysID import, working-dir independence). Possible low-priority follow-ups (not blocking): config-izing the few remaining stable biomaRt ensembl hosts; an end-to-end smoke run against a throwaway DB.

Closes #33
