### PR TITLE
feat(pubtator): startup auto-bootstrap for enrichment (closes #421)

### DIFF
--- a/api/functions/pubtatornidd-nightly.R
+++ b/api/functions/pubtatornidd-nightly.R
@@ -296,3 +296,50 @@ pubtatornidd_nightly_job_run <- function(job, payload, progress_reporter_fn) {
 
   result
 }
+
+#' Bootstrap the PubtatorNDD enrichment snapshot on startup if missing (#421)
+#'
+#' If no current `pubtator_corpus_stats` snapshot exists, idempotently enqueue a
+#' `pubtatornidd_nightly` job so a fresh deploy populates enrichment (and the
+#' gene-summary table) without waiting for the nightly cron. Dedup-safe: when a
+#' current snapshot already exists this is a no-op, and `async_job_service_submit`
+#' dedups by request_hash so a restart while a bootstrap job is queued does not
+#' double-enqueue. Never throws (callable directly in API startup).
+#'
+#' @param query_fn Query function (injectable for tests). Default
+#'   `db_execute_query`.
+#' @param submit_fn Job-submit function (injectable for tests). Default
+#'   `async_job_service_submit`.
+#' @return Invisibly TRUE when a job was enqueued, FALSE otherwise.
+#' @export
+pubtatornidd_bootstrap_enrichment <- function(query_fn = db_execute_query,
+                                              submit_fn = async_job_service_submit) {
+  rows <- tryCatch(
+    query_fn("SELECT COUNT(*) AS n FROM pubtator_corpus_stats WHERE is_current = 1"),
+    error = function(e) NULL
+  )
+  has_current <- !is.null(rows) && nrow(rows) > 0 &&
+    !is.na(rows$n[[1]]) && as.integer(rows$n[[1]]) > 0L
+  if (isTRUE(has_current)) {
+    return(invisible(FALSE))
+  }
+
+  submitted <- tryCatch(
+    submit_fn(
+      job_type = "pubtatornidd_nightly",
+      request_payload = list(trigger = "startup_bootstrap")
+    ),
+    error = function(e) {
+      message(sprintf("[pubtatornidd-bootstrap] enqueue failed: %s",
+                      conditionMessage(e)))
+      NULL
+    }
+  )
+  if (!is.null(submitted)) {
+    message(paste(
+      "[pubtatornidd-bootstrap] no current enrichment snapshot;",
+      "enqueued nightly refresh to populate it"
+    ))
+  }
+  invisible(!is.null(submitted))
+}

--- a/api/start_sysndd_api.R
+++ b/api/start_sysndd_api.R
@@ -139,6 +139,18 @@ schedule_cleanup(3600)
 root <- bootstrap_mount_endpoints(api_spec, pool, logging_temp_file)
 
 ## -------------------------------------------------------------------##
+# 9b) Bootstrap PubtatorNDD enrichment if no current snapshot exists (#421):
+#     a fresh deploy gets enrichment + the gene-summary table populated without
+#     waiting for the nightly cron. Idempotent + dedup-safe; never crashes boot.
+## -------------------------------------------------------------------##
+tryCatch(
+  pubtatornidd_bootstrap_enrichment(),
+  error = function(e) message(sprintf(
+    "[pubtatornidd-bootstrap] skipped: %s", conditionMessage(e)
+  ))
+)
+
+## -------------------------------------------------------------------##
 # 10) Run the API.
 ## -------------------------------------------------------------------##
 root %>% pr_run(host = "0.0.0.0", port = as.numeric(dw$port_self))

--- a/api/start_sysndd_api.R
+++ b/api/start_sysndd_api.R
@@ -145,9 +145,9 @@ root <- bootstrap_mount_endpoints(api_spec, pool, logging_temp_file)
 ## -------------------------------------------------------------------##
 tryCatch(
   pubtatornidd_bootstrap_enrichment(),
-  error = function(e) message(sprintf(
-    "[pubtatornidd-bootstrap] skipped: %s", conditionMessage(e)
-  ))
+  error = function(e) {
+    message(sprintf("[pubtatornidd-bootstrap] skipped: %s", conditionMessage(e)))
+  }
 )
 
 ## -------------------------------------------------------------------##

--- a/api/tests/testthat/test-unit-pubtatornidd-nightly.R
+++ b/api/tests/testthat/test-unit-pubtatornidd-nightly.R
@@ -90,3 +90,43 @@ test_that("pubtatornidd_nightly job type is registered in the handler registry",
   expect_true(is.function(entry$run))
   expect_equal(entry$cancel_mode, "non_interruptible")
 })
