### PR TITLE
fix(app): NDDScore mobile record rows + v0.21.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.21.4] — 2026-06-13
+
+Patch release fixing the NDDScore gene-predictions table on mobile.
+
+### Fixed
+
+- **NDDScore predictions are readable on mobile again.** The `/NDDScore` gene table rendered its 10-column fixed-layout `b-table` directly on small screens, crushing every column to ~28px so values truncated to `0..`, `Ve`, `Kn` with overlapping headers — the "stacked Bootstrap table" anti-pattern the visual design guide warns against. It now follows the same responsive pattern as the reference `/Entities` and `/Genes` tables: the desktop table is hidden below the `md` breakpoint (`d-none d-md-block`) and a purpose-built `NddScoreGeneMobileRows` record-card list renders instead (`d-md-none`). Each card shows gene + rank + an ML-prediction score / risk-tier / confidence / Known-vs-New chip row, with an expandable details panel for HGNC, percentile, top inheritance, model split, and predicted HPO. No horizontal overflow at 390px; the desktop table is unchanged. The "model-derived prediction, separate from curated SysNDD evidence" framing is preserved.
+
 ## [0.21.3] — 2026-06-13
 
 Patch release hardening the API against slow external/analysis endpoints blocking cheap routes (#344), fixing the gene-page request-ordering regression that made our own "Associated" data load last, and repairing two latent defects that made it impossible for any public analysis snapshot (GeneNetworks, clustering, correlations) to be built.

--- a/api/version_spec.json
+++ b/api/version_spec.json
@@ -1,7 +1,7 @@
 {
   "title": "SysNDD API",
   "description": "This is the API powering the SysNDD website, allowing programmatic access to the database contents.",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "contact": {
     "name": "API Support",
     "url": "https://berntpopp.github.io/sysndd/api.html",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/app/src/components/nddscore/NddScoreGeneMobileRows.spec.ts
+++ b/app/src/components/nddscore/NddScoreGeneMobileRows.spec.ts
@@ -1,0 +1,105 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import NddScoreGeneMobileRows from './NddScoreGeneMobileRows.vue';
+
+vi.mock('vue-router', () => ({
+  RouterLink: {
+    props: ['to'],
+    template: '<a :href="to"><slot /></a>',
+  },
+}));
+
+const bLinkStub = {
+  props: ['to', 'href'],
+  template: '<a :href="to || href"><slot /></a>',
+};
+
+function mountRows(items: Array<Record<string, unknown>>) {
+  return mount(NddScoreGeneMobileRows, {
+    props: { items },
+    global: {
+      stubs: {
+        BLink: bLinkStub,
+      },
+    },
+  });
+}
+
+describe('NddScoreGeneMobileRows', () => {
+  it('renders a scannable prediction card with gene, rank, score, tiers, and toggleable details', async () => {
+    const wrapper = mountRows([
+      {
+        gene_symbol: 'CLCN4',
+        hgnc_id: 'HGNC:2022',
+        ndd_score: 0.994,
+        rank: 1,
+        percentile: 100,
+        risk_tier: 'Very High',
+        confidence_tier: 'High',
+        known_sysndd_gene: true,
+        model_split: 'train',
+        top_inheritance_mode: 'XLD',
+        n_predicted_hpo: 2,
+        top_hpo_predictions_json: [
+          { phenotype_name: 'Intellectual disability', probability: 0.998 },
+          { phenotype_name: 'Seizure', probability: 0.832 },
+        ],
+      },
+    ]);
+
+    // Collapsed headline metrics are readable, not truncated.
+    expect(wrapper.text()).toContain('CLCN4');
+    expect(wrapper.text()).toContain('#1');
+    expect(wrapper.text()).toContain('0.994');
+    expect(wrapper.text()).toContain('Very High');
+    expect(wrapper.text()).toContain('High');
+    expect(wrapper.text()).toContain('Known');
+
+    // Gene badge links to the NDDScore gene detail page; "Known" links to curated gene page.
+    expect(wrapper.get('a[href="/NDDScore/Gene/HGNC%3A2022"]').text()).toContain('CLCN4');
+    expect(wrapper.get('a[href="/Genes/HGNC:2022"]').text()).toContain('Known');
+
+    // Secondary detail is hidden until requested.
+    const detailsButton = wrapper.get('button');
+    expect(detailsButton.attributes('aria-expanded')).toBe('false');
+    expect(wrapper.find('dl').exists()).toBe(false);
+
+    await detailsButton.trigger('click');
+
+    expect(detailsButton.attributes('aria-expanded')).toBe('true');
+    const details = wrapper.get('dl');
+    expect(details.text()).toContain('HGNC:2022');
+    expect(details.text()).toContain('100.0%');
+    expect(details.text()).toContain('XLD');
+    expect(details.text()).toContain('train');
+    expect(details.text()).toContain('Intellectual disability');
+    expect(details.text()).toContain('Seizure');
+  });
+
+  it('marks genes outside curated SysNDD as New and does not link to a curated gene page', () => {
+    const wrapper = mountRows([
+      {
+        gene_symbol: 'NEWGENE',
+        hgnc_id: 'HGNC:99999',
+        ndd_score: 0.5,
+        rank: 42,
+        percentile: 50,
+        risk_tier: 'Moderate',
+        confidence_tier: 'Low',
+        known_sysndd_gene: false,
+      },
+    ]);
+
+    expect(wrapper.text()).toContain('New');
+    expect(wrapper.find('a[href="/Genes/HGNC:99999"]').exists()).toBe(false);
+    // Detail navigation to the NDDScore gene page is still available.
+    expect(wrapper.find('a[href="/NDDScore/Gene/HGNC%3A99999"]').exists()).toBe(true);
+  });
+
+  it('shows an empty state when there are no predictions', () => {
+    const wrapper = mountRows([]);
+
+    expect(wrapper.text()).toContain('No gene predictions found.');
+    expect(wrapper.find('.mobile-record-row').exists()).toBe(false);
+  });
+});

--- a/app/src/components/nddscore/NddScoreGeneMobileRows.vue
+++ b/app/src/components/nddscore/NddScoreGeneMobileRows.vue
@@ -1,0 +1,215 @@
+<template>
+  <MobileTableList
+    :items="items"
+    label="Gene predictions"
+    empty-text="No gene predictions found."
+    :item-key="rowKey"
+  >
+    <template #default="{ item, index }">
+      <article class="mobile-record-row" role="listitem">
+        <!-- Primary identity + action cluster -->
+        <div class="mobile-record-row__topline">
+          <div class="mobile-record-row__chips">
+            <GeneBadge
+              v-if="hasValue(item.gene_symbol)"
+              :symbol="displayValue(item.gene_symbol)"
+              :hgnc-id="displayValue(item.hgnc_id)"
+              :link-to="detailLink(item)"
+              size="sm"
+            />
+            <span v-else class="mobile-record-row__fallback">Unknown gene</span>
+
+            <span
+              v-if="hasValue(item.rank)"
+              class="mobile-record-row__chip nddscore-mobile-row__rank"
+              :title="`Rank: ${displayValue(item.rank)}`"
+            >
+              #{{ displayValue(item.rank) }}
+            </span>
+          </div>
+
+          <button
+            type="button"
+            class="mobile-record-row__details-button"
+            :aria-expanded="isExpanded(rowKey(item, index)) ? 'true' : 'false'"
+            :aria-controls="`nddscore-mobile-row-details-${index}`"
+            @click="toggleDetails(rowKey(item, index))"
+          >
+            {{ isExpanded(rowKey(item, index)) ? 'Hide' : 'Details' }}
+          </button>
+        </div>
+
+        <!-- Headline prediction metrics -->
+        <div class="mobile-record-row__chips" aria-label="NDDScore prediction summary">
+          <span
+            class="mobile-record-row__chip nddscore-mobile-row__score"
+            :title="`NDDScore (ML prediction): ${formatDecimal(item.ndd_score, 3)}`"
+          >
+            <span class="nddscore-mobile-row__score-label">Score</span>
+            <span class="nddscore-mobile-row__score-value">{{
+              formatDecimal(item.ndd_score, 3)
+            }}</span>
+          </span>
+
+          <BBadge
+            :variant="riskVariant(item.risk_tier)"
+            :title="`Risk tier: ${displayValue(item.risk_tier)}`"
+          >
+            {{ displayValue(item.risk_tier) }}
+          </BBadge>
+
+          <BBadge
+            :variant="confidenceVariant(item.confidence_tier)"
+            :title="`Confidence: ${displayValue(item.confidence_tier)}`"
+          >
+            {{ displayValue(item.confidence_tier) }}
+          </BBadge>
+
+          <RouterLink
+            v-if="isKnownGene(item.known_sysndd_gene)"
+            :to="knownGeneLink(item)"
+            class="nddscore-mobile-row__known-link"
+            title="Open the curated SysNDD gene page for this HGNC identifier."
+          >
+            <BBadge variant="info">Known</BBadge>
+          </RouterLink>
+          <BBadge v-else variant="light" title="Not a curated SysNDD gene"> New </BBadge>
+        </div>
+
+        <!-- Secondary detail, on demand -->
+        <dl
+          v-if="isExpanded(rowKey(item, index))"
+          :id="`nddscore-mobile-row-details-${index}`"
+          class="mobile-record-row__details"
+        >
+          <div v-if="hasValue(item.hgnc_id)" class="mobile-record-row__detail">
+            <dt>HGNC</dt>
+            <dd>{{ displayValue(item.hgnc_id) }}</dd>
+          </div>
+          <div class="mobile-record-row__detail">
+            <dt>Percentile</dt>
+            <dd>{{ formatPercentile(item.percentile) }}</dd>
+          </div>
+          <div v-if="hasValue(item.top_inheritance_mode)" class="mobile-record-row__detail">
+            <dt>Top inheritance</dt>
+            <dd>{{ displayValue(item.top_inheritance_mode) }}</dd>
+          </div>
+          <div v-if="hasValue(item.model_split)" class="mobile-record-row__detail">
+            <dt>Split</dt>
+            <dd>{{ displayValue(item.model_split) }}</dd>
+          </div>
+          <div class="mobile-record-row__detail">
+            <dt>Predicted HPO</dt>
+            <dd>{{ topHpoTooltip(item.top_hpo_predictions_json) }}</dd>
+          </div>
+        </dl>
+      </article>
+    </template>
+  </MobileTableList>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import { RouterLink } from 'vue-router';
+import { BBadge } from 'bootstrap-vue-next';
+import MobileTableList from '@/components/table/MobileTableList.vue';
+import GeneBadge from '@/components/ui/GeneBadge.vue';
+import { withReturnTo } from '@/utils/returnNavigation';
+import {
+  displayValue,
+  formatDecimal,
+  formatPercentile,
+  riskVariant,
+  confidenceVariant,
+  isKnownGene,
+  topHpoTooltip,
+} from './nddScoreGeneTableFormatters';
+
+// Mobile record rows for the NDDScore gene predictions table. Mirrors the
+// EntitiesMobileRows/GenesMobileRows pattern so small viewports get scannable
+// cards instead of a crushed fixed-layout table. These remain model-derived
+// prediction-layer presentation, separate from curated SysNDD evidence.
+
+defineOptions({
+  name: 'NddScoreGeneMobileRows',
+});
+
+type Item = Record<string, unknown>;
+
+const props = defineProps<{
+  items: Item[];
+}>();
+
+const expandedRows = ref<Set<string>>(new Set());
+
+watch(
+  () => props.items,
+  (items) => {
+    const currentKeys = new Set(items.map((item, index) => rowKey(item, index)));
+    expandedRows.value = new Set([...expandedRows.value].filter((key) => currentKeys.has(key)));
+  },
+  { deep: false }
+);
+
+function hasValue(value: unknown): boolean {
+  return value !== null && value !== undefined && value !== '';
+}
+
+function rowKey(item: Item, index: number): string {
+  const stableValue = item.hgnc_id ?? item.gene_symbol;
+  return hasValue(stableValue) ? String(stableValue) : `row-${index}`;
+}
+
+function detailLink(item: Item): string | undefined {
+  return hasValue(item.hgnc_id)
+    ? withReturnTo(`/NDDScore/Gene/${encodeURIComponent(displayValue(item.hgnc_id))}`)
+    : undefined;
+}
+
+function knownGeneLink(item: Item): string {
+  return withReturnTo(`/Genes/${displayValue(item.hgnc_id)}`);
+}
+
+function isExpanded(key: string): boolean {
+  return expandedRows.value.has(key);
+}
+
+function toggleDetails(key: string): void {
+  const nextExpandedRows = new Set(expandedRows.value);
+
+  if (nextExpandedRows.has(key)) {
+    nextExpandedRows.delete(key);
+  } else {
+    nextExpandedRows.add(key);
+  }
+
+  expandedRows.value = nextExpandedRows;
+}
+</script>
+
+<style scoped>
+.nddscore-mobile-row__rank {
+  font-family: var(--font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+.nddscore-mobile-row__score {
+  gap: 0.3rem;
+}
+
+.nddscore-mobile-row__score-label {
+  color: #475569;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.nddscore-mobile-row__score-value {
+  font-family: var(--font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-weight: 700;
+}
+
+.nddscore-mobile-row__known-link {
+  text-decoration: none;
+}
+</style>

--- a/app/src/components/nddscore/NddScoreGeneTable.styles.css
+++ b/app/src/components/nddscore/NddScoreGeneTable.styles.css
@@ -1,0 +1,134 @@
+/* Styles for NddScoreGeneTable.vue. Extracted to a co-located scoped stylesheet
+   (referenced via `<style scoped src>`) to keep the component file within the
+   600-line maintainability ceiling. Scoping and `:deep()` behave the same as an
+   inline `<style scoped>` block — the SFC compiler processes `src` styles
+   through the identical compileStyle pipeline. */
+
+.nddscore-gene-table__id-link,
+.nddscore-gene-table__gene-link {
+  text-decoration: none;
+}
+
+.nddscore-gene-table__numeric {
+  font-family: var(--font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+.nddscore-gene-table__chip {
+  min-width: 2.5rem;
+  font-weight: 700;
+}
+
+.nddscore-gene-table__hpo {
+  display: inline-block;
+  max-width: 18rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
+  cursor: help;
+}
+
+.nddscore-gene-table__empty {
+  padding: 1.5rem;
+  color: var(--neutral-600, #757575);
+  text-align: center;
+}
+
+.nddscore-gene-table__filter-dropdown {
+  width: 100%;
+  min-width: 7.5rem;
+}
+
+.nddscore-gene-table__filter-dropdown :deep(.btn) {
+  width: 100%;
+  min-height: calc(1.5em + 1rem + 2px);
+  padding: 0.5rem 0.5rem;
+  overflow: hidden;
+  border-color: #dee2e6;
+  color: #212529;
+  font-size: 0.875rem;
+  font-weight: 400;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  background-color: #fff;
+}
+
+.nddscore-gene-table__filter-control {
+  min-height: calc(1.5em + 1rem + 2px);
+}
+
+.nddscore-gene-table__filter-control--empty,
+.nddscore-gene-table__filter-dropdown :deep(.nddscore-gene-table__filter-toggle--empty) {
+  color: var(--neutral-600, #757575);
+}
+
+.nddscore-gene-table__filter-control::placeholder {
+  color: var(--neutral-600, #757575);
+  opacity: 1;
+}
+
+.nddscore-gene-table__filter-dropdown :deep(.btn:hover),
+.nddscore-gene-table__filter-dropdown :deep(.btn:focus) {
+  border-color: #86b7fe;
+  color: #212529;
+  background-color: #fff;
+  box-shadow: 0 0 0 0.15rem rgba(13, 110, 253, 0.12);
+}
+
+.nddscore-gene-table__range-menu {
+  display: grid;
+  width: 15rem;
+  gap: 0.5rem;
+}
+
+.nddscore-gene-table__filter-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0.35rem 0.75rem 0.45rem;
+}
+
+:deep(.nddscore-gene-table__filter-menu) {
+  min-width: 16rem;
+}
+
+:deep(.nddscore-gene-table__hpo-menu) {
+  min-width: 22rem;
+  max-width: 30rem;
+}
+
+.nddscore-gene-table__hpo-options {
+  max-height: 16rem;
+  overflow-y: auto;
+}
+
+.nddscore-gene-table__hpo-options :deep(.dropdown-item) {
+  padding: 0.45rem 0.75rem;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.nddscore-gene-table__hpo-options :deep(.dropdown-item.active) {
+  background-color: #e9f5ff;
+  color: #0f172a;
+}
+
+:deep(.entities-table) {
+  width: 100%;
+  min-width: 100%;
+}
+
+:deep(.entities-table th) {
+  color: var(--neutral-600, #757575);
+  font-size: 0.75rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+:deep(.entities-table td) {
+  white-space: nowrap;
+}
+
+:deep(.entities-table thead input),
+:deep(.entities-table thead select) {
+  min-width: 7.5rem;
+}

--- a/app/src/components/nddscore/NddScoreGeneTable.vue
+++ b/app/src/components/nddscore/NddScoreGeneTable.vue
@@ -46,245 +46,253 @@
       </BRow>
     </template>
 
-    <GenericTable
-      :items="rows"
-      :fields="fields"
-      :sort-by="sortBy"
-      :fixed-layout="true"
-      :stacked-mode="false"
-      :is-busy="loading"
-      @update-sort="handleSortUpdate"
-    >
-      <template #column-header="{ data }">
-        <div v-b-tooltip.hover.bottom :title="columnHelp[data.column] || data.label">
-          {{ data.label }}
-        </div>
-      </template>
+    <!-- Desktop: fixed-layout prediction table -->
+    <div class="d-none d-md-block">
+      <GenericTable
+        :items="rows"
+        :fields="fields"
+        :sort-by="sortBy"
+        :fixed-layout="true"
+        :stacked-mode="false"
+        :is-busy="loading"
+        @update-sort="handleSortUpdate"
+      >
+        <template #column-header="{ data }">
+          <div v-b-tooltip.hover.bottom :title="columnHelp[data.column] || data.label">
+            {{ data.label }}
+          </div>
+        </template>
 
-      <template #filter-controls>
-        <td v-for="field in fields" :key="field.key">
-          <BDropdown
-            v-if="field.filterType === 'range'"
-            :auto-close="false"
-            variant="outline-secondary"
-            size="sm"
-            :class="rangeFilterDropdownClass(field)"
-            :toggle-class="rangeFilterToggleClass(field)"
-            menu-class="nddscore-gene-table__filter-menu"
-            :aria-label="`${field.label} filter`"
-          >
-            <template #button-content>
-              {{ rangeFilterLabel(field) }}
-            </template>
+        <template #filter-controls>
+          <td v-for="field in fields" :key="field.key">
+            <BDropdown
+              v-if="field.filterType === 'range'"
+              :auto-close="false"
+              variant="outline-secondary"
+              size="sm"
+              :class="rangeFilterDropdownClass(field)"
+              :toggle-class="rangeFilterToggleClass(field)"
+              menu-class="nddscore-gene-table__filter-menu"
+              :aria-label="`${field.label} filter`"
+            >
+              <template #button-content>
+                {{ rangeFilterLabel(field) }}
+              </template>
 
-            <BDropdownForm class="nddscore-gene-table__range-menu" @submit.prevent>
-              <BFormSelect
-                v-model="rangeFilters[rangeKey(field.key)].operator"
-                :options="rangeOperatorOptions"
-                size="sm"
-                :aria-label="`${field.label} filter operator`"
-                @update:model-value="handleRangeOperatorChange(field.key)"
-              />
-              <BFormInput
-                v-if="rangeFilters[rangeKey(field.key)].operator !== 'any'"
-                v-model="rangeFilters[rangeKey(field.key)].value"
-                :aria-label="`${field.label} filter value`"
-                :placeholder="rangeValuePlaceholder(field)"
-                type="number"
-                :step="field.numericStep ?? '1'"
-                size="sm"
-                @click="removeSearch"
-                @update:model-value="handleColumnFilterChange"
-              />
-              <BFormInput
-                v-if="rangeFilters[rangeKey(field.key)].operator === 'range'"
-                v-model="rangeFilters[rangeKey(field.key)].valueMax"
-                :aria-label="`${field.label} upper filter value`"
-                placeholder="to"
-                type="number"
-                :step="field.numericStep ?? '1'"
-                size="sm"
-                @click="removeSearch"
-                @update:model-value="handleColumnFilterChange"
-              />
-            </BDropdownForm>
-            <BDropdownDivider />
-            <div class="nddscore-gene-table__filter-actions">
-              <BButton
-                variant="link"
-                size="sm"
-                class="text-decoration-none p-0"
-                :disabled="rangeFilters[rangeKey(field.key)].operator === 'any'"
-                @click="clearRangeFilter(field.key)"
-              >
-                Clear
-              </BButton>
-            </div>
-          </BDropdown>
-
-          <BFormInput
-            v-else-if="field.filterType === 'text'"
-            v-model="columnFilters[field.key]"
-            :placeholder="'.. ' + field.label + ' ..'"
-            type="search"
-            autocomplete="off"
-            size="sm"
-            class="nddscore-gene-table__filter-control"
-            @click="removeSearch"
-            @update:model-value="handleColumnFilterChange"
-          />
-
-          <BFormSelect
-            v-else-if="field.filterType === 'select'"
-            v-model="columnFilters[field.key]"
-            :options="selectOptionsFor(field)"
-            size="sm"
-            :class="filterControlClass(field.key)"
-            @update:model-value="
-              removeSearch();
-              handleColumnFilterChange();
-            "
-          />
-
-          <BDropdown
-            v-else-if="field.filterType === 'multi-select'"
-            :auto-close="false"
-            variant="outline-secondary"
-            size="sm"
-            :class="hpoFilterDropdownClass"
-            :toggle-class="hpoFilterToggleClass"
-            menu-class="nddscore-gene-table__hpo-menu"
-            aria-label="Predicted HPO terms"
-            data-testid="nddscore-hpo-filter"
-          >
-            <template #button-content>
-              {{ hpoFilterLabel }}
-            </template>
-
-            <BDropdownForm @submit.prevent>
-              <BFormInput
-                v-model="hpoTermSearch"
-                placeholder="Search HPO terms"
-                type="search"
-                size="sm"
-                autocomplete="off"
-                aria-label="Search HPO terms"
-              />
-            </BDropdownForm>
-            <BDropdownDivider />
-            <div class="nddscore-gene-table__hpo-options">
-              <BDropdownItemButton
-                v-for="option in filteredHpoTermOptions"
-                :key="option.value"
-                :active="hpoTermFilter.includes(option.value)"
-                :data-testid="`nddscore-hpo-option-${option.value}`"
-                @click="toggleHpoTerm(option.value)"
-              >
-                <i
-                  class="bi me-2"
-                  :class="
-                    hpoTermFilter.includes(option.value)
-                      ? 'bi-check-square text-primary'
-                      : 'bi-square text-muted'
-                  "
-                  aria-hidden="true"
+              <BDropdownForm class="nddscore-gene-table__range-menu" @submit.prevent>
+                <BFormSelect
+                  v-model="rangeFilters[rangeKey(field.key)].operator"
+                  :options="rangeOperatorOptions"
+                  size="sm"
+                  :aria-label="`${field.label} filter operator`"
+                  @update:model-value="handleRangeOperatorChange(field.key)"
                 />
-                {{ option.text }}
-              </BDropdownItemButton>
-              <BDropdownText v-if="filteredHpoTermOptions.length === 0">
-                No matching HPO terms
-              </BDropdownText>
-            </div>
-            <BDropdownDivider />
-            <div class="nddscore-gene-table__filter-actions">
-              <BButton
-                variant="link"
-                size="sm"
-                class="text-decoration-none p-0"
-                :disabled="!hpoTermFilter.length"
-                @click="clearHpoTerms"
-              >
-                Clear
-              </BButton>
-            </div>
-          </BDropdown>
-        </td>
-      </template>
+                <BFormInput
+                  v-if="rangeFilters[rangeKey(field.key)].operator !== 'any'"
+                  v-model="rangeFilters[rangeKey(field.key)].value"
+                  :aria-label="`${field.label} filter value`"
+                  :placeholder="rangeValuePlaceholder(field)"
+                  type="number"
+                  :step="field.numericStep ?? '1'"
+                  size="sm"
+                  @click="removeSearch"
+                  @update:model-value="handleColumnFilterChange"
+                />
+                <BFormInput
+                  v-if="rangeFilters[rangeKey(field.key)].operator === 'range'"
+                  v-model="rangeFilters[rangeKey(field.key)].valueMax"
+                  :aria-label="`${field.label} upper filter value`"
+                  placeholder="to"
+                  type="number"
+                  :step="field.numericStep ?? '1'"
+                  size="sm"
+                  @click="removeSearch"
+                  @update:model-value="handleColumnFilterChange"
+                />
+              </BDropdownForm>
+              <BDropdownDivider />
+              <div class="nddscore-gene-table__filter-actions">
+                <BButton
+                  variant="link"
+                  size="sm"
+                  class="text-decoration-none p-0"
+                  :disabled="rangeFilters[rangeKey(field.key)].operator === 'any'"
+                  @click="clearRangeFilter(field.key)"
+                >
+                  Clear
+                </BButton>
+              </div>
+            </BDropdown>
 
-      <template #cell-gene_symbol="{ row }">
-        <GeneBadge
-          :symbol="displayValue(row.gene_symbol)"
-          :hgnc-id="displayValue(row.hgnc_id)"
-          :link-to="detailPath(row)"
-          size="sm"
-        />
-      </template>
+            <BFormInput
+              v-else-if="field.filterType === 'text'"
+              v-model="columnFilters[field.key]"
+              :placeholder="'.. ' + field.label + ' ..'"
+              type="search"
+              autocomplete="off"
+              size="sm"
+              class="nddscore-gene-table__filter-control"
+              @click="removeSearch"
+              @update:model-value="handleColumnFilterChange"
+            />
 
-      <template #cell-hgnc_id="{ row }">
-        <RouterLink class="nddscore-gene-table__id-link" :to="detailPath(row)">
-          {{ displayValue(row.hgnc_id) }}
-        </RouterLink>
-      </template>
+            <BFormSelect
+              v-else-if="field.filterType === 'select'"
+              v-model="columnFilters[field.key]"
+              :options="selectOptionsFor(field)"
+              size="sm"
+              :class="filterControlClass(field.key)"
+              @update:model-value="
+                removeSearch();
+                handleColumnFilterChange();
+              "
+            />
 
-      <template #cell-ndd_score="{ row }">
-        <span class="nddscore-gene-table__numeric">{{ formatDecimal(row.ndd_score, 3) }}</span>
-      </template>
+            <BDropdown
+              v-else-if="field.filterType === 'multi-select'"
+              :auto-close="false"
+              variant="outline-secondary"
+              size="sm"
+              :class="hpoFilterDropdownClass"
+              :toggle-class="hpoFilterToggleClass"
+              menu-class="nddscore-gene-table__hpo-menu"
+              aria-label="Predicted HPO terms"
+              data-testid="nddscore-hpo-filter"
+            >
+              <template #button-content>
+                {{ hpoFilterLabel }}
+              </template>
 
-      <template #cell-rank="{ row }">
-        <span class="nddscore-gene-table__numeric">{{ displayValue(row.rank) }}</span>
-      </template>
+              <BDropdownForm @submit.prevent>
+                <BFormInput
+                  v-model="hpoTermSearch"
+                  placeholder="Search HPO terms"
+                  type="search"
+                  size="sm"
+                  autocomplete="off"
+                  aria-label="Search HPO terms"
+                />
+              </BDropdownForm>
+              <BDropdownDivider />
+              <div class="nddscore-gene-table__hpo-options">
+                <BDropdownItemButton
+                  v-for="option in filteredHpoTermOptions"
+                  :key="option.value"
+                  :active="hpoTermFilter.includes(option.value)"
+                  :data-testid="`nddscore-hpo-option-${option.value}`"
+                  @click="toggleHpoTerm(option.value)"
+                >
+                  <i
+                    class="bi me-2"
+                    :class="
+                      hpoTermFilter.includes(option.value)
+                        ? 'bi-check-square text-primary'
+                        : 'bi-square text-muted'
+                    "
+                    aria-hidden="true"
+                  />
+                  {{ option.text }}
+                </BDropdownItemButton>
+                <BDropdownText v-if="filteredHpoTermOptions.length === 0">
+                  No matching HPO terms
+                </BDropdownText>
+              </div>
+              <BDropdownDivider />
+              <div class="nddscore-gene-table__filter-actions">
+                <BButton
+                  variant="link"
+                  size="sm"
+                  class="text-decoration-none p-0"
+                  :disabled="!hpoTermFilter.length"
+                  @click="clearHpoTerms"
+                >
+                  Clear
+                </BButton>
+              </div>
+            </BDropdown>
+          </td>
+        </template>
 
-      <template #cell-percentile="{ row }">
-        <span class="nddscore-gene-table__numeric">{{ formatPercentile(row.percentile) }}</span>
-      </template>
+        <template #cell-gene_symbol="{ row }">
+          <GeneBadge
+            :symbol="displayValue(row.gene_symbol)"
+            :hgnc-id="displayValue(row.hgnc_id)"
+            :link-to="detailPath(row)"
+            size="sm"
+          />
+        </template>
 
-      <template #cell-risk_tier="{ row }">
-        <BBadge :variant="riskVariant(row.risk_tier)">
-          {{ displayValue(row.risk_tier) }}
-        </BBadge>
-      </template>
+        <template #cell-hgnc_id="{ row }">
+          <RouterLink class="nddscore-gene-table__id-link" :to="detailPath(row)">
+            {{ displayValue(row.hgnc_id) }}
+          </RouterLink>
+        </template>
 
-      <template #cell-confidence_tier="{ row }">
-        <BBadge :variant="confidenceVariant(row.confidence_tier)">
-          {{ displayValue(row.confidence_tier) }}
-        </BBadge>
-      </template>
+        <template #cell-ndd_score="{ row }">
+          <span class="nddscore-gene-table__numeric">{{ formatDecimal(row.ndd_score, 3) }}</span>
+        </template>
 
-      <template #cell-known_sysndd_gene="{ row }">
-        <RouterLink
-          v-if="isKnownGene(row.known_sysndd_gene)"
-          v-b-tooltip.hover.left
-          :to="`/Genes/${row.hgnc_id}`"
-          class="nddscore-gene-table__gene-link"
-          title="Open the curated SysNDD gene page for this HGNC identifier."
-        >
-          <BBadge variant="info">Known</BBadge>
-        </RouterLink>
-        <BBadge v-else variant="light">New</BBadge>
-      </template>
+        <template #cell-rank="{ row }">
+          <span class="nddscore-gene-table__numeric">{{ displayValue(row.rank) }}</span>
+        </template>
 
-      <template #cell-model_split="{ row }">
-        <BBadge class="nddscore-gene-table__chip" variant="secondary">
-          {{ displayValue(row.model_split) }}
-        </BBadge>
-      </template>
+        <template #cell-percentile="{ row }">
+          <span class="nddscore-gene-table__numeric">{{ formatPercentile(row.percentile) }}</span>
+        </template>
 
-      <template #cell-top_inheritance_mode="{ row }">
-        <BBadge class="nddscore-gene-table__chip" variant="primary">
-          {{ displayValue(row.top_inheritance_mode) }}
-        </BBadge>
-      </template>
+        <template #cell-risk_tier="{ row }">
+          <BBadge :variant="riskVariant(row.risk_tier)">
+            {{ displayValue(row.risk_tier) }}
+          </BBadge>
+        </template>
 
-      <template #cell-top_hpo_predictions_json="{ row }">
-        <span
-          v-b-tooltip.hover.left
-          class="nddscore-gene-table__hpo"
-          :title="topHpoTooltip(row.top_hpo_predictions_json)"
-        >
-          {{ topHpoLabel(row.top_hpo_predictions_json, row.n_predicted_hpo) }}
-        </span>
-      </template>
-    </GenericTable>
+        <template #cell-confidence_tier="{ row }">
+          <BBadge :variant="confidenceVariant(row.confidence_tier)">
+            {{ displayValue(row.confidence_tier) }}
+          </BBadge>
+        </template>
+
+        <template #cell-known_sysndd_gene="{ row }">
+          <RouterLink
+            v-if="isKnownGene(row.known_sysndd_gene)"
+            v-b-tooltip.hover.left
+            :to="`/Genes/${row.hgnc_id}`"
+            class="nddscore-gene-table__gene-link"
+            title="Open the curated SysNDD gene page for this HGNC identifier."
+          >
+            <BBadge variant="info">Known</BBadge>
+          </RouterLink>
+          <BBadge v-else variant="light">New</BBadge>
+        </template>
+
+        <template #cell-model_split="{ row }">
+          <BBadge class="nddscore-gene-table__chip" variant="secondary">
+            {{ displayValue(row.model_split) }}
+          </BBadge>
+        </template>
+
+        <template #cell-top_inheritance_mode="{ row }">
+          <BBadge class="nddscore-gene-table__chip" variant="primary">
+            {{ displayValue(row.top_inheritance_mode) }}
+          </BBadge>
+        </template>
+
+        <template #cell-top_hpo_predictions_json="{ row }">
+          <span
+            v-b-tooltip.hover.left
+            class="nddscore-gene-table__hpo"
+            :title="topHpoTooltip(row.top_hpo_predictions_json)"
+          >
+            {{ topHpoLabel(row.top_hpo_predictions_json, row.n_predicted_hpo) }}
+          </span>
+        </template>
+      </GenericTable>
+    </div>
+
+    <!-- Mobile: purpose-built prediction record rows -->
+    <div class="d-md-none">
+      <NddScoreGeneMobileRows :items="rows" />
+    </div>
 
     <div v-if="!loading && !rows.length" class="nddscore-gene-table__empty">
       No gene predictions found.
@@ -318,6 +326,7 @@ import { fetchGenePredictions, fetchHpoTerms, type NddScoreGenePrediction } from
 import GeneBadge from '@/components/ui/GeneBadge.vue';
 import TableShell from '@/components/table/TableShell.vue';
 import GenericTable from '@/components/small/GenericTable.vue';
+import NddScoreGeneMobileRows from './NddScoreGeneMobileRows.vue';
 import TableSearchInput from '@/components/small/TableSearchInput.vue';
 import TablePaginationControls from '@/components/small/TablePaginationControls.vue';
 import TableDownloadLinkCopyButtons from '@/components/small/TableDownloadLinkCopyButtons.vue';
@@ -766,133 +775,4 @@ onMounted(() => {
 });
 </script>
 
-<style scoped>
-.nddscore-gene-table__id-link,
-.nddscore-gene-table__gene-link {
-  text-decoration: none;
-}
-
-.nddscore-gene-table__numeric {
-  font-family: var(--font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-}
-
-.nddscore-gene-table__chip {
-  min-width: 2.5rem;
-  font-weight: 700;
-}
-
-.nddscore-gene-table__hpo {
-  display: inline-block;
-  max-width: 18rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  vertical-align: bottom;
-  cursor: help;
-}
-
-.nddscore-gene-table__empty {
-  padding: 1.5rem;
-  color: var(--neutral-600, #757575);
-  text-align: center;
-}
-
-.nddscore-gene-table__filter-dropdown {
-  width: 100%;
-  min-width: 7.5rem;
-}
-
-.nddscore-gene-table__filter-dropdown :deep(.btn) {
-  width: 100%;
-  min-height: calc(1.5em + 1rem + 2px);
-  padding: 0.5rem 0.5rem;
-  overflow: hidden;
-  border-color: #dee2e6;
-  color: #212529;
-  font-size: 0.875rem;
-  font-weight: 400;
-  text-align: left;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  background-color: #fff;
-}
-
-.nddscore-gene-table__filter-control {
-  min-height: calc(1.5em + 1rem + 2px);
-}
-
-.nddscore-gene-table__filter-control--empty,
-.nddscore-gene-table__filter-dropdown :deep(.nddscore-gene-table__filter-toggle--empty) {
-  color: var(--neutral-600, #757575);
-}
-
-.nddscore-gene-table__filter-control::placeholder {
-  color: var(--neutral-600, #757575);
-  opacity: 1;
-}
-
-.nddscore-gene-table__filter-dropdown :deep(.btn:hover),
-.nddscore-gene-table__filter-dropdown :deep(.btn:focus) {
-  border-color: #86b7fe;
-  color: #212529;
-  background-color: #fff;
-  box-shadow: 0 0 0 0.15rem rgba(13, 110, 253, 0.12);
-}
-
-.nddscore-gene-table__range-menu {
-  display: grid;
-  width: 15rem;
-  gap: 0.5rem;
-}
-
-.nddscore-gene-table__filter-actions {
-  display: flex;
-  justify-content: flex-end;
-  padding: 0.35rem 0.75rem 0.45rem;
-}
-
-:deep(.nddscore-gene-table__filter-menu) {
-  min-width: 16rem;
-}
-
-:deep(.nddscore-gene-table__hpo-menu) {
-  min-width: 22rem;
-  max-width: 30rem;
-}
-
-.nddscore-gene-table__hpo-options {
-  max-height: 16rem;
-  overflow-y: auto;
-}
-
-.nddscore-gene-table__hpo-options :deep(.dropdown-item) {
-  padding: 0.45rem 0.75rem;
-  overflow-wrap: anywhere;
-  white-space: normal;
-}
-
-.nddscore-gene-table__hpo-options :deep(.dropdown-item.active) {
-  background-color: #e9f5ff;
-  color: #0f172a;
-}
-
-:deep(.entities-table) {
-  width: 100%;
-  min-width: 100%;
-}
-
-:deep(.entities-table th) {
-  color: var(--neutral-600, #757575);
-  font-size: 0.75rem;
-  font-weight: 700;
-  white-space: nowrap;
-}
-
-:deep(.entities-table td) {
-  white-space: nowrap;
-}
-
-:deep(.entities-table thead input),
-:deep(.entities-table thead select) {
-  min-width: 7.5rem;
-}
-</style>
+<style scoped src="./NddScoreGeneTable.styles.css"></style>

--- a/scripts/code-quality-file-size-baseline.tsv
+++ b/scripts/code-quality-file-size-baseline.tsv
@@ -30,7 +30,7 @@ app/src/components/analyses/PubtatorNDDTable.vue	922
 app/src/components/ApprovalTableView.vue	689
 app/src/components/forms/BatchCriteriaForm.vue	747
 app/src/components/gene/GeneStructurePlotWithVariants.vue	680
-app/src/components/nddscore/NddScoreGeneTable.vue	898
+app/src/components/nddscore/NddScoreGeneTable.vue	778
 app/src/components/small/GenericTable.vue	923
 app/src/components/tables/TablesEntities.vue	843
 app/src/components/tables/TablesGenes.vue	775


### PR DESCRIPTION
## Summary

Fixes the `/NDDScore` gene-predictions table on mobile, which rendered its 10-column fixed-layout `b-table` directly on small screens — crushing every column to ~28px so values truncated to `0..`, `Ve`, `Kn` with overlapping headers (the "stacked Bootstrap table" anti-pattern the visual design guide warns against).

Now mirrors the reference `/Entities` and `/Genes` responsive pattern:
- Desktop table wrapped in `d-none d-md-block` (unchanged at ≥768px).
- New `NddScoreGeneMobileRows.vue` rendered in `d-md-none`: per-record cards with **gene + rank** topline, an **ML-prediction score / risk-tier / confidence / Known-vs-New** chip row, and an expandable details panel (HGNC, percentile, top inheritance, model split, predicted HPO).
- Reuses the existing `nddScoreGeneTableFormatters`; the "model-derived prediction, separate from curated SysNDD evidence" framing is preserved.

## Before / After (390×844)

| Before | After |
|---|---|
| 10 cols @ ~28px, `0..`/`Ve`/`Kn`, overlapping headers | Scannable record cards, no horizontal overflow |

## Verification

- Playwright @ 390px: desktop table `display:none`, 10 mobile cards, first row `CLCN4 · #1 · Score 0.994 · Very High · High · Known`, **no horizontal overflow**; Details expands to HGNC:2022 / 100.0% / XLD / train / HPO list.
- Playwright @ 1440px: full 10-column table at 132px/col, mobile block hidden — **desktop unchanged**.
- `npm run type-check` ✅ · `type-check:strict` ✅ · `npm run test:unit` → **219 files / 1494 pass** ✅ · `eslint` (changed files) clean ✅ · existing `NddScoreGeneTable.spec.ts` 7/7 still pass.
- New `NddScoreGeneMobileRows.spec.ts` (3 tests: scannable card + toggle, Known/New gating, empty state).

## Release

`chore(release): v0.21.4` — bumps `app/package.json` + `api/version_spec.json`, adds the CHANGELOG entry.
