### PR TITLE
fix(app): unify detail-page card borders with the subtle surface border (v0.21.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.21.6] — 2026-06-13
+
+Patch release unifying the Genes/Entities detail-page card borders with the rest of the app.
+
+### Fixed
+
+- **Detail-page cards no longer use a heavy black border.** The Genes (`/Genes/:symbol`) and Entities (`/Entities/:entity_id`) detail pages — plus the Ontology view (`/Ontology/:disease_term`) and the admin Job History card — wrapped their cards in `border-variant="dark"`, which rendered a heavy near-black Bootstrap border (`#212529`) that clashed with the home page and the public `/Entities`/`/Genes` tables. They now use the app-wide subtle surface border (pale blue-gray, `#d9e0ea`), so the detail/admin cards match the home hero/panels and the reference tables. This aligns with the visual design guide ("borders: pale neutral/blue-gray lines with low visual weight"; "avoid heavy black/dark borders"). The change is presentation-only — verified with Playwright at `1440px` and `390px`, every visible detail-page card border now computes to `rgb(217, 224, 234)` (`#d9e0ea`) with no remaining visible dark card borders.
+
+### Changed
+
+- **Introduced a canonical `--border-subtle` design token (`#d9e0ea`) and a `.border-subtle` utility class.** The ~30 component stylesheets that previously hard-coded the `1px solid #d9e0ea` panel border (home, user, analyses, curation, and form/wizard surfaces) now reference the token, giving the subtle surface border a single source of truth. The migration is value-identical; no surface changes appearance except the detail/admin cards described above.
+
 ## [0.21.5] — 2026-06-13
 
 Patch release making the global search input look consistent between the home hero and the navbar.

--- a/api/version_spec.json
+++ b/api/version_spec.json
@@ -1,7 +1,7 @@
 {
   "title": "SysNDD API",
   "description": "This is the API powering the SysNDD website, allowing programmatic access to the database contents.",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "contact": {
     "name": "API Support",
     "url": "https://berntpopp.github.io/sysndd/api.html",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/app/src/assets/css/custom.css
+++ b/app/src/assets/css/custom.css
@@ -121,6 +121,15 @@
   border: 1;
   border-color: #000;
 }
+/*
+ * Canonical subtle surface border for cards/panels. Pairs with Bootstrap's
+ * `.card` (which supplies 1px solid + radius) to override the heavy dark
+ * border with the app-wide pale blue-gray used by the home page and public
+ * surfaces. See documentation/10-visual-design-guide.md.
+ */
+.border-subtle {
+  border-color: var(--border-subtle) !important;
+}
 .word {
   font-size: 1.25em;
 }

--- a/app/src/assets/scss/partials/_colors.scss
+++ b/app/src/assets/scss/partials/_colors.scss
@@ -58,6 +58,13 @@
   --neutral-700: #616161; // 5.74:1 (WCAG AA text - passes)
   --neutral-800: #424242; // 8.59:1 (WCAG AAA text - passes)
   --neutral-900: #212121; // 16.10:1 (WCAG AAA text - passes)
+
+  // Surface borders
+  // Canonical low-weight panel/card border. This pale blue-gray is the
+  // app-wide subtle surface border used by the home page, public panels,
+  // and the user/analyses/curation surfaces. Use it instead of heavy dark
+  // Bootstrap card borders (see documentation/10-visual-design-guide.md).
+  --border-subtle: #d9e0ea; // 1.18:1 (UI border, low visual weight)
 }
 
 // WCAG 2.2 Level AA Requirements:

