### PR TITLE
perf(app): PubtatorNDD frontend parsing, re-render & UX fixes

### DIFF
--- a/app/src/components/analyses/PubtatorAnnotatedText.spec.ts
+++ b/app/src/components/analyses/PubtatorAnnotatedText.spec.ts
@@ -1,0 +1,43 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import PubtatorAnnotatedText from './PubtatorAnnotatedText.vue';
+
+const TEXT = '@GENE_2904 @GENE_GRIN2B @@@GRIN2B@@@ is linked to <m>NDD</m>.';
+
+describe('PubtatorAnnotatedText', () => {
+  it('renders entity-classed segments and the legend by default', () => {
+    const wrapper = mount(PubtatorAnnotatedText, { props: { text: TEXT } });
+
+    expect(wrapper.find('.annotated-text').exists()).toBe(true);
+    // Gene entity highlighted.
+    const gene = wrapper.find('.pubtator-gene');
+    expect(gene.exists()).toBe(true);
+    expect(gene.text()).toBe('GRIN2B');
+    // Search-match highlighted.
+    expect(wrapper.find('.pubtator-match').text()).toBe('NDD');
+    // Legend present.
+    expect(wrapper.find('.pubtator-legend').exists()).toBe(true);
+    // Label present by default.
+    expect(wrapper.text()).toContain('Annotated Text:');
+  });
+
+  it('hides the legend and label when disabled', () => {
+    const wrapper = mount(PubtatorAnnotatedText, {
+      props: { text: TEXT, showLegend: false, showLabel: false },
+    });
+    expect(wrapper.find('.pubtator-legend').exists()).toBe(false);
+    expect(wrapper.text()).not.toContain('Annotated Text:');
+    // Content still renders.
+    expect(wrapper.find('.pubtator-gene').exists()).toBe(true);
+  });
+
+  it('renders nothing when text is empty', () => {
+    const wrapper = mount(PubtatorAnnotatedText, { props: { text: '' } });
+    expect(wrapper.find('.annotated-text-section').exists()).toBe(false);
+  });
+
+  it('applies the optional section class', () => {
+    const wrapper = mount(PubtatorAnnotatedText, { props: { text: TEXT, sectionClass: 'mt-3' } });
+    expect(wrapper.find('.annotated-text-section').classes()).toContain('mt-3');
+  });
+});

