### PR TITLE
perf(app): keep heavy libs off the home critical path + lean PWA precache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.21.9] — 2026-06-14
+
+Patch release: home-page performance — keep heavy libraries off the landing-page critical path.
+
+### Changed
+
+- **Home page no longer downloads ~600 KB of unused code.** `HomeView.vue` imported from the `@/composables` barrel, which statically re-exports heavy composables (`use3DStructure` → `ngl` 1.3 MB, `useMarkdownRenderer` 0.7 MB, `useCytoscape`/`useNetworkData` → d3, exceljs). Rollup cannot tree-shake the barrel, so the home route chunk eagerly pulled all of that in. Importing the two light composables (`useToast`, `useText`) directly bypasses the barrel; home JS payload dropped 740 → 211 KiB (−71%) and main-thread blocking from those modules executing went to ~0. This directly targets the mobile-Lighthouse LCP and TBT losses.
+- **`gsap` is loaded lazily** (and split out of the `viz` chunk) — it is only needed for the home count-up animation that runs after statistics load, so it no longer sits on the first-load critical path; it degrades gracefully to instant numbers if not yet ready.
+- **Leaner PWA precache.** The service worker no longer precaches the largest route-only chunks (`ngl`, `exceljs`, Swagger/`ApiView`, markdown) on first visit; they are runtime-cached on demand instead. First-visit background precache dropped 8.59 → 4.76 MB (−45%).
+
+### Internal
+
+- `app/.gitignore` now robustly ignores build output (`dist`, `dist-*`, `stats.html`, `*.tsbuildinfo`, `.lighthouseci`).
+
 ## [0.21.8] — 2026-06-13
 
 Patch release: a public-page design + accessibility pass, plus review fixes.