--- a/app/src/components/analyses/AnalyseGeneClusters.vue
+++ b/app/src/components/analyses/AnalyseGeneClusters.vue
@@ -1067,7 +1067,7 @@ mark {
   gap: 0.75rem;
   margin-bottom: 0.75rem;
   padding: 0.625rem 0.75rem;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #f8fbff;
   color: #495057;

--- a/app/src/components/analyses/AnalysesCurationMatrixPlot.vue
+++ b/app/src/components/analyses/AnalysesCurationMatrixPlot.vue
@@ -204,7 +204,7 @@ export default {
 <style scoped>
 .analysis-panel {
   overflow: hidden;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
 }

--- a/app/src/components/analyses/AnalysesCurationUpset.vue
+++ b/app/src/components/analyses/AnalysesCurationUpset.vue
@@ -443,7 +443,7 @@ export default {
 <style scoped>
 .analysis-panel {
   overflow: hidden;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 6px;
   background: #fff;
 }

--- a/app/src/components/analyses/AnalysisPanel.vue
+++ b/app/src/components/analyses/AnalysisPanel.vue
@@ -32,7 +32,7 @@ withDefaults(
 <style scoped>
 .analysis-panel {
   overflow: visible;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);

--- a/app/src/components/analyses/AnalysisShell.vue
+++ b/app/src/components/analyses/AnalysisShell.vue
@@ -70,7 +70,7 @@ withDefaults(
   width: min(100%, 1480px);
   margin: 0 auto;
   overflow: hidden;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);

--- a/app/src/components/analyses/NetworkVisualization.vue
+++ b/app/src/components/analyses/NetworkVisualization.vue
@@ -877,7 +877,7 @@ defineExpose({
 
 .network-panel {
   overflow: hidden;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
 }

--- a/app/src/components/annotations/JobHistoryCard.vue
+++ b/app/src/components/annotations/JobHistoryCard.vue
@@ -4,8 +4,7 @@
     header-tag="header"
     body-class="p-0"
     header-class="p-2"
-    border-variant="dark"
-    class="mb-3 text-start"
+    class="mb-3 text-start border-subtle"
   >
     <template #header>
       <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">

--- a/app/src/components/forms/BatchCriteriaForm.vue
+++ b/app/src/components/forms/BatchCriteriaForm.vue
@@ -524,7 +524,7 @@ const onReset = () => {
 .batch-form-panel {
   min-width: 0;
   padding: 0.8rem;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
 }
@@ -642,7 +642,7 @@ const onReset = () => {
 .batch-summary {
   margin-bottom: 0;
   padding: 0.65rem 0.75rem;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
 }

--- a/app/src/components/forms/wizard/FormWizard.vue
+++ b/app/src/components/forms/wizard/FormWizard.vue
@@ -289,7 +289,7 @@ export default defineComponent({
   z-index: 2;
   min-height: 2.35rem;
   padding: 0.35rem 0.5rem;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
 }
@@ -366,7 +366,7 @@ export default defineComponent({
 .wizard-content {
   min-width: 0;
   margin-bottom: 1rem;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
 }

--- a/app/src/components/forms/wizard/StepReview.vue
+++ b/app/src/components/forms/wizard/StepReview.vue
@@ -262,7 +262,7 @@ export default defineComponent({
 .review-entity-strip,
 .review-panel,
 .review-warning {
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
 }

--- a/app/src/components/gene/GeneClinVarCard.vue
+++ b/app/src/components/gene/GeneClinVarCard.vue
@@ -1,9 +1,8 @@
 <template>
   <BCard
-    class="clinvar-card"
+    class="clinvar-card border-subtle"
     body-class="p-0"
     header-class="p-1"
-    border-variant="dark"
     role="region"
     aria-label="ClinVar variant summary"
   >

--- a/app/src/components/gene/GeneConstraintCard.vue
+++ b/app/src/components/gene/GeneConstraintCard.vue
@@ -1,9 +1,8 @@
 <template>
   <BCard
-    class="constraint-card constraint-card--compact"
+    class="constraint-card constraint-card--compact border-subtle"
     body-class="p-0"
     header-class="p-1"
-    border-variant="dark"
     role="region"
     aria-label="Gene constraint scores from gnomAD"
   >

--- a/app/src/components/gene/ModelOrganismsCard.vue
+++ b/app/src/components/gene/ModelOrganismsCard.vue
@@ -1,10 +1,9 @@
 <template>
   <BCard
     v-if="showCard"
-    class="model-organisms-card"
+    class="model-organisms-card border-subtle"
     body-class="p-0"
     header-class="p-1"
-    border-variant="dark"
     role="region"
     aria-label="Model organism phenotypes"
   >

--- a/app/src/components/home/HomeConceptPanel.vue
+++ b/app/src/components/home/HomeConceptPanel.vue
@@ -79,7 +79,7 @@ defineProps<{
 <style scoped>
 .home-panel {
   overflow: hidden;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);

--- a/app/src/components/home/HomeNewsPanel.vue
+++ b/app/src/components/home/HomeNewsPanel.vue
@@ -133,7 +133,7 @@ defineProps<{
 <style scoped>
 .home-panel {
   overflow: hidden;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);

--- a/app/src/components/home/HomeStatsPanel.vue
+++ b/app/src/components/home/HomeStatsPanel.vue
@@ -204,7 +204,7 @@ function entityDetailLink(detail: StatDetail) {
 <style scoped>
 .home-panel {
   overflow: hidden;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);

--- a/app/src/components/layout/AuthenticatedPageShell.vue
+++ b/app/src/components/layout/AuthenticatedPageShell.vue
@@ -55,7 +55,7 @@ withDefaults(
 .authenticated-frame {
   width: min(100%, 1480px);
   margin: 0 auto;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);

--- a/app/src/components/ui/SectionCard.vue
+++ b/app/src/components/ui/SectionCard.vue
@@ -30,10 +30,10 @@
   <BCard
     v-else-if="loading"
     data-testid="section-card-skeleton"
+    class="border-subtle"
     :style="{ minHeight }"
     body-class="p-0"
     header-class="p-1"
-    border-variant="dark"
   >
     <template #header>
       <slot name="header">
@@ -82,9 +82,9 @@
   <BCard
     v-else-if="!empty"
     data-testid="section-card-content"
+    class="border-subtle"
     body-class="p-0"
     header-class="p-1"
-    border-variant="dark"
   >
     <template #header>
       <slot name="header">

--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -215,7 +215,7 @@ export default {
   width: min(100%, 1480px);
   margin: 0 auto 1rem;
   padding: 1.1rem 1rem;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);

--- a/app/src/views/analyses/CurationComparisons.vue
+++ b/app/src/views/analyses/CurationComparisons.vue
@@ -152,7 +152,7 @@ onMounted(() => {
   width: min(100%, 1480px);
   margin: 0 auto;
   overflow: hidden;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);

--- a/app/src/views/curate/ManageReReview.vue
+++ b/app/src/views/curate/ManageReReview.vue
@@ -982,7 +982,7 @@ export default {
   gap: 0.75rem;
   min-width: 0;
   padding: 0.65rem 0.85rem;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
 }
@@ -1013,7 +1013,7 @@ export default {
 
 .re-review-section {
   overflow: hidden;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
 }
@@ -1097,7 +1097,7 @@ export default {
   gap: 0.75rem;
   width: 100%;
   padding: 0.8rem 0.9rem;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
   color: inherit;
@@ -1170,7 +1170,7 @@ export default {
   gap: 0.45rem;
   margin-bottom: 0.85rem;
   padding: 0.65rem 0.75rem;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #f8fafc;
   color: #526070;
@@ -1318,7 +1318,7 @@ export default {
   gap: 0.75rem;
   align-items: end;
   padding: 0.75rem;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #f8fafc;
 }
@@ -1337,7 +1337,7 @@ export default {
   gap: 0.25rem;
   min-height: 2rem;
   padding: 0 0.65rem;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
   color: #526070;

--- a/app/src/views/curate/ModifyEntity.vue
+++ b/app/src/views/curate/ModifyEntity.vue
@@ -406,7 +406,7 @@ export default defineComponent({
 .modify-entity-section {
   display: grid;
   gap: 0.85rem;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);

--- a/app/src/views/curate/components/CombinedStatusReviewWorkflow.vue
+++ b/app/src/views/curate/components/CombinedStatusReviewWorkflow.vue
@@ -298,7 +298,7 @@ function updateDirectApproval(value: unknown): void {
   display: grid;
   gap: 0.85rem;
   padding: 0.85rem;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #f8fafc;
 }

--- a/app/src/views/curate/components/InlineEntityWorkflow.vue
+++ b/app/src/views/curate/components/InlineEntityWorkflow.vue
@@ -406,7 +406,7 @@ function submit(): void {
   display: grid;
   gap: 0.85rem;
   padding: 0.85rem;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #f8fafc;
 }

--- a/app/src/views/pages/GeneView.vue
+++ b/app/src/views/pages/GeneView.vue
@@ -17,7 +17,7 @@
       <BContainer fluid>
         <BRow class="justify-content-md-center pt-2">
           <BCol col md="12">
-            <BCard body-class="p-0" header-class="p-1" border-variant="dark">
+            <BCard class="border-subtle" body-class="p-0" header-class="p-1">
               <template #header>
                 <div class="d-flex align-items-center gap-1 flex-wrap">
                   <h1 class="gene-page-title mb-0">

--- a/app/src/views/pages/OntologyView.vue
+++ b/app/src/views/pages/OntologyView.vue
@@ -8,10 +8,9 @@
           <!-- Ontology overview card -->
           <BCard
             header-tag="header"
-            class="my-3 text-start"
+            class="my-3 text-start border-subtle"
             body-class="p-0"
             header-class="p-1"
-            border-variant="dark"
           >
             <template #header>
               <h3 class="mb-1 text-start font-weight-bold d-flex align-items-center gap-2">

--- a/app/src/views/review/ReviewInstructions.vue
+++ b/app/src/views/review/ReviewInstructions.vue
@@ -80,7 +80,7 @@ useHead({
   align-items: center;
   gap: 0.75rem;
   padding: 0.8rem 0.9rem;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
   color: #172033;

--- a/app/src/views/user/UserContributionStats.vue
+++ b/app/src/views/user/UserContributionStats.vue
@@ -36,7 +36,7 @@ defineProps<{
   justify-items: center;
   gap: 0.25rem;
   padding: 1rem;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);

--- a/app/src/views/user/UserProfileDetails.vue
+++ b/app/src/views/user/UserProfileDetails.vue
@@ -147,7 +147,7 @@ defineEmits<{
 
 <style scoped>
 .profile-card {
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);

--- a/app/src/views/user/UserProfileHeader.vue
+++ b/app/src/views/user/UserProfileHeader.vue
@@ -71,7 +71,7 @@ defineProps<{
 <style scoped>
 .profile-card {
   overflow: hidden;
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);

--- a/app/src/views/user/UserSecurityPanel.vue
+++ b/app/src/views/user/UserSecurityPanel.vue
@@ -149,7 +149,7 @@ defineEmits<{
 
 <style scoped>
 .profile-card {
-  border: 1px solid #d9e0ea;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: #fff;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);

--- a/documentation/10-visual-design-guide.md
+++ b/documentation/10-visual-design-guide.md
@@ -54,6 +54,7 @@ Neutral foundation:
 - Secondary text: `--neutral-600: #757575`
 - Surface backgrounds: white and near-white neutrals
 - Borders: pale neutral/blue-gray lines with low visual weight
+- Canonical surface border token: `--border-subtle: #d9e0ea` (the app-wide low-weight panel/card border used by the home page, public tables, and the user/analyses/curation surfaces). Use this token for card and panel borders; never use a heavy dark Bootstrap card border (`border-variant="dark"` / `.border-dark`). On a Bootstrap `BCard`, add the `.border-subtle` utility class instead of a dark variant.
 
 Rules:
 


### PR DESCRIPTION
## Summary

The Genes (`/Genes/:symbol`) and Entities (`/Entities/:entity_id`) detail pages rendered their cards with `border-variant="dark"` → a heavy near-black Bootstrap border (`#212529`) that clashed with the home page and the public `/Entities`/`/Genes` tables. The same anti-pattern was present on the Ontology view and the admin Job History card.

This unifies them on the **app-wide subtle surface border** (pale blue-gray `#d9e0ea`) that the home hero/panels and reference tables already use.

### Changes
- **Fix:** removed `border-variant="dark"` from `SectionCard` (Entities page), the `GeneView` header, the three gene cards (`GeneConstraintCard`, `GeneClinVarCard`, `ModelOrganismsCard`), `OntologyView`, and `JobHistoryCard`; they now carry the `.border-subtle` class.
- **Refactor / DRY:** introduced a canonical `--border-subtle` design token (`#d9e0ea`) + `.border-subtle` utility, and migrated the ~30 stylesheets that hard-coded `1px solid #d9e0ea` to the token (value-identical).
- **Docs:** recorded the token + the no-dark-card-borders rule in `documentation/10-visual-design-guide.md`.

### Verification
Playwright at `1440px` and `390px`: every visible detail-page card border now computes to `rgb(217, 224, 234)` (`#d9e0ea`); **no remaining visible dark card borders**. Local app CI gates all green: ESLint (0 errors), `type-check`, `type-check:strict`, Vitest (1494 tests), `build:docker`.

Presentation-only; API lanes are untouched (skip via path filter).