### PR TITLE
refactor(api): WP7 API endpoint helper extraction — publication + user (#400)

### DIFF
--- a/api/bootstrap/load_modules.R
+++ b/api/bootstrap/load_modules.R
@@ -82,6 +82,7 @@ bootstrap_load_modules <- function() {
     "functions/mcp-analysis-cache-repository.R",
     "functions/mcp-analysis-repository.R",
     "functions/user-repository.R",
+    "functions/user-endpoint-helpers.R",
     "functions/hash-repository.R",
     "functions/metadata-vocabulary-repository.R",
     "functions/category-normalization.R",

--- a/api/endpoints/publication_endpoints.R
+++ b/api/endpoints/publication_endpoints.R
@@ -211,29 +211,14 @@ function(req,
 
   # Get publication data from database. Push the filter expression to SQL when
   # possible so we don't collect ~4,700 rows just to throw most away in R.
-  # `count` and `count_filtered` already coincide on this endpoint (line ~301),
-  # so unconditional pushdown is safe — no `compact` flag needed. Falls back
-  # to the legacy collect-then-filter path on dbplyr translation errors.
-  publication_lazy <- pool %>% tbl("publication")
-  has_filter <- length(filter_exprs) > 0 && nzchar(filter_exprs[[1]])
-  publication_tbl <- if (has_filter) {
-    tryCatch(
-      publication_lazy %>%
-        filter(!!!rlang::parse_exprs(filter_exprs)) %>%
-        collect(),
-      error = function(e) {
-        message(sprintf(
-          "[publication-list] SQL filter pushdown failed (%s); falling back",
-          conditionMessage(e)
-        ))
-        publication_lazy %>%
-          collect() %>%
-          filter(!!!rlang::parse_exprs(filter_exprs))
-      }
-    )
-  } else {
-    publication_lazy %>% collect()
-  }
+  # `count` and `count_filtered` already coincide on this endpoint, so
+  # unconditional pushdown is safe — no `compact` flag needed. Falls back to
+  # the legacy collect-then-filter path on dbplyr translation errors.
+  publication_tbl <- collect_with_filter_pushdown(
+    pool %>% tbl("publication"),
+    filter_exprs,
+    "publication-list"
+  )
 
   # Handle numeric sorting for publication_id (PMID:12345 format)
   # Extract the sort column and direction
@@ -290,38 +275,18 @@ function(req,
   )
 
   # Build the meta object
-  meta <- publication_pag_info$meta %>%
-    add_column(
-      tibble::as_tibble(list(
-        "sort" = sort,
-        "filter" = filter,
-        "fields" = fields,
-        "fspec" = publication_fspec,
-        "executionTime" = execution_time
-      ))
-    )
+  meta <- build_cursor_meta(
+    publication_pag_info$meta,
+    sort, filter, fields,
+    publication_fspec, execution_time
+  )
 
-  # Add host, port, etc. to the links (if needed). Adjust to your environment:
-  links <- publication_pag_info$links %>%
-    pivot_longer(everything(), names_to = "type", values_to = "link") %>%
-    mutate(
-      link = case_when(
-        link != "null" ~ paste0(
-          dw$api_base_url,
-          "/publication?",
-          "sort=", sort,
-          ifelse(filter != "", paste0("&filter=", filter), ""),
-          ifelse(fields != "", paste0("&fields=", fields), ""),
-          link
-        ),
-        link == "null" ~ "null"
-      )
-    ) %>%
-    pivot_wider(
-      id_cols = everything(),
-      names_from = "type",
-      values_from = "link"
-    )
+  # Build the cursor next/prev links for this resource
+  links <- build_cursor_links(
+    publication_pag_info$links,
+    "/publication",
+    sort, filter, fields
+  )
 
   # Return final list
   publications_list <- list(
@@ -403,32 +368,14 @@ function(req,
   # Collect from DB - gene_symbols is now pre-computed during pubtator_db_update.
   # The gene_symbols column contains comma-separated human gene symbols from HGNC.
   # Push the user filter to SQL when possible (no fspec global/filtered split on
-  # this endpoint, so unconditional pushdown is safe). Fallback to in-R filter
-  # if dbplyr can't translate the expression.
-  pubtator_lazy <- pool %>% tbl("pubtator_search_cache")
-  has_filter <- length(filter_exprs) > 0 && nzchar(filter_exprs[[1]])
-  table_data <- if (has_filter) {
-    tryCatch(
-      pubtator_lazy %>%
-        filter(!!!rlang::parse_exprs(filter_exprs)) %>%
-        collect() %>%
-        arrange(!!!rlang::parse_exprs(sort_exprs)),
-      error = function(e) {
-        message(sprintf(
-          "[pubtator-table] SQL filter pushdown failed (%s); falling back",
-          conditionMessage(e)
-        ))
-        pubtator_lazy %>%
-          collect() %>%
-          arrange(!!!rlang::parse_exprs(sort_exprs)) %>%
-          filter(!!!rlang::parse_exprs(filter_exprs))
-      }
-    )
-  } else {
-    pubtator_lazy %>%
-      collect() %>%
-      arrange(!!!rlang::parse_exprs(sort_exprs))
-  }
+  # this endpoint, so unconditional pushdown is safe), then sort in R. Filtering
+  # before or after the sort yields the same ordered result set.
+  table_data <- collect_with_filter_pushdown(
+    pool %>% tbl("pubtator_search_cache"),
+    filter_exprs,
+    "pubtator-table"
+  ) %>%
+    arrange(!!!rlang::parse_exprs(sort_exprs))
 
   # Select columns
   table_data <- select_tibble_fields(
@@ -449,38 +396,18 @@ function(req,
   execution_time <- paste0(round(end_time - start_time, 2), " secs")
 
   # Build meta
-  meta <- pag_info$meta %>%
-    add_column(
-      tibble::as_tibble(list(
-        sort = sort,
-        filter = filter,
-        fields = fields,
-        fspec = fspec_obj,
-        executionTime = execution_time
-      ))
-    )
+  meta <- build_cursor_meta(
+    pag_info$meta,
+    sort, filter, fields,
+    fspec_obj, execution_time
+  )
 
-  # Build links (here we assume something like dw$api_base_url plus path)
-  links <- pag_info$links %>%
-    pivot_longer(everything(), names_to = "type", values_to = "link") %>%
-    mutate(
-      link = case_when(
-        link != "null" ~ paste0(
-          dw$api_base_url,
-          "/pubtator/table?",
-          "sort=", sort,
-          ifelse(filter != "", paste0("&filter=", filter), ""),
-          ifelse(fields != "", paste0("&fields=", fields), ""),
-          link
-        ),
-        TRUE ~ "null"
-      )
-    ) %>%
-    pivot_wider(
-      id_cols = everything(),
-      names_from = "type",
-      values_from = "link"
-    )
+  # Build the cursor next/prev links for this resource
+  links <- build_cursor_links(
+    pag_info$links,
+    "/pubtator/table",
+    sort, filter, fields
+  )
 
   final_list <- list(
     links = links,
@@ -634,38 +561,18 @@ function(req,
   execution_time <- paste0(round(end_time - start_time, 2), " secs")
 
   # 13) Build meta
-  meta <- pag_info$meta %>%
-    add_column(
-      tibble::as_tibble(list(
-        sort = sort,
-        filter = filter,
-        fields = fields,
-        fspec = tbl_fspec,
-        executionTime = execution_time
-      ))
-    )
+  meta <- build_cursor_meta(
+    pag_info$meta,
+    sort, filter, fields,
+    tbl_fspec, execution_time
+  )
 
-  # 13) Build links for next/prev
-  links <- pag_info$links %>%
-    tidyr::pivot_longer(everything(), names_to = "type", values_to = "link") %>%
-    dplyr::mutate(
-      link = dplyr::case_when(
-        link != "null" ~ paste0(
-          dw$api_base_url,
-          "/pubtator/genes?",
-          "sort=", sort,
-          ifelse(filter != "", paste0("&filter=", filter), ""),
-          ifelse(fields != "", paste0("&fields=", fields), ""),
-          link
-        ),
-        TRUE ~ "null"
-      )
-    ) %>%
-    tidyr::pivot_wider(
-      id_cols = dplyr::everything(),
-      names_from = "type",
-      values_from = "link"
-    )
+  # 14) Build the cursor next/prev links for this resource
+  links <- build_cursor_links(
+    pag_info$links,
+    "/pubtator/genes",
+    sort, filter, fields
+  )
 
   final_list <- list(
     links = links,

--- a/api/endpoints/user_endpoints.R
+++ b/api/endpoints/user_endpoints.R
@@ -472,13 +472,7 @@ function(req, res) {
   user_id_pass_change_approved <- as.logical(user_table$approved[1])
   # Use verify_password to support both plaintext and hashed passwords
   old_pass_match <- verify_password(user_table$password[1], old_pass)
-  new_pass_match_and_valid <- (new_pass_1 == new_pass_2) &&
-    (new_pass_1 != old_pass) &&
-    nchar(new_pass_1) > 7 &&
-    grepl("[a-z]", new_pass_1) &&
-    grepl("[A-Z]", new_pass_1) &&
-    grepl("\\d", new_pass_1) &&
-    grepl("[!@#$%^&*]", new_pass_1)
+  new_pass_match_and_valid <- new_password_valid(new_pass_1, new_pass_2, old_pass)
 
   if (length(user) == 0) {
     res$status <- 401
@@ -764,12 +758,7 @@ function(req, res) {
       (user_jwt$hash == user_table$hash[[1]]) &&
       iat_tolerance
 
-    new_pass_match_and_valid <- (new_pass_1 == new_pass_2) &&
-      nchar(new_pass_1) > 7 &&
-      grepl("[a-z]", new_pass_1) &&
-      grepl("[A-Z]", new_pass_1) &&
-      grepl("\\d", new_pass_1) &&
-      grepl("[!@#$%^&*]", new_pass_1)
+    new_pass_match_and_valid <- new_password_valid(new_pass_1, new_pass_2)
 
     if (jwt_claims_valid && new_pass_match_and_valid) {
       # Hash new password with Argon2id before storing

--- a/api/functions/publication-endpoint-helpers.R
+++ b/api/functions/publication-endpoint-helpers.R
@@ -143,3 +143,93 @@ pubtator_enrichment_status_response <- function(query_fn = db_execute_query) {
     refreshed_at = as.character(rows$created_at[[1]])
   )
 }
+
+#' Collect a lazy table, pushing a user filter down to SQL when possible
+#'
+#' Shared list-endpoint pattern: when a non-empty filter expression is present,
+#' push it to SQL and collect; on a dbplyr translation error fall back to
+#' collect-then-filter in R (emitting one diagnostic). Sorting is intentionally
+#' left to the caller so endpoints can apply custom (e.g. numeric) ordering
+#' after collection.
+#'
+#' @param lazy_tbl A dbplyr lazy table (e.g. `pool %>% dplyr::tbl("publication")`).
+#' @param filter_exprs Character vector from `generate_filter_expressions()`.
+#' @param source_label Short label used in the fallback diagnostic message.
+#' @return A collected tibble (unsorted).
+#' @export
+collect_with_filter_pushdown <- function(lazy_tbl, filter_exprs, source_label) {
+  has_filter <- length(filter_exprs) > 0 && nzchar(filter_exprs[[1]])
+  if (!has_filter) {
+    return(dplyr::collect(lazy_tbl))
+  }
+  tryCatch(
+    lazy_tbl %>%
+      dplyr::filter(!!!rlang::parse_exprs(filter_exprs)) %>%
+      dplyr::collect(),
+    error = function(e) {
+      message(sprintf(
+        "[%s] SQL filter pushdown failed (%s); falling back",
+        source_label, conditionMessage(e)
+      ))
+      dplyr::collect(lazy_tbl) %>%
+        dplyr::filter(!!!rlang::parse_exprs(filter_exprs))
+    }
+  )
+}
+
+#' Build the standard cursor-pagination meta tibble for list endpoints
+#'
+#' @param pag_meta The `meta` tibble from `generate_cursor_pag_inf()`.
+#' @param sort,filter,fields Raw query parameters echoed back to the client.
+#' @param fspec_obj Field-spec object from `generate_tibble_fspec_mem()`.
+#' @param execution_time Human-readable execution-time string.
+#' @return `pag_meta` with the standard echo columns appended.
+#' @export
+build_cursor_meta <- function(pag_meta, sort, filter, fields, fspec_obj,
+                              execution_time) {
+  pag_meta %>%
+    tibble::add_column(
+      tibble::as_tibble(list(
+        sort = sort,
+        filter = filter,
+        fields = fields,
+        fspec = fspec_obj,
+        executionTime = execution_time
+      ))
+    )
+}
+
+#' Build cursor-pagination next/prev links for a list endpoint
+#'
+#' @param pag_links The `links` tibble from `generate_cursor_pag_inf()`.
+#' @param resource_path API resource path without query string
+#'   (e.g. "/publication", "/pubtator/genes").
+#' @param sort,filter,fields Raw query parameters carried into the links.
+#' @param api_base_url Base URL prefix; defaults to the global `dw$api_base_url`.
+#' @return A one-row tibble of named links.
+#' @export
+build_cursor_links <- function(pag_links, resource_path, sort, filter, fields,
+                               api_base_url = dw$api_base_url) {
+  pag_links %>%
+    tidyr::pivot_longer(
+      dplyr::everything(),
+      names_to = "type", values_to = "link"
+    ) %>%
+    dplyr::mutate(
+      link = dplyr::case_when(
+        link != "null" ~ paste0(
+          api_base_url,
+          resource_path, "?",
+          "sort=", sort,
+          ifelse(filter != "", paste0("&filter=", filter), ""),
+          ifelse(fields != "", paste0("&fields=", fields), ""),
+          link
+        ),
+        TRUE ~ "null"
+      )
+    ) %>%
+    tidyr::pivot_wider(
+      id_cols = dplyr::everything(),
+      names_from = "type", values_from = "link"
+    )
+}

--- a/api/functions/user-endpoint-helpers.R
+++ b/api/functions/user-endpoint-helpers.R
@@ -1,0 +1,36 @@
+# api/functions/user-endpoint-helpers.R
+
+#' Shared password complexity rule for the change and reset flows
+#'
+#' A candidate password must be longer than 7 characters and contain at least
+#' one lowercase letter, one uppercase letter, one digit, and one of the
+#' permitted special characters (`!@#$%^&*`).
+#'
+#' @param password Candidate password string.
+#' @return `TRUE` when the password satisfies every rule, otherwise `FALSE`.
+#' @export
+password_meets_complexity <- function(password) {
+  nchar(password) > 7 &&
+    grepl("[a-z]", password) &&
+    grepl("[A-Z]", password) &&
+    grepl("\\d", password) &&
+    grepl("[!@#$%^&*]", password)
+}
+
+#' Validate a new-password pair for the change/reset flows
+#'
+#' Confirms the new password and its confirmation match, optionally differ from
+#' the current password (password-change flow only), and satisfy the shared
+#' complexity rule. The reset flow has no current password and omits `old_pass`.
+#'
+#' @param new_pass_1 The proposed new password.
+#' @param new_pass_2 The confirmation of the new password.
+#' @param old_pass Optional current password. When supplied, the new password
+#'   must differ from it; the reset flow passes `NULL`.
+#' @return `TRUE` when the pair is valid, otherwise `FALSE`.
+#' @export
+new_password_valid <- function(new_pass_1, new_pass_2, old_pass = NULL) {
+  (new_pass_1 == new_pass_2) &&
+    (is.null(old_pass) || new_pass_1 != old_pass) &&
+    password_meets_complexity(new_pass_1)
+}

--- a/api/tests/testthat/test-unit-publication-endpoint-helpers.R
+++ b/api/tests/testthat/test-unit-publication-endpoint-helpers.R
@@ -75,3 +75,73 @@ test_that("publication_stats_response ignores invalid optional date filter", {
   expect_null(result$filtered_count)
   expect_null(result$filter_date)
 })
+
+test_that("collect_with_filter_pushdown returns all rows when no filter", {
+  df <- tibble::tibble(id = 1:3, val = c("a", "b", "c"))
+
+  expect_equal(nrow(collect_with_filter_pushdown(df, character(0), "t")), 3L)
+  expect_equal(nrow(collect_with_filter_pushdown(df, "", "t")), 3L)
+})
+
+test_that("collect_with_filter_pushdown applies a valid filter", {
+  df <- tibble::tibble(id = 1:3, val = c("a", "b", "c"))
+
+  out <- collect_with_filter_pushdown(df, "id == 2", "t")
+
+  expect_equal(out$val, "b")
+})
+
+test_that("build_cursor_meta appends the standard echo columns", {
+  meta <- tibble::tibble(perpage = 10L, currentItemCount = 3L)
+
+  out <- build_cursor_meta(
+    meta, "publication_id", "Title=='x'", "a,b", "FSPEC", "0.12 secs"
+  )
+
+  expect_equal(out$sort, "publication_id")
+  expect_equal(out$filter, "Title=='x'")
+  expect_equal(out$fields, "a,b")
+  expect_equal(out$fspec, "FSPEC")
+  expect_equal(out$executionTime, "0.12 secs")
+  expect_equal(out$perpage, 10L)
+})
+
+test_that("build_cursor_links builds absolute URLs and preserves null", {
+  links <- tibble::tibble(
+    prev = "null",
+    `next` = "&page_after=20&page_size=10",
+    self = "&page_after=0&page_size=10"
+  )
+
+  out <- build_cursor_links(
+    links, "/publication", "publication_id", "", "",
+    api_base_url = "https://api.test"
+  )
+
+  expect_equal(out$prev, "null")
+  expect_equal(
+    out$`next`,
+    "https://api.test/publication?sort=publication_id&page_after=20&page_size=10"
+  )
+  expect_equal(
+    out$self,
+    "https://api.test/publication?sort=publication_id&page_after=0&page_size=10"
+  )
+})
+
+test_that("build_cursor_links carries filter and fields when present", {
+  links <- tibble::tibble(
+    prev = "null",
+    `next` = "&page_after=0"
+  )
+
+  out <- build_cursor_links(
+    links, "/pubtator/genes", "-is_novel",
+    "gene_symbol=='BRCA1'", "gene_symbol,pmids",
+    api_base_url = "https://api.test"
+  )
+
+  expect_match(out$`next`, "&filter=gene_symbol=='BRCA1'", fixed = TRUE)
+  expect_match(out$`next`, "&fields=gene_symbol,pmids", fixed = TRUE)
+  expect_equal(out$prev, "null")
+})

--- a/api/tests/testthat/test-unit-user-endpoint-helpers.R
+++ b/api/tests/testthat/test-unit-user-endpoint-helpers.R
@@ -1,0 +1,30 @@
+source_api_file("functions/user-endpoint-helpers.R", local = FALSE)
+
+test_that("password_meets_complexity enforces length and character classes", {
+  expect_true(password_meets_complexity("Abcdef1!"))   # 8 chars, all classes
+  expect_false(password_meets_complexity("Abc1!"))      # too short
+  expect_false(password_meets_complexity("abcdef1!"))   # no uppercase
+  expect_false(password_meets_complexity("ABCDEF1!"))   # no lowercase
+  expect_false(password_meets_complexity("Abcdefg!"))   # no digit
+  expect_false(password_meets_complexity("Abcdefg1"))   # no special character
+})
+
+test_that("new_password_valid requires the confirmation to match", {
+  expect_true(new_password_valid("Abcdef1!", "Abcdef1!"))
+  expect_false(new_password_valid("Abcdef1!", "Different1!"))
+})
+
+test_that("new_password_valid (change flow) rejects reuse of the old password", {
+  expect_false(
+    new_password_valid("Abcdef1!", "Abcdef1!", old_pass = "Abcdef1!")
+  )
+  expect_true(
+    new_password_valid("Abcdef1!", "Abcdef1!", old_pass = "OldPass1!")
+  )
+})
+
+test_that("new_password_valid (reset flow) ignores the old password", {
+  # old_pass = NULL means the reuse check is skipped (no current password)
+  expect_true(new_password_valid("Abcdef1!", "Abcdef1!"))
+  expect_false(new_password_valid("weak", "weak"))
+})

--- a/scripts/code-quality-file-size-baseline.tsv
+++ b/scripts/code-quality-file-size-baseline.tsv
@@ -3,7 +3,7 @@ api/endpoints/backup_endpoints.R	630
 api/endpoints/entity_endpoints.R	848
 api/endpoints/jobs_endpoints.R	1011
 api/endpoints/llm_admin_endpoints.R	733
-api/endpoints/publication_endpoints.R	1234
+api/endpoints/publication_endpoints.R	1141
 api/endpoints/re_review_endpoints.R	856
 api/endpoints/statistics_endpoints.R	782
 api/endpoints/user_endpoints.R	1128

--- a/scripts/code-quality-file-size-baseline.tsv
+++ b/scripts/code-quality-file-size-baseline.tsv
@@ -6,7 +6,7 @@ api/endpoints/llm_admin_endpoints.R	733
 api/endpoints/publication_endpoints.R	1141
 api/endpoints/re_review_endpoints.R	856
 api/endpoints/statistics_endpoints.R	782
-api/endpoints/user_endpoints.R	1128
+api/endpoints/user_endpoints.R	1117
 api/functions/async-job-handlers.R	912
 api/functions/async-job-repository.R	638
 api/functions/comparisons-functions.R	967


### PR DESCRIPTION
## WP7 (#400) — behavior-preserving endpoint helper extraction

Continues the #346 oversized-file refactor program. Established pattern only: extract cohesive helpers into `api/functions/*-endpoint-helpers.R` (registered in `load_modules.R`) with paired `test-unit-*` coverage. **No endpoint files were split**; `mount_endpoint()` wiring untouched.

### `publication_endpoints.R` (1234 → 1141, −93)
The `/`, `/pubtator/table`, and `/pubtator/genes` list handlers carried three near-identical inline blocks. Extracted to `publication-endpoint-helpers.R`:
- `collect_with_filter_pushdown(lazy_tbl, filter_exprs, source_label)` — SQL filter pushdown with the collect-then-filter fallback (sorting left to the caller; filter/sort order yields the same result set).
- `build_cursor_meta(...)` — the standard echo-column meta tibble.
- `build_cursor_links(pag_links, resource_path, sort, filter, fields)` — the next/prev absolute-URL builder.

### `user_endpoints.R` (1128 → 1117, −11)
DRY the new-password validation duplicated across `password/update` and `password/reset/change` into `user-endpoint-helpers.R`:
- `password_meets_complexity(password)` — length + character-class rule.
- `new_password_valid(new_pass_1, new_pass_2, old_pass = NULL)` — match + optional "differs from old" (change flow) + complexity. Reset flow omits `old_pass`.

### Verification
- `Rscript testthat::test_file` on both new helper specs: **PASS 25** (publication) + **PASS 12** (user), FAIL 0.
- `lintr::lint` on all four changed `.R` files: **0 lints**.
- `bash scripts/code-quality-audit.sh`: **OK** (baseline ratcheted down for both files).

Advances #400. Part of #346. Pending orchestrator integration verification.