### PR TITLE
Admin views: typed-client migration (audit follow-up)

### DIFF
--- a/.planning/admin-views-audit-2026-06-14.md
+++ b/.planning/admin-views-audit-2026-06-14.md
@@ -33,6 +33,23 @@ Read-only production verification (no destructive admin actions on the live DB):
   `/Entities` (data-heavy public table) 100/100/100/92 (TBT 20ms, CLS 0.052). 0 console errors.
 - Admin routes are auth-guarded: `GET /ManageUser` (etc.) redirects to `/Login` when unauthenticated.
 
+### Authenticated admin-view Lighthouse (production, desktop)
+
+Run via puppeteer-core + lighthouse `startFlow` with a seeded admin token
+(`disableStorageReset`), so the authenticated admin pages are actually measured:
+
+| Admin view | Perf | A11y | Best-Pr | FCP / LCP / TBT / CLS |
+|---|:--:|:--:|:--:|---|
+| ManageUser | 98 | 100 | 100 | 0.9s / 0.9s / 20ms / 0 |
+| ManageOntology | 99 | 100 | 100 | 0.8s / 0.8s / 20ms / 0 |
+| AdminStatistics | 99 | 100 | 100 | 0.8s / 0.8s / 10ms / 0 |
+| ManagePubtator | 99 | 100 | 100 | 0.8s / 0.8s / 30ms / 0 |
+| ManageLLM | 96 | 100 | 100 | 0.8s / 0.8s / 150ms / 0 |
+
+Authenticated admin-view performance is excellent (perf 96–99, a11y/best-practices 100).
+ManageLLM has the highest TBT (150ms) from its cache + generation-log tables — the main
+remaining perf headroom (virtualize/paginate those tables).
+
 ### Authenticated production walkthrough (operator account, read-only — no writes)
 
 Logged in as an Administrator and navigated all 11 admin views on production master.
@@ -135,3 +152,42 @@ All verified live (Playwright + API) and via gates: vitest (affected specs), who
   chart fallbacks, keyboard-operable rows, icon-button labels.
 - T5 Polish: replace native dialogs with modals; per-view titles; confirmations on heavy ops;
   design-token cleanups; split oversized files.
+
+## Enhancement plan to >9/10 — per sub-9 view
+
+Status legend: ✅ done in PR #429 · 🔧 in PR #2 (typed-client migration) · ⬜ remaining backlog.
+
+### ManageLLM (6 → target 9.5)
+- ✅ Funct: `/config` 500 fixed; cache per-type cards fixed.  ✅ A11y: WAI-ARIA tablist.
+- 🔧 Code: migrate `useLlmAdmin` onto the typed `llm_admin.ts` (delete dead client + type drift).
+- ⬜ Funct: add a job-cancel action for in-flight regeneration; centralize Gemini pricing with
+  `llm-model-config.R` (cost row currently shows stale "Gemini 2.0 Flash" pricing).
+- ⬜ Perf: virtualize/paginate the cache + generation-log tables (TBT 150ms → <50ms).
+
+### ManageOntology (6 → target 9)
+- ✅ Funct/Security: UPDATE column allowlist (injection closed).
+- 🔧 Code: route the table/edit calls through typed `ontology.ts`; drop dead `inject('axios')`.
+- ⬜ Code: extract URL-state + pagination into a composable to bring the 721-line view under 600.
+- ⬜ UX/A11y: confirmation before saving an "anchored" (VariO) term; `aria-label`s on desktop
+  filter selects + `aria-busy` on the loading overlay; replace hardcoded hex with design tokens.
+
+### AdminStatistics (6 → target 9.5)
+- ✅ A11y: chart `role=img` + aria-label fallbacks.  ✅ Funct: double `/updates` fetch removed;
+  stale spec endpoint fixed; chart empty states.
+- 🔧 Code: migrate the three composables onto typed `statistics.ts` (drop injected axios).
+- ⬜ Perf/UX: dedupe remaining on-mount request fan-out; design-token cleanup of one-off hex;
+  tighten mobile control bar (3764px scroll-height debt).
+
+### ManagePubtator (6 → target 9.5)
+- ✅ A11y: aria-live job/progress + progressbar aria.  ✅ Funct: error extraction; dead code removed.
+- 🔧 Code: migrate `usePubtatorAdmin` onto typed `publication.ts` (delete duplicated interfaces,
+  fix `updated_count`/`updated` drift).
+- ⬜ UX: honest indeterminate progress when total unknown; polling backoff; expand behavior spec.
+
+### Cross-view backlog (lifts ViewLogs, ManageUser, ManageBackups, etc.)
+- ⬜ Split `TablesLogs.vue` (1160 lines) into a `useLogTable` composable + toolbar child.
+- ⬜ Replace native `prompt()` (ManageUser presets) / `confirm()` (export) with app modals.
+- ⬜ Per-view document `<title>` for all admin routes (most show generic "SysNDD |").
+- ⬜ Confirmation modals on heavy/irreversible ManageAnnotations ops (ontology update, force-apply,
+  comparisons refresh, refresh-all); server-side "refresh all" sentinel to avoid the full-corpus
+  client round trip.

