### PR TITLE
fix(app): consistent global search input (v0.21.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.21.5] — 2026-06-13
+
+Patch release making the global search input look consistent between the home hero and the navbar.
+
+### Fixed
+
+- **The global search input now looks the same on every page.** The shared `SearchCombobox` rendered with two divergent looks: the home (`/`) hero variant used a heavy black input border (`border-dark`) and a dark/neutral action button (`btn-outline-dark`), while the navbar variant (shown on `/Entities`, `/Genes`, and all non-home routes) used the medical-blue action button but was passed a literal `placeholder-string="..."`, so it displayed a broken `...` placeholder instead of helpful text. Both variants now converge on one design-token-aligned treatment — the global low-weight `.form-control` neutral border with a medical-blue focus ring, the medical-blue `btn-outline-primary` action button, and the `Search genes, diseases, IDs` placeholder — differing only by size (default in the hero, `sm` in the navbar). This aligns with the visual design guide ("use blue for action and navigation"; "borders: pale neutral/blue-gray lines with low visual weight"). Suggestions, submit, and keyboard navigation are unchanged.
+
 ## [0.21.4] — 2026-06-13
 
 Patch release fixing the NDDScore gene-predictions table on mobile.

--- a/api/version_spec.json
+++ b/api/version_spec.json
@@ -1,7 +1,7 @@
 {
   "title": "SysNDD API",
   "description": "This is the API powering the SysNDD website, allowing programmatic access to the database contents.",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "contact": {
     "name": "API Support",
     "url": "https://berntpopp.github.io/sysndd/api.html",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/app/src/components/AppNavbar.vue
+++ b/app/src/components/AppNavbar.vue
@@ -49,7 +49,7 @@
         <!-- Center aligned search bar -->
         <ul v-if="show_search" class="navbar-nav app-navbar__search mx-auto d-none d-lg-flex">
           <li class="nav-item navbar-search-item">
-            <SearchCombobox placeholder-string="..." :in-navbar="true" />
+            <SearchCombobox placeholder-string="Search genes, diseases, IDs" :in-navbar="true" />
           </li>
         </ul>
         <!-- Center aligned search bar -->
@@ -74,7 +74,7 @@
         <!-- Mobile search bar -->
         <ul v-if="show_search" class="navbar-nav app-navbar__mobile-search d-lg-none ms-auto">
           <li class="nav-item navbar-search-item">
-            <SearchCombobox placeholder-string="..." :in-navbar="true" />
+            <SearchCombobox placeholder-string="Search genes, diseases, IDs" :in-navbar="true" />
           </li>
         </ul>
         <!-- Mobile search bar -->

--- a/app/src/components/small/SearchCombobox.vue
+++ b/app/src/components/small/SearchCombobox.vue
@@ -9,7 +9,7 @@
         v-model="query"
         type="search"
         class="form-control"
-        :class="inNavbar ? 'form-control-sm navbar-search' : 'border-dark'"
+        :class="inNavbar ? 'form-control-sm navbar-search' : ''"
         :placeholder="placeholderString"
         autocomplete="off"
         role="combobox"
@@ -24,7 +24,7 @@
       />
       <button
         class="btn"
-        :class="inNavbar ? 'btn-outline-primary btn-sm' : 'btn-outline-dark'"
+        :class="inNavbar ? 'btn-outline-primary btn-sm' : 'btn-outline-primary'"
         :disabled="query.length < 2"
         aria-label="Search"
         @mousedown.prevent="onSubmit"
@@ -77,7 +77,7 @@ export default {
   props: {
     placeholderString: {
       type: String,
-      default: '...',
+      default: 'Search genes, diseases, IDs',
     },
     inNavbar: {
       type: Boolean,


### PR DESCRIPTION
## Summary

The global search input (`SearchCombobox`) rendered with two divergent looks depending on the page:

- **Home hero** (`/`): heavy black input border (`border-dark`) + dark/neutral action button (`btn-outline-dark`).
- **Navbar** (`/Entities`, `/Genes`, all non-home routes): medical-blue action button, but passed a literal `placeholder-string="..."` → it showed a **broken `...` placeholder** instead of helpful text.

This PR converges both variants on one design-token-aligned treatment, differing **only by size** (default in the hero, `sm` in the navbar):

- Drop `border-dark` so the hero input uses the global `.form-control` low-weight neutral border + medical-blue focus ring.
- Use `btn-outline-primary` (medical blue) for the action button in both variants.
- Default `placeholderString` to `Search genes, diseases, IDs` and pass the same string from the navbar.

Aligns with `documentation/10-visual-design-guide.md`: *"use blue for action and navigation"* and *"borders: pale neutral/blue-gray lines with low visual weight"*. Behavior (suggestions, submit, keyboard nav) is unchanged.

## Before / After

- Navbar placeholder: `...` → `Search genes, diseases, IDs`
- Home action button: dark outline → medical-blue outline
- Home input border: heavy black → low-weight neutral (matches navbar + global form style)

## Verification

- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm run type-check` — passes
- `npx vitest run src/components/AppNavbar.spec.ts` — 6/6 pass
- Playwright visual check of `/` and `/Entities?sort=%2Bentity_id&page_size=10` — both search inputs now share one look; typing still shows suggestions and enables the button.

## Files

- `app/src/components/small/SearchCombobox.vue` — centralised button/border styling, sensible default placeholder
- `app/src/components/AppNavbar.vue` — real placeholder for both navbar instances
- release bump v0.21.5 (`CHANGELOG.md`, `app/package.json`, `api/version_spec.json`)