+
+test_that("bootstrap is a no-op when a current enrichment snapshot exists", {
+  submitted <- FALSE
+  res <- pubtatornidd_bootstrap_enrichment(
+    query_fn = function(sql) data.frame(n = 1L),
+    submit_fn = function(...) {
+      submitted <<- TRUE
+      list(job = list(job_id = "x"))
+    }
+  )
+  expect_false(res)
+  expect_false(submitted)
+})
+
+test_that("bootstrap enqueues a nightly job when no current snapshot exists", {
+  captured <- NULL
+  res <- pubtatornidd_bootstrap_enrichment(
+    query_fn = function(sql) data.frame(n = 0L),
+    submit_fn = function(job_type, request_payload, ...) {
+      captured <<- list(job_type = job_type, payload = request_payload)
+      list(job = list(job_id = "x"))
+    }
+  )
+  expect_true(res)
+  expect_equal(captured$job_type, "pubtatornidd_nightly")
+  expect_equal(captured$payload$trigger, "startup_bootstrap")
+})
+
+test_that("bootstrap treats a query error as missing snapshot and enqueues", {
+  submitted <- FALSE
+  res <- pubtatornidd_bootstrap_enrichment(
+    query_fn = function(sql) stop("db down"),
+    submit_fn = function(...) {
+      submitted <<- TRUE
+      list(job = list(job_id = "x"))
+    }
+  )
+  expect_true(res)
+  expect_true(submitted)
+})


### PR DESCRIPTION
## Closes #421

Issue #421 (PubtatorNDD pages 12–14s "forever loading" — empty precompute tables recomputed live) was **substantially resolved in v0.22.0** (#422–#426): the `pubtator_gene_summary` table + a fast SQL-aggregation fallback replaced the per-request R nesting (`/genes` ~100ms), and the nightly cron + enrichment fix populate `pubtator_gene_enrichment`/`pubtator_corpus_stats`.

This PR closes the one remaining explicit acceptance criterion — **"fresh deploy auto-populates without a manual step"** (the issue's proposal #2):

- `pubtatornidd_bootstrap_enrichment()` runs on API startup (before `pr_run`). If no current `pubtator_corpus_stats` snapshot exists, it idempotently enqueues a `pubtatornidd_nightly` job (which populates enrichment + the gene-summary table).
- **No-op** when a current snapshot is present; **dedup-safe** via the async `request_hash` (a restart while a bootstrap job is queued won't double-enqueue); `tryCatch`-wrapped so it never crashes boot.
- Unit-tested: present-snapshot (no-op), missing-snapshot (enqueues `pubtatornidd_nightly` / `startup_bootstrap`), and query-error (treated as missing) paths.

### #421 acceptance criteria
- [x] enrichment + corpus_stats populated by a background job (+ enqueue script / nightly)
- [x] `/genes` well under 2s with tables populated (~100ms; SQL fallback fast even when unpopulated)
- [x] **fresh deploy auto-populates** (this PR) **or clearly schedules** (nightly cron)
- [x] pages render quickly; no multi-second forever-loading

### Verification
- 28 nightly unit tests pass (incl. 3 new bootstrap cases); lint, parse, `make code-quality-audit` clean.

Note: the secondary frontend items in #421 (axios request timeout + a dedicated server-side stats-aggregation endpoint) are optional hardening — the Stats path is now flat + fast (~83ms), so they're not required to close the issue, but could be a small follow-up.