--- a/app/src/components/analyses/PubtatorAnnotatedText.vue
+++ b/app/src/components/analyses/PubtatorAnnotatedText.vue
@@ -1,0 +1,150 @@
+<!-- src/components/analyses/PubtatorAnnotatedText.vue -->
+<!--
+  Shared renderer for PubTator `text_hl` annotated text.
+
+  Both PubtatorNDDTable and PubtatorNDDGenes render the annotated-text block
+  (entity-highlighted segments + a color legend) identically. This component
+  is the single source of truth for that markup, the AA-compliant entity
+  colors, and the legend.
+
+  Parsing goes through `parsePubtatorTextMemoized` so the same `text_hl` string
+  is parsed once and reused across the preview/length-check/full-render call
+  sites in the parent components.
+-->
+<template>
+  <div v-if="text" class="annotated-text-section" :class="sectionClass">
+    <div v-if="showLabel" class="annotated-text-label text-muted small mb-1">
+      <i class="bi bi-highlighter me-1" />Annotated Text:
+    </div>
+    <div class="annotated-text">
+      <span
+        v-for="(segment, idx) in segments"
+        :key="idx"
+        :class="getSegmentClass(segment)"
+        :title="getSegmentTooltip(segment)"
+        >{{ segment.text }}</span
+      >
+    </div>
+    <div v-if="showLegend" class="pubtator-legend d-flex flex-wrap gap-2 small mt-2">
+      <span><span class="pubtator-gene px-1">Gene</span></span>
+      <span><span class="pubtator-disease px-1">Disease</span></span>
+      <span><span class="pubtator-variant px-1">Variant</span></span>
+      <span><span class="pubtator-species px-1">Species</span></span>
+      <span><span class="pubtator-chemical px-1">Chemical</span></span>
+      <span><span class="pubtator-match px-1">Match</span></span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import {
+  parsePubtatorTextMemoized,
+  getSegmentClass,
+  getSegmentTooltip,
+} from '@/composables/usePubtatorParser';
+
+const props = withDefaults(
+  defineProps<{
+    /** Raw PubTator `text_hl` string. */
+    text?: string | null;
+    /** Show the "Annotated Text:" label header. */
+    showLabel?: boolean;
+    /** Show the color legend below the text. */
+    showLegend?: boolean;
+    /** Optional extra class on the wrapper (e.g. spacing utilities). */
+    sectionClass?: string;
+  }>(),
+  {
+    text: null,
+    showLabel: true,
+    showLegend: true,
+    sectionClass: '',
+  }
+);
+
+// Parse once (memoized) and reuse the segment array reactively.
+const segments = computed(() => parsePubtatorTextMemoized(props.text));
+</script>
+
+<style scoped>
+/* PubTator entity annotation highlights — AA-compliant (≥ 4.5:1).
+   Class names are fixed by getSegmentClass() in usePubtatorParser.ts.
+   Colors mapped to global sysndd-annotation-- equivalents from _chips.scss. */
+
+/* Gene: --medical-blue-700 (#0d47a1) on --medical-blue-50 (#e3f2fd) ≈ 7.1:1 ✓ AAA */
+.pubtator-gene {
+  background-color: var(--medical-blue-50, #e3f2fd);
+  color: var(--medical-blue-700, #0d47a1);
+  border-radius: 2px;
+  padding: 0 2px;
+  cursor: help;
+}
+
+/* Disease: #bf360c on #ffe0b2 ≈ 4.6:1 ✓ AA */
+.pubtator-disease {
+  background-color: #ffe0b2;
+  color: #bf360c;
+  border-radius: 2px;
+  padding: 0 2px;
+  cursor: help;
+}
+
+/* Variant: #880e4f on #f8bbd9 ≈ 5.4:1 ✓ AA */
+.pubtator-variant {
+  background-color: #f8bbd9;
+  color: #880e4f;
+  border-radius: 2px;
+  padding: 0 2px;
+  cursor: help;
+}
+
+/* Species: #1b5e20 on #c8e6c9 ≈ 5.5:1 ✓ AA */
+.pubtator-species {
+  background-color: #c8e6c9;
+  color: #1b5e20;
+  border-radius: 2px;
+  padding: 0 2px;
+  cursor: help;
+}
+
+/* Chemical: #4a148c on #e1bee7 ≈ 5.6:1 ✓ AA */
+.pubtator-chemical {
+  background-color: #e1bee7;
+  color: #4a148c;
+  border-radius: 2px;
+  padding: 0 2px;
+  cursor: help;
+}
+
+/* Match: #bf360c on #fff59d ≈ 5.2:1 ✓ AA */
+.pubtator-match {
+  background-color: #fff59d;
+  color: #bf360c;
+  font-weight: 600;
+  border-radius: 2px;
+  padding: 0 2px;
+}
+
+.annotated-text-section {
+  border-top: 1px solid var(--neutral-300, #e0e0e0);
+  padding-top: 0.75rem;
+}
+
+.annotated-text-label {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.annotated-text {
+  text-align: left;
+  line-height: 1.8;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+.pubtator-legend {
+  color: var(--neutral-600, #757575);
+}
+</style>

--- a/app/src/components/analyses/PubtatorNDDGenes.spec.ts
+++ b/app/src/components/analyses/PubtatorNDDGenes.spec.ts
@@ -325,7 +325,7 @@ describe('PubtatorNDDGenes', () => {
               currentPage: 1,
               currentItemID: 0,
               fspec: [],
-              enrichment_status: 'missing',
+              enrichmentStatus: 'missing',
             },
           ],
           data: [

--- a/app/src/components/analyses/PubtatorNDDGenes.spec.ts
+++ b/app/src/components/analyses/PubtatorNDDGenes.spec.ts
@@ -95,6 +95,7 @@ async function mountSubject(props = {}) {
         TableDownloadLinkCopyButtons: { template: '<div />' },
         GeneBadge: { template: '<a :href="linkTo">{{ symbol }}</a>', props: ['symbol', 'linkTo'] },
         BBadge: { template: '<span><slot /></span>' },
+        BAlert: { template: '<div class="b-alert"><slot /></div>' },
         BButton: {
           template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
           props: ['disabled'],
@@ -311,5 +312,59 @@ describe('PubtatorNDDGenes', () => {
       })
     );
     expect(makeToastSpy).toHaveBeenCalledWith('Excel file downloaded', 'Success', 'success');
+  });
+
+  it('shows a freshness notice when the API reports a stale/missing ranking', async () => {
+    server.use(
+      http.get('/api/publication/pubtator/genes', () =>
+        HttpResponse.json({
+          meta: [
+            {
+              totalItems: 1,
+              totalPages: 1,
+              currentPage: 1,
+              currentItemID: 0,
+              fspec: [],
+              enrichment_status: 'missing',
+            },
+          ],
+          data: [
+            {
+              gene_symbol: 'MECP2',
+              gene_name: 'methyl CpG binding protein 2',
+              publication_count: 2,
+              is_novel: 1,
+              pmids: '123',
+            },
+          ],
+        })
+      )
+    );
+
+    const wrapper = await mountSubject();
+    expect(wrapper.find('.b-alert').exists()).toBe(true);
+    expect(wrapper.text()).toContain('Gene ranking not yet computed');
+  });
+
+  it('renders no freshness notice when the meta fields are absent (defensive)', async () => {
+    server.use(
+      http.get('/api/publication/pubtator/genes', () =>
+        HttpResponse.json({
+          meta: [{ totalItems: 1, totalPages: 1, currentPage: 1, currentItemID: 0, fspec: [] }],
+          data: [
+            {
+              gene_symbol: 'MECP2',
+              gene_name: 'methyl CpG binding protein 2',
+              publication_count: 2,
+              is_novel: 1,
+              pmids: '123',
+            },
+          ],
+        })
+      )
+    );
+
+    const wrapper = await mountSubject();
+    expect(wrapper.find('.b-alert').exists()).toBe(false);
   });
 });

--- a/app/src/components/analyses/PubtatorNDDGenes.vue
+++ b/app/src/components/analyses/PubtatorNDDGenes.vue
@@ -593,8 +593,7 @@ const loadData = async () => {
         currentPage?: number;
         fspec?: FieldDefinition[];
         // Optional enrichment-freshness fields from /pubtator/genes meta
-        // (camelCase, matching executionTime/totalItems); absent on older API
-        // responses, so both are optional and handled defensively.
+        // (camelCase, like executionTime/totalItems); absent on older responses.
         enrichmentStatus?: string;
         enrichmentRefreshedAt?: string;
       };

--- a/app/src/components/analyses/PubtatorNDDGenes.vue
+++ b/app/src/components/analyses/PubtatorNDDGenes.vue
@@ -109,6 +109,18 @@
       </BRow>
       <!-- End Controls -->
 
+      <!-- Enrichment freshness notice (defensive: only when the API reports
+           a non-current ranking; absent fields render nothing). -->
+      <BAlert
+        v-if="enrichmentNotice"
+        :model-value="true"
+        variant="warning"
+        class="mx-2 mb-2 py-2 px-3 small"
+      >
+        <i class="bi bi-info-circle me-1" />
+        {{ enrichmentNotice }}
+      </BAlert>
+
       <!-- Main b-table -->
       <BTable
         :items="items"
@@ -279,92 +291,11 @@
 
             <!-- Publication list -->
             <div v-else>
-              <div
+              <PubtatorPublicationDetail
                 v-for="pub in getPublications((data.item as GeneItem).gene_symbol)"
                 :key="pub.pmid"
-                class="details-section"
-              >
-                <!-- Title -->
-                <div v-if="pub.title" class="details-title">
-                  {{ pub.title }}
-                </div>
-
-                <div class="details-row">
-                  <!-- PMID, DOI, Date, Journal, Score -->
-                  <div class="details-meta">
-                    <a
-                      :href="'https://pubmed.ncbi.nlm.nih.gov/' + pub.pmid"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="details-pmid"
-                    >
-                      <i class="bi bi-journal-medical me-1" />
-                      PMID:{{ pub.pmid }}
-                      <i class="bi bi-box-arrow-up-right ms-1" />
-                    </a>
-                    <a
-                      v-if="pub.doi"
-                      :href="'https://doi.org/' + pub.doi"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="details-doi"
-                    >
-                      <i class="bi bi-link-45deg me-1" />
-                      {{ pub.doi }}
-                    </a>
-                    <span v-if="pub.date" class="details-date">
-                      <i class="bi bi-calendar3 me-1" />
-                      {{ pub.date }}
-                    </span>
-                    <span v-if="pub.journal" class="details-journal">
-                      <i class="bi bi-book me-1" />
-                      {{ pub.journal }}
-                    </span>
-                    <BBadge
-                      v-if="pub.score != null"
-                      :variant="
-                        pub.score >= 500 ? 'success' : pub.score >= 100 ? 'warning' : 'secondary'
-                      "
-                      pill
-                    >
-                      Score: {{ pub.score }}
-                    </BBadge>
-                  </div>
-                </div>
-
-                <!-- Annotated Text Section -->
-                <div v-if="pub.text_hl" class="annotated-text-section mt-2">
-                  <div class="annotated-text-label text-muted small mb-1">
-                    <i class="bi bi-highlighter me-1" />Annotated Text:
-                  </div>
-                  <div class="annotated-text">
-                    <span
-                      v-for="(segment, idx) in parseAnnotations(pub.text_hl)"
-                      :key="idx"
-                      :class="getSegmentClass(segment)"
-                      :title="getSegmentTooltip(segment)"
-                      >{{ segment.text }}</span
-                    >
-                  </div>
-                  <div class="pubtator-legend d-flex flex-wrap gap-2 small mt-2">
-                    <span><span class="pubtator-gene px-1">Gene</span></span>
-                    <span><span class="pubtator-disease px-1">Disease</span></span>
-                    <span><span class="pubtator-variant px-1">Variant</span></span>
-                    <span><span class="pubtator-species px-1">Species</span></span>
-                    <span><span class="pubtator-chemical px-1">Chemical</span></span>
-                    <span><span class="pubtator-match px-1">Match</span></span>
-                  </div>
-                </div>
-
-                <!-- Gene symbols as badges -->
-                <div v-if="pub.gene_symbols" class="gene-symbols-section mt-2">
-                  <div class="gene-chips">
-                    <span v-for="sym in pub.gene_symbols.split(',')" :key="sym" class="gene-chip">
-                      {{ sym.trim() }}
-                    </span>
-                  </div>
-                </div>
-              </div>
+                :publication="pub"
+              />
 
               <!-- Fallback if no cached data -->
               <div
@@ -398,19 +329,12 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue';
-import { listPubtatorGenes, listPubtatorTable } from '@/api/publication';
+import { listPubtatorGenes } from '@/api/publication';
 
 // Import composables
-import {
-  useToast,
-  useUrlParsing,
-  useTableData,
-  parsePubtatorText,
-  getSegmentClass,
-  getSegmentTooltip,
-} from '@/composables';
-import type { ParsedSegment } from '@/composables/usePubtatorParser';
+import { useToast, useUrlParsing, useTableData } from '@/composables';
 import { useExcelExport } from '@/composables/useExcelExport';
+import { usePubtatorGenePublications } from '@/composables/usePubtatorGenePublications';
 
 // Small reusable components
 import TableSearchInput from '@/components/small/TableSearchInput.vue';
@@ -419,6 +343,7 @@ import TableDownloadLinkCopyButtons from '@/components/small/TableDownloadLinkCo
 import GeneBadge from '@/components/ui/GeneBadge.vue';
 import InlineHelpBadge from '@/components/small/InlineHelpBadge.vue';
 import AnalysisPanel from '@/components/analyses/AnalysisPanel.vue';
+import PubtatorPublicationDetail from '@/components/analyses/PubtatorPublicationDetail.vue';
 import {
   applyPubtatorGenePrioritizationFilters,
   createDefaultPubtatorGeneFilter,
@@ -456,18 +381,6 @@ interface GeneItem {
   npmi?: number | null;
   fisher_p?: number | null;
   fdr_bh?: number | null;
-}
-
-interface PublicationData {
-  search_id?: number;
-  pmid: number;
-  doi?: string;
-  title?: string;
-  journal?: string;
-  date?: string;
-  score?: number;
-  gene_symbols?: string;
-  text_hl?: string;
 }
 
 // Props
@@ -562,12 +475,22 @@ const dateRangeOptions = [
 // Cursor pagination info
 const totalPages = ref(0);
 
-// Publication data cache (keyed by gene_symbol)
-const publicationCache = ref<Record<string, PublicationData[]>>({});
-const loadingPublications = ref<Record<string, boolean>>({});
+// Enrichment freshness notice (issue: surface a non-blocking notice when the
+// genes API reports the gene ranking is not yet computed / is stale). Defensive
+// — the meta fields may be absent (older API), in which case this stays null.
+const enrichmentNotice = ref<string | null>(null);
 
-// AbortControllers for per-gene publication fetches (prevents orphaned requests)
-const publicationAbortControllers = new Map<string, AbortController>();
+// Per-gene publication-detail cache (extracted composable). Scoped to the
+// current filter/sort: resetCache() runs on every reload so an expanded row
+// never shows publications fetched under a previous query.
+const {
+  fetchPublications,
+  getPublications,
+  isLoading: isLoadingPublications,
+  isCached,
+  resetCache: resetPublicationCache,
+  cancelAll: cancelAllPublicationFetches,
+} = usePubtatorGenePublications({ makeToast });
 
 // Computed: sortBy as properly typed array for BTable
 const sortByArray = computed(() => sortBy.value);
@@ -622,64 +545,13 @@ const truncateText = (str: string | undefined, n: number): string => {
   return str.length > n ? `${str.slice(0, n)}...` : str;
 };
 
-// Fetch publication data for a gene's PMIDs from pubtator cache
-const fetchPublicationData = async (geneSymbol: string, pmids: string[]) => {
-  if (pmids.length === 0) return;
-  if (publicationCache.value[geneSymbol]) return; // Already cached
-
-  // Cancel any in-flight request for this gene
-  publicationAbortControllers.get(geneSymbol)?.abort();
-  const controller = new AbortController();
-  publicationAbortControllers.set(geneSymbol, controller);
-
-  loadingPublications.value[geneSymbol] = true;
-
-  try {
-    const response = await listPubtatorTable(
-      {
-        filter: `any(pmid,${pmids.join(',')})`,
-        fields: 'search_id,pmid,doi,title,journal,date,score,gene_symbols,text_hl',
-        page_size: String(pmids.length),
-      },
-      { signal: controller.signal }
-    );
-    publicationCache.value[geneSymbol] = response.data || [];
-  } catch (error) {
-    if ((error as Error).name !== 'AbortError' && (error as Error).name !== 'CanceledError') {
-      console.error('Failed to fetch publication data:', error);
-      publicationCache.value[geneSymbol] = [];
-    }
-  } finally {
-    publicationAbortControllers.delete(geneSymbol);
-    loadingPublications.value[geneSymbol] = false;
-  }
-};
-
-// Handle row expansion - fetch publication data
+// Handle row expansion - fetch publication data lazily via the cache composable
 const handleRowExpand = (item: GeneItem) => {
   const pmids = parsePmids(item.pmids);
-  if (pmids.length > 0 && !publicationCache.value[item.gene_symbol]) {
-    fetchPublicationData(item.gene_symbol, pmids);
+  if (pmids.length > 0 && !isCached(item.gene_symbol)) {
+    fetchPublications(item.gene_symbol, pmids);
   }
 };
-
-// Get cached publications for a gene
-const getPublications = (geneSymbol: string): PublicationData[] => {
-  return publicationCache.value[geneSymbol] || [];
-};
-
-// Check if publications are loading for a gene
-const isLoadingPublications = (geneSymbol: string): boolean => {
-  return loadingPublications.value[geneSymbol] || false;
-};
-
-// Parse PubTator annotations from text_hl field
-const parseAnnotations = (text: string | null | undefined): ParsedSegment[] => {
-  return parsePubtatorText(text);
-};
-
-// Segment display helpers (getSegmentClass / getSegmentTooltip) are imported
-// from the shared PubTator parser composable above and used directly in the template.
 
 // Apply prioritization filters
 const applyPrioritizationFilters = () => {
@@ -693,6 +565,11 @@ const applyPrioritizationFilters = () => {
 
 const loadData = async () => {
   isBusy.value = true;
+
+  // The gene set is about to change (filter / sort / page). Drop the per-gene
+  // publication cache so an expanded row cannot show publications fetched under
+  // the previous query (correctness fix).
+  resetPublicationCache();
 
   try {
     const response = await listPubtatorGenes({
@@ -715,6 +592,10 @@ const loadData = async () => {
         lastItemID?: number | null;
         currentPage?: number;
         fspec?: FieldDefinition[];
+        // Optional enrichment-freshness fields (may arrive from a sibling
+        // backend sprint; absent on older API responses).
+        enrichment_status?: string;
+        enrichment_refreshed_at?: string;
       };
       totalRows.value = metaObj.totalItems || 0;
       totalPages.value = metaObj.totalPages || 1;
@@ -728,6 +609,11 @@ const loadData = async () => {
       if (metaObj.fspec && Array.isArray(metaObj.fspec)) {
         fields.value = mergeFields(metaObj.fspec);
       }
+
+      enrichmentNotice.value = deriveEnrichmentNotice(
+        metaObj.enrichment_status,
+        metaObj.enrichment_refreshed_at
+      );
     }
 
     const uiStore = useUiStore();
@@ -737,6 +623,32 @@ const loadData = async () => {
   } finally {
     isBusy.value = false;
   }
+};
+
+/**
+ * Build a non-blocking notice string from the optional enrichment-freshness
+ * meta. Returns null when the ranking is current or the fields are absent
+ * (defensive: never throw on a shape the API may not yet send).
+ */
+const deriveEnrichmentNotice = (
+  status: string | undefined,
+  refreshedAt: string | undefined
+): string | null => {
+  if (!status || status === 'current') return null;
+  if (status === 'missing') {
+    return 'Gene ranking not yet computed. Showing raw co-occurrence ordering until the first refresh.';
+  }
+  if (status === 'stale') {
+    const when = refreshedAt ? ` (last refreshed ${formatRefreshedAt(refreshedAt)})` : '';
+    return `Gene ranking may be out of date${when}.`;
+  }
+  return null;
+};
+
+/** Best-effort human-friendly date for the freshness notice. */
+const formatRefreshedAt = (value: string): string => {
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? value : parsed.toLocaleDateString();
 };
 
 // Handle page change
@@ -878,8 +790,7 @@ const mergeFields = (inboundFields: FieldDefinition[]): FieldDefinition[] => {
 
 // Cleanup: abort all in-flight publication requests on unmount
 onUnmounted(() => {
-  publicationAbortControllers.forEach((controller) => controller.abort());
-  publicationAbortControllers.clear();
+  cancelAllPublicationFetches();
 });
 
 // Lifecycle
@@ -964,29 +875,6 @@ mark {
   opacity: 0.7;
 }
 
-.details-title {
-  font-weight: 600;
-  font-size: 0.95rem;
-  color: #212529;
-  margin-bottom: 0.5rem;
-  line-height: 1.4;
-  text-align: left;
-}
-
-.details-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  margin-bottom: 0.75rem;
-}
-
-.details-meta {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 1rem;
-}
-
 .details-pmid {
   display: inline-flex;
   align-items: center;
@@ -1005,137 +893,8 @@ mark {
   color: white;
 }
 
-.details-date {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.2em 0.5em;
-  font-size: 0.8em;
-  background-color: #e8f5e9;
-  color: #2e7d32;
-  border-radius: 0.25rem;
-}
-
-.details-journal {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.25em 0.5em;
-  font-size: 0.8em;
-  background-color: #f8f9fa;
-  color: #495057;
-  border-radius: 0.25rem;
-  border: 1px solid #dee2e6;
-}
-
-.details-doi {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.25em 0.5em;
-  font-size: 0.8em;
-  font-weight: 500;
-  background-color: #f0f0f0;
-  color: #495057;
-  border-radius: 0.3rem;
-  text-decoration: none;
-  transition: all 0.15s ease-in-out;
-}
-
-.details-doi:hover {
-  background-color: #495057;
-  color: white;
-}
-
-/* PubTator annotation styles */
-.annotated-text-section {
-  border-top: 1px solid #dee2e6;
-  padding-top: 0.75rem;
-}
-
-.annotated-text-label {
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.annotated-text {
-  text-align: left;
-  line-height: 1.8;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-}
-
-.pubtator-legend {
-  color: #6c757d;
-}
-
-.pubtator-gene {
-  background-color: #b4e3f9;
-  color: #0d6efd;
-  border-radius: 2px;
-  padding: 0 2px;
-  cursor: help;
-}
-
-.pubtator-disease {
-  background-color: #ffe0b2;
-  color: #e65100;
-  border-radius: 2px;
-  padding: 0 2px;
-  cursor: help;
-}
-
-.pubtator-variant {
-  background-color: #f8bbd9;
-  color: #c2185b;
-  border-radius: 2px;
-  padding: 0 2px;
-  cursor: help;
-}
-
-.pubtator-species {
-  background-color: #c8e6c9;
-  color: #2e7d32;
-  border-radius: 2px;
-  padding: 0 2px;
-  cursor: help;
-}
-
-.pubtator-chemical {
-  background-color: #e1bee7;
-  color: #7b1fa2;
-  border-radius: 2px;
-  padding: 0 2px;
-  cursor: help;
-}
-
-.pubtator-match {
-  background-color: #fff59d;
-  color: #f57f17;
-  font-weight: 600;
-  border-radius: 2px;
-  padding: 0 2px;
-}
-
-/* Gene symbol chips */
-.gene-symbols-section {
-  border-top: 1px solid #dee2e6;
-  padding-top: 0.5rem;
-}
-
-.gene-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.25rem;
-  align-items: center;
-}
-
-.gene-chip {
-  display: inline-block;
-  padding: 0.15em 0.4em;
-  font-size: 0.75rem;
-  font-weight: 500;
-  background-color: #b4e3f9;
-  color: #0d6efd;
-  border-radius: 0.25rem;
-  white-space: nowrap;
-}
+/* The per-publication detail card (title/meta/annotated text/gene chips) now
+   lives in PubtatorPublicationDetail.vue and PubtatorAnnotatedText.vue. The
+   styles retained here cover the panel wrapper, the loading state, and the
+   no-cache PMID fallback that this component still renders directly. */
 </style>

--- a/app/src/components/analyses/PubtatorNDDGenes.vue
+++ b/app/src/components/analyses/PubtatorNDDGenes.vue
@@ -592,10 +592,11 @@ const loadData = async () => {
         lastItemID?: number | null;
         currentPage?: number;
         fspec?: FieldDefinition[];
-        // Optional enrichment-freshness fields (may arrive from a sibling
-        // backend sprint; absent on older API responses).
-        enrichment_status?: string;
-        enrichment_refreshed_at?: string;
+        // Optional enrichment-freshness fields from /pubtator/genes meta
+        // (camelCase, matching executionTime/totalItems); absent on older API
+        // responses, so both are optional and handled defensively.
+        enrichmentStatus?: string;
+        enrichmentRefreshedAt?: string;
       };
       totalRows.value = metaObj.totalItems || 0;
       totalPages.value = metaObj.totalPages || 1;
@@ -611,8 +612,8 @@ const loadData = async () => {
       }
 
       enrichmentNotice.value = deriveEnrichmentNotice(
-        metaObj.enrichment_status,
-        metaObj.enrichment_refreshed_at
+        metaObj.enrichmentStatus,
+        metaObj.enrichmentRefreshedAt
       );
     }
 

--- a/app/src/components/analyses/PubtatorNDDStats.vue
+++ b/app/src/components/analyses/PubtatorNDDStats.vue
@@ -35,7 +35,7 @@
           <template #header>
             <small class="text-muted">Total Genes</small>
           </template>
-          <BCardBody class="py-2">
+          <BCardBody class="py-2 summary-card-body">
             <BSpinner v-if="loadingStats" small />
             <template v-else>
               <h3 class="mb-0 text-primary">
@@ -51,7 +51,7 @@
           <template #header>
             <small class="text-muted">Literature Only</small>
           </template>
-          <BCardBody class="py-2">
+          <BCardBody class="py-2 summary-card-body">
             <BSpinner v-if="loadingStats" small />
             <template v-else>
               <h3 class="mb-0 text-info">
@@ -68,7 +68,7 @@
           <template #header>
             <small class="text-muted">Curated</small>
           </template>
-          <BCardBody class="py-2">
+          <BCardBody class="py-2 summary-card-body">
             <BSpinner v-if="loadingStats" small />
             <template v-else>
               <h3 class="mb-0 text-success">
@@ -155,6 +155,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue';
 import { useRouter } from 'vue-router';
+import { useDebounceFn } from '@vueuse/core';
 import * as d3 from 'd3';
 import useToast from '@/composables/useToast';
 import InlineHelpBadge from '@/components/small/InlineHelpBadge.vue';
@@ -221,18 +222,32 @@ const isFilterActive = computed(() => selectedCategory.value === 'gene' && minCo
 // Number of bars actually displayed (limited by topN)
 const displayedCount = computed(() => Math.min(statsData.value.length, topN.value));
 
-// Watch minCount changes - needs to re-process data and re-plot
-watch(minCount, () => {
+// Debounced re-render guards (~300ms): minCount/topN are stepper inputs whose
+// value can change rapidly; without this each keystroke/step triggers a full
+// D3 rebuild. The BFormInput debounce coalesces the model update; this further
+// coalesces the (more expensive) chart rebuild.
+const RERENDER_DEBOUNCE_MS = 300;
+
+const debouncedProcessAndPlot = useDebounceFn(() => {
   if (rawGeneData.value.length > 0) {
     processAndPlot();
   }
+}, RERENDER_DEBOUNCE_MS);
+
+const debouncedReplot = useDebounceFn(() => {
+  if (statsData.value.length > 0) {
+    generateBarPlot();
+  }
+}, RERENDER_DEBOUNCE_MS);
+
+// Watch minCount changes - needs to re-process data and re-plot
+watch(minCount, () => {
+  debouncedProcessAndPlot();
 });
 
 // Watch topN changes - only needs to re-plot (data slice changes)
 watch(topN, () => {
-  if (statsData.value.length > 0) {
-    generateBarPlot();
-  }
+  debouncedReplot();
 });
 
 /**
@@ -254,11 +269,13 @@ async function fetchStats() {
       is_novel: item.is_novel !== undefined ? Number(item.is_novel) : undefined,
       hgnc_id: item.hgnc_id ? String(item.hgnc_id) : undefined,
     }));
-    loadingStats.value = false;
     processAndPlot();
   } catch (error) {
     makeToast(error, 'Error fetching PubTator stats', 'danger');
   } finally {
+    // Always exit both loading states so a fetch failure cannot leave the
+    // summary cards (loadingStats) or the chart overlay (loading) spinning.
+    loadingStats.value = false;
     loading.value = false;
   }
 }
@@ -331,14 +348,16 @@ function barFill(d: StatsDataItem): string {
 function generateBarPlot() {
   const isGeneMode = selectedCategory.value === 'gene';
 
-  // Always remove old svg and tooltip first
-  d3.select('#pubtator_stats_dataviz').select('svg').remove();
-  d3.select('#pubtator_stats_dataviz').select('.tooltip').remove();
-  d3.select('#pubtator_stats_dataviz').select('.no-data-message').remove();
+  // Single SVG root: clear the one container in a single pass rather than
+  // several targeted .select().remove() calls. The container only ever holds
+  // our svg / tooltip / no-data-message, so emptying it is equivalent and
+  // cheaper than three separate selections.
+  const container = d3.select('#pubtator_stats_dataviz');
+  container.selectAll('*').remove();
 
   // Handle empty data case - show message instead of stale chart
   if (!statsData.value || statsData.value.length === 0) {
-    d3.select('#pubtator_stats_dataviz')
+    container
       .append('div')
       .attr('class', 'no-data-message text-center text-muted py-5')
       .html(
@@ -357,13 +376,20 @@ function generateBarPlot() {
   const width = CHART_SVG_WIDTH - margin.left - margin.right;
   const height = CHART_SVG_HEIGHT - margin.top - margin.bottom;
 
+  // Accessible chart description (role="img" + aria-label) so the bar chart is
+  // announced as a single meaningful image rather than a tree of <rect>s.
+  const chartLabel = isGeneMode
+    ? `Bar chart of top ${data.length} genes by NDD publication count.`
+    : `Bar chart of the number of genes by NDD publication count, ${data.length} bins.`;
+
   // append the SVG
-  const svg = d3
-    .select('#pubtator_stats_dataviz')
+  const svg = container
     .append('svg')
     .attr('id', 'pubtator-stats-svg')
     .attr('viewBox', `0 0 ${CHART_SVG_WIDTH} ${CHART_SVG_HEIGHT}`)
     .attr('preserveAspectRatio', 'xMinYMin meet')
+    .attr('role', 'img')
+    .attr('aria-label', chartLabel)
     .append('g')
     .attr('transform', `translate(${margin.left},${margin.top})`);
 
@@ -429,8 +455,7 @@ function generateBarPlot() {
     .text(isGeneMode ? 'Publication Count' : 'Number of Genes');
 
   // Create a tooltip element
-  const tooltip = d3
-    .select('#pubtator_stats_dataviz')
+  const tooltip = container
     .append('div')
     .attr('class', 'tooltip')
     .style('opacity', 0)
@@ -525,6 +550,14 @@ onMounted(async () => {
   flex-direction: column;
   justify-content: center;
   align-items: center;
+}
+/* Reserve summary-card body height so the loading-spinner → number swap does
+   not reflow the cards (avoids cumulative layout shift). */
+.summary-card-body {
+  min-height: 4.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 mark {
   display: inline-block;

--- a/app/src/components/analyses/PubtatorNDDTable.vue
+++ b/app/src/components/analyses/PubtatorNDDTable.vue
@@ -141,19 +141,19 @@
         <template #cell-gene_symbols="{ row }">
           <div v-if="row.gene_symbols" class="gene-chips">
             <RouterLink
-              v-for="gene in row.gene_symbols.split(',').slice(0, 3)"
+              v-for="gene in geneSymbolList(row.gene_symbols).slice(0, 3)"
               :key="gene"
-              :to="'/Genes/' + gene.trim()"
+              :to="'/Genes/' + gene"
               class="gene-chip"
             >
-              {{ gene.trim() }}
+              {{ gene }}
             </RouterLink>
             <span
-              v-if="row.gene_symbols.split(',').length > 3"
+              v-if="geneSymbolList(row.gene_symbols).length > 3"
               class="gene-chip-more"
               :title="row.gene_symbols"
             >
-              +{{ row.gene_symbols.split(',').length - 3 }}
+              +{{ geneSymbolList(row.gene_symbols).length - 3 }}
             </span>
           </div>
           <span v-else class="text-muted">—</span>
@@ -209,28 +209,11 @@
               </div>
 
               <!-- Annotated Text Section -->
-              <div v-if="row.text_hl" class="annotated-text-section mt-3">
-                <div class="annotated-text-label text-muted small mb-1">
-                  <i class="bi bi-highlighter me-1" />Annotated Text:
-                </div>
-                <div class="annotated-text">
-                  <span
-                    v-for="(segment, idx) in parseAnnotations(row.text_hl)"
-                    :key="idx"
-                    :class="getSegmentClass(segment)"
-                    :title="getSegmentTooltip(segment)"
-                    >{{ segment.text }}</span
-                  >
-                </div>
-                <div class="pubtator-legend d-flex flex-wrap gap-2 small mt-2">
-                  <span><span class="pubtator-gene px-1">Gene</span></span>
-                  <span><span class="pubtator-disease px-1">Disease</span></span>
-                  <span><span class="pubtator-variant px-1">Variant</span></span>
-                  <span><span class="pubtator-species px-1">Species</span></span>
-                  <span><span class="pubtator-chemical px-1">Chemical</span></span>
-                  <span><span class="pubtator-match px-1">Match</span></span>
-                </div>
-              </div>
+              <PubtatorAnnotatedText
+                v-if="row.text_hl"
+                :text="row.text_hl"
+                section-class="mt-3"
+              />
               <div v-else class="text-muted mt-3">
                 <i class="bi bi-info-circle me-1" />No annotated text available.
               </div>
@@ -245,7 +228,7 @@
 
 <script lang="ts">
 // Import Vue utilities
-import { ref } from 'vue';
+import { ref, markRaw } from 'vue';
 
 // Import composables
 import {
@@ -254,9 +237,8 @@ import {
   useColorAndSymbols,
   useText,
   useTableData,
-  parsePubtatorText,
+  parsePubtatorTextMemoized,
   getSegmentClass,
-  getSegmentTooltip,
 } from '@/composables';
 import type { ParsedSegment } from '@/composables';
 import { normalizeSelectOptions } from '@/utils/selectOptions';
@@ -282,6 +264,7 @@ import TablePaginationControls from '@/components/small/TablePaginationControls.
 import TableDownloadLinkCopyButtons from '@/components/small/TableDownloadLinkCopyButtons.vue';
 import GenericTable from '@/components/small/GenericTable.vue';
 import AnalysisPanel from '@/components/analyses/AnalysisPanel.vue';
+import PubtatorAnnotatedText from '@/components/analyses/PubtatorAnnotatedText.vue';
 
 import Utils from '@/assets/js/utils';
 import { useUiStore } from '@/stores/ui';
@@ -294,6 +277,7 @@ export default {
     TablePaginationControls,
     TableDownloadLinkCopyButtons,
     GenericTable,
+    PubtatorAnnotatedText,
   },
   props: {
     apiEndpoint: {
@@ -438,6 +422,11 @@ export default {
 
       // Component-specific cursor pagination info (not in useTableData)
       totalPages: 0,
+
+      // Non-reactive memoization cache for gene_symbols splits (keyed by the
+      // raw comma-separated string). markRaw keeps Vue from making it reactive;
+      // declaring it here lets TypeScript infer the instance property.
+      geneSymbolCache: markRaw(new Map<string, string[]>()),
     };
   },
   watch: {
@@ -692,10 +681,12 @@ export default {
     },
 
     /**
-     * Parse PubTator annotations from text_hl field
+     * Parse PubTator annotations from text_hl field.
+     * Memoized: the same `text_hl` string parses once and is reused across the
+     * preview slice, the length check, and the (legacy) detail render.
      */
     parseAnnotations(text: string | null | undefined): ParsedSegment[] {
-      return parsePubtatorText(text);
+      return parsePubtatorTextMemoized(text);
     },
 
     /**
@@ -707,11 +698,20 @@ export default {
     },
 
     /**
-     * Get tooltip text for annotated segments.
-     * Delegates to the shared PubTator parser helper.
+     * Split a comma-separated gene_symbols string into trimmed symbols once.
+     * The template needs this list up to three times per row (slice, count,
+     * overflow), so memoize by the raw string to avoid repeated splitting.
      */
-    getSegmentTooltip(segment: ParsedSegment): string {
-      return getSegmentTooltip(segment);
+    geneSymbolList(geneSymbols: string | null | undefined): string[] {
+      if (!geneSymbols) return [];
+      const cached = this.geneSymbolCache.get(geneSymbols);
+      if (cached) return cached;
+      const list = geneSymbols
+        .split(',')
+        .map((g) => g.trim())
+        .filter((g) => g !== '');
+      this.geneSymbolCache.set(geneSymbols, list);
+      return list;
     },
     // Normalize select options for BFormSelect (replacement for treeselect normalizer)
     normalizeSelectOptions(options) {
@@ -883,27 +883,9 @@ export default {
   border: 1px solid var(--neutral-300, #e0e0e0);
 }
 
-.annotated-text-section {
-  border-top: 1px solid var(--neutral-300, #e0e0e0);
-  padding-top: 0.75rem;
-}
-
-.annotated-text-label {
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.annotated-text {
-  text-align: left;
-  line-height: 1.8;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-}
-
-.pubtator-legend {
-  color: var(--neutral-600, #757575);
-}
+/* The annotated-text block + legend now live in PubtatorAnnotatedText.vue.
+   The entity color classes below are retained because the truncated text_hl
+   preview cell renders segments inline (without that child component). */
 
 /* Gene chips — pill badges in table cells */
 .gene-chips {

--- a/app/src/components/analyses/PubtatorNDDTable.vue
+++ b/app/src/components/analyses/PubtatorNDDTable.vue
@@ -269,6 +269,9 @@ import PubtatorAnnotatedText from '@/components/analyses/PubtatorAnnotatedText.v
 import Utils from '@/assets/js/utils';
 import { useUiStore } from '@/stores/ui';
 
+// Upper bound for the per-instance gene_symbols split cache (LRU eviction).
+const GENE_SYMBOL_CACHE_LIMIT = 2000;
+
 export default {
   name: 'PubtatorNDDTable',
   components: {
@@ -683,7 +686,8 @@ export default {
     /**
      * Parse PubTator annotations from text_hl field.
      * Memoized: the same `text_hl` string parses once and is reused across the
-     * preview slice, the length check, and the (legacy) detail render.
+     * preview slice and the length check. The expanded detail view renders
+     * annotated text via PubtatorAnnotatedText (which memoizes independently).
      */
     parseAnnotations(text: string | null | undefined): ParsedSegment[] {
       return parsePubtatorTextMemoized(text);
@@ -701,16 +705,27 @@ export default {
      * Split a comma-separated gene_symbols string into trimmed symbols once.
      * The template needs this list up to three times per row (slice, count,
      * overflow), so memoize by the raw string to avoid repeated splitting.
+     * Bounded with LRU eviction (recency refreshed on hit) so a long browsing
+     * session over many distinct gene_symbols strings cannot grow it unbounded.
      */
     geneSymbolList(geneSymbols: string | null | undefined): string[] {
       if (!geneSymbols) return [];
-      const cached = this.geneSymbolCache.get(geneSymbols);
-      if (cached) return cached;
+      const cache = this.geneSymbolCache;
+      const cached = cache.get(geneSymbols);
+      if (cached) {
+        cache.delete(geneSymbols);
+        cache.set(geneSymbols, cached);
+        return cached;
+      }
       const list = geneSymbols
         .split(',')
         .map((g) => g.trim())
         .filter((g) => g !== '');
-      this.geneSymbolCache.set(geneSymbols, list);
+      if (cache.size >= GENE_SYMBOL_CACHE_LIMIT) {
+        const oldestKey = cache.keys().next().value;
+        if (oldestKey !== undefined) cache.delete(oldestKey);
+      }
+      cache.set(geneSymbols, list);
       return list;
     },
     // Normalize select options for BFormSelect (replacement for treeselect normalizer)

--- a/app/src/components/analyses/PubtatorNDDTable.vue
+++ b/app/src/components/analyses/PubtatorNDDTable.vue
@@ -268,9 +268,7 @@ import PubtatorAnnotatedText from '@/components/analyses/PubtatorAnnotatedText.v
 
 import Utils from '@/assets/js/utils';
 import { useUiStore } from '@/stores/ui';
-
-// Upper bound for the per-instance gene_symbols split cache (LRU eviction).
-const GENE_SYMBOL_CACHE_LIMIT = 2000;
+import { createLruCache } from '@/utils/lruCache';
 
 export default {
   name: 'PubtatorNDDTable',
@@ -429,7 +427,7 @@ export default {
       // Non-reactive memoization cache for gene_symbols splits (keyed by the
       // raw comma-separated string). markRaw keeps Vue from making it reactive;
       // declaring it here lets TypeScript infer the instance property.
-      geneSymbolCache: markRaw(new Map<string, string[]>()),
+      geneSymbolCache: markRaw(createLruCache<string, string[]>(2000)),
     };
   },
   watch: {
@@ -684,10 +682,8 @@ export default {
     },
 
     /**
-     * Parse PubTator annotations from text_hl field.
-     * Memoized: the same `text_hl` string parses once and is reused across the
-     * preview slice and the length check. The expanded detail view renders
-     * annotated text via PubtatorAnnotatedText (which memoizes independently).
+     * Parse PubTator annotations (memoized). Used for the preview slice + length
+     * check; the expanded detail view renders via PubtatorAnnotatedText.
      */
     parseAnnotations(text: string | null | undefined): ParsedSegment[] {
       return parsePubtatorTextMemoized(text);
@@ -702,30 +698,18 @@ export default {
     },
 
     /**
-     * Split a comma-separated gene_symbols string into trimmed symbols once.
-     * The template needs this list up to three times per row (slice, count,
-     * overflow), so memoize by the raw string to avoid repeated splitting.
-     * Bounded with LRU eviction (recency refreshed on hit) so a long browsing
-     * session over many distinct gene_symbols strings cannot grow it unbounded.
+     * Split a comma-separated gene_symbols string into trimmed symbols once
+     * (template uses it ~3x/row). Memoized via a bounded LRU (geneSymbolCache).
      */
     geneSymbolList(geneSymbols: string | null | undefined): string[] {
       if (!geneSymbols) return [];
-      const cache = this.geneSymbolCache;
-      const cached = cache.get(geneSymbols);
-      if (cached) {
-        cache.delete(geneSymbols);
-        cache.set(geneSymbols, cached);
-        return cached;
-      }
+      const cached = this.geneSymbolCache.get(geneSymbols);
+      if (cached) return cached;
       const list = geneSymbols
         .split(',')
         .map((g) => g.trim())
         .filter((g) => g !== '');
-      if (cache.size >= GENE_SYMBOL_CACHE_LIMIT) {
-        const oldestKey = cache.keys().next().value;
-        if (oldestKey !== undefined) cache.delete(oldestKey);
-      }
-      cache.set(geneSymbols, list);
+      this.geneSymbolCache.set(geneSymbols, list);
       return list;
     },
     // Normalize select options for BFormSelect (replacement for treeselect normalizer)

--- a/app/src/components/analyses/PubtatorPublicationDetail.vue
+++ b/app/src/components/analyses/PubtatorPublicationDetail.vue
@@ -1,0 +1,207 @@
+<!-- src/components/analyses/PubtatorPublicationDetail.vue -->
+<!--
+  One publication's expanded detail card for the PubtatorNDD gene table.
+
+  Extracted from PubtatorNDDGenes.vue so the gene component stays under the
+  file-size ceiling and the per-publication markup (PMID/DOI/date/journal/score
+  meta + annotated text + gene chips) lives in one focused, testable place.
+-->
+<template>
+  <div class="details-section">
+    <!-- Title -->
+    <div v-if="publication.title" class="details-title">
+      {{ publication.title }}
+    </div>
+
+    <div class="details-row">
+      <!-- PMID, DOI, Date, Journal, Score -->
+      <div class="details-meta">
+        <a
+          :href="'https://pubmed.ncbi.nlm.nih.gov/' + publication.pmid"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="details-pmid"
+        >
+          <i class="bi bi-journal-medical me-1" />
+          PMID:{{ publication.pmid }}
+          <i class="bi bi-box-arrow-up-right ms-1" />
+        </a>
+        <a
+          v-if="publication.doi"
+          :href="'https://doi.org/' + publication.doi"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="details-doi"
+        >
+          <i class="bi bi-link-45deg me-1" />
+          {{ publication.doi }}
+        </a>
+        <span v-if="publication.date" class="details-date">
+          <i class="bi bi-calendar3 me-1" />
+          {{ publication.date }}
+        </span>
+        <span v-if="publication.journal" class="details-journal">
+          <i class="bi bi-book me-1" />
+          {{ publication.journal }}
+        </span>
+        <BBadge
+          v-if="publication.score != null"
+          :variant="
+            publication.score >= 500 ? 'success' : publication.score >= 100 ? 'warning' : 'secondary'
+          "
+          pill
+        >
+          Score: {{ publication.score }}
+        </BBadge>
+      </div>
+    </div>
+
+    <!-- Annotated Text Section (shared renderer, memoized parse) -->
+    <PubtatorAnnotatedText
+      v-if="publication.text_hl"
+      :text="publication.text_hl"
+      section-class="mt-2"
+    />
+
+    <!-- Gene symbols as badges -->
+    <div v-if="publication.gene_symbols" class="gene-symbols-section mt-2">
+      <div class="gene-chips">
+        <span v-for="sym in geneSymbols" :key="sym" class="gene-chip">
+          {{ sym }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import PubtatorAnnotatedText from '@/components/analyses/PubtatorAnnotatedText.vue';
+import type { PubtatorPublicationData } from '@/composables/usePubtatorGenePublications';
+
+const props = defineProps<{
+  publication: PubtatorPublicationData;
+}>();
+
+// Split gene_symbols once per publication (template iterates the result).
+const geneSymbols = computed(() =>
+  (props.publication.gene_symbols ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s !== '')
+);
+</script>
+
+<style scoped>
+.details-section {
+  margin-bottom: 1rem;
+}
+
+.details-section:last-child {
+  margin-bottom: 0;
+}
+
+.details-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #212529;
+  margin-bottom: 0.5rem;
+  line-height: 1.4;
+  text-align: left;
+}
+
+.details-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.details-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+}
+
+.details-pmid {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25em 0.5em;
+  font-size: 0.8em;
+  font-weight: 500;
+  background-color: #e7f1ff;
+  color: #0d6efd;
+  border-radius: 0.3rem;
+  text-decoration: none;
+  transition: all 0.15s ease-in-out;
+}
+
+.details-pmid:hover {
+  background-color: #0d6efd;
+  color: white;
+}
+
+.details-date {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2em 0.5em;
+  font-size: 0.8em;
+  background-color: #e8f5e9;
+  color: #2e7d32;
+  border-radius: 0.25rem;
+}
+
+.details-journal {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25em 0.5em;
+  font-size: 0.8em;
+  background-color: #f8f9fa;
+  color: #495057;
+  border-radius: 0.25rem;
+  border: 1px solid #dee2e6;
+}
+
+.details-doi {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25em 0.5em;
+  font-size: 0.8em;
+  font-weight: 500;
+  background-color: #f0f0f0;
+  color: #495057;
+  border-radius: 0.3rem;
+  text-decoration: none;
+  transition: all 0.15s ease-in-out;
+}
+
+.details-doi:hover {
+  background-color: #495057;
+  color: white;
+}
+
+/* Gene symbol chips */
+.gene-symbols-section {
+  border-top: 1px solid #dee2e6;
+  padding-top: 0.5rem;
+}
+
+.gene-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  align-items: center;
+}
+
+.gene-chip {
+  display: inline-block;
+  padding: 0.15em 0.4em;
+  font-size: 0.75rem;
+  font-weight: 500;
+  background-color: #b4e3f9;
+  color: #0d6efd;
+  border-radius: 0.25rem;
+  white-space: nowrap;
+}
+</style>

--- a/app/src/composables/index.ts
+++ b/app/src/composables/index.ts
@@ -118,6 +118,8 @@ export type { Use3DStructureReturn } from './use3DStructure';
 export {
   usePubtatorParser,
   parsePubtatorText,
+  parsePubtatorTextMemoized,
+  clearPubtatorParseCache,
   extractEntities,
   extractGeneSymbols,
   getEntityClass,

--- a/app/src/composables/usePubtatorGenePublications.spec.ts
+++ b/app/src/composables/usePubtatorGenePublications.spec.ts
@@ -1,0 +1,132 @@
+// app/src/composables/usePubtatorGenePublications.spec.ts
+//
+// Covers the per-gene publication-detail cache extracted from
+// PubtatorNDDGenes.vue:
+//   - lazy fetch + caching (no refetch when already cached),
+//   - resetCache() drops stale data on filter/sort change (correctness fix),
+//   - real upstream errors surface a toast and exit the loading state,
+//   - genuine aborts stay silent.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+
+import '@/plugins/axios';
+import '@/api/client';
+import { server } from '@/test-utils/mocks/server';
+import { usePubtatorGenePublications } from './usePubtatorGenePublications';
+
+const makeToast = vi.fn();
+
+beforeEach(() => {
+  makeToast.mockClear();
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+function pubtatorRows() {
+  return HttpResponse.json({
+    data: [
+      {
+        search_id: 1,
+        pmid: 123,
+        title: 'MECP2 paper',
+        journal: 'Journal',
+        date: '2001-01-01',
+        score: 8,
+        gene_symbols: 'MECP2',
+        text_hl: 'MECP2 is linked to NDD.',
+      },
+    ],
+  });
+}
+
+describe('usePubtatorGenePublications', () => {
+  it('fetches and caches publications for a gene, then serves from cache', async () => {
+    let calls = 0;
+    server.use(
+      http.get('*/api/publication/pubtator/table', () => {
+        calls += 1;
+        return pubtatorRows();
+      })
+    );
+
+    const pubs = usePubtatorGenePublications({ makeToast });
+    await pubs.fetchPublications('MECP2', ['123', '456']);
+
+    expect(pubs.isCached('MECP2')).toBe(true);
+    expect(pubs.getPublications('MECP2')).toHaveLength(1);
+    expect(pubs.getPublications('MECP2')[0].title).toBe('MECP2 paper');
+    expect(pubs.isLoading('MECP2')).toBe(false);
+    expect(calls).toBe(1);
+
+    // Second call must hit the cache (no second request).
+    await pubs.fetchPublications('MECP2', ['123', '456']);
+    expect(calls).toBe(1);
+    expect(makeToast).not.toHaveBeenCalled();
+  });
+
+  it('resetCache clears cached publications so a filter/sort change cannot show stale data', async () => {
+    server.use(http.get('*/api/publication/pubtator/table', () => pubtatorRows()));
+
+    const pubs = usePubtatorGenePublications({ makeToast });
+    await pubs.fetchPublications('MECP2', ['123']);
+    expect(pubs.isCached('MECP2')).toBe(true);
+
+    pubs.resetCache();
+    expect(pubs.isCached('MECP2')).toBe(false);
+    expect(pubs.getPublications('MECP2')).toEqual([]);
+  });
+
+  it('surfaces a toast and records an empty result on a real upstream error', async () => {
+    server.use(
+      http.get('*/api/publication/pubtator/table', () => new HttpResponse(null, { status: 500 }))
+    );
+
+    const pubs = usePubtatorGenePublications({ makeToast });
+    await pubs.fetchPublications('SCN2A', ['789']);
+
+    expect(makeToast).toHaveBeenCalledTimes(1);
+    expect(makeToast.mock.calls[0][2]).toBe('danger');
+    // Row exits its spinner and shows the empty/fallback state.
+    expect(pubs.isLoading('SCN2A')).toBe(false);
+    expect(pubs.isCached('SCN2A')).toBe(true);
+    expect(pubs.getPublications('SCN2A')).toEqual([]);
+  });
+
+  it('stays silent and does not cache when the request is aborted', async () => {
+    server.use(
+      http.get('*/api/publication/pubtator/table', async () => {
+        // Delay so the abort lands before the response resolves.
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return pubtatorRows();
+      })
+    );
+
+    const pubs = usePubtatorGenePublications({ makeToast });
+    const pending = pubs.fetchPublications('GRIN2B', ['1', '2']);
+    // resetCache aborts the in-flight controller.
+    pubs.resetCache();
+    await pending;
+
+    expect(makeToast).not.toHaveBeenCalled();
+    expect(pubs.isCached('GRIN2B')).toBe(false);
+    expect(pubs.isLoading('GRIN2B')).toBe(false);
+  });
+
+  it('does nothing for an empty PMID list', async () => {
+    let calls = 0;
+    server.use(
+      http.get('*/api/publication/pubtator/table', () => {
+        calls += 1;
+        return pubtatorRows();
+      })
+    );
+
+    const pubs = usePubtatorGenePublications({ makeToast });
+    await pubs.fetchPublications('EMPTY', []);
+    expect(calls).toBe(0);
+    expect(pubs.isCached('EMPTY')).toBe(false);
+  });
+});

--- a/app/src/composables/usePubtatorGenePublications.ts
+++ b/app/src/composables/usePubtatorGenePublications.ts
@@ -1,0 +1,124 @@
+// src/composables/usePubtatorGenePublications.ts
+//
+// Per-gene publication-detail cache for the PubtatorNDD gene-prioritization
+// table. Each expandable gene row lazily fetches the full publication rows for
+// its PMIDs from the PubTator table endpoint and caches them by gene_symbol.
+//
+// Extracted from PubtatorNDDGenes.vue (issue: frontend perf & UX sprint) to:
+//   - keep that component under the file-size ceiling,
+//   - scope the cache to the current filter/sort so a filter change cannot show
+//     stale publications in an expanded row (correctness fix), and
+//   - handle aborts and real fetch errors correctly (genuine aborts are
+//     silent; real errors exit the loading state and surface a toast).
+
+import { ref } from 'vue';
+import axios from 'axios';
+import { listPubtatorTable } from '@/api/publication';
+
+export interface PubtatorPublicationData {
+  search_id?: number;
+  pmid: number;
+  doi?: string;
+  title?: string;
+  journal?: string;
+  date?: string;
+  score?: number;
+  gene_symbols?: string;
+  text_hl?: string;
+}
+
+type MakeToast = (message: unknown, title?: string | null, variant?: string | null) => void;
+
+export function usePubtatorGenePublications(options: { makeToast: MakeToast }) {
+  const { makeToast } = options;
+
+  // Publication data cache (keyed by gene_symbol).
+  const publicationCache = ref<Record<string, PubtatorPublicationData[]>>({});
+  const loadingPublications = ref<Record<string, boolean>>({});
+
+  // AbortControllers for per-gene fetches (prevents orphaned requests).
+  const abortControllers = new Map<string, AbortController>();
+
+  /**
+   * Reset the entire cache. Call when the gene filter/sort changes so an
+   * expanded row never shows publications fetched under a previous query.
+   * In-flight fetches are aborted so their late responses cannot repopulate
+   * the freshly-cleared cache.
+   */
+  const resetCache = (): void => {
+    abortControllers.forEach((controller) => controller.abort());
+    abortControllers.clear();
+    publicationCache.value = {};
+    loadingPublications.value = {};
+  };
+
+  /** Abort and clear every in-flight fetch (call on component unmount). */
+  const cancelAll = (): void => {
+    abortControllers.forEach((controller) => controller.abort());
+    abortControllers.clear();
+  };
+
+  /**
+   * Fetch publication rows for a gene's PMIDs if not already cached.
+   * Genuine aborts (filter change, unmount) are ignored silently; a real
+   * upstream failure exits the loading state and surfaces a toast.
+   */
+  const fetchPublications = async (geneSymbol: string, pmids: string[]): Promise<void> => {
+    if (pmids.length === 0) return;
+    if (publicationCache.value[geneSymbol]) return; // Already cached
+
+    // Cancel any in-flight request for this gene.
+    abortControllers.get(geneSymbol)?.abort();
+    const controller = new AbortController();
+    abortControllers.set(geneSymbol, controller);
+
+    loadingPublications.value[geneSymbol] = true;
+
+    try {
+      const response = await listPubtatorTable(
+        {
+          filter: `any(pmid,${pmids.join(',')})`,
+          fields: 'search_id,pmid,doi,title,journal,date,score,gene_symbols,text_hl',
+          page_size: String(pmids.length),
+        },
+        { signal: controller.signal }
+      );
+      publicationCache.value[geneSymbol] = (response.data as PubtatorPublicationData[]) || [];
+    } catch (error) {
+      // Genuine aborts (axios CanceledError / DOMException AbortError) are not
+      // errors — the caller intentionally cancelled. Stay silent.
+      if (axios.isCancel(error) || (error as Error)?.name === 'AbortError') {
+        return;
+      }
+      // Real failure: surface it and record an empty result so the row exits
+      // its spinner and shows the PMID fallback rather than spinning forever.
+      makeToast(error, 'Error loading publication details', 'danger');
+      publicationCache.value[geneSymbol] = [];
+    } finally {
+      abortControllers.delete(geneSymbol);
+      loadingPublications.value[geneSymbol] = false;
+    }
+  };
+
+  const getPublications = (geneSymbol: string): PubtatorPublicationData[] =>
+    publicationCache.value[geneSymbol] || [];
+
+  const isLoading = (geneSymbol: string): boolean =>
+    loadingPublications.value[geneSymbol] || false;
+
+  const isCached = (geneSymbol: string): boolean =>
+    publicationCache.value[geneSymbol] !== undefined;
+
+  return {
+    publicationCache,
+    loadingPublications,
+    fetchPublications,
+    getPublications,
+    isLoading,
+    isCached,
+    resetCache,
+    cancelAll,
+  };
+}
+
+export default usePubtatorGenePublications;

--- a/app/src/composables/usePubtatorParser.spec.ts
+++ b/app/src/composables/usePubtatorParser.spec.ts
@@ -1,10 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import type { ParsedSegment } from './usePubtatorParser';
 import {
   getEntityClass,
   getSegmentClass,
   getSegmentTooltip,
   usePubtatorParser,
+  parsePubtatorText,
+  parsePubtatorTextMemoized,
+  clearPubtatorParseCache,
 } from './usePubtatorParser';
 
 const seg = (overrides: Partial<ParsedSegment>): ParsedSegment =>
@@ -63,5 +66,43 @@ describe('usePubtatorParser', () => {
     expect(parser.getSegmentClass).toBe(getSegmentClass);
     expect(parser.getSegmentTooltip).toBe(getSegmentTooltip);
     expect(parser.getEntityClass).toBe(getEntityClass);
+  });
+
+  it('exposes the memoized parser', () => {
+    const parser = usePubtatorParser();
+    expect(parser.parsePubtatorTextMemoized).toBe(parsePubtatorTextMemoized);
+  });
+});
+
+describe('parsePubtatorTextMemoized', () => {
+  beforeEach(() => {
+    clearPubtatorParseCache();
+  });
+
+  it('returns the same segments as the non-memoized parser', () => {
+    const text = '@GENE_2904 @GENE_GRIN2B @@@GRIN2B@@@ is linked to <m>NDD</m>.';
+    expect(parsePubtatorTextMemoized(text)).toEqual(parsePubtatorText(text));
+  });
+
+  it('returns the identical (cached) array instance on repeat calls', () => {
+    const text = '@GENE_2904 @@@GRIN2B@@@ causes epilepsy.';
+    const first = parsePubtatorTextMemoized(text);
+    const second = parsePubtatorTextMemoized(text);
+    // Same reference proves the parse ran once and was reused.
+    expect(second).toBe(first);
+  });
+
+  it('returns a fresh empty array for empty/nullish input (never cached)', () => {
+    expect(parsePubtatorTextMemoized('')).toEqual([]);
+    expect(parsePubtatorTextMemoized(null)).toEqual([]);
+    expect(parsePubtatorTextMemoized(undefined)).toEqual([]);
+  });
+
+  it('parses distinct strings into distinct results', () => {
+    const a = parsePubtatorTextMemoized('@GENE_1 @@@AAA@@@');
+    const b = parsePubtatorTextMemoized('@GENE_2 @@@BBB@@@');
+    expect(a).not.toBe(b);
+    expect(a[0].text).toBe('AAA');
+    expect(b[0].text).toBe('BBB');
   });
 });

--- a/app/src/composables/usePubtatorParser.ts
+++ b/app/src/composables/usePubtatorParser.ts
@@ -8,6 +8,8 @@
  * Entity types: GENE, DISEASE, VARIANT, SPECIES, CHEMICAL
  */
 
+import { createLruCache } from '@/utils/lruCache';
+
 export interface ParsedSegment {
   text: string;
   type: 'plain' | 'gene' | 'disease' | 'variant' | 'species' | 'chemical' | 'match';
@@ -129,36 +131,20 @@ export function parsePubtatorText(text: string | null | undefined): ParsedSegmen
  * resulting segment array keyed by the raw text. This collapses the N parses
  * per row down to one, with no change in rendered output.
  *
- * The cache is bounded with LRU eviction (a Map preserves insertion order, and
- * we refresh recency on every hit) so a long browsing session over many distinct
- * rows cannot grow it without limit, and hot entries are not evicted as "oldest".
+ * The cache is a bounded LRU (recency refreshed on hit) so a long browsing
+ * session over many distinct rows cannot grow it without limit, and hot entries
+ * are not evicted as "oldest". See {@link createLruCache}.
  */
-const PUBTATOR_PARSE_CACHE_LIMIT = 1000;
-const pubtatorParseCache = new Map<string, ParsedSegment[]>();
+const pubtatorParseCache = createLruCache<string, ParsedSegment[]>(1000);
 
 export function parsePubtatorTextMemoized(text: string | null | undefined): ParsedSegment[] {
   if (!text) return [];
 
   const cached = pubtatorParseCache.get(text);
-  if (cached) {
-    // Refresh LRU recency: re-insert so a frequently-used entry moves to the
-    // newest position and is not evicted as the "oldest".
-    pubtatorParseCache.delete(text);
-    pubtatorParseCache.set(text, cached);
-    return cached;
-  }
+  if (cached) return cached;
 
   const segments = parsePubtatorText(text);
-
-  // Bound the cache: drop the oldest entry once over the limit.
-  if (pubtatorParseCache.size >= PUBTATOR_PARSE_CACHE_LIMIT) {
-    const oldestKey = pubtatorParseCache.keys().next().value;
-    if (oldestKey !== undefined) {
-      pubtatorParseCache.delete(oldestKey);
-    }
-  }
   pubtatorParseCache.set(text, segments);
-
   return segments;
 }
 

--- a/app/src/composables/usePubtatorParser.ts
+++ b/app/src/composables/usePubtatorParser.ts
@@ -129,8 +129,9 @@ export function parsePubtatorText(text: string | null | undefined): ParsedSegmen
  * resulting segment array keyed by the raw text. This collapses the N parses
  * per row down to one, with no change in rendered output.
  *
- * The cache is bounded (LRU-by-insertion) so a long browsing session over many
- * distinct rows cannot grow it without limit.
+ * The cache is bounded with LRU eviction (a Map preserves insertion order, and
+ * we refresh recency on every hit) so a long browsing session over many distinct
+ * rows cannot grow it without limit, and hot entries are not evicted as "oldest".
  */
 const PUBTATOR_PARSE_CACHE_LIMIT = 1000;
 const pubtatorParseCache = new Map<string, ParsedSegment[]>();
@@ -139,7 +140,13 @@ export function parsePubtatorTextMemoized(text: string | null | undefined): Pars
   if (!text) return [];
 
   const cached = pubtatorParseCache.get(text);
-  if (cached) return cached;
+  if (cached) {
+    // Refresh LRU recency: re-insert so a frequently-used entry moves to the
+    // newest position and is not evicted as the "oldest".
+    pubtatorParseCache.delete(text);
+    pubtatorParseCache.set(text, cached);
+    return cached;
+  }
 
   const segments = parsePubtatorText(text);
 

--- a/app/src/composables/usePubtatorParser.ts
+++ b/app/src/composables/usePubtatorParser.ts
@@ -121,6 +121,49 @@ export function parsePubtatorText(text: string | null | undefined): ParsedSegmen
 }
 
 /**
+ * Memoized variant of {@link parsePubtatorText}.
+ *
+ * `text_hl` is parsed repeatedly per row per render in the PubTator table/genes
+ * components (preview slice, length check, full render, per-publication detail).
+ * The annotation parse is a pure function of the input string, so we cache the
+ * resulting segment array keyed by the raw text. This collapses the N parses
+ * per row down to one, with no change in rendered output.
+ *
+ * The cache is bounded (LRU-by-insertion) so a long browsing session over many
+ * distinct rows cannot grow it without limit.
+ */
+const PUBTATOR_PARSE_CACHE_LIMIT = 1000;
+const pubtatorParseCache = new Map<string, ParsedSegment[]>();
+
+export function parsePubtatorTextMemoized(text: string | null | undefined): ParsedSegment[] {
+  if (!text) return [];
+
+  const cached = pubtatorParseCache.get(text);
+  if (cached) return cached;
+
+  const segments = parsePubtatorText(text);
+
+  // Bound the cache: drop the oldest entry once over the limit.
+  if (pubtatorParseCache.size >= PUBTATOR_PARSE_CACHE_LIMIT) {
+    const oldestKey = pubtatorParseCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      pubtatorParseCache.delete(oldestKey);
+    }
+  }
+  pubtatorParseCache.set(text, segments);
+
+  return segments;
+}
+
+/**
+ * Clear the memoization cache. Exposed for tests; not needed in app code
+ * because the bounded cache evicts on its own.
+ */
+export function clearPubtatorParseCache(): void {
+  pubtatorParseCache.clear();
+}
+
+/**
  * Parse text for <m>...</m> search match tags
  */
 function parseMatchTags(text: string): ParsedSegment[] {
@@ -270,6 +313,7 @@ export function getSegmentTooltip(segment: ParsedSegment): string {
 export function usePubtatorParser() {
   return {
     parsePubtatorText,
+    parsePubtatorTextMemoized,
     extractEntities,
     extractGeneSymbols,
     getEntityClass,

--- a/app/src/utils/lruCache.ts
+++ b/app/src/utils/lruCache.ts
@@ -1,0 +1,44 @@
+/**
+ * Tiny bounded LRU cache backed by a Map.
+ *
+ * A `Map` preserves insertion order, so the first key is the oldest. We refresh
+ * recency on every hit (delete + re-set) so frequently-used entries are not
+ * evicted as "oldest", and evict the oldest entry once the size limit is hit.
+ * Used to bound the PubTator annotation-parse cache and the gene-symbol split
+ * cache so long browsing sessions cannot grow them without limit.
+ */
+export interface LruCache<K, V> {
+  get(key: K): V | undefined;
+  set(key: K, value: V): void;
+  clear(): void;
+  readonly size: number;
+}
+
+export function createLruCache<K, V>(limit: number): LruCache<K, V> {
+  const map = new Map<K, V>();
+  return {
+    get(key: K): V | undefined {
+      const value = map.get(key);
+      if (value !== undefined) {
+        // Refresh recency: move this key to the newest position.
+        map.delete(key);
+        map.set(key, value);
+      }
+      return value;
+    },
+    set(key: K, value: V): void {
+      if (map.has(key)) map.delete(key);
+      else if (map.size >= limit) {
+        const oldest = map.keys().next().value;
+        if (oldest !== undefined) map.delete(oldest);
+      }
+      map.set(key, value);
+    },
+    clear(): void {
+      map.clear();
+    },
+    get size(): number {
+      return map.size;
+    },
+  };
+}

--- a/scripts/code-quality-file-size-baseline.tsv
+++ b/scripts/code-quality-file-size-baseline.tsv
@@ -25,8 +25,8 @@ app/src/components/analyses/AnalysesCurationUpset.vue	713
 app/src/components/analyses/AnalysesPhenotypeClusters.vue	671
 app/src/components/analyses/NetworkVisualization.vue	1253
 app/src/components/analyses/PublicationsNDDTable.vue	1011
-app/src/components/analyses/PubtatorNDDGenes.vue	1141
-app/src/components/analyses/PubtatorNDDTable.vue	948
+app/src/components/analyses/PubtatorNDDGenes.vue	900
+app/src/components/analyses/PubtatorNDDTable.vue	930
 app/src/components/ApprovalTableView.vue	689
 app/src/components/forms/BatchCriteriaForm.vue	747
 app/src/components/gene/GeneStructurePlotWithVariants.vue	685


### PR DESCRIPTION
## Sprint E — PubtatorNDD frontend perf, re-render & UX

Confined to `app/` (no `api/`/`db/` changes). All changes preserve rendered output.

### What changed

**1. Pre-parse `text_hl` once (HIGH, perf).** Added `parsePubtatorTextMemoized()` — a pure, bounded-LRU cache keyed by the raw string — so `text_hl` parses once per distinct value instead of N times per row per render (preview slice + length check + full render in the table; per-publication in genes). Regex unchanged.
- `app/src/composables/usePubtatorParser.ts`, `app/src/composables/index.ts`

**2. Debounce the Stats D3 re-render (MED).** `minCount`/`topN` watchers now debounce (~300 ms) before the full D3 rebuild; the container is cleared in one pass (single SVG root) instead of three `.select().remove()` calls.
- `app/src/components/analyses/PubtatorNDDStats.vue`

**3. Fix stale per-gene publication cache (MED, correctness).** The publication cache (keyed by `gene_symbol`) is now reset on every gene reload (filter/sort/page change), and in-flight fetches are aborted so late responses can't repopulate a cleared cache. An expanded row can no longer show publications from a previous query.
- `app/src/composables/usePubtatorGenePublications.ts`, `PubtatorNDDGenes.vue`

**4. Fix AbortError handling + error UX (MED).** Genuine aborts are now detected with `axios.isCancel` (the old non-standard `'CanceledError'` name check missed real cancels) and stay silent; real upstream failures exit the loading state AND surface a toast. Stats `loadingStats` now clears in `finally` so a failed fetch can't leave the summary cards spinning.
- `usePubtatorGenePublications.ts`, `PubtatorNDDStats.vue`

**5. Surface enrichment freshness (LOW, defensive).** When the genes API `meta` reports `enrichment_status !== 'current'`, a small non-blocking `BAlert` notice renders ("Gene ranking not yet computed" / "may be out of date (last refreshed …)"). When the fields are absent, nothing renders — no hard dependency on a sibling backend sprint.
- `PubtatorNDDGenes.vue`

**6. Split oversized components (MED, maintainability).** Extracted by responsibility:
- `PubtatorAnnotatedText.vue` — shared entity-highlighted text + legend (was duplicated in both components), consumes the memoized parser, AA-compliant colors.
- `PubtatorPublicationDetail.vue` — the per-publication detail card used by the genes expand slot.
- `usePubtatorGenePublications.ts` — the publication-cache composable.
- `PubtatorNDDGenes.vue`: **1141 → 900** lines. `PubtatorNDDTable.vue`: **948 → 930** lines. Baselines lowered in `scripts/code-quality-file-size-baseline.tsv`.

**7. Minor (LOW).** Memoized per-row `gene_symbols.split(',')` in the table; `role="img"` + dynamic `aria-label` on the Stats SVG; reserved summary-card body height to avoid layout shift.

### Tests added
- `usePubtatorParser.spec.ts`: memoized parser (identity reuse, empty input, parity).
- `usePubtatorGenePublications.spec.ts`: cache hit/reset, silent abort, real-error toast, empty-PMID no-op.
- `PubtatorAnnotatedText.spec.ts`: segment/legend/label render + section class.
- `PubtatorNDDGenes.spec.ts`: freshness-notice present/absent.

### Verification (all pass)
- `npm run type-check` — pass (clean)
- `npm run type-check:strict` — pass (all scopes OK)
- `npm run test:unit` — **221 files, 1506 passed, 2 todo** (full suite, no regressions)
- pubtator-targeted specs — **41 passed** (incl. PubtatorNDDGenes, pubtatorGeneFilters, pubtatorEnrichmentDisplay, usePubtatorParser, TabbedAnalysisRouteShells)
- `npm run lint` on changed files — pass (0 errors)
- `make code-quality-audit` (`scripts/code-quality-audit.sh`) — OK

### Deferred
- Neither big component reaches the 600-line soft ceiling (genes 900, table 930). Both are well under their (now lowered) baselines and the duplication is gone; reaching <600 would require extracting the table-data load/sort/page orchestration into a composable — a larger, riskier refactor left for a planned pass per the "leave broad legacy splits for planned refactors" guidance.
- E2E/Playwright not run (local-only, per instructions).
