### PR TITLE
feat(app): per-view admin titles + filter-preset save modal

### DIFF
--- a/app/src/views/admin/AdminStatistics.vue
+++ b/app/src/views/admin/AdminStatistics.vue
@@ -287,6 +287,9 @@ import EntityTrendChart from './components/charts/EntityTrendChart.vue';
 import ContributorBarChart from './components/charts/ContributorBarChart.vue';
 import ReReviewBarChart from './components/charts/ReReviewBarChart.vue';
 import StatCard from './components/statistics/StatCard.vue';
+import { useHead } from '@unhead/vue';
+
+useHead({ title: 'Admin Statistics' });
 
 const { makeToast } = useToast();
 

--- a/app/src/views/admin/ManageAbout.vue
+++ b/app/src/views/admin/ManageAbout.vue
@@ -155,9 +155,12 @@
 import AuthenticatedPageShell from '@/components/layout/AuthenticatedPageShell.vue';
 import AdminOperationPanel from '@/components/admin/AdminOperationPanel.vue';
 import { computed, ref, onMounted, onBeforeUnmount } from 'vue';
+import { useHead } from '@unhead/vue';
 import { useCmsContent } from '@/composables';
 import type { AboutSection } from '@/types';
 import SectionList from '@/components/cms/SectionList.vue';
