### PR TITLE
fix(pubtator): repair enrichment refresh + graceful-degrade gene ranking

### DIFF
--- a/api/endpoints/publication_endpoints.R
+++ b/api/endpoints/publication_endpoints.R
@@ -476,13 +476,23 @@ function(req,
   # 2) Start time
   start_time <- Sys.time()
 
-  # 3) Generate sort/filter expressions.
+  # 3) Resolve enrichment snapshot status. Before the first enrichment refresh
+  #    the metric columns are all-NA and the default `-enrichment_ratio` sort
+  #    silently degrades to publication_count ASC (least-studied first). When no
+  #    current snapshot exists we drop enrichment keys and fall back to a
+  #    deterministic `-publication_count` order, and we surface the status to the
+  #    client in meta so the UI can explain that ranking is not yet computed.
+  enrichment_meta <- pubtator_genes_enrichment_meta()
+  enrichment_available <- identical(enrichment_meta$status, "current")
+  effective_sort <- pubtator_resolve_genes_sort(sort, enrichment_available)
+
+  # 3b) Generate sort/filter expressions.
   # TODO allowlist: Filtering here operates on computed post-collect fields
   # (publication_count, entities_count, is_novel, oldest_pub_date, pmids) that
   # do not exist in the underlying view; the view-derived allowlist would reject
   # them. Pass NULL to preserve legacy behavior (bare-identifier check still
   # applies). Wire a real allowlist once the computed column set is stabilised.
-  sort_exprs <- generate_sort_expressions(sort, unique_id = "gene_symbol",
+  sort_exprs <- generate_sort_expressions(effective_sort, unique_id = "gene_symbol",
     allowed_columns = NULL)
   filter_exprs <- generate_filter_expressions(filter,
     allowed_columns = NULL)
@@ -560,12 +570,18 @@ function(req,
   end_time <- Sys.time()
   execution_time <- paste0(round(end_time - start_time, 2), " secs")
 
-  # 13) Build meta
+  # 13) Build meta. Echo the originally requested `sort` (links/cursor stay
+  #     consistent) and append the enrichment snapshot status so the client can
+  #     show whether the ranking is current or not yet computed.
   meta <- build_cursor_meta(
     pag_info$meta,
     sort, filter, fields,
     tbl_fspec, execution_time
-  )
+  ) %>%
+    tibble::add_column(
+      enrichmentStatus = enrichment_meta$status,
+      enrichmentRefreshedAt = enrichment_meta$refreshed_at %||% NA_character_
+    )
 
   # 14) Build the cursor next/prev links for this resource
   links <- build_cursor_links(

--- a/api/endpoints/publication_endpoints.R
+++ b/api/endpoints/publication_endpoints.R
@@ -497,42 +497,9 @@ function(req,
   filter_exprs <- generate_filter_expressions(filter,
     allowed_columns = NULL)
 
-  # 4) Fetch from DB (no filter yet - computed fields don't exist)
-  df_raw <- pool %>%
-    tbl("pubtator_human_gene_entity_view") %>%
-    collect()
-
-  # 5) Nest the data => one row per gene
-  df_nested <- nest_pubtator_gene_tibble_mem(df_raw)
-
-  # 6) Add computed fields for prioritization
-  #    - publication_count: number of valid publications
-  #    - entities_count: number of SysNDD entities (0 = novel/coverage gap)
-  #    - is_novel: 1 if gene has no SysNDD entity, 0 otherwise
-  #    - oldest_pub_date: earliest publication date
-  #    - pmids: comma-separated list of PMIDs (string, not array)
-  df_counts <- df_nested %>%
-    dplyr::mutate(
-      publication_count = purrr::map_int(publications, ~
-        dplyr::filter(.x, !is.na(pmid)) %>% nrow()),
-      entities_count = purrr::map_int(entities, ~
-        dplyr::filter(.x, !is.na(entity_id)) %>% nrow()),
-      is_novel = as.integer(entities_count == 0),
-      oldest_pub_date = purrr::map_chr(publications, ~ {
-        valid_pubs <- dplyr::filter(.x, !is.na(pmid) & !is.na(date))
-        if (nrow(valid_pubs) == 0) {
-          return(NA_character_)
-        }
-        min_date <- min(valid_pubs$date, na.rm = TRUE)
-        as.character(min_date)
-      }),
-      pmids = purrr::map_chr(publications, ~ {
-        valid_pubs <- dplyr::filter(.x, !is.na(pmid)) %>%
-          dplyr::arrange(date) %>%
-          dplyr::distinct(pmid)
-        paste(valid_pubs$pmid, collapse = ",")
-      })
-    )
+  # 4-6) Flat per-gene rows (collect + nest + derive prioritization fields).
+  #      Extracted to a helper to keep this endpoint within its size baseline.
+  df_counts <- pubtator_genes_nest_base(pool)
 
   # 6b) Left-join normalized enrichment metrics (issue #175): normalize raw NDD
   #     co-occurrence for research-popularity bias. Worker-precomputed; LEFT JOIN
@@ -570,18 +537,15 @@ function(req,
   end_time <- Sys.time()
   execution_time <- paste0(round(end_time - start_time, 2), " secs")
 
-  # 13) Build meta. Echo the originally requested `sort` (links/cursor stay
-  #     consistent) and append the enrichment snapshot status so the client can
-  #     show whether the ranking is current or not yet computed.
+  # 13) Build meta (echo the requested `sort`) and append the enrichment snapshot
+  #     status so the client can show whether the ranking is current.
   meta <- build_cursor_meta(
     pag_info$meta,
     sort, filter, fields,
     tbl_fspec, execution_time
-  ) %>%
-    tibble::add_column(
-      enrichmentStatus = enrichment_meta$status,
-      enrichmentRefreshedAt = enrichment_meta$refreshed_at %||% NA_character_
-    )
+  )
+  meta$enrichmentStatus <- enrichment_meta$status
+  meta$enrichmentRefreshedAt <- enrichment_meta$refreshed_at %||% NA_character_
 
   # 14) Build the cursor next/prev links for this resource
   links <- build_cursor_links(

--- a/api/functions/publication-endpoint-helpers.R
+++ b/api/functions/publication-endpoint-helpers.R
@@ -37,6 +37,45 @@ publication_stats_response <- function(not_updated_since = NULL,
   result
 }
 
+#' Compute the flat per-gene base tibble for the gene listing
+#'
+#' Collects `pubtator_human_gene_entity_view`, nests it per gene, and derives the
+#' flat prioritization fields (publication_count, entities_count, is_novel,
+#' oldest_pub_date, pmids). Extracted from the `/pubtator/genes` endpoint to keep
+#' that file within the code-quality size baseline; enrichment metrics are joined
+#' separately by the caller via [pubtator_join_enrichment_metrics()].
+#'
+#' @param pool_obj A dbplyr-capable pool/connection.
+#' @return A per-gene tibble with the flat prioritization fields.
+#' @export
+pubtator_genes_nest_base <- function(pool_obj) {
+  df_raw <- pool_obj %>%
+    dplyr::tbl("pubtator_human_gene_entity_view") %>%
+    dplyr::collect()
+  df_nested <- nest_pubtator_gene_tibble_mem(df_raw)
+  df_nested %>%
+    dplyr::mutate(
+      publication_count = purrr::map_int(publications, ~
+        dplyr::filter(.x, !is.na(pmid)) %>% nrow()),
+      entities_count = purrr::map_int(entities, ~
+        dplyr::filter(.x, !is.na(entity_id)) %>% nrow()),
+      is_novel = as.integer(entities_count == 0),
+      oldest_pub_date = purrr::map_chr(publications, ~ {
+        valid_pubs <- dplyr::filter(.x, !is.na(pmid) & !is.na(date))
+        if (nrow(valid_pubs) == 0) {
+          return(NA_character_)
+        }
+        as.character(min(valid_pubs$date, na.rm = TRUE))
+      }),
+      pmids = purrr::map_chr(publications, ~ {
+        valid_pubs <- dplyr::filter(.x, !is.na(pmid)) %>%
+          dplyr::arrange(date) %>%
+          dplyr::distinct(pmid)
+        paste(valid_pubs$pmid, collapse = ",")
+      })
+    )
+}
+
 #' Left-join normalized PubtatorNDD enrichment metrics onto the gene listing
 #'
 #' Issue #175: raw NDD co-occurrence count conflates true NDD relevance with

--- a/api/functions/publication-endpoint-helpers.R
+++ b/api/functions/publication-endpoint-helpers.R
@@ -77,6 +77,94 @@ pubtator_join_enrichment_metrics <- function(df_counts, pool_obj) {
   dplyr::left_join(df_counts, df_enrichment, by = "gene_symbol")
 }
 
+#' Read the current PubtatorNDD enrichment snapshot status (lightweight)
+#'
+#' Cheap companion to [pubtator_enrichment_status_response()] used by the gene
+#' listing to decide whether the enrichment-based ranking is meaningful. Returns
+#' `status = "current"` when a `pubtator_corpus_stats` row with `is_current = 1`
+#' exists, otherwise `status = "missing"` (e.g. before the first refresh). A
+#' future "stale" state (snapshot present but older than the source data) can be
+#' added here once the nightly job records a data version.
+#'
+#' @param query_fn Query function (injectable for tests). Default
+#'   `db_execute_query`.
+#' @return List with `status` (`"current"`/`"missing"`), `refreshed_at`
+#'   (character or NA), and `genes_scored` (integer or NA).
+#' @export
+pubtator_genes_enrichment_meta <- function(query_fn = db_execute_query) {
+  rows <- tryCatch(
+    query_fn(
+      "SELECT created_at, genes_scored
+       FROM pubtator_corpus_stats
+       WHERE is_current = 1
+       LIMIT 1"
+    ),
+    error = function(e) NULL
+  )
+
+  if (is.null(rows) || nrow(rows) == 0) {
+    return(list(
+      status = "missing",
+      refreshed_at = NA_character_,
+      genes_scored = NA_integer_
+    ))
+  }
+
+  list(
+    status = "current",
+    refreshed_at = as.character(rows$created_at[[1]]),
+    genes_scored = rows$genes_scored[[1]]
+  )
+}
+
+#' Resolve the effective gene-listing sort given enrichment availability
+#'
+#' The default gene sort leads with enrichment metrics
+#' (`-enrichment_ratio,-npmi,publication_count`). Before the first enrichment
+#' refresh those columns are all-NA, so `arrange()` silently degrades to ordering
+#' by the first non-NA key (publication_count ASC) — i.e. the *least*-studied
+#' genes first, which is a misleading default.
+#'
+#' When enrichment is unavailable AND the requested sort actually depends on an
+#' enrichment metric, this helper drops the enrichment keys (and any
+#' publication_count token) and forces a deterministic, sensible
+#' `-publication_count` (most-studied first) lead, preserving any remaining
+#' non-enrichment tiebreak keys. A sort that does not reference enrichment is an
+#' explicit user choice and is returned unchanged. When enrichment is available
+#' the requested sort is always returned unchanged.
+#'
+#' Pure function (no DB/IO) so it is unit-testable in isolation.
+#'
+#' @param sort Raw sort string (comma-separated, `-` prefix = descending).
+#' @param enrichment_available Logical; TRUE when a current enrichment snapshot
+#'   exists.
+#' @return The sort string to actually apply.
+#' @export
+pubtator_resolve_genes_sort <- function(sort, enrichment_available) {
+  if (isTRUE(enrichment_available)) {
+    return(sort)
+  }
+
+  enrichment_keys <- c(
+    "enrichment_ratio", "npmi", "fisher_p", "fdr_bh",
+    "observed", "background_count"
+  )
+
+  tokens <- trimws(strsplit(sort %||% "", ",", fixed = TRUE)[[1]])
+  tokens <- tokens[nzchar(tokens)]
+  bare <- sub("^-", "", tokens)
+
+  # A sort that never relied on enrichment is an explicit choice: respect it.
+  if (!any(bare %in% enrichment_keys)) {
+    return(sort)
+  }
+
+  # Drop enrichment keys and any publication_count token, then force a
+  # descending publication_count lead so the fallback ranking is sensible.
+  kept <- tokens[!bare %in% c(enrichment_keys, "publication_count")]
+  paste(c("-publication_count", kept), collapse = ",")
+}
+
 #' Submit the durable PubtatorNDD enrichment refresh job and shape the response
 #'
 #' @param res Plumber response (status/headers are set here).

--- a/api/functions/pubtator-enrichment-collector.R
+++ b/api/functions/pubtator-enrichment-collector.R
@@ -27,10 +27,16 @@ require(logger)
 # corpus probe -- the refresh records which value was actually used.
 PUBTATOR_FALLBACK_TOTAL_CORPUS <- 37000000L
 
-# The disease-side query that defines the "NDD corpus". Mirrors the broad
-# neurodevelopmental concept used elsewhere in PubtatorNDD; kept as a single
-# constant so the NDD-corpus size and the per-gene observed counts stay aligned.
-PUBTATOR_NDD_CORPUS_QUERY <- "@DISEASE_neurodevelopmental"
+# The disease-side query that defines the "NDD corpus" size probe. This MUST be
+# a PubTator3 entity query that the search endpoint actually resolves to a
+# non-zero count. The previous value "@DISEASE_neurodevelopmental" silently
+# returned count=0 (no such normalized entity), which made every enrichment
+# refresh fail at the corpus-size step with "Failed to fetch NDD corpus size".
+# "@DISEASE_Neurodevelopmental_Disorders" is the resolvable concept form
+# (search count ~6.5k as of 2026-06). Keep this as a single constant so the
+# NDD-corpus size and the per-gene observed counts stay aligned, and verify any
+# replacement returns a non-zero count before changing it.
+PUBTATOR_NDD_CORPUS_QUERY <- "@DISEASE_Neurodevelopmental_Disorders"
 
 #' Fetch the total PubTator publication count for a single search query
 #'

--- a/api/tests/testthat/test-unit-publication-endpoint-helpers.R
+++ b/api/tests/testthat/test-unit-publication-endpoint-helpers.R
@@ -145,3 +145,90 @@ test_that("build_cursor_links carries filter and fields when present", {
   expect_match(out$`next`, "&fields=gene_symbol,pmids", fixed = TRUE)
   expect_equal(out$prev, "null")
 })
+
+test_that("pubtator_genes_enrichment_meta reports current snapshot", {
+  query_fn <- function(sql, params = list()) {
+    expect_match(sql, "pubtator_corpus_stats", fixed = TRUE)
+    expect_match(sql, "is_current = 1", fixed = TRUE)
+    data.frame(
+      created_at = "2026-06-14 09:00:00",
+      genes_scored = 352L,
+      stringsAsFactors = FALSE
+    )
+  }
+
+  res <- pubtator_genes_enrichment_meta(query_fn = query_fn)
+
+  expect_equal(res$status, "current")
+  expect_equal(res$refreshed_at, "2026-06-14 09:00:00")
+  expect_equal(res$genes_scored, 352L)
+})
+
+test_that("pubtator_genes_enrichment_meta reports missing snapshot when empty", {
+  query_fn <- function(sql, params = list()) data.frame()
+
+  res <- pubtator_genes_enrichment_meta(query_fn = query_fn)
+
+  expect_equal(res$status, "missing")
+  expect_true(is.na(res$refreshed_at))
+  expect_true(is.na(res$genes_scored))
+})
+
+test_that("pubtator_genes_enrichment_meta degrades to missing on query error", {
+  query_fn <- function(sql, params = list()) stop("db down")
+
+  res <- pubtator_genes_enrichment_meta(query_fn = query_fn)
+
+  expect_equal(res$status, "missing")
+  expect_true(is.na(res$refreshed_at))
+})
+
+test_that("pubtator_resolve_genes_sort keeps requested sort when enrichment available", {
+  sort <- "-enrichment_ratio,-npmi,publication_count"
+  expect_equal(
+    pubtator_resolve_genes_sort(sort, enrichment_available = TRUE),
+    sort
+  )
+})
+
+test_that("pubtator_resolve_genes_sort forces -publication_count lead when enrichment missing", {
+  # Default sort depends on enrichment: enrichment keys + the ascending
+  # publication_count token are dropped, replaced by a descending lead.
+  expect_equal(
+    pubtator_resolve_genes_sort(
+      "-enrichment_ratio,-npmi,publication_count",
+      enrichment_available = FALSE
+    ),
+    "-publication_count"
+  )
+
+  # Sort referencing ONLY enrichment keys collapses to the deterministic fallback.
+  expect_equal(
+    pubtator_resolve_genes_sort("-enrichment_ratio,-fdr_bh", enrichment_available = FALSE),
+    "-publication_count"
+  )
+
+  # Enrichment lead with a non-enrichment, non-publication_count tiebreak: the
+  # tiebreak is preserved after the forced descending lead.
+  expect_equal(
+    pubtator_resolve_genes_sort("-npmi,gene_symbol", enrichment_available = FALSE),
+    "-publication_count,gene_symbol"
+  )
+})
+
+test_that("pubtator_resolve_genes_sort respects explicit non-enrichment sorts when missing", {
+  # No enrichment key referenced => explicit user choice, returned unchanged
+  # (including an explicit ascending publication_count).
+  expect_equal(
+    pubtator_resolve_genes_sort("-publication_count,gene_symbol", enrichment_available = FALSE),
+    "-publication_count,gene_symbol"
+  )
+  expect_equal(
+    pubtator_resolve_genes_sort("gene_symbol", enrichment_available = FALSE),
+    "gene_symbol"
+  )
+  expect_equal(
+    pubtator_resolve_genes_sort("publication_count", enrichment_available = FALSE),
+    "publication_count"
+  )
+})


### PR DESCRIPTION
## Sprint B of the PubTatorNDD perf + automation program

**Stacked on #422 (Sprint A).** Base = `perf/pubtatornidd-db-indexes`; merge after #422.

### Two related root-cause bugs fixed
**1. The enrichment refresh job failed on every run.** `PUBTATOR_NDD_CORPUS_QUERY` was `@DISEASE_neurodevelopmental`, which the PubTator3 search endpoint resolves to **count=0** (no such normalized entity) → `ndd_corpus_size=0` → the `Failed to fetch NDD corpus size` guard aborted the job. This is why `pubtator_gene_enrichment` / `pubtator_corpus_stats` were **empty in production**, so the gene page's default `-enrichment_ratio` sort had nothing to rank on.
- Fix: `@DISEASE_Neurodevelopmental_Disorders` (the resolvable concept form, count ~6.5k).
- ✅ Verified end-to-end: enqueued the durable job, worker completed it — *"Scored 352 genes against NDD corpus of 6468 publications"*; `pubtator_corpus_stats` now has 1 `is_current` snapshot and `pubtator_gene_enrichment` has 352 rows.

**2. Degenerate fallback ordering when no snapshot exists.** The default sort ordered on all-NULL enrichment columns, silently collapsing to `publication_count` **ASC** (least-studied genes first).
- New pure, unit-tested helper `pubtator_resolve_genes_sort(sort, enrichment_available)` drops enrichment keys and forces a deterministic `-publication_count` (most-studied first) lead **only** when the sort depends on enrichment and no snapshot exists. Explicit non-enrichment sorts are respected unchanged.
- ✅ Verified live (pre-population): `enrichmentStatus: missing`, genes ordered GRIN2B(86) → GRIN1(42) → SCN1A(20)…

### Client-visible status contract
`/pubtator/genes` `meta` now carries `enrichmentStatus` (`current`|`missing`) and `enrichmentRefreshedAt`, via new helper `pubtator_genes_enrichment_meta()`, so the UI can show "ranking not yet computed / last refreshed …". (The frontend sprint consumes these defensively.)

### Tests
- New unit tests for both helpers (missing / current / query-error; sort resolution incl. explicit-sort respect). All green host-side; existing `test-unit-pubtator-enrichment.R` still green; changed files lint clean.

### Follow-up (noted, not fixed here)
The `*` total-corpus probe also returns 0, so `total_corpus_size` uses the 37M fallback (`total_is_fallback` is flagged + exposed). There's no clean count-all on the PubTator search API; the flagged fallback is acceptable.