### PR TITLE
refactor(app): WP5 curation views — safe extractions, deep decomposition deferred (#398)

### DIFF
--- a/app/src/composables/useEntityCreateOptions.spec.ts
+++ b/app/src/composables/useEntityCreateOptions.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { flattenTreeOptions, transformModifierTree } from './useEntityCreateOptions';
+
+describe('flattenTreeOptions', () => {
+  it('flattens nested children into a single value/text list (depth-first)', () => {
+    const result = flattenTreeOptions([
+      { id: 1, label: 'A', children: [{ id: 2, label: 'B' }] },
+      { id: 3, label: 'C' },
+    ] as never);
+
+    expect(result).toEqual([
+      { value: 1, text: 'A' },
+      { value: 2, text: 'B' },
+      { value: 3, text: 'C' },
+    ]);
+  });
+
+  it('returns an empty list for empty input', () => {
+    expect(flattenTreeOptions([])).toEqual([]);
+  });
+});
+
+describe('transformModifierTree', () => {
+  it('lifts "present:" to the parent and makes every modifier a selectable child', () => {
+    const result = transformModifierTree([
+      {
+        id: '12-HP:0001250',
+        label: 'present: Seizure',
+        children: [{ id: '12-HP:0001250-unc', label: 'uncertain: Seizure' }],
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        id: 'parent-HP:0001250',
+        label: 'Seizure',
+        children: [
+          { id: '12-HP:0001250', label: 'present: Seizure' },
+          { id: '12-HP:0001250-unc', label: 'uncertain: Seizure' },
+        ],
+      },
+    ]);
+  });
+
+  it('handles nodes without children', () => {
+    const result = transformModifierTree([{ id: '1-VO:0001', label: 'present: Missense' }]);
+    expect(result[0].id).toBe('parent-VO:0001');
+    expect(result[0].label).toBe('Missense');
+    expect(result[0].children).toEqual([{ id: '1-VO:0001', label: 'present: Missense' }]);
+  });
+});

--- a/app/src/composables/useEntityCreateOptions.ts
+++ b/app/src/composables/useEntityCreateOptions.ts
@@ -1,0 +1,132 @@
+import { ref } from 'vue';
+import { useToast, type TreeNode } from '@/composables';
+import { type SelectOption } from '@/composables/useEntityForm';
+import {
+  listInheritanceTree,
+  listPhenotypesTree,
+  listVariationOntologyTree,
+  listStatusCategoriesTree,
+  type TreeNode as ApiTreeNode,
+} from '@/api/list';
+
+/**
+ * Flatten tree options for simple selects (inheritance, status). The typed-list
+ * helpers return `ApiTreeNode[]` whose nested `children` entries are typed as
+ * `{ id; label }` (a structural subset of the top-level node), so the recursive
+ * call accepts them directly without an `as unknown` cast.
+ */
+export function flattenTreeOptions(
+  options: ReadonlyArray<ApiTreeNode | { id: string | number; label: string }>,
+  result: SelectOption[] = []
+): SelectOption[] {
+  options.forEach((opt) => {
+    result.push({
+      value: opt.id,
+      text: opt.label,
+    });
+    const children = (opt as ApiTreeNode).children;
+    if (children && Array.isArray(children)) {
+      flattenTreeOptions(children, result);
+    }
+  });
+  return result;
+}
+
+/**
+ * Transform phenotype/variation tree to make all modifiers selectable children.
+ * Copied from ModifyEntity.vue - API returns "present: X" as parent with
+ * [uncertain, variable, rare, absent] as children. We want "X" as parent
+ * with [present, uncertain, variable, rare, absent] as children.
+ *
+ * Output format matches TreeMultiSelect's expected { id, label, children } structure.
+ */
+export function transformModifierTree(
+  nodes: { id: string; label: string; children?: { id: string; label: string }[] }[]
+): TreeNode[] {
+  return nodes.map((node) => {
+    const phenotypeName = node.label.replace(/^present:\s*/, '');
+    const ontologyCode = node.id.replace(/^\d+-/, '');
+    return {
+      id: `parent-${ontologyCode}`,
+      label: phenotypeName,
+      children: [
+        { id: node.id, label: `present: ${phenotypeName}` },
+        ...(node.children || []).map((child) => {
+          const modifier = child.label.replace(/:\s*.*$/, '');
+          return { id: child.id, label: `${modifier}: ${phenotypeName}` };
+        }),
+      ],
+    };
+  });
+}
+
+/**
+ * Load and shape the inheritance / phenotype / variation / status option trees
+ * for the entity create wizard. Extracted verbatim from CreateEntity.vue
+ * (#346 WP5) so the view stays a thin shell. Returns the option refs plus a
+ * `loadAllOptions()` that the view calls from `onMounted`.
+ */
+export default function useEntityCreateOptions() {
+  const { makeToast } = useToast();
+
+  const inheritanceOptions = ref<SelectOption[]>([]);
+  const phenotypeOptions = ref<TreeNode[]>([]);
+  const variationOptions = ref<TreeNode[]>([]);
+  const statusOptions = ref<SelectOption[]>([]);
+
+  // API helper for loading flat options (inheritance, status). Maps the legacy
+  // `endpoint` string to the corresponding typed-tree client; `flattenTreeOptions`
+  // then collapses the tree into a flat <SelectOption> list.
+  const loadFlatOptions = async (
+    endpoint: 'inheritance' | 'status',
+    targetRef: typeof inheritanceOptions
+  ) => {
+    try {
+      const fetcher = endpoint === 'inheritance' ? listInheritanceTree : listStatusCategoriesTree;
+      const data = await fetcher();
+      targetRef.value = flattenTreeOptions(data);
+    } catch (e) {
+      makeToast(e as Error, 'Error', 'danger');
+    }
+  };
+
+  // API helper for loading tree options (phenotypes, variations). Maps the
+  // legacy `endpoint` string to the matching typed-tree client.
+  const loadTreeOptions = async (
+    endpoint: 'phenotype' | 'variation_ontology',
+    targetRef: typeof phenotypeOptions
+  ) => {
+    try {
+      const fetcher = endpoint === 'phenotype' ? listPhenotypesTree : listVariationOntologyTree;
+      const data = await fetcher();
+      const rawData = (
+        Array.isArray(data) ? data : ((data as { data?: unknown[] })?.data ?? [])
+      ) as {
+        id: string;
+        label: string;
+        children?: { id: string; label: string }[];
+      }[];
+      targetRef.value = transformModifierTree(rawData);
+    } catch (e) {
+      makeToast(e as Error, 'Error', 'danger');
+      targetRef.value = [];
+    }
+  };
+
+  const loadAllOptions = async () => {
+    await Promise.all([
+      loadFlatOptions('inheritance', inheritanceOptions),
+      loadTreeOptions('phenotype', phenotypeOptions),
+      loadTreeOptions('variation_ontology', variationOptions),
+      loadFlatOptions('status', statusOptions),
+    ]);
+  };
+
+  return {
+    inheritanceOptions,
+    phenotypeOptions,
+    variationOptions,
+    statusOptions,
+    loadAllOptions,
+  };
+}

--- a/app/src/views/curate/CreateEntity.vue
+++ b/app/src/views/curate/CreateEntity.vue
@@ -99,18 +99,12 @@ import { defineComponent, ref, provide, onMounted, watch } from 'vue';
 import { BOverlay, BAlert, BButton } from 'bootstrap-vue-next';
 
 // Composables
-import { useToast, type TreeNode } from '@/composables';
-import useEntityForm, { type SelectOption, type EntityFormData } from '@/composables/useEntityForm';
+import { useToast } from '@/composables';
+import useEntityForm, { type EntityFormData } from '@/composables/useEntityForm';
 import useFormDraft from '@/composables/useFormDraft';
+import useEntityCreateOptions from '@/composables/useEntityCreateOptions';
 
 // Typed API clients
-import {
-  listInheritanceTree,
-  listPhenotypesTree,
-  listVariationOntologyTree,
-  listStatusCategoriesTree,
-  type TreeNode as ApiTreeNode,
-} from '@/api/list';
 import {
   searchGene,
   searchOntology,
@@ -198,11 +192,15 @@ export default defineComponent({
     const showDraftRecovery = ref(false);
     const draftLastSaved = ref<string | null>(null);
 
-    // Options loaded from API
-    const inheritanceOptions = ref<SelectOption[]>([]);
-    const phenotypeOptions = ref<TreeNode[]>([]);
-    const variationOptions = ref<TreeNode[]>([]);
-    const statusOptions = ref<SelectOption[]>([]);
+    // Entity option trees (inheritance / phenotype / variation / status),
+    // loaded from the typed list API in a dedicated composable.
+    const {
+      inheritanceOptions,
+      phenotypeOptions,
+      variationOptions,
+      statusOptions,
+      loadAllOptions,
+    } = useEntityCreateOptions();
 
     // Provide form state to child components
     provide('formData', formData);
@@ -221,104 +219,9 @@ export default defineComponent({
       { deep: true }
     );
 
-    // API helper for loading flat options (inheritance, status). Maps the
-    // legacy `endpoint` string (`"inheritance"` | `"status"`) to the
-    // corresponding typed-tree client; `flattenTreeOptions` then collapses
-    // the tree into a flat <SelectOption> list.
-    const loadFlatOptions = async (
-      endpoint: 'inheritance' | 'status',
-      targetRef: typeof inheritanceOptions
-    ) => {
-      try {
-        const fetcher = endpoint === 'inheritance' ? listInheritanceTree : listStatusCategoriesTree;
-        const data = await fetcher();
-        targetRef.value = flattenTreeOptions(data);
-      } catch (e) {
-        makeToast(e as Error, 'Error', 'danger');
-      }
-    };
-
-    // Flatten tree options for simple selects (inheritance, status). The
-    // typed-list helpers return `ApiTreeNode[]` whose nested `children`
-    // entries are typed as `{ id; label }` (a structural subset of the
-    // top-level node), so the recursive call accepts them directly without
-    // an `as unknown` cast.
-    const flattenTreeOptions = (
-      options: ReadonlyArray<ApiTreeNode | { id: string | number; label: string }>,
-      result: SelectOption[] = []
-    ): SelectOption[] => {
-      options.forEach((opt) => {
-        result.push({
-          value: opt.id,
-          text: opt.label,
-        });
-        const children = (opt as ApiTreeNode).children;
-        if (children && Array.isArray(children)) {
-          flattenTreeOptions(children, result);
-        }
-      });
-      return result;
-    };
-
-    /**
-     * Transform phenotype/variation tree to make all modifiers selectable children.
-     * Copied from ModifyEntity.vue - API returns "present: X" as parent with
-     * [uncertain, variable, rare, absent] as children. We want "X" as parent
-     * with [present, uncertain, variable, rare, absent] as children.
-     *
-     * Output format matches TreeMultiSelect's expected { id, label, children } structure.
-     */
-    const transformModifierTree = (
-      nodes: { id: string; label: string; children?: { id: string; label: string }[] }[]
-    ): TreeNode[] => {
-      return nodes.map((node) => {
-        const phenotypeName = node.label.replace(/^present:\s*/, '');
-        const ontologyCode = node.id.replace(/^\d+-/, '');
-        return {
-          id: `parent-${ontologyCode}`,
-          label: phenotypeName,
-          children: [
-            { id: node.id, label: `present: ${phenotypeName}` },
-            ...(node.children || []).map((child) => {
-              const modifier = child.label.replace(/:\s*.*$/, '');
-              return { id: child.id, label: `${modifier}: ${phenotypeName}` };
-            }),
-          ],
-        };
-      });
-    };
-
-    // API helper for loading tree options (phenotypes, variations). Maps
-    // the legacy `endpoint` string to the matching typed-tree client.
-    const loadTreeOptions = async (
-      endpoint: 'phenotype' | 'variation_ontology',
-      targetRef: typeof phenotypeOptions
-    ) => {
-      try {
-        const fetcher = endpoint === 'phenotype' ? listPhenotypesTree : listVariationOntologyTree;
-        const data = await fetcher();
-        const rawData = (
-          Array.isArray(data) ? data : ((data as { data?: unknown[] })?.data ?? [])
-        ) as {
-          id: string;
-          label: string;
-          children?: { id: string; label: string }[];
-        }[];
-        targetRef.value = transformModifierTree(rawData);
-      } catch (e) {
-        makeToast(e as Error, 'Error', 'danger');
-        targetRef.value = [];
-      }
-    };
-
     // Load all options on mount
     onMounted(async () => {
-      await Promise.all([
-        loadFlatOptions('inheritance', inheritanceOptions),
-        loadTreeOptions('phenotype', phenotypeOptions),
-        loadTreeOptions('variation_ontology', variationOptions),
-        loadFlatOptions('status', statusOptions),
-      ]);
+      await loadAllOptions();
 
       // Check for existing draft
       if (checkForDraft()) {

--- a/app/src/views/curate/ManageReReview.vue
+++ b/app/src/views/curate/ManageReReview.vue
@@ -529,6 +529,11 @@ import ManualEntityAssignmentPanel from '@/views/curate/components/ManualEntityA
 import RefusedReReviewPanel from '@/views/curate/components/RefusedReReviewPanel.vue';
 import { filterReReviewBatches, sortReReviewBatches } from '@/views/curate/utils/reReviewFilters';
 import {
+  reReviewTableFields,
+  reReviewEntitySelectFields,
+  reReviewLegendItems,
+} from '@/views/curate/reReviewTableConfig';
+import {
   assignReReviewBatch,
   assignReReviewEntities,
   getAssignmentTable,
@@ -573,64 +578,7 @@ export default {
       user_id_assignment: 0,
       items_ReReviewTable: [],
       sortBy: [{ key: 'user_name', order: 'asc' }],
-      fields_ReReviewTable: [
-        {
-          key: 'user_name',
-          label: 'User',
-          sortable: true,
-          sortDirection: 'desc',
-          class: 'text-start',
-          thStyle: { width: '140px' },
-        },
-        {
-          key: 're_review_batch',
-          label: 'Batch',
-          sortable: true,
-          class: 'text-center',
-          thStyle: { width: '80px' },
-        },
-        {
-          key: 're_review_review_saved',
-          label: 'Saved',
-          sortable: true,
-          class: 'text-center',
-          thStyle: { width: '70px' },
-        },
-        {
-          key: 're_review_status_saved',
-          label: 'Status',
-          sortable: true,
-          class: 'text-center',
-          thStyle: { width: '70px' },
-        },
-        {
-          key: 're_review_submitted',
-          label: 'Submitted',
-          sortable: true,
-          class: 'text-center',
-          thStyle: { width: '85px' },
-        },
-        {
-          key: 're_review_approved',
-          label: 'Approved',
-          sortable: true,
-          class: 'text-center',
-          thStyle: { width: '85px' },
-        },
-        {
-          key: 'entity_count',
-          label: 'Total',
-          sortable: true,
-          class: 'text-center',
-          thStyle: { width: '70px' },
-        },
-        {
-          key: 'actions',
-          label: 'Actions',
-          class: 'text-center',
-          thStyle: { width: '100px' },
-        },
-      ],
+      fields_ReReviewTable: reReviewTableFields,
       currentPage: 1,
       perPage: 25,
       totalRows: 0,
@@ -652,14 +600,7 @@ export default {
       previewBoundaryGene: null,
       previewGeneCount: 0,
       previewEntityCount: 0,
-      entitySelectFields: [
-        { key: 'selected', label: '', thStyle: { width: '44px' } },
-        { key: 'entity_id', label: 'ID', sortable: true },
-        { key: 'gene_symbol', label: 'Gene', sortable: true },
-        { key: 'disease_ontology_name', label: 'Disease', sortable: true },
-        { key: 'review_date', label: 'Last Review', sortable: true },
-        { key: 'status_name', label: 'Status', sortable: true },
-      ],
+      entitySelectFields: reReviewEntitySelectFields,
 
       // Reassignment
       reassignModalShow: false,
@@ -681,13 +622,7 @@ export default {
       status_options: [],
 
       // Icon legend items for ManageReReview
-      legendItems: [
-        { icon: 'bi bi-person-fill', color: '#0d6efd', label: 'Assigned user' },
-        { icon: 'bi bi-person', color: '#6c757d', label: 'Unassigned batch' },
-        { icon: 'bi bi-calculator', color: '#6c757d', label: 'Recalculate batch' },
-        { icon: 'bi bi-person-lines-fill', color: '#b45309', label: 'Reassign batch' },
-        { icon: 'bi bi-person-dash-fill', color: '#dc3545', label: 'Unassign batch' },
-      ],
+      legendItems: reReviewLegendItems,
     };
   },
   computed: {

--- a/app/src/views/curate/reReviewTableConfig.ts
+++ b/app/src/views/curate/reReviewTableConfig.ts
@@ -1,0 +1,98 @@
+// Static table/display configuration for ManageReReview.vue.
+// Extracted verbatim (#346 WP5) to keep the view thinner. These are read-only
+// display constants (never mutated at runtime), so the view references them
+// directly as the initial value of the corresponding data() fields.
+
+export interface ReReviewTableField {
+  key: string;
+  label: string;
+  sortable?: boolean;
+  sortDirection?: string;
+  class?: string;
+  thStyle?: Record<string, string>;
+}
+
+export interface ReReviewLegendItem {
+  icon: string;
+  color: string;
+  label: string;
+}
+
+/** Column definitions for the main re-review management table. */
+export const reReviewTableFields: ReReviewTableField[] = [
+  {
+    key: 'user_name',
+    label: 'User',
+    sortable: true,
+    sortDirection: 'desc',
+    class: 'text-start',
+    thStyle: { width: '140px' },
+  },
+  {
+    key: 're_review_batch',
+    label: 'Batch',
+    sortable: true,
+    class: 'text-center',
+    thStyle: { width: '80px' },
+  },
+  {
+    key: 're_review_review_saved',
+    label: 'Saved',
+    sortable: true,
+    class: 'text-center',
+    thStyle: { width: '70px' },
+  },
+  {
+    key: 're_review_status_saved',
+    label: 'Status',
+    sortable: true,
+    class: 'text-center',
+    thStyle: { width: '70px' },
+  },
+  {
+    key: 're_review_submitted',
+    label: 'Submitted',
+    sortable: true,
+    class: 'text-center',
+    thStyle: { width: '85px' },
+  },
+  {
+    key: 're_review_approved',
+    label: 'Approved',
+    sortable: true,
+    class: 'text-center',
+    thStyle: { width: '85px' },
+  },
+  {
+    key: 'entity_count',
+    label: 'Total',
+    sortable: true,
+    class: 'text-center',
+    thStyle: { width: '70px' },
+  },
+  {
+    key: 'actions',
+    label: 'Actions',
+    class: 'text-center',
+    thStyle: { width: '100px' },
+  },
+];
+
+/** Column definitions for the gene-specific entity selection table. */
+export const reReviewEntitySelectFields: ReReviewTableField[] = [
+  { key: 'selected', label: '', thStyle: { width: '44px' } },
+  { key: 'entity_id', label: 'ID', sortable: true },
+  { key: 'gene_symbol', label: 'Gene', sortable: true },
+  { key: 'disease_ontology_name', label: 'Disease', sortable: true },
+  { key: 'review_date', label: 'Last Review', sortable: true },
+  { key: 'status_name', label: 'Status', sortable: true },
+];
+
+/** Icon legend shown alongside the re-review management table. */
+export const reReviewLegendItems: ReReviewLegendItem[] = [
+  { icon: 'bi bi-person-fill', color: '#0d6efd', label: 'Assigned user' },
+  { icon: 'bi bi-person', color: '#6c757d', label: 'Unassigned batch' },
+  { icon: 'bi bi-calculator', color: '#6c757d', label: 'Recalculate batch' },
+  { icon: 'bi bi-person-lines-fill', color: '#b45309', label: 'Reassign batch' },
+  { icon: 'bi bi-person-dash-fill', color: '#dc3545', label: 'Unassign batch' },
+];

--- a/scripts/code-quality-file-size-baseline.tsv
+++ b/scripts/code-quality-file-size-baseline.tsv
@@ -55,7 +55,7 @@ app/src/views/admin/ManageUser.vue	675
 app/src/views/curate/ApproveReview.vue	841
 app/src/views/curate/ApproveUser.vue	842
 app/src/views/curate/CreateEntity.vue	540
-app/src/views/curate/ManageReReview.vue	1579
+app/src/views/curate/ManageReReview.vue	1514
 app/src/views/pages/EntityView.vue	811
 db/11_Rcommands_sysndd_db_table_database_comparisons.R	636
 db/C_Rcommands_set-table-connections.R	791

--- a/scripts/code-quality-file-size-baseline.tsv
+++ b/scripts/code-quality-file-size-baseline.tsv
@@ -54,7 +54,7 @@ app/src/views/admin/ManagePubtator.vue	638
 app/src/views/admin/ManageUser.vue	675
 app/src/views/curate/ApproveReview.vue	841
 app/src/views/curate/ApproveUser.vue	842
-app/src/views/curate/CreateEntity.vue	637
+app/src/views/curate/CreateEntity.vue	540
 app/src/views/curate/ManageReReview.vue	1579
 app/src/views/pages/EntityView.vue	811
 db/11_Rcommands_sysndd_db_table_database_comparisons.R	636


### PR DESCRIPTION
## WP5 (#398) — curation views (highest-risk, deliberately last)

Curation views (`ManageReReview`, `ApproveReview`, `ApproveUser`, `EntityView`, `BatchCriteriaForm`, `CreateEntity`) are active, recently-touched (#36/#37/#54), and `ManageReReview.vue` is the largest file in the repo (1579 lines, Options-API). A full Options→composition thin-shell rewrite of these is genuinely risky and deserves its own dedicated, well-tested effort — so this pass makes only **clearly-safe, behavior-preserving** extractions and **honestly defers** the deep decomposition.

### Done (verified, behavior-preserving)
- **`CreateEntity.vue` 637 → 540 (under the ceiling).** Extracted the inheritance/phenotype/variation/status option-tree loaders (pure `flattenTreeOptions`/`transformModifierTree` + typed-list API loaders) into `composables/useEntityCreateOptions.ts`, with unit tests for the pure transforms.
- **`ManageReReview.vue` 1579 → 1514.** Moved the never-mutated static table column definitions and icon legend into `reReviewTableConfig.ts`. **No workflow, soft-LIMIT, batch-preview/create, or reassignment logic was touched** — pure display constants only.

### Deferred (with rationale)
Deep thin-shell decomposition of `ManageReReview` (Options→composition of ~268 lines of `this`-bound methods + ~552-line style block), and composable extraction from `ApproveReview`/`ApproveUser`/`EntityView`/`BatchCriteriaForm`, is left to a dedicated follow-up. These are curation-critical flows where a subtle regression is costly; batching them into a tail-end sprint would trade integrity for line-count. `BatchCriteriaForm` additionally has no spec, so it needs a safety net first.

### Verification
- `vue-tsc --noEmit` exit 0.
- `CreateEntity.spec` + new `useEntityCreateOptions.spec` pass (5 tests); `ManageReReview.spec` passes (22 tests).
- `eslint` clean on all changed/new files; `code-quality-audit` OK (baseline ratcheted down only for the two real reductions).

Advances #398. Part of #346. Pending orchestrator integration verification.