+
+useHead({ title: 'Manage About Page' });
 
 // CMS content composable
 const {

--- a/app/src/views/admin/ManageBackups.vue
+++ b/app/src/views/admin/ManageBackups.vue
@@ -348,11 +348,14 @@
 import AuthenticatedPageShell from '@/components/layout/AuthenticatedPageShell.vue';
 import TableShell from '@/components/table/TableShell.vue';
 import { onMounted } from 'vue';
+import { useHead } from '@unhead/vue';
 import useToast from '@/composables/useToast';
 import BackupMobileRows from './components/BackupMobileRows.vue';
 import BackupConfirmModal from './components/BackupConfirmModal.vue';
 import { useBackupInventory } from './composables/useBackupInventory';
 import { useBackupJobs } from './composables/useBackupJobs';
+
+useHead({ title: 'Manage Backups' });
 
 // Composables
 const { makeToast } = useToast();

--- a/app/src/views/admin/ManageLLM.vue
+++ b/app/src/views/admin/ManageLLM.vue
@@ -173,6 +173,9 @@ import type { PromptType, ClusterType } from '@/types/llm';
 import { useLlmAdminTabs } from './useLlmAdminTabs';
 import { useLlmCacheOverview } from './useLlmCacheOverview';
 import { useLlmRegenerationJobs } from './useLlmRegenerationJobs';
+import { useHead } from '@unhead/vue';
+
+useHead({ title: 'LLM Administration' });
 
 const { makeToast } = useToast();
 const {

--- a/app/src/views/admin/ManageMetadata.vue
+++ b/app/src/views/admin/ManageMetadata.vue
@@ -163,6 +163,7 @@
 
 <script lang="ts">
 import { computed, defineComponent, nextTick, onMounted, ref } from 'vue';
+import { useHead } from '@unhead/vue';
 import AuthenticatedPageShell from '@/components/layout/AuthenticatedPageShell.vue';
 import AdminOperationPanel from '@/components/admin/AdminOperationPanel.vue';
 import MetadataEntryModal from './components/MetadataEntryModal.vue';
@@ -208,6 +209,7 @@ export default defineComponent({
     MetadataDeleteModal,
   },
   setup() {
+    useHead({ title: 'Manage Metadata' });
     const { makeToast } = useToast();
     const admin = useMetadataAdmin({ onToast: makeToast });
 

--- a/app/src/views/admin/ManageNDDScore.vue
+++ b/app/src/views/admin/ManageNDDScore.vue
@@ -305,6 +305,9 @@ import {
 } from './nddScoreAdminFormatters';
 import { useNddScoreAdminDerivedRows } from './useNddScoreAdminDerivedRows';
 import { extractApiErrorMessage } from '@/utils/api-errors';
+import { useHead } from '@unhead/vue';
+
+useHead({ title: 'Manage NDDScore' });
 
 type AdminRecord = NddScoreAdminRecord;
 
@@ -388,15 +391,12 @@ async function submitValidateOnly() {
   actionMessage.value = '';
   try {
     const result = await submitNddScoreImport({ validateOnly: true });
-    if (result.status === 'already_running') {
-      importJob.reset();
-      importJob.startJob(result.jobId);
-      actionMessage.value = 'An import is already running.';
-    } else {
-      importJob.reset();
-      importJob.startJob(result.jobId);
-      actionMessage.value = 'Validate-only job submitted.';
-    }
+    importJob.reset();
+    importJob.startJob(result.jobId);
+    actionMessage.value =
+      result.status === 'already_running'
+        ? 'An import is already running.'
+        : 'Validate-only job submitted.';
   } catch (err) {
     actionError.value = extractApiErrorMessage(err, 'Failed to submit validate-only job.');
   } finally {
@@ -411,15 +411,12 @@ async function confirmImport() {
   actionMessage.value = '';
   try {
     const result = await submitNddScoreImport({ validateOnly: false });
-    if (result.status === 'already_running') {
-      importJob.reset();
-      importJob.startJob(result.jobId);
-      actionMessage.value = 'An import is already running.';
-    } else {
-      importJob.reset();
-      importJob.startJob(result.jobId);
-      actionMessage.value = 'Import and activation job submitted.';
-    }
+    importJob.reset();
+    importJob.startJob(result.jobId);
+    actionMessage.value =
+      result.status === 'already_running'
+        ? 'An import is already running.'
+        : 'Import and activation job submitted.';
   } catch (err) {
     actionError.value = extractApiErrorMessage(err, 'Failed to submit import job.');
   } finally {

--- a/app/src/views/admin/ManageOntology.vue
+++ b/app/src/views/admin/ManageOntology.vue
@@ -230,6 +230,7 @@ component. */
 </template>
 
 <script>
+import { useHead } from '@unhead/vue';
 import AuthenticatedPageShell from '@/components/layout/AuthenticatedPageShell.vue';
 import TableShell from '@/components/table/TableShell.vue';
 import { ref } from 'vue';
@@ -266,6 +267,7 @@ export default {
     OntologyEditModal,
   },
   setup() {
+    useHead({ title: 'Manage Ontology' });
     const { makeToast } = useToast();
     const { filterObjToStr, filterStrToObj, sortStringToVariables } = useUrlParsing();
     const { isExporting, exportToExcel } = useExcelExport();

--- a/app/src/views/admin/ManagePubtator.vue
+++ b/app/src/views/admin/ManagePubtator.vue
@@ -284,6 +284,7 @@ ManagePubtator */
 </template>
 
 <script setup lang="ts">
+import { useHead } from '@unhead/vue';
 import AuthenticatedPageShell from '@/components/layout/AuthenticatedPageShell.vue';
 import AdminOperationPanel from '@/components/admin/AdminOperationPanel.vue';
 import {
@@ -301,6 +302,8 @@ import {
   BModal,
 } from 'bootstrap-vue-next';
 import { usePubtatorAdminPanel } from '@/composables/usePubtatorAdminPanel';
+
+useHead({ title: 'Manage PubTator' });
 
 // View-level orchestration: wraps usePubtatorAdmin (cache/job state) and adds
 // the page's form state, feedback banner, modal flag, and action handlers.

--- a/app/src/views/admin/ManageUser.vue
+++ b/app/src/views/admin/ManageUser.vue
@@ -73,7 +73,7 @@
                         variant="outline-primary"
                         class="py-0"
                         title="Save current filter as preset"
-                        @click="showSavePresetPrompt"
+                        @click="savePresetModalOpen = true"
                       >
                         <i class="bi bi-plus-lg" /> Save Preset
                       </BButton>
@@ -309,6 +309,8 @@
           @confirm="onConfirmBulkRole"
           @cancel="close"
         />
+
+        <SavePresetModal v-model:visible="savePresetModalOpen" @confirm="confirmSavePreset" />
       </BContainer>
     </div>
   </AuthenticatedPageShell>
@@ -318,6 +320,7 @@
 import AuthenticatedPageShell from '@/components/layout/AuthenticatedPageShell.vue';
 import TableShell from '@/components/table/TableShell.vue';
 import { computed, defineComponent, nextTick, onMounted, shallowRef, watch } from 'vue';
+import { useHead } from '@unhead/vue';
 import useToast from '@/composables/useToast';
 import { useBulkSelection } from '@/composables';
 import { useUiStore } from '@/stores/ui';
@@ -332,6 +335,7 @@ import UserBulkApproveModal from './components/UserBulkApproveModal.vue';
 import UserBulkDeleteModal from './components/UserBulkDeleteModal.vue';
 import UserBulkRoleModal from './components/UserBulkRoleModal.vue';
 import UserAdminMobileRows from './components/UserAdminMobileRows.vue';
+import SavePresetModal from './components/SavePresetModal.vue';
 
 import { useUserData } from './composables/useUserData';
 import type { ManageUserFilter } from './composables/useUserData';
@@ -355,8 +359,11 @@ export default defineComponent({
     UserBulkDeleteModal,
     UserBulkRoleModal,
     UserAdminMobileRows,
+    SavePresetModal,
   },
   setup() {
+    useHead({ title: 'Manage Users' });
+
     const { makeToast } = useToast();
     const uiStore = useUiStore();
     const bulkSelection = useBulkSelection(20);
@@ -449,15 +456,6 @@ export default defineComponent({
       const success = bulkSelection.toggleSelection(userId);
       if (!success)
         makeToast('Maximum 20 users can be selected at once', 'Selection Limit Reached', 'warning');
-    }
-
-    // ── Utility helpers ────────────────────────────────────────────────────────
-    function showSavePresetPrompt(): void {
-      const name = prompt('Enter a name for this filter preset:');
-      if (name && name.trim()) {
-        data.saveFilterPreset(name.trim());
-        makeToast(`Saved preset: ${name.trim()}`, 'Filter Preset', 'success', true, 3000);
-      }
     }
 
     // ── Lifecycle ─────────────────────────────────────────────────────────────
@@ -582,7 +580,6 @@ export default defineComponent({
       handleRowSelect,
       getRoleBadgeVariant,
       getRoleIcon,
-      showSavePresetPrompt,
       // ── plan-named actions ──
       onConfirmDelete,
       onSubmitUpdate,

--- a/app/src/views/admin/components/SavePresetModal.spec.ts
+++ b/app/src/views/admin/components/SavePresetModal.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * SavePresetModal contract tests.
+ *
+ * Replaces a native window.prompt() for naming a filter preset. Pins the
+ * v-model:visible contract, the trimmed-name confirm emit, the empty-name
+ * guard on the confirm button, and the @hidden reset of the input.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import SavePresetModal from './SavePresetModal.vue';
+
+const stubs = {
+  BModal: {
+    name: 'BModal',
+    template: '<div><slot /><slot name="footer" /></div>',
+    props: ['modelValue', 'title'],
+    emits: ['update:modelValue', 'hidden'],
+  },
+  BFormInput: {
+    template:
+      '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+    props: ['modelValue', 'state'],
+    emits: ['update:modelValue'],
+  },
+  BButton: { template: '<button v-bind="$attrs"><slot /></button>' },
+};
+
+function mountModal(props = {}) {
+  return mount(SavePresetModal, {
+    props: { visible: true, ...props },
+    global: { stubs },
+  });
+}
+
+describe('SavePresetModal', () => {
+  it('keeps the confirm button disabled until a non-blank name is entered', async () => {
+    const wrapper = mountModal();
+    const confirm = wrapper.findAll('button')[1];
+    expect(confirm.attributes('disabled')).toBeDefined();
+
+    await wrapper.find('input').setValue('   ');
+    expect(confirm.attributes('disabled')).toBeDefined();
+
+    await wrapper.find('input').setValue('Pending curators');
+    expect(confirm.attributes('disabled')).toBeUndefined();
+  });
+
+  it('emits the trimmed name and closes on confirm', async () => {
+    const wrapper = mountModal();
+    await wrapper.find('input').setValue('  My preset  ');
+    await wrapper.findAll('button')[1].trigger('click');
+
+    expect(wrapper.emitted('confirm')).toEqual([['My preset']]);
+    expect(wrapper.emitted('update:visible')).toEqual([[false]]);
+  });
+
+  it('emits cancel and closes without confirming', async () => {
+    const wrapper = mountModal();
+    await wrapper.find('input').setValue('discarded');
+    await wrapper.findAll('button')[0].trigger('click');
+
+    expect(wrapper.emitted('cancel')).toHaveLength(1);
+    expect(wrapper.emitted('confirm')).toBeUndefined();
+    expect(wrapper.emitted('update:visible')).toEqual([[false]]);
+  });
+
+  it('resets the input when the modal hides', async () => {
+    const wrapper = mountModal();
+    await wrapper.find('input').setValue('typed name');
+    wrapper.findComponent({ name: 'BModal' }).vm.$emit('hidden');
+    await nextTick();
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('');
+  });
+});

--- a/app/src/views/admin/components/SavePresetModal.vue
+++ b/app/src/views/admin/components/SavePresetModal.vue
@@ -1,0 +1,67 @@
+<!-- views/admin/components/SavePresetModal.vue -->
+<!--
+  Names and saves the current user-table filter as a quick-filter preset.
+  Replaces a native window.prompt() with the app's modal language. Visibility
+  is two-way via v-model:visible (matching the sibling user modals); the
+  component owns its input state and emits `confirm` with the trimmed name.
+  Kept mounted by the parent so @hidden can reset the field on every close.
+-->
+<template>
+  <BModal
+    :model-value="visible"
+    title="Save filter preset"
+    centered
+    @update:model-value="$emit('update:visible', $event)"
+    @hidden="onHidden"
+  >
+    <label class="form-label fw-semibold" :for="inputId">Preset name</label>
+    <BFormInput
+      :id="inputId"
+      v-model="name"
+      placeholder="e.g. Pending curators"
+      autocomplete="off"
+      :state="name.trim() ? true : null"
+      @keyup.enter="onConfirm"
+    />
+    <p class="text-muted small mt-2 mb-0">Saves the currently active filters under this name.</p>
+    <template #footer>
+      <BButton variant="outline-secondary" @click="onCancel">Cancel</BButton>
+      <BButton variant="primary" :disabled="!name.trim()" @click="onConfirm">Save preset</BButton>
+    </template>
+  </BModal>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { BModal, BButton, BFormInput } from 'bootstrap-vue-next';
+
+defineProps<{
+  /** Two-way modal visibility flag (v-model:visible). */
+  visible: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:visible', value: boolean): void;
+  (e: 'confirm', name: string): void;
+  (e: 'cancel'): void;
+}>();
+
+const inputId = 'save-preset-name-input';
+const name = ref('');
+
+function onConfirm(): void {
+  const trimmed = name.value.trim();
+  if (!trimmed) return;
+  emit('confirm', trimmed);
+  emit('update:visible', false);
+}
+
+function onCancel(): void {
+  emit('cancel');
+  emit('update:visible', false);
+}
+
+function onHidden(): void {
+  name.value = '';
+}
+</script>

--- a/app/src/views/admin/composables/useUserData.ts
+++ b/app/src/views/admin/composables/useUserData.ts
@@ -262,6 +262,16 @@ export function useUserData(options: UseUserDataOptions = {}) {
     filterPresets.savePreset(name, JSON.parse(JSON.stringify(filter.value)));
   }
 
+  // Filter-preset naming uses the app's modal language (SavePresetModal) rather
+  // than a native window.prompt(); the modal state lives here next to the
+  // preset actions it drives.
+  const savePresetModalOpen = ref(false);
+
+  function confirmSavePreset(name: string): void {
+    saveFilterPreset(name);
+    onToast?.(`Saved preset: ${name}`, 'Filter Preset', 'success', true, 3000);
+  }
+
   function setInitialized(): void {
     nextTick(() => {
       isInitializing.value = false;
@@ -301,6 +311,8 @@ export function useUserData(options: UseUserDataOptions = {}) {
     loadFilterPreset,
     deleteFilterPreset,
     saveFilterPreset,
+    savePresetModalOpen,
+    confirmSavePreset,
     setInitialized,
   };
 }

--- a/app/vitest.setup.ts
+++ b/app/vitest.setup.ts
@@ -7,6 +7,8 @@ import { Blob as NodeBlob } from 'node:buffer';
 import { vi, beforeEach, afterEach, beforeAll, afterAll, expect } from 'vitest';
 import * as matchers from 'vitest-axe/matchers';
 import axios from 'axios';
+import { config } from '@vue/test-utils';
+import { createHead } from '@unhead/vue/client';
 
 // =============================================================================
 // Accessibility Testing Matchers (vitest-axe)
@@ -14,6 +16,16 @@ import axios from 'axios';
 
 // Extend Vitest expect with accessibility matchers (toHaveNoViolations)
 expect.extend(matchers);
+
+// =============================================================================
+// Global head (@unhead/vue) for useHead() in isolated component mounts
+// =============================================================================
+// Views call useHead() in setup() to set the per-route document <title>.
+// Without a provided head, injectHead() throws "useHead() was called without
+// provide context". Install a shared head plugin into every VTU mount via the
+// global config so isolated view specs don't need to wire it themselves. The
+// head's accumulated state is irrelevant to assertions.
+config.global.plugins = [...(config.global.plugins ?? []), createHead()];
 
 // Axios 1.16 + MSW 2.14 can fail under Vitest/jsdom when the XHR adapter
 // synthesizes binary responses (`responseType: "blob"`). The fetch adapter


### PR DESCRIPTION
Part of the admin-views enhancement program (>9/10). Follow-up to #429 (bug fixes/a11y) and #430 (typed-client migration). Backlog ref: \`.planning/admin-views-audit-2026-06-14.md\` ("Path to >9/10" — T5 Polish + cross-view backlog).

## What

- **Per-view document `<title>` (item 3).** Nine Administrator views previously rendered the generic `SysNDD |`. They now set a view-specific title via `useHead()` (matching the existing `ViewLogs` pattern), rendering e.g. `Manage Users | SysNDD …`:
  ManageUser, ManageOntology, ManageAbout, ManageBackups, ManagePubtator, ManageLLM, ManageNDDScore, ManageMetadata, AdminStatistics. (ManageAnnotations' title ships with its confirmation-modal change in a follow-up PR.)
- **Native dialog → modal (item 2, ManageUser half).** ManageUser's `window.prompt()` for naming a filter preset is replaced with `SavePresetModal` in the app's modal language. The preset-modal state + confirm handler move into `useUserData` (next to the preset actions they drive). The `TablesLogs` export `confirm()` is handled in the TablesLogs-split PR (same file).

## Notes

- `vitest.setup.ts` installs a shared `@unhead/vue` head plugin into the VTU global config so isolated view specs that call `useHead()` don't throw without a provided head.
- **File-size ratchet:** ManageUser and ManageNDDScore are already over the 600-line soft ceiling, so growth was offset by cohesive/DRY changes — preset state moved to `useUserData`; ManageNDDScore's duplicated `already_running` submit branches collapsed (behavior-preserving). `make code-quality-audit` is clean.

## Tests

- New: `SavePresetModal.spec.ts` (visibility v-model, trimmed-name confirm, empty-name guard, hidden reset).
- Full unit suite: 224 files / 1543 pass.

## Verification

- `npm run type-check` ✓ · `npm run type-check:strict` ✓ · `eslint` (changed files) ✓ · `npx vitest run` ✓ · `make code-quality-audit` ✓