--- a/api/version_spec.json
+++ b/api/version_spec.json
@@ -1,7 +1,7 @@
 {
   "title": "SysNDD API",
   "description": "This is the API powering the SysNDD website, allowing programmatic access to the database contents.",
-  "version": "0.21.8",
+  "version": "0.21.9",
   "contact": {
     "name": "API Support",
     "url": "https://berntpopp.github.io/sysndd/api.html",

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,6 +1,13 @@
 .DS_Store
 node_modules
+
+# Build output (vite build -> dist) plus local build/measurement variants
 /dist
+/dist-*/
+# Bundle-analyzer output + build/CI artifacts
+stats.html
+*.tsbuildinfo
+.lighthouseci/
 
 # local env files
 .env.local

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.21.8",
+  "version": "0.21.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/app/src/views/HomeView.vue
+++ b/app/src/views/HomeView.vue
@@ -40,10 +40,13 @@
 </template>
 
 <script>
-import { gsap } from 'gsap';
-
 import { useHead } from '@unhead/vue';
-import { useToast, useText } from '@/composables';
+// Import composables directly (not via the '@/composables' barrel): the barrel
+// statically re-exports heavy composables (use3DStructure->ngl, useMarkdownRenderer,
+// useCytoscape/useNetworkData->d3, exceljs) that Rollup cannot tree-shake out, so
+// pulling anything from it dragged ~600 KB of unused code onto the home critical path.
+import useToast from '@/composables/useToast';
+import useText from '@/composables/useText';
 
 // Importing initial objects from a constants file to avoid hardcoding them in this component
 import INIT_OBJ from '@/assets/js/constants/init_obj_constants';
@@ -59,6 +62,26 @@ import SearchCombobox from '@/components/small/SearchCombobox.vue';
 import HomeStatsPanel from '@/components/home/HomeStatsPanel.vue';
 import HomeNewsPanel from '@/components/home/HomeNewsPanel.vue';
 import HomeConceptPanel from '@/components/home/HomeConceptPanel.vue';
+
+// gsap is loaded lazily so the dataviz bundle (d3/upsetjs/gsap) stays off the
+// home page's critical render path. It is only needed for the count-up
+// animation that runs *after* statistics load, so a dynamic import that races
+// the API call costs nothing perceptible while removing the dataviz code from
+// the home page's first load.
+let gsapLib = null;
+let gsapPromise = null;
+function ensureGsap() {
+  if (gsapLib) return Promise.resolve(gsapLib);
+  if (!gsapPromise) {
+    gsapPromise = import('gsap')
+      .then((mod) => {
+        gsapLib = mod.gsap;
+        return gsapLib;
+      })
+      .catch(() => null);
+  }
+  return gsapPromise;
+}
 
 export default {
   name: 'HomeView',
@@ -139,6 +162,9 @@ export default {
     },
   },
   created() {
+    // Kick off the gsap import in parallel with the first data load so the
+    // count-up animation is ready by the time statistics arrive.
+    ensureGsap();
     // watch the params of the route to fetch the data again
     this.$watch(
       () => this.$route.params,
@@ -155,9 +181,16 @@ export default {
     // Function to animate changes in data.
     // This uses the GSAP library to create a transition effect.
     animateOnChange(after, before) {
+      // If gsap hasn't finished loading yet, the reactive values already hold
+      // their final numbers — just render them without the count-up tween.
+      if (!gsapLib) {
+        ensureGsap();
+        this.$forceUpdate();
+        return;
+      }
       for (let i = 0; i < after.length; i += 1) {
         if (before[i].n !== after[i].n) {
-          gsap.fromTo(
+          gsapLib.fromTo(
             after[i],
             {
               n: before[i].n,

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -28,6 +28,37 @@ export function createViteConfig(mode: string): UserConfig {
       vue(),
       VitePWA({
         registerType: 'prompt',
+        workbox: {
+          // The build emits ~250 content-hashed chunks. The Workbox default
+          // precaches every one of them, so on a first visit the service worker
+          // downloads several MB in the background — competing with the landing
+          // page's critical render path (this was pulling the 1.3 MB 3D viewer
+          // and 0.7 MB markdown renderer onto the home page network window).
+          // Instead, exclude the largest route-only chunks from precache and
+          // cache them at runtime on first use, so first paint is never slowed
+          // by code the home page does not execute.
+          globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2,webmanifest}'],
+          globIgnores: [
+            '**/ngl-*.js', // ~1.3 MB — 3D structure viewer (gene detail only)
+            '**/exceljs*.js', // ~0.9 MB — spreadsheet export (downloads only)
+            '**/ApiView-*.{js,css}', // ~1.5 MB — Swagger UI (API docs page only)
+            '**/useMarkdownRenderer-*.js', // ~0.7 MB — markdown (CMS/admin only)
+          ],
+          cleanupOutdatedCaches: true,
+          runtimeCaching: [
+            {
+              // Content-hashed build assets are immutable, so CacheFirst is safe
+              // and makes the excluded chunks offline-capable after first use.
+              urlPattern: /\/assets\/.*\.(?:js|css|woff2?)$/,
+              handler: 'CacheFirst',
+              options: {
+                cacheName: 'sysndd-runtime-assets',
+                expiration: { maxEntries: 300, maxAgeSeconds: 60 * 60 * 24 * 30 },
+                cacheableResponse: { statuses: [0, 200] },
+              },
+            },
+          ],
+        },
         manifest: {
           name: 'SysNDD',
           short_name: 'SysNDD',
@@ -190,7 +221,10 @@ export function createViteConfig(mode: string): UserConfig {
             vendor: ['vue', 'vue-router', 'pinia'],
             bootstrap: ['bootstrap', 'bootstrap-vue-next'],
             // Heavy visualization libraries (lazy-loaded)
-            viz: ['d3', '@upsetjs/bundle', 'gsap'],
+            // gsap is intentionally NOT bundled here: it is dynamically imported
+            // by HomeView for the count-up animation, so Vite emits it as its own
+            // small chunk and the home page no longer pulls in d3/upsetjs.
+            viz: ['d3', '@upsetjs/bundle'],
             // 3D structure viewer (lazy-loaded via BTab lazy)
             ngl: ['ngl'],
           },


### PR DESCRIPTION
## Summary

Mobile Lighthouse **Performance** on the public home page was held back by ~600 KB of code the landing page downloads and **executes** but never uses. Desktop is already 100/100/100/100; A11y/Best-Practices/SEO are 100 (the "Best Practices 96" some runs show is Chrome-extension noise that Lighthouse flags — incognito/PSI is 100).

**Root cause** (found by reading the built chunk's static imports — the PWA precache was a red herring): `HomeView.vue` imported from the `@/composables` barrel, which statically re-exports heavy composables (`use3DStructure`→`ngl` 1.3 MB, `useMarkdownRenderer` 0.7 MB, `useCytoscape`/`useNetworkData`→d3, exceljs). Rollup can't tree-shake the barrel, so importing *anything* from it dragged all of that onto the home route chunk as eager side-effect imports. `gsap` was also imported eagerly and bundled with d3.

## Changes
- **HomeView.vue**: import `useToast`/`useText` directly (bypass the barrel) → ngl/markdown/d3/exceljs no longer on the home critical path; **lazy-load `gsap`** (only needed for the count-up animation after stats load; degrades gracefully to instant numbers).
- **vite.config.ts**: split `gsap` out of the `viz` chunk; configure Workbox to stop precaching the 4 largest route-only chunks (ngl, exceljs, ApiView/Swagger, markdown) on first visit and runtime-cache them on demand.
- **app/.gitignore**: robustly ignore build output (`dist`, `dist-*`, `stats.html`, `*.tsbuildinfo`, `.lighthouseci`).

## Measured impact (production build, verified in-browser with live data)
| Metric | Before | After |
|---|---|---|
| Home JS payload | 740 KiB | **211 KiB (−71%)** |
| TBT (observed throttling) | ~100 ms | **0 ms** |
| Speed Index | 3.3 s | **3.0 s** |
| First-visit PWA precache | 8.59 MB | **4.76 MB (−45%)** |

Verified in a real browser: count-up animation works, data renders, service worker registers, **no new console errors**, and ngl/markdown/d3 confirmed absent from the home page.

## Verification
`eslint` ✓ · `type-check` ✓ · `vitest` (home + routing, 13/13) ✓ · `make verify-seo-app` ✓

## Out of scope (intentional)
Remaining mobile **FCP (~79)** is gated by the bootstrap-vue-next shell boot (~183 ms eval) — framework-inherent. Closing it would need home prerendering (a server-config change to serve a separate file for `/`) or granular BVN imports, deliberately left out to avoid risky/unverifiable changes on freshly-merged design code.