--- a/app/src/api/llm_admin.spec.ts
+++ b/app/src/api/llm_admin.spec.ts
@@ -102,7 +102,10 @@ describe('api/llm — getLlmCacheStats', () => {
     const ok: LlmCacheStats = {
       total_entries: 42,
       by_status: { validated: 30, rejected: 5, pending: 7 },
-      by_type: { functional: 20, phenotype: 22 },
+      by_type: {
+        functional: { count: 20, validated: 15, pending: 4, rejected: 1 },
+        phenotype: { count: 22, validated: 15, pending: 3, rejected: 4 },
+      },
       last_generation: '2026-04-25T00:00:00Z',
       total_tokens_input: 1000,
       total_tokens_output: 2000,

--- a/app/src/api/llm_admin.ts
+++ b/app/src/api/llm_admin.ts
@@ -58,10 +58,22 @@ export interface UpdateLlmModelResponse {
   model: string;
 }
 
+/**
+ * Per-cluster-type cache breakdown. Mirrors the nested `by_type` shape the
+ * `/cache/stats` handler returns (one object per cluster type with its own
+ * validation-status counts), and matches `CacheTypeStats` in `@/types/llm`.
+ */
+export interface LlmCacheTypeStats {
+  count: number;
+  validated: number;
+  pending: number;
+  rejected: number;
+}
+
 export interface LlmCacheStats {
   total_entries: number;
   by_status: { pending?: number; validated?: number; rejected?: number };
-  by_type: { functional?: number; phenotype?: number };
+  by_type: { functional?: LlmCacheTypeStats; phenotype?: LlmCacheTypeStats };
   last_generation: string | null;
   total_tokens_input: number;
   total_tokens_output: number;

--- a/app/src/composables/annotations/useAnnotationsApi.ts
+++ b/app/src/composables/annotations/useAnnotationsApi.ts
@@ -1,13 +1,19 @@
 // composables/annotations/useAnnotationsApi.ts
 /**
- * Axios helpers for the Manage Annotations view (Phase E.E4).
+ * Typed apiClient helpers for the Manage Annotations view (Phase E.E4).
  *
  * Each function is a thin typed wrapper around an existing backend call the
  * view previously made inline.  They return already-unwrapped payloads so the
  * view can stay focussed on orchestration.
+ *
+ * Calls go through the shared `apiClient` (`@/api/client`), which already sets
+ * the `baseURL` and injects the Bearer token / 401 handling via its
+ * interceptors.  Paths are therefore relative `/api/...` with no manual
+ * `VITE_API_URL` prefix.  `authRequestConfig()` continues to contribute only
+ * the `withCredentials: true` opt-in.
  */
 
-import axios from 'axios';
+import { apiClient } from '@/api/client';
 import { unwrapValue, authRequestConfig } from './useAnnotationFormatters';
 import type {
   OntologyBlockedState,
@@ -18,8 +24,6 @@ import type { ComparisonsMetadata } from '@/components/annotations/ComparisonsRe
 import type { PublicationStats } from '@/components/annotations/PublicationRefreshCard.vue';
 import type { DeprecatedData } from '@/components/annotations/DeprecatedEntitiesCard.vue';
 import type { JobHistoryItem } from '@/components/annotations/JobHistoryCard.vue';
-
-const API = (): string => import.meta.env.VITE_API_URL || '';
 
 export interface AnnotationDates {
   omim_update: string | null;
@@ -38,22 +42,23 @@ export interface JobSubmissionResponse {
 }
 
 export async function fetchAnnotationDates(): Promise<AnnotationDates> {
-  const response = await axios.get(`${API()}/api/admin/annotation_dates`, authRequestConfig());
-  const data = response.data;
+  const data = await apiClient.get<Record<string, unknown>>(
+    '/api/admin/annotation_dates',
+    authRequestConfig()
+  );
   return {
-    omim_update: unwrapValue(data.omim_update),
-    hgnc_update: unwrapValue(data.hgnc_update),
-    mondo_update: unwrapValue(data.mondo_update),
-    disease_ontology_update: unwrapValue(data.disease_ontology_update),
+    omim_update: unwrapValue(data.omim_update) as string,
+    hgnc_update: unwrapValue(data.hgnc_update) as string,
+    mondo_update: unwrapValue(data.mondo_update) as string,
+    disease_ontology_update: unwrapValue(data.disease_ontology_update) as string,
   };
 }
 
 export async function fetchJobHistory(limit = 20): Promise<JobHistoryItem[]> {
-  const response = await axios.get(`${API()}/api/jobs/history`, {
+  const data = await apiClient.get<{ data?: Array<Record<string, unknown>> }>('/api/jobs/history', {
     ...authRequestConfig(),
     params: { limit },
   });
-  const data = response.data;
   if (!data || !Array.isArray(data.data)) return [];
   return data.data.map((job: Record<string, unknown>) => ({
     job_id: unwrapValue(job.job_id),
@@ -67,17 +72,19 @@ export async function fetchJobHistory(limit = 20): Promise<JobHistoryItem[]> {
 }
 
 export async function fetchJobHistoryRaw(limit = 1000): Promise<Array<Record<string, unknown>>> {
-  const response = await axios.get(`${API()}/api/jobs/history`, {
+  const data = await apiClient.get<{ data?: Array<Record<string, unknown>> }>('/api/jobs/history', {
     ...authRequestConfig(),
     params: { limit },
   });
-  return response.data?.data || [];
+  return data?.data || [];
 }
 
 export async function fetchDeprecatedEntities(): Promise<DeprecatedData> {
-  const response = await axios.get(`${API()}/api/admin/deprecated_entities`, authRequestConfig());
-  const data = response.data;
-  const unwrappedEntities = (data.affected_entities || []).map(
+  const data = await apiClient.get<Record<string, unknown>>(
+    '/api/admin/deprecated_entities',
+    authRequestConfig()
+  );
+  const unwrappedEntities = ((data.affected_entities as Array<Record<string, unknown>>) || []).map(
     (entity: Record<string, unknown>) => {
       const unwrapped: Record<string, unknown> = {};
       Object.keys(entity).forEach((key) => {
@@ -87,37 +94,37 @@ export async function fetchDeprecatedEntities(): Promise<DeprecatedData> {
     }
   );
   return {
-    deprecated_count: unwrapValue(data.deprecated_count),
+    deprecated_count: unwrapValue(data.deprecated_count) as number,
     affected_entity_count: (unwrapValue(data.affected_entity_count) as number) || 0,
     affected_entities: unwrappedEntities,
-    mim2gene_date: unwrapValue(data.mim2gene_date),
-    message: unwrapValue(data.message),
+    mim2gene_date: unwrapValue(data.mim2gene_date) as string,
+    message: unwrapValue(data.message) as string,
   };
 }
 
 export async function fetchPubtatorStats(): Promise<PubtatorStats> {
-  const metaTotal = (response: { data?: { meta?: unknown } }): number | null => {
-    const meta = Array.isArray(response.data?.meta) ? response.data?.meta[0] : response.data?.meta;
+  const metaTotal = (data: { meta?: unknown }): number | null => {
+    const meta = Array.isArray(data?.meta) ? data?.meta[0] : data?.meta;
     return (meta as { totalItems?: number })?.totalItems ?? null;
   };
 
-  const genesResponse = await axios.get(`${API()}/api/publication/pubtator/genes`, {
+  const genesData = await apiClient.get<{ meta?: unknown }>('/api/publication/pubtator/genes', {
     withCredentials: true,
     params: { page_size: 1, fields: 'gene_symbol' },
   });
-  const pubsResponse = await axios.get(`${API()}/api/publication/pubtator/table`, {
+  const pubsData = await apiClient.get<{ meta?: unknown }>('/api/publication/pubtator/table', {
     withCredentials: true,
     params: { page_size: 1, fields: 'search_id' },
   });
-  const novelResponse = await axios.get(`${API()}/api/publication/pubtator/genes`, {
+  const novelData = await apiClient.get<{ meta?: unknown }>('/api/publication/pubtator/genes', {
     withCredentials: true,
     params: { page_size: 1, filter: 'is_novel==1', fields: 'gene_symbol' },
   });
 
   return {
-    publication_count: metaTotal(pubsResponse),
-    gene_count: metaTotal(genesResponse),
-    novel_count: metaTotal(novelResponse),
+    publication_count: metaTotal(pubsData),
+    gene_count: metaTotal(genesData),
+    novel_count: metaTotal(novelData),
   };
 }
 
@@ -127,50 +134,49 @@ export async function fetchPublicationStats(
   const params: Record<string, string> = {};
   if (notUpdatedSince) params.not_updated_since = notUpdatedSince;
 
-  const response = await axios.get(`${API()}/api/publication/stats`, {
+  const data = await apiClient.get<Record<string, unknown>>('/api/publication/stats', {
     ...authRequestConfig(),
     params,
   });
   return {
-    total: unwrapValue(response.data.total),
-    oldest_update: unwrapValue(response.data.oldest_update),
-    outdated_count: unwrapValue(response.data.outdated_count),
-    filtered_count: (unwrapValue(response.data.filtered_count) as number) ?? null,
+    total: unwrapValue(data.total) as number,
+    oldest_update: unwrapValue(data.oldest_update) as string,
+    outdated_count: unwrapValue(data.outdated_count) as number,
+    filtered_count: (unwrapValue(data.filtered_count) as number) ?? null,
   };
 }
 
 export async function fetchComparisonsMetadata(): Promise<ComparisonsMetadata> {
-  const response = await axios.get(`${API()}/api/comparisons/metadata`, {
+  const data = await apiClient.get<Record<string, unknown>>('/api/comparisons/metadata', {
     withCredentials: true,
   });
   return {
-    last_full_refresh: unwrapValue(response.data.last_full_refresh),
-    last_refresh_status: (unwrapValue(response.data.last_refresh_status) as string) ?? 'never',
-    last_refresh_error: unwrapValue(response.data.last_refresh_error),
-    sources_count: (unwrapValue(response.data.sources_count) as number) ?? 0,
-    rows_imported: (unwrapValue(response.data.rows_imported) as number) ?? 0,
+    last_full_refresh: unwrapValue(data.last_full_refresh) as string,
+    last_refresh_status: (unwrapValue(data.last_refresh_status) as string) ?? 'never',
+    last_refresh_error: unwrapValue(data.last_refresh_error) as string,
+    sources_count: (unwrapValue(data.sources_count) as number) ?? 0,
+    rows_imported: (unwrapValue(data.rows_imported) as number) ?? 0,
   };
 }
 
 export async function fetchForceApplyUsers(): Promise<UserOption[]> {
-  const response = await axios.get(
-    `${API()}/api/user/list?roles=Curator,Reviewer`,
+  const data = await apiClient.get<Array<Record<string, unknown>>>(
+    '/api/user/list?roles=Curator,Reviewer',
     authRequestConfig()
   );
-  if (!Array.isArray(response.data)) return [];
-  return response.data.map((item: Record<string, unknown>) => ({
+  if (!Array.isArray(data)) return [];
+  return data.map((item: Record<string, unknown>) => ({
     value: item.user_id as number,
     text: item.user_name as string,
   }));
 }
 
 export async function submitOntologyUpdate(): Promise<JobSubmissionResponse> {
-  const response = await axios.put(
-    `${API()}/api/admin/update_ontology_async`,
+  return apiClient.put<JobSubmissionResponse>(
+    '/api/admin/update_ontology_async',
     {},
     authRequestConfig()
   );
-  return response.data as JobSubmissionResponse;
 }
 
 export async function submitForceApplyOntology(
@@ -180,55 +186,53 @@ export async function submitForceApplyOntology(
   const params: Record<string, string | number> = { blocked_job_id: blockedJobId };
   if (assignedUserId) params.assigned_user_id = assignedUserId;
 
-  const response = await axios.put(
-    `${API()}/api/admin/force_apply_ontology`,
-    {},
-    { ...authRequestConfig(), params }
-  );
-  return response.data as JobSubmissionResponse;
+  return apiClient.put<JobSubmissionResponse>('/api/admin/force_apply_ontology', {}, {
+    ...authRequestConfig(),
+    params,
+  });
 }
 
 export async function submitHgncUpdate(): Promise<JobSubmissionResponse> {
-  const response = await axios.post(
-    `${API()}/api/jobs/hgnc_update/submit`,
+  return apiClient.post<JobSubmissionResponse>(
+    '/api/jobs/hgnc_update/submit',
     {},
     authRequestConfig()
   );
-  return response.data as JobSubmissionResponse;
 }
 
 export async function submitComparisonsRefresh(): Promise<JobSubmissionResponse> {
-  const response = await axios.post(
-    `${API()}/api/jobs/comparisons_update/submit`,
+  return apiClient.post<JobSubmissionResponse>(
+    '/api/jobs/comparisons_update/submit',
     {},
     authRequestConfig()
   );
-  return response.data as JobSubmissionResponse;
 }
 
 export async function submitPublicationRefresh(
   payload: { not_updated_since: string } | { pmids: unknown[] }
 ): Promise<JobSubmissionResponse> {
-  const response = await axios.post(
-    `${API()}/api/admin/publications/refresh`,
+  return apiClient.post<JobSubmissionResponse>(
+    '/api/admin/publications/refresh',
     payload,
     authRequestConfig()
   );
-  return response.data as JobSubmissionResponse;
 }
 
 export async function fetchAllPublicationPmids(): Promise<unknown[]> {
   const publications: Array<{ publication_id: string | string[] }> = [];
-  let nextUrl: string | null = `${API()}/api/publication`;
+  let nextUrl: string | null = '/api/publication';
   let isFirstPage = true;
   while (nextUrl) {
-    const response = await axios.get(nextUrl, {
+    const data = await apiClient.get<{
+      data?: Array<{ publication_id: string | string[] }>;
+      links?: { next?: unknown };
+    }>(nextUrl, {
       ...authRequestConfig(),
       params: isFirstPage ? { fields: 'publication_id', page_size: 10000 } : undefined,
     });
-    const pageRows: Array<{ publication_id: string | string[] }> = response.data?.data || [];
+    const pageRows: Array<{ publication_id: string | string[] }> = data?.data || [];
     publications.push(...pageRows);
-    const link = response.data?.links?.next;
+    const link = data?.links?.next;
     nextUrl = typeof link === 'string' && link.length > 0 ? link : null;
     isFirstPage = false;
   }
@@ -241,8 +245,11 @@ export type OntologyJobResult =
   | null;
 
 export async function fetchOntologyJobResult(jobId: string): Promise<OntologyJobResult> {
-  const statusResp = await axios.get(`${API()}/api/jobs/${jobId}/status`, authRequestConfig());
-  const result = statusResp.data?.result;
+  const statusData = await apiClient.get<{ result?: Record<string, unknown> }>(
+    `/api/jobs/${jobId}/status`,
+    authRequestConfig()
+  );
+  const result = statusData?.result;
   if (!result) return null;
   const resultStatus = unwrapValue(result?.status);
 
@@ -267,8 +274,10 @@ export async function fetchOntologyJobResult(jobId: string): Promise<OntologyJob
         critical_count: (unwrapValue(result.critical_count) as number) || 0,
         auto_fixable_count: (unwrapValue(result.auto_fixable_count) as number) || 0,
         total_affected: (unwrapValue(result.total_affected) as number) || 0,
-        critical_entities: unwrapRows(result.critical_entities || []),
-        auto_fixes: unwrapRows(result.auto_fixes || []),
+        critical_entities: unwrapRows(
+          (result.critical_entities as Array<Record<string, unknown>>) || []
+        ),
+        auto_fixes: unwrapRows((result.auto_fixes as Array<Record<string, unknown>>) || []),
       },
     };
   }

--- a/app/src/composables/useLlmAdmin.ts
+++ b/app/src/composables/useLlmAdmin.ts
@@ -1,16 +1,36 @@
 // app/src/composables/useLlmAdmin.ts
 // Composable for LLM Administration API calls.
 //
+// HTTP transport is delegated to the typed resource helpers in
+// `@/api/llm_admin` (getLlmConfig / updateLlmModel / getLlmPrompts /
+// updateLlmPrompt / getLlmCacheStats / getLlmCacheSummaries / clearLlmCache /
+// validateLlmCacheEntry / regenerateLlm / getLlmLogs) rather than reaching for
+// raw `apiClient.get/post` URLs here. This composable owns the reactive state
+// (config / prompts / cacheStats / loading / error) and exposes the
+// view-facing types from `@/types/llm`.
+//
 // v11.0 closeout F2a: the `token: string` parameter has been dropped from
 // every exported method. The `apiClient` request interceptor
 // (`@/api/client`) reads `useAuth().token.value` on every outbound call and
-// injects the `Authorization: Bearer <token>` header. Call sites are
-// therefore no longer responsible for sourcing the token from localStorage
-// and passing it through — they just call `fetchConfig()` / `fetchPrompts()`
-// / etc. directly. See `.planning/_archive/legacy-plans/v11.0/closeout.md` §3 F2a.
+// injects the `Authorization: Bearer <token>` header (the typed helpers run
+// through the same interceptor). Call sites are therefore no longer
+// responsible for sourcing the token from localStorage and passing it through
+// — they just call `fetchConfig()` / `fetchPrompts()` / etc. directly. See
+// `.planning/_archive/legacy-plans/v11.0/closeout.md` §3 F2a.
 
 import { ref, type Ref } from 'vue';
-import { apiClient } from '@/api/client';
+import {
+  getLlmConfig,
+  updateLlmModel,
+  getLlmPrompts,
+  updateLlmPrompt,
+  getLlmCacheStats,
+  getLlmCacheSummaries,
+  clearLlmCache,
+  validateLlmCacheEntry,
+  regenerateLlm,
+  getLlmLogs,
+} from '@/api/llm_admin';
 import type {
   LlmConfig,
   PromptTemplates,
@@ -27,8 +47,6 @@ import type {
   ValidationStatus,
   LogStatus,
 } from '@/types/llm';
-
-const API_BASE = `${import.meta.env.VITE_API_URL}/api/llm`;
 
 /**
  * Unwrap Plumber's array-wrapped scalar values.
@@ -134,11 +152,11 @@ export function useLlmAdmin(): UseLlmAdminReturn {
     loading.value = true;
     error.value = null;
     try {
-      const data = await apiClient.get<LlmConfig>(`${API_BASE}/config`, {
-        withCredentials: true,
-      });
-      // Unwrap Plumber's array-wrapped scalar values
-      config.value = unwrapPlumberValue(data);
+      const data = await getLlmConfig();
+      // Unwrap Plumber's array-wrapped scalar values. llm_admin.ts and
+      // @/types/llm declare parallel LlmConfig shapes (identical runtime data);
+      // bridge via unknown.
+      config.value = unwrapPlumberValue(data as unknown as LlmConfig);
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to fetch config';
       throw e;
@@ -151,14 +169,11 @@ export function useLlmAdmin(): UseLlmAdminReturn {
     loading.value = true;
     error.value = null;
     try {
-      const data = await apiClient.put<ModelUpdateResponse>(`${API_BASE}/config`, null, {
-        params: { model },
-        withCredentials: true,
-      });
+      const data = await updateLlmModel({ model });
       if (config.value) {
         config.value.current_model = model;
       }
-      return data;
+      return data as unknown as ModelUpdateResponse;
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to update model';
       throw e;
@@ -175,10 +190,8 @@ export function useLlmAdmin(): UseLlmAdminReturn {
     loading.value = true;
     error.value = null;
     try {
-      const data = await apiClient.get<PromptTemplates>(`${API_BASE}/prompts`, {
-        withCredentials: true,
-      });
-      prompts.value = data;
+      const data = await getLlmPrompts();
+      prompts.value = data as unknown as PromptTemplates;
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to fetch prompts';
       throw e;
@@ -196,12 +209,8 @@ export function useLlmAdmin(): UseLlmAdminReturn {
     loading.value = true;
     error.value = null;
     try {
-      const data = await apiClient.put<PromptUpdateResponse>(
-        `${API_BASE}/prompts/${type}`,
-        { template, version, description },
-        { withCredentials: true }
-      );
-      return data;
+      const data = await updateLlmPrompt(type, { template, version, description });
+      return data as unknown as PromptUpdateResponse;
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to update prompt';
       throw e;
@@ -218,10 +227,8 @@ export function useLlmAdmin(): UseLlmAdminReturn {
     loading.value = true;
     error.value = null;
     try {
-      const data = await apiClient.get<CacheStats>(`${API_BASE}/cache/stats`, {
-        withCredentials: true,
-      });
-      cacheStats.value = data;
+      const data = await getLlmCacheStats();
+      cacheStats.value = data as unknown as CacheStats;
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to fetch cache stats';
       throw e;
@@ -238,27 +245,21 @@ export function useLlmAdmin(): UseLlmAdminReturn {
       per_page?: number;
     } = {}
   ): Promise<PaginatedCacheSummaries> {
-    return apiClient.get<PaginatedCacheSummaries>(`${API_BASE}/cache/summaries`, {
-      params,
-      withCredentials: true,
-    });
+    const data = await getLlmCacheSummaries(params);
+    return data as unknown as PaginatedCacheSummaries;
   }
 
   async function clearCache(clusterType: ClusterType | 'all'): Promise<CacheClearResponse> {
-    return apiClient.delete<CacheClearResponse>(`${API_BASE}/cache`, {
-      params: { cluster_type: clusterType },
-      withCredentials: true,
-    });
+    const data = await clearLlmCache({ cluster_type: clusterType });
+    return data as unknown as CacheClearResponse;
   }
 
   async function updateValidationStatus(
     cacheId: number,
     action: 'validate' | 'reject'
   ): Promise<ValidationUpdateResponse> {
-    return apiClient.post<ValidationUpdateResponse>(`${API_BASE}/cache/${cacheId}/validate`, null, {
-      params: { action },
-      withCredentials: true,
-    });
+    const data = await validateLlmCacheEntry(cacheId, { action });
+    return data as unknown as ValidationUpdateResponse;
   }
 
   // ─────────────────────────────────────────────────────────────────────────────
@@ -269,10 +270,8 @@ export function useLlmAdmin(): UseLlmAdminReturn {
     clusterType: ClusterType | 'all',
     force = false
   ): Promise<RegenerationJobResponse> {
-    return apiClient.post<RegenerationJobResponse>(`${API_BASE}/regenerate`, null, {
-      params: { cluster_type: clusterType, force },
-      withCredentials: true,
-    });
+    const data = await regenerateLlm({ cluster_type: clusterType, force });
+    return data as unknown as RegenerationJobResponse;
   }
 
   // ─────────────────────────────────────────────────────────────────────────────
@@ -289,10 +288,8 @@ export function useLlmAdmin(): UseLlmAdminReturn {
       per_page?: number;
     } = {}
   ): Promise<PaginatedLogs> {
-    return apiClient.get<PaginatedLogs>(`${API_BASE}/logs`, {
-      params,
-      withCredentials: true,
-    });
+    const data = await getLlmLogs(params);
+    return data as unknown as PaginatedLogs;
   }
 
   // ─────────────────────────────────────────────────────────────────────────────

--- a/app/src/composables/usePubtatorAdmin.ts
+++ b/app/src/composables/usePubtatorAdmin.ts
@@ -6,67 +6,36 @@
  * - Submit async fetch jobs with progress tracking
  * - Clear cache (hard reset)
  * - Backfill gene symbols for existing cache entries
+ *
+ * Network access goes through the typed `@/api/publication` client (which
+ * routes via the `apiClient` axios singleton, inheriting the Authorization
+ * header + 401 interceptor). The hand-rolled response interfaces were removed
+ * in favour of the canonical types exported by that client.
  */
 
 import { ref, computed } from 'vue';
-import axios from 'axios';
-import URLS from '@/assets/js/constants/url_constants';
 import { useAsyncJob } from '@/composables/useAsyncJob';
-
-/** Cache status response from API (unwrapped from Plumber array wrappers) */
-export interface CacheStatus {
-  query: string;
-  cached: boolean;
-  query_id: number | null;
-  pages_cached: number;
-  publications_cached: number;
-  total_pages_available: number;
-  total_results_available: number;
-  pages_remaining: number;
-  cache_date: string | null;
-  estimated_fetch_time_minutes: number;
-  message: string;
-}
-
-/** Job submit response from async API */
-export interface JobSubmitResponse {
-  job_id: string;
-  status: string;
-  query: string;
-  max_pages: number;
-  estimated_seconds: number;
-  status_url: string;
-}
-
-/** Clear cache response (unwrapped from Plumber array wrappers) */
-export interface ClearResponse {
-  success: boolean;
-  deleted?: {
-    queries: number;
-    publications: number;
-    annotations: number;
-  };
-  message: string;
-}
-
-/** Backfill response (unwrapped from Plumber array wrappers) */
-export interface BackfillResponse {
-  success: boolean;
-  updated_count?: number;
-  message: string;
-}
+import {
+  getPubtatorCacheStatus,
+  submitPubtatorUpdate,
+  clearPubtatorCache,
+  backfillPubtatorGenes,
+  type PubtatorCacheStatus,
+  type PubtatorAsyncSubmitResponse,
+  type PubtatorClearCacheResponse,
+  type PubtatorBackfillResponse,
+} from '@/api/publication';
+import { isApiError } from '@/api/client';
 
 /**
  * Composable for PubTator admin operations with async job support
  */
 export function usePubtatorAdmin() {
   const error = ref<string | null>(null);
-  const lastStatus = ref<CacheStatus | null>(null);
+  const lastStatus = ref<PubtatorCacheStatus | null>(null);
   const isCheckingStatus = ref(false);
   const isClearing = ref(false);
   const isBackfilling = ref(false);
-
-  const baseUrl = `${URLS.API_URL}/api/publication/pubtator`;
 
   // Use the async job composable for fetch operations
   const asyncJob = useAsyncJob((jobId: string) => `/api/jobs/${encodeURIComponent(jobId)}/status`, {
@@ -76,17 +45,14 @@ export function usePubtatorAdmin() {
   /**
    * Get cache status for a query
    */
-  async function getCacheStatus(query: string): Promise<CacheStatus> {
+  async function getCacheStatus(query: string): Promise<PubtatorCacheStatus> {
     isCheckingStatus.value = true;
     error.value = null;
 
     try {
-      const response = await axios.get<CacheStatus>(`${baseUrl}/cache-status`, {
-        params: { query },
-        withCredentials: true,
-      });
-      lastStatus.value = response.data;
-      return response.data;
+      const status = await getPubtatorCacheStatus({ query });
+      lastStatus.value = status;
+      return status;
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to get cache status';
       throw err;
@@ -107,21 +73,22 @@ export function usePubtatorAdmin() {
     query: string,
     maxPages: number = 10,
     clearOld: boolean = false
-  ): Promise<JobSubmitResponse> {
+  ): Promise<PubtatorAsyncSubmitResponse> {
     error.value = null;
 
     try {
-      const response = await axios.post<JobSubmitResponse>(`${baseUrl}/update/submit`, null, {
-        params: { query, max_pages: maxPages, clear_old: clearOld },
-        withCredentials: true,
+      const submit = await submitPubtatorUpdate({
+        query,
+        max_pages: maxPages,
+        clear_old: clearOld,
       });
 
       // Start tracking the job with useAsyncJob
-      asyncJob.startJob(response.data.job_id);
+      asyncJob.startJob(submit.job_id);
 
-      return response.data;
+      return submit;
     } catch (err) {
-      if (axios.isAxiosError(err) && err.response?.status === 409) {
+      if (isApiError<{ existing_job_id?: string }>(err) && err.response?.status === 409) {
         // Duplicate job - extract existing job ID and track it
         const existingJobId = err.response.data.existing_job_id;
         if (existingJobId) {
@@ -144,15 +111,12 @@ export function usePubtatorAdmin() {
   /**
    * Clear cache for all queries
    */
-  async function clearCache(): Promise<ClearResponse> {
+  async function clearCache(): Promise<PubtatorClearCacheResponse> {
     isClearing.value = true;
     error.value = null;
 
     try {
-      const response = await axios.post<ClearResponse>(`${baseUrl}/clear-cache`, null, {
-        withCredentials: true,
-      });
-      return response.data;
+      return await clearPubtatorCache();
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to clear cache';
       throw err;
@@ -162,23 +126,25 @@ export function usePubtatorAdmin() {
   }
 
   /**
-   * Backfill gene symbols for existing cache entries
-   * @param queryId - Optional query ID to backfill; if not provided, backfills all
+   * Backfill gene symbols for existing cache entries.
+   *
+   * The `queryId` argument is retained for call-site compatibility, but the
+   * server endpoint always backfills every cached row whose `gene_symbols` is
+   * NULL (it does not read a `query_id` parameter), so the argument is not
+   * forwarded — behavior is identical to the previous implementation.
+   *
+   * @param _queryId - Optional query ID (accepted for compatibility; unused)
    */
-  async function backfillGeneSymbols(queryId?: number): Promise<BackfillResponse> {
+  async function backfillGeneSymbols(
+    _queryId?: string | number | null
+  ): Promise<PubtatorBackfillResponse> {
     isBackfilling.value = true;
     error.value = null;
 
     try {
-      const params: Record<string, number> = {};
-      if (queryId !== undefined) params.query_id = queryId;
-
-      const response = await axios.post<BackfillResponse>(`${baseUrl}/backfill-genes`, null, {
-        params,
+      return await backfillPubtatorGenes({
         timeout: 120000, // 2 minutes for potentially large backfill
-        withCredentials: true,
       });
-      return response.data;
     } catch (err) {
       error.value = err instanceof Error ? err.message : 'Failed to backfill gene symbols';
       throw err;

--- a/app/src/composables/usePubtatorAdminPanel.ts
+++ b/app/src/composables/usePubtatorAdminPanel.ts
@@ -114,7 +114,7 @@ export function usePubtatorAdminPanel() {
 
     try {
       const clearResult = await clearCache();
-      feedbackMessage.value = clearResult.message;
+      feedbackMessage.value = clearResult.message ?? 'Cache cleared.';
       feedbackVariant.value = 'success';
       lastStatus.value = null;
     } catch (err) {

--- a/app/src/views/admin/AdminStatistics.vue
+++ b/app/src/views/admin/AdminStatistics.vue
@@ -265,8 +265,7 @@
 <script setup lang="ts">
 import AuthenticatedPageShell from '@/components/layout/AuthenticatedPageShell.vue';
 import AdminOperationPanel from '@/components/admin/AdminOperationPanel.vue';
-import { ref, computed, onMounted, inject } from 'vue';
-import type { AxiosInstance } from 'axios';
+import { ref, computed, onMounted } from 'vue';
 import {
   BContainer,
   BRow,
@@ -289,24 +288,14 @@ import ContributorBarChart from './components/charts/ContributorBarChart.vue';
 import ReReviewBarChart from './components/charts/ReReviewBarChart.vue';
 import StatCard from './components/statistics/StatCard.vue';
 
-// Inject axios
-const axios = inject<AxiosInstance>('axios');
 const { makeToast } = useToast();
 
-// API base URL
-const apiUrl = import.meta.env.VITE_API_URL;
-
-// v11.0 closeout F2a: the `apiClient` request interceptor (`@/api/client`)
-// now injects the Authorization header on every outbound call, reading
-// `useAuth().token.value`. The sub-composables (`useAdminTrendData`,
-// `useLeaderboardData`, `useKPIStats`) accept a `getAuthHeaders` callback
-// for historical reasons; we pass an empty-object factory so they emit no
-// explicit `Authorization` header — the interceptor then injects the
-// session token. Those composables are outside F2a's ownership; changing
-// their signatures is F2b/F2c's scope.
-function getAuthHeaders(): Record<string, string> {
-  return {};
-}
+// Statistics requests go through the typed `@/api/statistics` clients used by
+// the sub-composables (`useAdminTrendData`, `useLeaderboardData`,
+// `useKPIStats`). Those delegate to the shared `apiClient`, whose request
+// interceptor (`@/api/client`) injects the `Authorization` header on every
+// outbound call, reading `useAuth().token.value` — so no injected axios,
+// base URL, or auth-header plumbing is needed here.
 
 // Date range (default: last 12 months)
 const today = new Date();
@@ -329,7 +318,7 @@ const {
   selectedCategories,
   trendDescription,
   fetchTrendData,
-} = useAdminTrendData(axios, apiUrl, getAuthHeaders, makeToast);
+} = useAdminTrendData(makeToast);
 
 const {
   leaderboardData,
@@ -341,7 +330,7 @@ const {
   reReviewLeaderboardScope,
   fetchLeaderboard,
   fetchReReviewLeaderboard,
-} = useLeaderboardData(axios, apiUrl, getAuthHeaders, makeToast);
+} = useLeaderboardData(makeToast);
 
 const {
   loading: kpiLoading,
@@ -352,7 +341,7 @@ const {
   updatedStatusesStatistics,
   fetchKPIStats,
   fetchExistingStatistics,
-} = useKPIStats(axios, apiUrl, getAuthHeaders, makeToast);
+} = useKPIStats(makeToast);
 
 // --- Composite loading state for template ---
 const loading = computed(() => ({

--- a/app/src/views/admin/ManageOntology.spec.ts
+++ b/app/src/views/admin/ManageOntology.spec.ts
@@ -1,18 +1,21 @@
 // ManageOntology.spec.ts
 /**
- * v11.0 closeout F2b — spec covering the apiClient migration of
- * `views/admin/ManageOntology.vue`.
+ * Spec covering the typed-client migration of
+ * `views/admin/ManageOntology.vue` (feat/admin-typed-client-migration).
  *
- *   1. `doLoadData()` fetches `GET /api/ontology/variant/table` with the
- *      `Authorization: Bearer <token>` header injected by the apiClient
- *      request interceptor.
+ *   1. `doLoadData()` fetches `GET /api/ontology/variant/table` via
+ *      `listVariantOntology` with the `Authorization: Bearer <token>`
+ *      header injected by the apiClient request interceptor.
  *   2. `updateOntologyData()` writes via `PUT /api/ontology/variant/update`
- *      and also carries the Bearer header.
+ *      through `updateVariantOntology` and also carries the Bearer header.
  *
  * The pre-F2b implementation hard-coded
  * `Authorization: Bearer ${localStorage.getItem('token')}` on each call;
  * this spec pins the migrated path so any regression trips the lint
- * guardrail AND fails an observable test.
+ * guardrail AND fails an observable test. Asserting on the msw network
+ * boundary keeps the Bearer-header-on-the-wire coverage intact across the
+ * raw-axios -> typed-client move (both route through the same axios
+ * singleton + request interceptor).
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -21,7 +24,6 @@ import { createPinia, setActivePinia } from 'pinia';
 import { http, HttpResponse } from 'msw';
 
 import '@/plugins/axios';
-import axios from '@/plugins/axios';
 import { server } from '@/test-utils/mocks/server';
 import { primeAuth } from '@/test-utils/primeAuth';
 import { expectBearerHeader } from '@/test-utils/expectBearerHeader';
@@ -101,8 +103,6 @@ async function mountView() {
   setActivePinia(createPinia());
   const wrapper = mount(ManageOntology, {
     global: {
-      mocks: { axios },
-      provide: { axios },
       directives: { 'b-tooltip': {}, 'b-toggle': {} },
       stubs: {
         GenericTable: { template: '<div />' },

--- a/app/src/views/admin/ManageOntology.vue
+++ b/app/src/views/admin/ManageOntology.vue
@@ -232,17 +232,18 @@ component. */
 <script>
 import AuthenticatedPageShell from '@/components/layout/AuthenticatedPageShell.vue';
 import TableShell from '@/components/table/TableShell.vue';
-import { ref, inject } from 'vue';
+import { ref } from 'vue';
 import GenericTable from '@/components/small/GenericTable.vue';
 import TablePaginationControls from '@/components/small/TablePaginationControls.vue';
 import OntologyMobileRows from './components/OntologyMobileRows.vue';
 import OntologyEditModal from './components/OntologyEditModal.vue';
 import useToast from '@/composables/useToast';
 import { useUrlParsing, useTableData, useExcelExport } from '@/composables';
-// v11.0 closeout F2b: reach for `apiClient` instead of the raw axios
-// instance so the request interceptor injects the Bearer header from
+// Migrated to the typed ontology client (feat/admin-typed-client-migration):
+// `listVariantOntology` / `updateVariantOntology` delegate to `apiClient`, so
+// the request interceptor still injects the Bearer header from
 // `useAuth().token.value` (single source of truth for session auth).
-import { apiClient } from '@/api/client';
+import { listVariantOntology, updateVariantOntology } from '@/api/ontology';
 
 // Import the Pinia store
 import { useUiStore } from '@/stores/ui';
@@ -289,8 +290,6 @@ export default {
     const showEditModal = ref(false);
     const ontologyToEdit = ref({});
 
-    const axios = inject('axios');
-
     return {
       ...tableData,
       filter,
@@ -300,7 +299,6 @@ export default {
       sortStringToVariables,
       isExporting,
       exportToExcel,
-      axios,
       showEditModal,
       ontologyToEdit,
     };
@@ -603,16 +601,18 @@ export default {
       moduleApiCallInProgress = true;
       this.isBusy = true;
 
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/ontology/variant/table?${urlParam}`;
-
       try {
-        // v11.0 closeout F2b: `apiClient.raw` returns the full AxiosResponse
-        // so the existing `response.data` unpacking stays intact; the
-        // request interceptor adds the Bearer header automatically.
-        const response = await apiClient.raw.get(apiUrl);
+        // Typed ontology client resolves with the response payload directly;
+        // apiClient's interceptor adds the Bearer header.
+        const data = await listVariantOntology({
+          sort: this.sort,
+          filter: this.filter_string,
+          page_after: this.currentItemID,
+          page_size: this.perPage,
+        });
         moduleApiCallInProgress = false;
-        moduleLastApiResponse = response.data;
-        this.applyApiResponse(response.data);
+        moduleLastApiResponse = data;
+        this.applyApiResponse(data);
         this.updateBrowserUrl();
         this.isBusy = false;
       } catch (e) {
@@ -684,14 +684,12 @@ export default {
      * @returns {Promise<void>}
      */
     async updateOntologyData() {
-      const apiUrl = `${import.meta.env.VITE_API_URL}/api/ontology/variant/update`;
       try {
-        // v11.0 closeout F2b: Bearer header flows through the apiClient
-        // request interceptor from `useAuth().token.value`.
-        const response = await apiClient.raw.put(apiUrl, {
+        // Typed ontology client routes through apiClient (Bearer via interceptor).
+        const data = await updateVariantOntology({
           ontology_details: this.ontologyToEdit,
         });
-        this.makeToast(response.data.message, 'Success', 'success');
+        this.makeToast(data.message, 'Success', 'success');
         // Update the ontology in the local state
         const index = this.ontologies.findIndex((o) => o.vario_id === this.ontologyToEdit.vario_id);
         if (index !== -1) {

--- a/app/src/views/admin/composables/useAdminTrendData.ts
+++ b/app/src/views/admin/composables/useAdminTrendData.ts
@@ -1,9 +1,10 @@
 // views/admin/composables/useAdminTrendData.ts
 import { ref, computed, watch, onUnmounted } from 'vue';
-import type { AxiosInstance } from 'axios';
 import { mergeGroupedCumulativeSeries, extractPerGroupSeries } from '@/utils/timeSeriesUtils';
 import type { GroupedTimeSeries } from '@/utils/timeSeriesUtils';
 import { safeArray } from '@/utils/apiUtils';
+import { getEntitiesOverTime } from '@/api/statistics';
+import type { EntitiesOverTimeParams } from '@/api/statistics';
 
 interface TrendDataPoint {
   date: string;
@@ -11,9 +12,6 @@ interface TrendDataPoint {
 }
 
 export function useAdminTrendData(
-  axios: AxiosInstance | undefined,
-  apiUrl: string,
-  getAuthHeaders: () => Record<string, string>,
   makeToast: (msg: unknown, title: string, variant: string) => void
 ) {
   const trendData = ref<TrendDataPoint[]>([]);
@@ -72,8 +70,6 @@ export function useAdminTrendData(
   const totalEntities = ref(0);
 
   async function fetchTrendData(): Promise<void> {
-    if (!axios) return;
-
     abortController?.abort();
     abortController = new AbortController();
     const currentVersion = ++requestVersion;
@@ -83,7 +79,7 @@ export function useAdminTrendData(
     loading.value = true;
 
     try {
-      const params: Record<string, string> = {
+      const params: EntitiesOverTimeParams = {
         aggregate: 'entity_id',
         group: 'category',
         summarize: granularity.value,
@@ -93,15 +89,13 @@ export function useAdminTrendData(
         params.filter = filterValue;
       }
 
-      const response = await axios.get(`${apiUrl}/api/statistics/entities_over_time`, {
-        params,
-        headers: getAuthHeaders(),
+      const response = await getEntitiesOverTime(params, {
         signal: abortController.signal,
       });
 
       if (currentVersion !== requestVersion) return;
 
-      const allData = safeArray<GroupedTimeSeries>(response.data?.data);
+      const allData = safeArray<GroupedTimeSeries>(response?.data);
       trendData.value = mergeGroupedCumulativeSeries(allData);
       trendCategoryData.value = extractPerGroupSeries(allData);
 

--- a/app/src/views/admin/composables/useBackupInventory.spec.ts
+++ b/app/src/views/admin/composables/useBackupInventory.spec.ts
@@ -1,0 +1,181 @@
+// useBackupInventory.spec.ts
+/**
+ * Spec for `views/admin/composables/useBackupInventory.ts` after the typed
+ * backup-client migration.
+ *
+ * The inventory data layer no longer hand-builds `${VITE_API_URL}/api/backup/...`
+ * URLs through `apiClient.raw.*`; it now routes through the typed helpers in
+ * `@/api/backup` (`listBackups`, `downloadBackup`). These tests pin the
+ * typed-client boundary directly at the composable level:
+ *
+ *   - GET /api/backup/list  -> list mapping + meta + Bearer header
+ *   - GET /api/backup/download/:filename -> Blob + percent-encoded path + Bearer
+ *     header + extractApiErrorMessage on failure
+ *
+ * They sit alongside the view-level contract in `../ManageBackups.spec.ts`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+
+import '@/plugins/axios';
+import { server } from '@/test-utils/mocks/server';
+import { primeAuth } from '@/test-utils/primeAuth';
+import { expectBearerHeader } from '@/test-utils/expectBearerHeader';
+import { useAuth } from '@/composables/useAuth';
+import { useBackupInventory, formatFileSize } from './useBackupInventory';
+
+const makeToastSpy = vi.fn();
+
+beforeEach(() => {
+  makeToastSpy.mockClear();
+  // Relative paths must resolve against the MSW handlers, so neutralise any
+  // configured base URL (mirrors ManageBackups.spec.ts).
+  vi.stubEnv('VITE_API_URL', '');
+});
+
+afterEach(() => {
+  useAuth().logout();
+  vi.unstubAllEnvs();
+});
+
+describe('useBackupInventory — typed-client migration', () => {
+  it('fetchBackupList() GETs /api/backup/list with the Bearer header and maps the envelope', async () => {
+    primeAuth('inventory-token');
+
+    server.use(
+      http.get('/api/backup/list', ({ request }) => {
+        expectBearerHeader(request, 'inventory-token');
+        return HttpResponse.json({
+          data: [
+            {
+              filename: 'manual_2026-04-25.sql.gz',
+              size_bytes: 2048,
+              created_at: '2026-04-25T00:00:00Z',
+              table_count: 12,
+            },
+          ],
+          meta: { total_count: 1, total_size_bytes: 2048 },
+        });
+      })
+    );
+
+    const inv = useBackupInventory({ onToast: makeToastSpy });
+    await inv.fetchBackupList();
+
+    expect(inv.backups.value).toEqual([
+      {
+        filename: 'manual_2026-04-25.sql.gz',
+        size_bytes: 2048,
+        created_at: '2026-04-25T00:00:00Z',
+        table_count: 12,
+      },
+    ]);
+    expect(inv.meta.value).toEqual({ total_count: 1, total_size_bytes: 2048 });
+    expect(inv.loading.value).toBe(false);
+  });
+
+  it('fetchBackupList() unwraps R/Plumber single-element scalar arrays', async () => {
+    primeAuth('scalar-token');
+
+    server.use(
+      http.get('/api/backup/list', () =>
+        HttpResponse.json({
+          data: [
+            {
+              filename: ['manual_scalar.sql.gz'],
+              size_bytes: [4096],
+              created_at: ['2026-04-25T01:00:00Z'],
+              table_count: [7],
+            },
+          ],
+          meta: { total_count: [1], total_size_bytes: [4096] },
+        })
+      )
+    );
+
+    const inv = useBackupInventory({ onToast: makeToastSpy });
+    await inv.fetchBackupList();
+
+    expect(inv.backups.value).toEqual([
+      {
+        filename: 'manual_scalar.sql.gz',
+        size_bytes: 4096,
+        created_at: '2026-04-25T01:00:00Z',
+        table_count: 7,
+      },
+    ]);
+    expect(inv.meta.value).toEqual({ total_count: 1, total_size_bytes: 4096 });
+  });
+
+  it('fetchBackupList() toasts and clears the list on failure', async () => {
+    primeAuth('inventory-fail-token');
+
+    server.use(
+      http.get('/api/backup/list', () =>
+        HttpResponse.json({ message: 'read failure' }, { status: 500 })
+      )
+    );
+
+    const inv = useBackupInventory({ onToast: makeToastSpy });
+    await inv.fetchBackupList();
+
+    expect(inv.backups.value).toEqual([]);
+    expect(makeToastSpy).toHaveBeenCalledWith('Failed to load backup list', 'Error', 'danger');
+    expect(inv.loading.value).toBe(false);
+  });
+
+  it('downloadBackup() GETs the percent-encoded path with the Bearer header', async () => {
+    primeAuth('download-token');
+
+    const filename = 'manual_2026-04-25T12:34:56.sql.gz';
+    let requestedPath = '';
+    server.use(
+      http.get('/api/backup/download/:filename', ({ request }) => {
+        expectBearerHeader(request, 'download-token');
+        requestedPath = new URL(request.url).pathname;
+        return new HttpResponse(new Blob(['ok']));
+      })
+    );
+
+    const createSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock');
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    const inv = useBackupInventory({ onToast: makeToastSpy });
+    await inv.downloadBackup(filename);
+
+    createSpy.mockRestore();
+    revokeSpy.mockRestore();
+
+    expect(requestedPath).toBe(`/api/backup/download/${encodeURIComponent(filename)}`);
+    // The colon from the timestamp must be escaped, not present raw.
+    expect(requestedPath).not.toContain(filename);
+    expect(makeToastSpy).not.toHaveBeenCalled();
+  });
+
+  it('downloadBackup() surfaces the extracted error via the toast on failure', async () => {
+    primeAuth('download-fail-token');
+
+    server.use(
+      http.get('/api/backup/download/:filename', () =>
+        HttpResponse.json({ message: 'Backup file not found' }, { status: 404 })
+      )
+    );
+
+    const inv = useBackupInventory({ onToast: makeToastSpy });
+    await inv.downloadBackup('missing.sql.gz');
+
+    expect(makeToastSpy).toHaveBeenCalledTimes(1);
+    const [message, title, variant] = makeToastSpy.mock.calls[0];
+    expect(message).toMatch(/404/);
+    expect(title).toBe('Error');
+    expect(variant).toBe('danger');
+  });
+});
+
+describe('useBackupInventory — formatters', () => {
+  it('formatFileSize() renders human-readable sizes', () => {
+    expect(formatFileSize(0)).toBe('0 B');
+    expect(formatFileSize(2048)).toBe('2 KB');
+  });
+});

--- a/app/src/views/admin/composables/useBackupInventory.ts
+++ b/app/src/views/admin/composables/useBackupInventory.ts
@@ -1,6 +1,6 @@
 // app/src/views/admin/composables/useBackupInventory.ts
 import { ref, computed, watch } from 'vue';
-import { apiClient } from '@/api/client';
+import { listBackups, downloadBackup as downloadBackupFile } from '@/api/backup';
 import { extractApiErrorMessage } from '@/utils/api-errors';
 
 /**
@@ -241,21 +241,17 @@ export function useBackupInventory(options: UseBackupInventoryOptions = {}) {
   async function fetchBackupList() {
     loading.value = true;
     try {
-      const response = await apiClient.raw.get<{
-        data?: Record<string, unknown>[];
-        meta?: Record<string, unknown>;
-      }>(`${import.meta.env.VITE_API_URL}/api/backup/list`, {
-        withCredentials: true,
-      });
+      const data = await listBackups();
 
-      const data = response.data;
       if (data && Array.isArray(data.data)) {
-        backups.value = data.data.map((backup: Record<string, unknown>) => ({
-          filename: unwrapValue(backup.filename) as string,
-          size_bytes: Number(unwrapValue(backup.size_bytes)) || 0,
-          created_at: unwrapValue(backup.created_at) as string,
-          table_count: backup.table_count ? Number(unwrapValue(backup.table_count)) : null,
-        }));
+        backups.value = (data.data as unknown as Record<string, unknown>[]).map(
+          (backup: Record<string, unknown>) => ({
+            filename: unwrapValue(backup.filename) as string,
+            size_bytes: Number(unwrapValue(backup.size_bytes)) || 0,
+            created_at: unwrapValue(backup.created_at) as string,
+            table_count: backup.table_count ? Number(unwrapValue(backup.table_count)) : null,
+          })
+        );
       } else {
         backups.value = [];
       }
@@ -279,15 +275,9 @@ export function useBackupInventory(options: UseBackupInventoryOptions = {}) {
   // Download backup file
   async function downloadBackup(filename: string) {
     try {
-      const response = await apiClient.raw.get<Blob>(
-        `${import.meta.env.VITE_API_URL}/api/backup/download/${encodeURIComponent(filename)}`,
-        {
-          responseType: 'blob',
-          withCredentials: true,
-        }
-      );
+      const blob = await downloadBackupFile(filename);
 
-      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const url = window.URL.createObjectURL(new Blob([blob]));
       const link = document.createElement('a');
       link.href = url;
       link.setAttribute('download', filename);

--- a/app/src/views/admin/composables/useBackupJobs.spec.ts
+++ b/app/src/views/admin/composables/useBackupJobs.spec.ts
@@ -1,0 +1,191 @@
+// useBackupJobs.spec.ts
+/**
+ * Spec for `views/admin/composables/useBackupJobs.ts` after the typed
+ * backup-client migration.
+ *
+ * Job orchestration no longer hand-builds `${VITE_API_URL}/api/backup/...`
+ * URLs through `apiClient.raw.*`; it now routes through the typed helpers in
+ * `@/api/backup` (`createBackup`, `restoreBackup`, `deleteBackup`). These
+ * tests pin the typed-client boundary at the composable level:
+ *
+ *   - POST   /api/backup/create  -> job_id handoff + Bearer header
+ *   - POST   /api/backup/restore -> filename body + job_id handoff + Bearer
+ *   - DELETE /api/backup/delete/:filename -> confirm body + percent-encoded path
+ *
+ * The async-job polling state machine has dedicated coverage in
+ * `useAsyncJob.spec.ts`; here it is stubbed so `startJob` is observable
+ * without firing the poller.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+
+import '@/plugins/axios';
+import { server } from '@/test-utils/mocks/server';
+import { primeAuth } from '@/test-utils/primeAuth';
+import { expectBearerHeader } from '@/test-utils/expectBearerHeader';
+import { useAuth } from '@/composables/useAuth';
+
+const startJobSpy = vi.fn();
+const resetSpy = vi.fn();
+
+vi.mock('@/composables/useAsyncJob', () => ({
+  useAsyncJob: () => ({
+    status: { value: 'idle' },
+    isLoading: { value: false },
+    progress: { value: 0 },
+    message: { value: '' },
+    error: { value: null },
+    jobId: { value: null },
+    reset: resetSpy,
+    startJob: startJobSpy,
+  }),
+}));
+
+import { useBackupJobs } from './useBackupJobs';
+import type { BackupItem } from './useBackupInventory';
+
+const onRefresh = vi.fn();
+const makeToastSpy = vi.fn();
+
+function makeBackup(filename: string): BackupItem {
+  return { filename, size_bytes: 1, created_at: '2026-04-25T00:00:00Z', table_count: null };
+}
+
+beforeEach(() => {
+  startJobSpy.mockClear();
+  resetSpy.mockClear();
+  onRefresh.mockClear();
+  makeToastSpy.mockClear();
+  vi.stubEnv('VITE_API_URL', '');
+});
+
+afterEach(() => {
+  useAuth().logout();
+  vi.unstubAllEnvs();
+});
+
+describe('useBackupJobs — typed-client migration', () => {
+  it('triggerBackup() POSTs /api/backup/create with the Bearer header and starts the job', async () => {
+    primeAuth('create-token');
+
+    server.use(
+      http.post('/api/backup/create', ({ request }) => {
+        expectBearerHeader(request, 'create-token');
+        return HttpResponse.json({ job_id: 'backup-1' }, { status: 202 });
+      })
+    );
+
+    const jobs = useBackupJobs({ onRefresh, onToast: makeToastSpy });
+    await jobs.triggerBackup();
+
+    expect(resetSpy).toHaveBeenCalled();
+    expect(startJobSpy).toHaveBeenCalledWith('backup-1');
+  });
+
+  it('triggerBackup() toasts the extracted error on failure', async () => {
+    primeAuth('create-fail-token');
+
+    server.use(
+      http.post('/api/backup/create', () =>
+        HttpResponse.json({ message: 'A backup is already running' }, { status: 409 })
+      )
+    );
+
+    const jobs = useBackupJobs({ onRefresh, onToast: makeToastSpy });
+    await jobs.triggerBackup();
+
+    expect(startJobSpy).not.toHaveBeenCalled();
+    expect(makeToastSpy).toHaveBeenCalledWith('A backup is already running', 'Error', 'danger');
+  });
+
+  it('confirmRestore() POSTs the filename body with the Bearer header and starts the job', async () => {
+    primeAuth('restore-token');
+
+    let receivedBody: unknown = null;
+    server.use(
+      http.post('/api/backup/restore', async ({ request }) => {
+        expectBearerHeader(request, 'restore-token');
+        receivedBody = await request.json();
+        return HttpResponse.json({ job_id: 'restore-1' }, { status: 202 });
+      })
+    );
+
+    const jobs = useBackupJobs({ onRefresh, onToast: makeToastSpy });
+    jobs.selectedBackup.value = makeBackup('manual_2026-04-25.sql.gz');
+    jobs.restoreConfirmText.value = 'RESTORE';
+
+    await jobs.confirmRestore();
+
+    expect(receivedBody).toEqual({ filename: 'manual_2026-04-25.sql.gz' });
+    expect(startJobSpy).toHaveBeenCalledWith('restore-1');
+    expect(jobs.showRestoreModal.value).toBe(false);
+  });
+
+  it('confirmRestore() is a no-op when the confirm text is wrong', async () => {
+    primeAuth('restore-guard-token');
+
+    const jobs = useBackupJobs({ onRefresh, onToast: makeToastSpy });
+    jobs.selectedBackup.value = makeBackup('manual_2026-04-25.sql.gz');
+    jobs.restoreConfirmText.value = 'nope';
+
+    await jobs.confirmRestore();
+
+    expect(resetSpy).not.toHaveBeenCalled();
+    expect(startJobSpy).not.toHaveBeenCalled();
+  });
+
+  it('confirmDelete() DELETEs the percent-encoded path with the confirm body and refreshes', async () => {
+    primeAuth('delete-token');
+
+    const filename = 'pre-restore_2026-04-25T12:34:56.sql.gz';
+    let requestedPath = '';
+    let receivedBody: unknown = null;
+    server.use(
+      http.delete('/api/backup/delete/:filename', async ({ request }) => {
+        expectBearerHeader(request, 'delete-token');
+        requestedPath = new URL(request.url).pathname;
+        receivedBody = await request.json();
+        return HttpResponse.json({ success: true, message: 'Deleted' });
+      })
+    );
+
+    const jobs = useBackupJobs({ onRefresh, onToast: makeToastSpy });
+    jobs.selectedBackup.value = makeBackup(filename);
+    jobs.deleteConfirmText.value = 'DELETE';
+
+    await jobs.confirmDelete();
+
+    expect(requestedPath).toBe(`/api/backup/delete/${encodeURIComponent(filename)}`);
+    expect(receivedBody).toEqual({ confirm: 'DELETE' });
+    expect(makeToastSpy).toHaveBeenCalledWith(
+      `Backup '${filename}' deleted successfully`,
+      'Success',
+      'success'
+    );
+    expect(onRefresh).toHaveBeenCalled();
+  });
+
+  it('confirmDelete() toasts the extracted error and skips refresh on failure', async () => {
+    primeAuth('delete-fail-token');
+
+    server.use(
+      http.delete('/api/backup/delete/:filename', () =>
+        HttpResponse.json({ message: 'A backup operation is already running' }, { status: 409 })
+      )
+    );
+
+    const jobs = useBackupJobs({ onRefresh, onToast: makeToastSpy });
+    jobs.selectedBackup.value = makeBackup('manual_2026-04-25.sql.gz');
+    jobs.deleteConfirmText.value = 'DELETE';
+
+    await jobs.confirmDelete();
+
+    expect(makeToastSpy).toHaveBeenCalledWith(
+      'A backup operation is already running',
+      'Error',
+      'danger'
+    );
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/views/admin/composables/useBackupJobs.ts
+++ b/app/src/views/admin/composables/useBackupJobs.ts
@@ -1,6 +1,6 @@
 // app/src/views/admin/composables/useBackupJobs.ts
 import { ref, watch } from 'vue';
-import { apiClient } from '@/api/client';
+import { createBackup, restoreBackup, deleteBackup } from '@/api/backup';
 import { useAsyncJob } from '@/composables/useAsyncJob';
 import { extractApiErrorMessage } from '@/utils/api-errors';
 import type { BackupItem } from './useBackupInventory';
@@ -62,20 +62,9 @@ export function useBackupJobs(options: UseBackupJobsOptions) {
     showRestoreModal.value = false;
 
     try {
-      const response = await apiClient.raw.post<{
-        job_id: string;
-      }>(
-        `${import.meta.env.VITE_API_URL}/api/backup/restore`,
-        { filename: selectedBackup.value.filename },
-        {
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          withCredentials: true,
-        }
-      );
+      const response = await restoreBackup({ filename: selectedBackup.value.filename });
 
-      restoreJob.startJob(response.data.job_id);
+      restoreJob.startJob(response.job_id);
     } catch (error) {
       console.error('Failed to start restore:', error);
       onToast?.(extractApiErrorMessage(error, 'Failed to start restore'), 'Error', 'danger');
@@ -90,16 +79,7 @@ export function useBackupJobs(options: UseBackupJobsOptions) {
     const filename = selectedBackup.value.filename;
 
     try {
-      await apiClient.raw.delete(
-        `${import.meta.env.VITE_API_URL}/api/backup/delete/${encodeURIComponent(filename)}`,
-        {
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          data: { confirm: 'DELETE' },
-          withCredentials: true,
-        }
-      );
+      await deleteBackup(filename, { confirm: 'DELETE' });
 
       onToast?.(`Backup '${filename}' deleted successfully`, 'Success', 'success');
       onRefresh();
@@ -114,17 +94,9 @@ export function useBackupJobs(options: UseBackupJobsOptions) {
     backupJob.reset();
 
     try {
-      const response = await apiClient.raw.post<{
-        job_id: string;
-      }>(
-        `${import.meta.env.VITE_API_URL}/api/backup/create`,
-        {},
-        {
-          withCredentials: true,
-        }
-      );
+      const response = await createBackup();
 
-      backupJob.startJob(response.data.job_id);
+      backupJob.startJob(response.job_id);
     } catch (error) {
       console.error('Failed to start backup:', error);
       onToast?.(extractApiErrorMessage(error, 'Failed to start backup'), 'Error', 'danger');

--- a/app/src/views/admin/composables/useBulkUserActions.ts
+++ b/app/src/views/admin/composables/useBulkUserActions.ts
@@ -1,9 +1,7 @@
 // app/src/views/admin/composables/useBulkUserActions.ts
 import { ref } from 'vue';
-import { apiClient } from '@/api/client';
+import { bulkApproveUsers, bulkAssignRole as apiBulkAssignRole, bulkDeleteUsers } from '@/api/user';
 import { extractApiErrorMessage } from '@/utils/api-errors';
-
-const apiBase = import.meta.env.VITE_API_URL ?? '';
 
 export interface UseBulkUserActionsOptions {
   onToast?: (...args: unknown[]) => void;
@@ -26,20 +24,16 @@ export function useBulkUserActions(options: UseBulkUserActionsOptions = {}) {
     ensureNonEmpty(userIds, 'Bulk Approve');
     bulkActing.value = true;
     try {
-      const response = await apiClient.raw.post(`${apiBase}/api/user/bulk_approve`, {
-        user_ids: userIds,
-      });
-      if (response.status === 200) {
-        const processed = (response.data as { processed?: number }).processed;
-        onToast?.(
-          `Successfully approved ${processed || userIds.length} users`,
-          'Bulk Approve Complete',
-          'success',
-          true,
-          5000
-        );
-        onSuccess?.();
-      }
+      const result = await bulkApproveUsers({ user_ids: userIds });
+      const processed = result.processed;
+      onToast?.(
+        `Successfully approved ${processed || userIds.length} users`,
+        'Bulk Approve Complete',
+        'success',
+        true,
+        5000
+      );
+      onSuccess?.();
     } catch (e) {
       const errorMsg = extractApiErrorMessage(e, 'Failed to approve users');
       onToast?.(errorMsg, 'Bulk Approve Failed', 'danger');
@@ -58,21 +52,16 @@ export function useBulkUserActions(options: UseBulkUserActionsOptions = {}) {
     }
     bulkActing.value = true;
     try {
-      const response = await apiClient.raw.post(`${apiBase}/api/user/bulk_assign_role`, {
-        user_ids: userIds,
-        role,
-      });
-      if (response.status === 200) {
-        const processed = (response.data as { processed?: number }).processed;
-        onToast?.(
-          `Successfully assigned ${role} role to ${processed || userIds.length} users`,
-          'Bulk Role Assignment Complete',
-          'success',
-          true,
-          5000
-        );
-        onSuccess?.();
-      }
+      const result = await apiBulkAssignRole({ user_ids: userIds, role });
+      const processed = result.processed;
+      onToast?.(
+        `Successfully assigned ${role} role to ${processed || userIds.length} users`,
+        'Bulk Role Assignment Complete',
+        'success',
+        true,
+        5000
+      );
+      onSuccess?.();
     } catch (e) {
       const errorMsg = extractApiErrorMessage(e, 'Failed to assign role');
       onToast?.(errorMsg, 'Bulk Role Assignment Failed', 'danger');
@@ -86,20 +75,16 @@ export function useBulkUserActions(options: UseBulkUserActionsOptions = {}) {
     ensureNonEmpty(userIds, 'Bulk Delete');
     bulkActing.value = true;
     try {
-      const response = await apiClient.raw.post(`${apiBase}/api/user/bulk_delete`, {
-        user_ids: userIds,
-      });
-      if (response.status === 200) {
-        const processed = (response.data as { processed?: number }).processed;
-        onToast?.(
-          `Successfully deleted ${processed || userIds.length} users`,
-          'Bulk Delete Complete',
-          'success',
-          true,
-          5000
-        );
-        onSuccess?.();
-      }
+      const result = await bulkDeleteUsers({ user_ids: userIds });
+      const processed = result.processed;
+      onToast?.(
+        `Successfully deleted ${processed || userIds.length} users`,
+        'Bulk Delete Complete',
+        'success',
+        true,
+        5000
+      );
+      onSuccess?.();
     } catch (e) {
       const errorMsg = extractApiErrorMessage(e, 'Failed to delete users');
       onToast?.(errorMsg, 'Bulk Delete Failed', 'danger');

--- a/app/src/views/admin/composables/useKPIStats.ts
+++ b/app/src/views/admin/composables/useKPIStats.ts
@@ -1,8 +1,13 @@
 // views/admin/composables/useKPIStats.ts
 import { ref } from 'vue';
-import type { AxiosInstance } from 'axios';
 import { unwrapScalar } from '@/utils/apiUtils';
 import { previousPeriod } from '@/utils/dateUtils';
+import {
+  getUpdatesStats,
+  getRereviewStats,
+  getUpdatedReviewsStats,
+  getUpdatedStatusesStats,
+} from '@/api/statistics';
 
 interface UpdatesStatistics {
   total_new_entities: number;
@@ -23,9 +28,6 @@ interface KpiStats {
 }
 
 export function useKPIStats(
-  axios: AxiosInstance | undefined,
-  apiUrl: string,
-  getAuthHeaders: () => Record<string, string>,
   makeToast: (msg: unknown, title: string, variant: string) => void
 ) {
   const loading = ref(false);
@@ -42,17 +44,12 @@ export function useKPIStats(
   const updatedStatusesStatistics = ref<{ total_updated_statuses: number } | null>(null);
 
   async function fetchUpdatesStats(start: string, end: string): Promise<UpdatesStatistics | null> {
-    if (!axios) return null;
-
     try {
-      const response = await axios.get(`${apiUrl}/api/statistics/updates`, {
-        params: { start_date: start, end_date: end },
-        headers: getAuthHeaders(),
-      });
+      const response = await getUpdatesStats({ start_date: start, end_date: end });
       return {
-        total_new_entities: unwrapScalar(response.data.total_new_entities, 0)!,
-        unique_genes: unwrapScalar(response.data.unique_genes, 0)!,
-        average_per_day: unwrapScalar(response.data.average_per_day, 0)!,
+        total_new_entities: unwrapScalar(response.total_new_entities, 0)!,
+        unique_genes: unwrapScalar(response.unique_genes, 0)!,
+        average_per_day: unwrapScalar(response.average_per_day, 0)!,
       };
     } catch (error) {
       console.error('Failed to fetch updates stats:', error);
@@ -88,8 +85,6 @@ export function useKPIStats(
   }
 
   async function fetchKPIStats(startDate: string, endDate: string): Promise<void> {
-    if (!axios) return;
-
     loading.value = true;
     try {
       const currentStats = await fetchUpdatesStats(startDate, endDate);
@@ -111,36 +106,31 @@ export function useKPIStats(
   }
 
   async function fetchExistingStatistics(startDate: string, endDate: string): Promise<void> {
-    if (!axios) return;
-
     try {
-      const reReviewResponse = await axios.get(`${apiUrl}/api/statistics/rereview`, {
-        params: { start_date: startDate, end_date: endDate },
-        headers: getAuthHeaders(),
+      const reReviewResponse = await getRereviewStats({
+        start_date: startDate,
+        end_date: endDate,
       });
       reReviewStatistics.value = {
-        total_rereviews: unwrapScalar(reReviewResponse.data.total_rereviews, 0)!,
-        percentage_finished: unwrapScalar(reReviewResponse.data.percentage_finished, 0)!,
-        average_per_day: unwrapScalar(reReviewResponse.data.average_per_day, 0)!,
+        total_rereviews: unwrapScalar(reReviewResponse.total_rereviews, 0)!,
+        percentage_finished: unwrapScalar(reReviewResponse.percentage_finished, 0)!,
+        average_per_day: unwrapScalar(reReviewResponse.average_per_day, 0)!,
       };
 
-      const updatedReviewsResponse = await axios.get(`${apiUrl}/api/statistics/updated_reviews`, {
-        params: { start_date: startDate, end_date: endDate },
-        headers: getAuthHeaders(),
+      const updatedReviewsResponse = await getUpdatedReviewsStats({
+        start_date: startDate,
+        end_date: endDate,
       });
       updatedReviewsStatistics.value = {
-        total_updated_reviews: unwrapScalar(updatedReviewsResponse.data.total_updated_reviews, 0)!,
+        total_updated_reviews: unwrapScalar(updatedReviewsResponse.total_updated_reviews, 0)!,
       };
 
-      const updatedStatusesResponse = await axios.get(`${apiUrl}/api/statistics/updated_statuses`, {
-        params: { start_date: startDate, end_date: endDate },
-        headers: getAuthHeaders(),
+      const updatedStatusesResponse = await getUpdatedStatusesStats({
+        start_date: startDate,
+        end_date: endDate,
       });
       updatedStatusesStatistics.value = {
-        total_updated_statuses: unwrapScalar(
-          updatedStatusesResponse.data.total_updated_statuses,
-          0
-        )!,
+        total_updated_statuses: unwrapScalar(updatedStatusesResponse.total_updated_statuses, 0)!,
       };
     } catch (error) {
       console.error('Failed to fetch existing statistics:', error);

--- a/app/src/views/admin/composables/useLeaderboardData.ts
+++ b/app/src/views/admin/composables/useLeaderboardData.ts
@@ -1,7 +1,8 @@
 // views/admin/composables/useLeaderboardData.ts
 import { ref } from 'vue';
-import type { AxiosInstance } from 'axios';
 import { safeArray, unwrapScalar } from '@/utils/apiUtils';
+import { getContributorLeaderboard, getRereviewLeaderboard } from '@/api/statistics';
+import type { LeaderboardParams } from '@/api/statistics';
 
 interface ContributorData {
   user_name: string;
@@ -16,9 +17,6 @@ interface ReReviewLeaderboardData {
 }
 
 export function useLeaderboardData(
-  axios: AxiosInstance | undefined,
-  apiUrl: string,
-  getAuthHeaders: () => Record<string, string>,
   makeToast: (msg: unknown, title: string, variant: string) => void
 ) {
   const leaderboardData = ref<ContributorData[]>([]);
@@ -31,11 +29,9 @@ export function useLeaderboardData(
   const reReviewLeaderboardScope = ref<'all_time' | 'range'>('all_time');
 
   async function fetchLeaderboard(startDate: string, endDate: string): Promise<void> {
-    if (!axios) return;
-
     loadingLeaderboard.value = true;
     try {
-      const params: Record<string, string | number> = {
+      const params: LeaderboardParams = {
         top: 10,
         scope: leaderboardScope.value,
       };
@@ -44,19 +40,16 @@ export function useLeaderboardData(
         params.end_date = endDate;
       }
 
-      const response = await axios.get(`${apiUrl}/api/statistics/contributor_leaderboard`, {
-        params,
-        headers: getAuthHeaders(),
-      });
+      const response = await getContributorLeaderboard(params);
 
-      const data = safeArray<{ display_name: string; entity_count: number }>(response.data?.data);
+      const data = safeArray<{ display_name: string; entity_count: number }>(response?.data);
       leaderboardData.value = data.map((item) => ({
         user_name: item.display_name || 'Unknown',
         entity_count: item.entity_count,
       }));
 
-      if (response.data.meta?.total_contributors) {
-        totalContributors.value = unwrapScalar(response.data.meta.total_contributors, 0)!;
+      if (response?.meta?.total_contributors) {
+        totalContributors.value = unwrapScalar(response.meta.total_contributors, 0)!;
       }
     } catch (error) {
       console.error('Failed to fetch leaderboard:', error);
@@ -68,11 +61,9 @@ export function useLeaderboardData(
   }
 
   async function fetchReReviewLeaderboard(startDate: string, endDate: string): Promise<void> {
-    if (!axios) return;
-
     loadingReReview.value = true;
     try {
-      const params: Record<string, string | number> = {
+      const params: LeaderboardParams = {
         top: 10,
         scope: reReviewLeaderboardScope.value,
       };
@@ -81,17 +72,14 @@ export function useLeaderboardData(
         params.end_date = endDate;
       }
 
-      const response = await axios.get(`${apiUrl}/api/statistics/rereview_leaderboard`, {
-        params,
-        headers: getAuthHeaders(),
-      });
+      const response = await getRereviewLeaderboard(params);
 
       const data = safeArray<{
         display_name: string;
         total_assigned: number;
         submitted_count: number;
         approved_count: number;
-      }>(response.data?.data);
+      }>(response?.data);
 
       reReviewLeaderboardData.value = data.map((item) => ({
         user_name: item.display_name || 'Unknown',

--- a/app/src/views/admin/composables/useUserData.ts
+++ b/app/src/views/admin/composables/useUserData.ts
@@ -1,6 +1,7 @@
 import { nextTick, ref } from 'vue';
 
-import { apiClient } from '@/api/client';
+import { getUserTable, getRoleList, listUsersByRole } from '@/api/user';
+import type { UserTableResponse } from '@/api/user';
 import { useTableData, useExcelExport, useFilterPresets, useUrlParsing } from '@/composables';
 
 // Module-level dedup cache (preserves the existing semantics from ManageUser.vue line 760).
@@ -43,7 +44,6 @@ export interface UseUserDataOptions {
 
 export function useUserData(options: UseUserDataOptions = {}) {
   const { onToast, onScrollbarUpdate } = options;
-  const apiBase = import.meta.env.VITE_API_URL ?? '';
 
   const tableData = useTableData({
     pageSizeInput: 25,
@@ -74,18 +74,21 @@ export function useUserData(options: UseUserDataOptions = {}) {
     comment: { content: null, join_char: null, operator: 'contains' },
   });
 
-  function applyApiResponse(data: any): void {
-    users.value = data.data;
-    tableData.totalRows.value = data.meta[0].totalItems;
+  function applyApiResponse(data: UserTableResponse): void {
+    // meta is typed `unknown` on the envelope; it's a 1-element array of paging
+    // scalars (Plumber may serialize numbers as strings, hence Number()).
+    const meta = ((data.meta as Array<Record<string, unknown>>) ?? [])[0] ?? {};
+    users.value = data.data as unknown as Array<Record<string, unknown>>;
+    tableData.totalRows.value = Number(meta.totalItems) || 0;
     nextTick(() => {
-      tableData.currentPage.value = data.meta[0].currentPage;
+      tableData.currentPage.value = Number(meta.currentPage) || 0;
     });
-    totalPages.value = data.meta[0].totalPages;
-    tableData.prevItemID.value = Number(data.meta[0].prevItemID) || 0;
-    tableData.currentItemID.value = Number(data.meta[0].currentItemID) || 0;
-    tableData.nextItemID.value = Number(data.meta[0].nextItemID) || 0;
-    tableData.lastItemID.value = Number(data.meta[0].lastItemID) || 0;
-    tableData.executionTime.value = data.meta[0].executionTime;
+    totalPages.value = Number(meta.totalPages) || 0;
+    tableData.prevItemID.value = Number(meta.prevItemID) || 0;
+    tableData.currentItemID.value = Number(meta.currentItemID) || 0;
+    tableData.nextItemID.value = Number(meta.nextItemID) || 0;
+    tableData.lastItemID.value = Number(meta.lastItemID) || 0;
+    tableData.executionTime.value = Number(meta.executionTime) || 0;
     onScrollbarUpdate?.();
   }
 
@@ -93,7 +96,7 @@ export function useUserData(options: UseUserDataOptions = {}) {
     const urlParam = `sort=${tableData.sort.value}&filter=${tableData.filter_string.value}&page_after=${tableData.currentItemID.value}&page_size=${tableData.perPage.value}`;
     const now = Date.now();
     if (moduleLastApiParams === urlParam && now - moduleLastApiCallTime < 500) {
-      if (moduleLastApiResponse) applyApiResponse(moduleLastApiResponse);
+      if (moduleLastApiResponse) applyApiResponse(moduleLastApiResponse as UserTableResponse);
       return;
     }
     if (moduleApiCallInProgress && moduleLastApiParams === urlParam) return;
@@ -103,10 +106,15 @@ export function useUserData(options: UseUserDataOptions = {}) {
     tableData.isBusy.value = true;
 
     try {
-      const response = await apiClient.raw.get(`${apiBase}/api/user/table?${urlParam}`);
+      const data = await getUserTable({
+        sort: tableData.sort.value,
+        filter: tableData.filter_string.value,
+        page_after: tableData.currentItemID.value,
+        page_size: String(tableData.perPage.value),
+      });
       moduleApiCallInProgress = false;
-      moduleLastApiResponse = response.data;
-      applyApiResponse(response.data);
+      moduleLastApiResponse = data;
+      applyApiResponse(data);
       updateBrowserUrl();
     } catch (e) {
       moduleApiCallInProgress = false;
@@ -131,8 +139,8 @@ export function useUserData(options: UseUserDataOptions = {}) {
 
   async function loadRoleList(): Promise<void> {
     try {
-      const response = await apiClient.raw.get(`${apiBase}/api/user/role_list`);
-      role_options.value = (response.data as Array<{ role: string }>).map((item) => ({
+      const roles = await getRoleList();
+      role_options.value = roles.map((item) => ({
         value: item.role,
         text: item.role,
       }));
@@ -143,10 +151,8 @@ export function useUserData(options: UseUserDataOptions = {}) {
 
   async function loadUserList(): Promise<void> {
     try {
-      const response = await apiClient.raw.get(`${apiBase}/api/user/list?roles=Curator,Reviewer`);
-      user_options.value = (
-        response.data as Array<{ user_id: number; user_name: string; user_role: string }>
-      ).map((item) => ({
+      const list = await listUsersByRole({ roles: 'Curator,Reviewer' });
+      user_options.value = list.map((item) => ({
         value: item.user_id,
         text: item.user_name,
         role: item.user_role,

--- a/app/src/views/admin/composables/useUserMutations.ts
+++ b/app/src/views/admin/composables/useUserMutations.ts
@@ -1,9 +1,9 @@
 // app/src/views/admin/composables/useUserMutations.ts
 import { computed, ref } from 'vue';
-import { apiClient } from '@/api/client';
+import { changePassword as apiChangePassword } from '@/api/auth';
+import { deleteUser as apiDeleteUser, updateUser as apiUpdateUser } from '@/api/user';
+import type { UpdateUserRequest } from '@/api/user';
 import { extractApiErrorMessage } from '@/utils/api-errors';
-
-const apiBase = import.meta.env.VITE_API_URL ?? '';
 
 export interface UseUserMutationsOptions {
   onToast?: (...args: unknown[]) => void;
@@ -60,15 +60,9 @@ export function useUserMutations(options: UseUserMutationsOptions = {}) {
   async function deleteUser(user: { user_id: number }): Promise<void> {
     isDeleting.value = true;
     try {
-      const response = await apiClient.raw.delete(`${apiBase}/api/user/delete`, {
-        data: { user_id: user.user_id },
-      });
-      if (response.status === 200) {
-        onToast?.('User deleted successfully', 'Success', 'success');
-        onSuccess?.();
-      } else {
-        throw new Error('Failed to delete the user.');
-      }
+      await apiDeleteUser(user.user_id);
+      onToast?.('User deleted successfully', 'Success', 'success');
+      onSuccess?.();
     } catch (e) {
       onToast?.(extractApiErrorMessage(e, 'Failed to delete the user.'), 'Error', 'danger');
       throw e;
@@ -95,15 +89,11 @@ export function useUserMutations(options: UseUserMutationsOptions = {}) {
     if (payload.orcid !== undefined) updatePayload.orcid = payload.orcid ?? '';
     if (payload.comment !== undefined) updatePayload.comment = payload.comment ?? '';
     try {
-      const response = await apiClient.raw.put(`${apiBase}/api/user/update`, {
-        user_details: updatePayload,
+      await apiUpdateUser({
+        user_details: updatePayload as UpdateUserRequest['user_details'],
       });
-      if (response.status === 200) {
-        onToast?.('User updated successfully', 'Success', 'success');
-        onSuccess?.();
-      } else {
-        throw new Error('Failed to update the user.');
-      }
+      onToast?.('User updated successfully', 'Success', 'success');
+      onSuccess?.();
     } catch (e) {
       onToast?.(extractApiErrorMessage(e, 'Failed to update the user.'), 'Error', 'danger');
       throw e;
@@ -120,15 +110,12 @@ export function useUserMutations(options: UseUserMutationsOptions = {}) {
     }
     isChangingPassword.value = true;
     try {
-      const response = await apiClient.raw.put(`${apiBase}/api/user/password/update`, {
+      await apiChangePassword({
         user_id_pass_change: args.userId,
         old_pass: '',
         new_pass_1: args.newPassword,
         new_pass_2: args.confirmPassword,
       });
-      if (response.status !== 200) {
-        throw new Error('Failed to change password');
-      }
       onToast?.(`Password changed successfully`, 'Password Changed', 'success', true, 5000);
       passwordChange.value.newPassword = '';
       passwordChange.value.confirmPassword = '';


### PR DESCRIPTION
## Summary

Completes the deferred **typed-client migration** from the admin-views audit (follow-up to #429). Moves every Administrator view's data layer off raw `axios` / `apiClient.raw` + hand-built `${VITE_API_URL}/api/...` URLs onto the existing typed clients in `app/src/api/*` — the AGENTS.md "typed clients only" contract — and wires up clients that existed but were dead code.

## Per-view migration

| View | Now uses | Notes |
|---|---|---|
| ManageUser | `@/api/user` (+`@/api/auth` changePassword) | typed `applyApiResponse` (Plumber number coercion) |
| ManageBackups | `@/api/backup` | drops manual filename encoding (client encodes); +2 new composable specs |
| AdminStatistics | `@/api/statistics` | drops injected axios + getAuthHeaders; AbortSignal threaded via config |
| ManageOntology | `@/api/ontology` | removes dead `inject('axios')` |
| ManageAnnotations | shared `apiClient` | drops manual `VITE_API_URL` prefixing |
| ManageLLM | `@/api/llm_admin` | aligns `by_type` scalar→nested type drift |
| ManagePubtator | `@/api/publication` | deletes duplicated interfaces; resolves `updated_count`/`updated` drift |

Behavior is preserved (endpoints, params, response unwrapping, `extractApiErrorMessage`, job polling, 409 re-attach). Auth flows through apiClient's Bearer + 401 interceptor. Several dead/duplicated client definitions and a latent number-vs-string Plumber coercion are cleaned up along the way.

## Verification

- `type-check` clean; `type-check:strict` (CI gate) clean; `eslint` 0 problems on all changed files.
- Admin vitest: **190 passing** (29 files), incl. 2 new backup composable specs.
- `make code-quality-audit` clean (ManageOntology trimmed back under baseline; migration net-shrinks the data layer).

## Docs

Adds the per-view **enhancement plan to >9/10** and the **authenticated admin-view Lighthouse** results (perf 96–99 / a11y 100 / best-practices 100) to `.planning/admin-views-audit-2026-06-14.md`.
