### PR TITLE
refactor(app): split TablesLogs.vue into useLogTable + LogFilterToolbar

### DIFF
--- a/app/src/components/tables/LogFilterToolbar.spec.ts
+++ b/app/src/components/tables/LogFilterToolbar.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * LogFilterToolbar contract tests.
+ *
+ * The toolbar is presentational: it binds the filter object's nested `.content`
+ * fields and surfaces user actions as events. These pin the action emits
+ * (show-delete, remove-filters, clear-filter, filtered, update:mobileSortValue)
+ * and the active-filter pill rendering.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import LogFilterToolbar from './LogFilterToolbar.vue';
+import { createEmptyLogFilter } from './useLogTable';
+
+const stubs = {
+  TableSearchInput: {
+    template: '<input class="search" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+    emits: ['update:modelValue'],
+  },
+  TablePaginationControls: { template: '<div class="pagination-stub" />' },
+  BRow: { template: '<div><slot /></div>' },
+  BCol: { template: '<div><slot /></div>' },
+  BContainer: { template: '<div><slot /></div>' },
+  BInputGroup: { template: '<div><slot /></div>' },
+  BFormSelect: {
+    template:
+      '<select v-bind="$attrs" @change="$emit(\'update:modelValue\', $event.target.value)"><option v-for="o in (options || [])" :key="o.value" :value="o.value">{{ o.text }}</option><slot /></select>',
+    props: ['modelValue', 'options'],
+    emits: ['update:modelValue'],
+  },
+  BFormSelectOption: { template: '<option><slot /></option>' },
+  BFormInput: {
+    template: '<input class="mobile-filter" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+    emits: ['update:modelValue'],
+  },
+  BButton: { template: '<button v-bind="$attrs"><slot /></button>' },
+  BBadge: { template: '<span class="badge"><slot /></span>' },
+};
+
+function mountToolbar(props = {}) {
+  return mount(LogFilterToolbar, {
+    props: {
+      filter: createEmptyLogFilter(),
+      totalRows: 42,
+      perPage: 10,
+      showPaginationControls: true,
+      pageOptions: [10, 25],
+      currentPage: 1,
+      methodOptions: [{ value: 'GET', text: 'GET' }],
+      statusOptions: [{ value: '200', text: '200 OK' }],
+      mobileSortOptions: [
+        { value: '-id', text: 'Newest ID first' },
+        { value: '-timestamp', text: 'Newest time first' },
+      ],
+      mobileSortValue: '-id',
+      itemsLength: 5,
+      hasActiveFilters: false,
+      activeFilters: [],
+      ...props,
+    },
+    global: { stubs, directives: { 'b-tooltip': {} } },
+  });
+}
+
+describe('LogFilterToolbar', () => {
+  it('emits show-delete when the delete button is clicked', async () => {
+    const wrapper = mountToolbar();
+    await wrapper.find('button[title="Delete all logs (requires confirmation)"]').trigger('click');
+    expect(wrapper.emitted('show-delete')).toHaveLength(1);
+  });
+
+  it('renders active-filter pills and emits clear-filter / remove-filters', async () => {
+    const wrapper = mountToolbar({
+      hasActiveFilters: true,
+      activeFilters: [{ key: 'status', label: 'Status', value: '200' }],
+    });
+    const badges = wrapper.findAll('.badge');
+    expect(badges).toHaveLength(1);
+    expect(wrapper.text()).toContain('Status: 200');
+
+    // Pill clear button (inside the badge)
+    await badges[0].find('button').trigger('click');
+    expect(wrapper.emitted('clear-filter')).toEqual([['status']]);
+
+    // "Clear all" button
+    const clearAll = wrapper.findAll('button').find((b) => b.text().includes('Clear all'));
+    await clearAll!.trigger('click');
+    expect(wrapper.emitted('remove-filters')).toHaveLength(1);
+  });
+
+  it('emits update-filter (key, value) when a filter select changes', async () => {
+    const wrapper = mountToolbar({ methodOptions: [{ value: 'GET', text: 'GET' }] });
+    const methodSelect = wrapper.findAll('select')[0];
+    await methodSelect.setValue('GET');
+    expect(wrapper.emitted('update-filter')).toEqual([['request_method', 'GET']]);
+  });
+
+  it('emits update:mobileSortValue when the mobile sort select changes', async () => {
+    const wrapper = mountToolbar();
+    // The mobile sort select is the last select (method, status, path, mobile-sort)
+    const selects = wrapper.findAll('select');
+    await selects[selects.length - 1].setValue('-timestamp');
+    expect(wrapper.emitted('update:mobileSortValue')).toEqual([['-timestamp']]);
+  });
+});

--- a/app/src/components/tables/LogFilterToolbar.vue
+++ b/app/src/components/tables/LogFilterToolbar.vue
@@ -1,0 +1,248 @@
+<!-- components/tables/LogFilterToolbar.vue -->
+<!--
+  Filter/search/pagination toolbar for the audit-log table. Extracted from
+  TablesLogs.vue so the SFC stays a thin shell. Follows props-down / events-up:
+  `filter` is read-only here and every field change emits `update-filter`
+  (key, value) so the parent (useLogTable) owns the filter object. Pagination,
+  delete, and clear actions are surfaced as events too.
+-->
+<template>
+  <div>
+    <BRow class="g-2">
+      <BCol sm="8">
+        <TableSearchInput
+          :model-value="filter['any'].content ?? undefined"
+          :placeholder="'Search any field by typing here'"
+          :debounce-time="500"
+          @update:model-value="updateField('any', $event)"
+        />
+      </BCol>
+
+      <BCol sm="4">
+        <BContainer v-if="totalRows > perPage || showPaginationControls">
+          <TablePaginationControls
+            :total-rows="totalRows"
+            :initial-per-page="perPage"
+            :page-options="pageOptions"
+            :current-page="currentPage"
+            @page-change="$emit('page-change', $event)"
+            @per-page-change="$emit('per-page-change', $event)"
+          />
+        </BContainer>
+      </BCol>
+    </BRow>
+
+    <BRow class="g-2 mt-1 align-items-center">
+      <BCol sm="3">
+        <BFormSelect
+          :model-value="filter.request_method.content"
+          :options="methodOptions"
+          size="sm"
+          @update:model-value="updateField('request_method', $event)"
+        >
+          <template #first>
+            <BFormSelectOption :value="null">All Methods</BFormSelectOption>
+          </template>
+        </BFormSelect>
+      </BCol>
+      <BCol sm="3">
+        <BFormSelect
+          :model-value="filter.status.content"
+          :options="statusOptions"
+          size="sm"
+          @update:model-value="updateField('status', $event)"
+        >
+          <template #first>
+            <BFormSelectOption :value="null">All Status</BFormSelectOption>
+          </template>
+        </BFormSelect>
+      </BCol>
+      <BCol sm="3">
+        <BFormSelect
+          :model-value="filter.path.content"
+          size="sm"
+          @update:model-value="updateField('path', $event)"
+        >
+          <BFormSelectOption :value="null">All Paths</BFormSelectOption>
+          <BFormSelectOption value="/api/">API Calls</BFormSelectOption>
+          <BFormSelectOption value="/signin">/signin</BFormSelectOption>
+          <BFormSelectOption value="/api/entity">/api/entity</BFormSelectOption>
+          <BFormSelectOption value="/api/logs">/api/logs</BFormSelectOption>
+        </BFormSelect>
+      </BCol>
+      <BCol sm="3" class="text-end">
+        <span class="text-muted small me-2">
+          {{ itemsLength }} of {{ totalRows.toLocaleString() }}
+        </span>
+        <BButton
+          v-b-tooltip.hover
+          size="sm"
+          variant="outline-danger"
+          title="Delete all logs (requires confirmation)"
+          @click="$emit('show-delete')"
+        >
+          <i class="bi bi-trash" />
+        </BButton>
+      </BCol>
+    </BRow>
+
+    <BRow class="g-2 mt-1 d-md-none">
+      <BCol>
+        <BInputGroup prepend="Sort" size="sm">
+          <BFormSelect
+            :model-value="mobileSortValue"
+            :options="mobileSortOptions"
+            size="sm"
+            @update:model-value="$emit('update:mobileSortValue', String($event))"
+          />
+        </BInputGroup>
+      </BCol>
+    </BRow>
+
+    <details class="log-mobile-filters d-md-none">
+      <summary>
+        <i class="bi bi-funnel" aria-hidden="true" />
+        More filters
+      </summary>
+      <div class="log-mobile-filters__grid">
+        <BFormInput
+          v-for="field in mobileFilterFields"
+          :key="field.key"
+          :model-value="filter[field.key].content ?? undefined"
+          size="sm"
+          :placeholder="field.label"
+          type="search"
+          autocomplete="off"
+          @update:model-value="updateField(field.key, $event)"
+        />
+      </div>
+    </details>
+
+    <!-- Active filter pills -->
+    <BRow v-if="hasActiveFilters" class="g-2 mt-1">
+      <BCol>
+        <BBadge
+          v-for="(activeFilter, index) in activeFilters"
+          :key="index"
+          variant="secondary"
+          class="me-2 mb-1"
+        >
+          {{ activeFilter.label }}: {{ activeFilter.value }}
+          <BButton
+            size="sm"
+            variant="link"
+            class="p-0 ms-1 text-light"
+            @click="$emit('clear-filter', activeFilter.key)"
+          >
+            <i class="bi bi-x" />
+          </BButton>
+        </BBadge>
+        <BButton size="sm" variant="link" class="p-0" @click="$emit('remove-filters')">
+          Clear all
+        </BButton>
+      </BCol>
+    </BRow>
+  </div>
+</template>
+
+<script setup lang="ts">
+import {
+  BRow,
+  BCol,
+  BContainer,
+  BFormSelect,
+  BFormSelectOption,
+  BFormInput,
+  BInputGroup,
+  BButton,
+  BBadge,
+} from 'bootstrap-vue-next';
+import TableSearchInput from '@/components/small/TableSearchInput.vue';
+import TablePaginationControls from '@/components/small/TablePaginationControls.vue';
+import type { LogFilter } from './useLogTable';
+
+interface SelectOption {
+  value: string;
+  text: string;
+}
+interface ActiveFilter {
+  key: string;
+  label: string;
+  value: string;
+}
+
+defineProps<{
+  /** The log filter object (read-only here; changes flow up via update-filter). */
+  filter: LogFilter;
+  totalRows: number;
+  perPage: number;
+  showPaginationControls: boolean;
+  pageOptions: number[];
+  currentPage: number;
+  methodOptions: SelectOption[];
+  statusOptions: SelectOption[];
+  mobileSortOptions: SelectOption[];
+  mobileSortValue: string;
+  itemsLength: number;
+  hasActiveFilters: boolean;
+  activeFilters: ActiveFilter[];
+}>();
+
+const emit = defineEmits<{
+  (e: 'update-filter', key: string, value: string | null): void;
+  (e: 'page-change', value: number): void;
+  (e: 'per-page-change', value: number): void;
+  (e: 'show-delete'): void;
+  (e: 'clear-filter', key: string): void;
+  (e: 'remove-filters'): void;
+  (e: 'update:mobileSortValue', value: string): void;
+}>();
+
+// Normalise input values to string | null before emitting up.
+function updateField(key: string, value: unknown): void {
+  emit('update-filter', key, value == null || value === '' ? null : String(value));
+}
+
+// Per-field mobile filter inputs (collapsed "More filters" panel on mobile).
+const mobileFilterFields: Array<{ key: keyof LogFilter & string; label: string }> = [
+  { key: 'id', label: 'ID' },
+  { key: 'timestamp', label: 'Timestamp' },
+  { key: 'address', label: 'IP address' },
+  { key: 'agent', label: 'Agent' },
+  { key: 'host', label: 'Host' },
+  { key: 'user', label: 'User' },
+  { key: 'query', label: 'Query' },
+  { key: 'post', label: 'POST body' },
+  { key: 'duration', label: 'Duration' },
+  { key: 'file', label: 'File' },
+  { key: 'modified', label: 'Modified' },
+];
+</script>
+
+<style scoped>
+.log-mobile-filters {
+  margin-top: 0.5rem;
+}
+
+.log-mobile-filters summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-height: 2rem;
+  color: #0d6efd;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.log-mobile-filters__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.log-mobile-filters:not([open]) .log-mobile-filters__grid {
+  display: none;
+}
+</style>

--- a/app/src/components/tables/TablesLogs.vue
+++ b/app/src/components/tables/TablesLogs.vue
@@ -24,213 +24,27 @@
             </template>
 
             <template #toolbar>
-              <BRow class="g-2">
-                <BCol sm="8">
-                  <TableSearchInput
-                    v-model="filter['any'].content"
-                    :placeholder="'Search any field by typing here'"
-                    :debounce-time="500"
-                    @update:model-value="filtered"
-                  />
-                </BCol>
-
-                <BCol sm="4">
-                  <BContainer v-if="totalRows > perPage || showPaginationControls">
-                    <TablePaginationControls
-                      :total-rows="totalRows"
-                      :initial-per-page="perPage"
-                      :page-options="pageOptions"
-                      :current-page="currentPage"
-                      @page-change="handlePageChange"
-                      @per-page-change="handlePerPageChange"
-                    />
-                  </BContainer>
-                </BCol>
-              </BRow>
-
-              <BRow class="g-2 mt-1 align-items-center">
-                <BCol sm="3">
-                  <BFormSelect
-                    v-model="filter.request_method.content"
-                    :options="method_options"
-                    size="sm"
-                    @update:model-value="filtered()"
-                  >
-                    <template #first>
-                      <BFormSelectOption :value="null">All Methods</BFormSelectOption>
-                    </template>
-                  </BFormSelect>
-                </BCol>
-                <BCol sm="3">
-                  <BFormSelect
-                    v-model="filter.status.content"
-                    :options="status_options"
-                    size="sm"
-                    @update:model-value="filtered()"
-                  >
-                    <template #first>
-                      <BFormSelectOption :value="null">All Status</BFormSelectOption>
-                    </template>
-                  </BFormSelect>
-                </BCol>
-                <BCol sm="3">
-                  <BFormSelect
-                    v-model="filter.path.content"
-                    size="sm"
-                    @update:model-value="filtered()"
-                  >
-                    <BFormSelectOption :value="null">All Paths</BFormSelectOption>
-                    <BFormSelectOption value="/api/">API Calls</BFormSelectOption>
-                    <BFormSelectOption value="/signin">/signin</BFormSelectOption>
-                    <BFormSelectOption value="/api/entity">/api/entity</BFormSelectOption>
-                    <BFormSelectOption value="/api/logs">/api/logs</BFormSelectOption>
-                  </BFormSelect>
-                </BCol>
-                <BCol sm="3" class="text-end">
-                  <span class="text-muted small me-2">
-                    {{ items.length }} of {{ totalRows.toLocaleString() }}
-                  </span>
-                  <BButton
-                    v-b-tooltip.hover
-                    size="sm"
-                    variant="outline-danger"
-                    title="Delete all logs (requires confirmation)"
-                    @click="showDeleteModal = true"
-                  >
-                    <i class="bi bi-trash" />
-                  </BButton>
-                </BCol>
-              </BRow>
-
-              <BRow class="g-2 mt-1 d-md-none">
-                <BCol>
-                  <BInputGroup prepend="Sort" size="sm">
-                    <BFormSelect v-model="mobileSortValue" :options="mobileSortOptions" size="sm" />
-                  </BInputGroup>
-                </BCol>
-              </BRow>
-
-              <details class="log-mobile-filters d-md-none">
-                <summary>
-                  <i class="bi bi-funnel" aria-hidden="true" />
-                  More filters
-                </summary>
-                <div class="log-mobile-filters__grid">
-                  <BFormInput
-                    v-model="filter.id.content"
-                    size="sm"
-                    placeholder="ID"
-                    type="search"
-                    autocomplete="off"
-                    @update:model-value="filtered()"
-                  />
-                  <BFormInput
-                    v-model="filter.timestamp.content"
-                    size="sm"
-                    placeholder="Timestamp"
-                    type="search"
-                    autocomplete="off"
-                    @update:model-value="filtered()"
-                  />
-                  <BFormInput
-                    v-model="filter.address.content"
-                    size="sm"
-                    placeholder="IP address"
-                    type="search"
-                    autocomplete="off"
-                    @update:model-value="filtered()"
-                  />
-                  <BFormInput
-                    v-model="filter.agent.content"
-                    size="sm"
-                    placeholder="Agent"
-                    type="search"
-                    autocomplete="off"
-                    @update:model-value="filtered()"
-                  />
-                  <BFormInput
-                    v-model="filter.host.content"
-                    size="sm"
-                    placeholder="Host"
-                    type="search"
-                    autocomplete="off"
-                    @update:model-value="filtered()"
-                  />
-                  <BFormInput
-                    v-model="filter.user.content"
-                    size="sm"
-                    placeholder="User"
-                    type="search"
-                    autocomplete="off"
-                    @update:model-value="filtered()"
-                  />
-                  <BFormInput
-                    v-model="filter.query.content"
-                    size="sm"
-                    placeholder="Query"
-                    type="search"
-                    autocomplete="off"
-                    @update:model-value="filtered()"
-                  />
-                  <BFormInput
-                    v-model="filter.post.content"
-                    size="sm"
-                    placeholder="POST body"
-                    type="search"
-                    autocomplete="off"
-                    @update:model-value="filtered()"
-                  />
-                  <BFormInput
-                    v-model="filter.duration.content"
-                    size="sm"
-                    placeholder="Duration"
-                    type="search"
-                    autocomplete="off"
-                    @update:model-value="filtered()"
-                  />
-                  <BFormInput
-                    v-model="filter.file.content"
-                    size="sm"
-                    placeholder="File"
-                    type="search"
-                    autocomplete="off"
-                    @update:model-value="filtered()"
-                  />
-                  <BFormInput
-                    v-model="filter.modified.content"
-                    size="sm"
-                    placeholder="Modified"
-                    type="search"
-                    autocomplete="off"
-                    @update:model-value="filtered()"
-                  />
-                </div>
-              </details>
-
-              <!-- Active filter pills -->
-              <BRow v-if="hasActiveFilters" class="g-2 mt-1">
-                <BCol>
-                  <BBadge
-                    v-for="(activeFilter, index) in activeFilters"
-                    :key="index"
-                    variant="secondary"
-                    class="me-2 mb-1"
-                  >
-                    {{ activeFilter.label }}: {{ activeFilter.value }}
-                    <BButton
-                      size="sm"
-                      variant="link"
-                      class="p-0 ms-1 text-light"
-                      @click="clearFilter(activeFilter.key)"
-                    >
-                      <i class="bi bi-x" />
-                    </BButton>
-                  </BBadge>
-                  <BButton size="sm" variant="link" class="p-0" @click="removeFilters">
-                    Clear all
-                  </BButton>
-                </BCol>
-              </BRow>
+              <LogFilterToolbar
+                v-model:mobile-sort-value="mobileSortValue"
+                :filter="filter"
+                :total-rows="totalRows"
+                :per-page="perPage"
+                :show-pagination-controls="showPaginationControls"
+                :page-options="pageOptions"
+                :current-page="currentPage"
+                :method-options="method_options"
+                :status-options="status_options"
+                :mobile-sort-options="mobileSortOptions"
+                :items-length="items.length"
+                :has-active-filters="hasActiveFilters"
+                :active-filters="activeFilters"
+                @update-filter="setFilterField"
+                @page-change="handlePageChange"
+                @per-page-change="handlePerPageChange"
+                @show-delete="showDeleteModal = true"
+                @clear-filter="clearFilter"
+                @remove-filters="removeFilters"
+              />
             </template>
             <!-- User Interface controls -->
 
@@ -430,92 +244,55 @@
         :is-deleting="isDeleting"
         @confirm="deleteLogs"
       />
+
+      <!-- Large-export confirmation (replaces window.confirm): only shown when
+           the export exceeds the row threshold. -->
+      <ConfirmActionModal
+        v-model="showExportModal"
+        title="Export a large number of logs?"
+        :message="`This export contains ${totalRows.toLocaleString()} rows and may take a while. Continue?`"
+        confirm-label="Export"
+        confirm-variant="primary"
+        header-bg-variant="primary"
+        header-text-variant="light"
+        :busy="downloading"
+        @confirm="doExportExcel"
+      />
     </BContainer>
   </div>
 </template>
 
 <script>
-// Import Vue utilities
-import { ref } from 'vue';
-import { useRoute } from 'vue-router';
+// Thin shell: all log-table state/loading/cursor/url-sync lives in the
+// useLogTable composable; the toolbar markup lives in LogFilterToolbar.vue.
+import { defineComponent } from 'vue';
 
-// Import composables
-import {
-  useToast,
-  useUrlParsing,
-  useColorAndSymbols,
-  useText,
-  useTableData,
-  useTableMethods,
-} from '@/composables';
-
-import TableSearchInput from '@/components/small/TableSearchInput.vue';
-import TablePaginationControls from '@/components/small/TablePaginationControls.vue';
 import TableDownloadLinkCopyButtons from '@/components/small/TableDownloadLinkCopyButtons.vue';
 import GenericTable from '@/components/small/GenericTable.vue';
 import LogDetailDrawer from '@/components/small/LogDetailDrawer.vue';
 import LogDeleteModal from '@/components/small/LogDeleteModal.vue';
 import TableShell from '@/components/table/TableShell.vue';
 import LogMobileRows from '@/views/admin/components/LogMobileRows.vue';
+import LogFilterToolbar from './LogFilterToolbar.vue';
+import ConfirmActionModal from '@/components/ui/ConfirmActionModal.vue';
 
-import Utils from '@/assets/js/utils';
-import { useUiStore } from '@/stores/ui';
-import {
-  formatAbsoluteLogTime,
-  formatLogDate,
-  formatLogDuration,
-  formatRelativeLogTime,
-  getLogDurationClass,
-  getLogMethodVariant,
-  getLogStatusVariant,
-} from './logTableFormatters';
 import { normalizeSelectOptions } from '@/utils/selectOptions';
-import { extractApiErrorMessage } from '@/utils/api-errors';
-import { listLogs, listLogsXlsx, deleteLogs as deleteLogsApi } from '@/api/logging';
-import { listUsersByRole } from '@/api/user';
-import { createLogTableRequestCache } from './logTableRequests';
+import { useLogTable } from './useLogTable';
 
-const moduleLogRequestCache = createLogTableRequestCache();
-
-// Single source of truth for the empty log-filter shape (used by both the
-// initial filter ref and removeFilters() to avoid drift between the two).
-function createEmptyLogFilter() {
-  return {
-    any: { content: null, join_char: null, operator: 'contains' },
-    id: { content: null, join_char: null, operator: 'contains' },
-    timestamp: { content: null, join_char: null, operator: 'contains' },
-    address: { content: null, join_char: null, operator: 'contains' },
-    agent: { content: null, join_char: null, operator: 'contains' },
-    host: { content: null, join_char: null, operator: 'contains' },
-    user: { content: null, join_char: null, operator: 'contains' },
-    request_method: { content: null, join_char: ',', operator: 'contains' },
-    path: { content: null, join_char: ',', operator: 'contains' },
-    query: { content: null, join_char: null, operator: 'contains' },
-    post: { content: null, join_char: ',', operator: 'contains' },
-    status: { content: null, join_char: ',', operator: 'contains' },
-    duration: { content: null, join_char: ',', operator: 'contains' },
-    file: { content: null, join_char: ',', operator: 'contains' },
-    modified: { content: null, join_char: ',', operator: 'contains' },
-  };
-}
-
-export default {
+export default defineComponent({
   name: 'TablesLogs',
   components: {
-    TablePaginationControls,
     TableDownloadLinkCopyButtons,
-    TableSearchInput,
     GenericTable,
     LogDetailDrawer,
     LogDeleteModal,
     TableShell,
     LogMobileRows,
+    LogFilterToolbar,
+    ConfirmActionModal,
   },
   props: {
-    apiEndpoint: {
-      type: String,
-      default: 'logs',
-    },
+    apiEndpoint: { type: String, default: 'logs' },
     showFilterControls: { type: Boolean, default: true },
     showPaginationControls: { type: Boolean, default: true },
     headerLabel: { type: String, default: 'Logging table' },
@@ -531,543 +308,13 @@ export default {
     },
   },
   setup(props) {
-    // Independent composables
-    const { makeToast } = useToast();
-    const { filterObjToStr, filterStrToObj, sortStringToVariables } = useUrlParsing();
-    const colorAndSymbols = useColorAndSymbols();
-    const text = useText();
-
-    // Table state composable
-    const tableData = useTableData({
-      pageSizeInput: props.pageSizeInput,
-      sortInput: props.sortInput,
-      pageAfterInput: props.pageAfterInput,
-    });
-
-    // Component-specific filter
-    const filter = ref(createEmptyLogFilter());
-
-    const route = useRoute();
-
-    // Table methods composable
-    const tableMethods = useTableMethods(tableData, {
-      filter,
-      filterObjToStr,
-      apiEndpoint: props.apiEndpoint,
-      route,
-    });
-
-    const {
-      filtered: _filtered,
-      handlePageChange: _handlePageChange,
-      handlePerPageChange: _handlePerPageChange,
-      handleSortByOrDescChange: _handleSortByOrDescChange,
-      removeFilters: _removeFilters,
-      removeSearch: _removeSearch,
-      requestExcel: _requestExcel,
-      copyLinkToClipboard: _copyLinkToClipboard,
-      truncate: _truncate,
-      ...restTableMethods
-    } = tableMethods;
-
-    // Return all needed properties
     return {
-      makeToast,
-      filterObjToStr,
-      filterStrToObj,
-      sortStringToVariables,
-      ...colorAndSymbols,
-      ...text,
-      ...tableData,
-      ...restTableMethods,
-      filter,
+      ...useLogTable(props),
       // Shared select-option normalizer used by the table-header filter row.
       normalizeSelectOptions,
     };
   },
-  data() {
-    return {
-      // Flag to prevent watchers from triggering during initialization
-      isInitializing: true,
-      // Debounce timer for loadData to prevent duplicate calls
-      loadDataDebounceTimer: null,
-      // Pagination state
-      totalPages: 0,
-      // User filter options (loaded from API)
-      user_options: [],
-      // HTTP method filter options
-      method_options: [
-        { value: 'GET', text: 'GET' },
-        { value: 'POST', text: 'POST' },
-        { value: 'PUT', text: 'PUT' },
-        { value: 'DELETE', text: 'DELETE' },
-      ],
-      // Log detail drawer state
-      showLogDetail: false,
-      selectedLog: null,
-      selectedLogIndex: -1,
-      // Field definitions - NOT overwritten by API
-      fields: [
-        {
-          key: 'id',
-          label: 'ID',
-          sortable: true,
-          class: 'text-center',
-          thStyle: { width: '80px' },
-        },
-        { key: 'timestamp', label: 'Time', sortable: true, thStyle: { width: '120px' } },
-        {
-          key: 'request_method',
-          label: 'Method',
-          sortable: true,
-          class: 'text-center',
-          thStyle: { width: '90px' },
-        },
-        {
-          key: 'status',
-          label: 'Status',
-          sortable: true,
-          class: 'text-center',
-          thStyle: { width: '80px' },
-        },
-        { key: 'path', label: 'Path', sortable: true },
-        {
-          key: 'duration',
-          label: 'Duration',
-          sortable: true,
-          class: 'text-end',
-          thStyle: { width: '90px' },
-        },
-        { key: 'address', label: 'IP', sortable: true, thStyle: { width: '120px' } },
-        {
-          key: 'actions',
-          label: '',
-          sortable: false,
-          class: 'text-center',
-          thStyle: { width: '60px' },
-        },
-      ],
-      fields_details: [],
-      // Status filter options
-      status_options: [
-        { value: '200', text: '200 OK' },
-        { value: '201', text: '201 Created' },
-        { value: '307', text: '307 Redirect' },
-        { value: '400', text: '400 Bad Request' },
-        { value: '401', text: '401 Unauthorized' },
-        { value: '403', text: '403 Forbidden' },
-        { value: '404', text: '404 Not Found' },
-        { value: '500', text: '500 Server Error' },
-      ],
-      mobileSortOptions: [
-        { value: '-id', text: 'Newest ID first' },
-        { value: '+id', text: 'Oldest ID first' },
-        { value: '-timestamp', text: 'Newest time first' },
-        { value: '+timestamp', text: 'Oldest time first' },
-        { value: '-duration', text: 'Slowest first' },
-        { value: '+duration', text: 'Fastest first' },
-      ],
-      // Delete confirmation modal state
-      showDeleteModal: false,
-      deleteMode: 'all', // 'all', '3', '7', '14', '30' (days)
-      isDeleting: false,
-    };
-  },
-  computed: {
-    mobileSortValue: {
-      get() {
-        return this.sort || '-id';
-      },
-      set(value) {
-        const sort_object = this.sortStringToVariables(value);
-        this.sortBy = sort_object.sortBy;
-        this.sort = value;
-        this.currentItemID = 0;
-        this.filtered();
-      },
-    },
-    canNavigatePrev() {
-      return this.selectedLogIndex > 0;
-    },
-    canNavigateNext() {
-      return this.selectedLogIndex < this.items.length - 1;
-    },
-    hasActiveFilters() {
-      return Object.values(this.filter).some((f) => f.content !== null && f.content !== '');
-    },
-    activeFilters() {
-      const filters = [];
-      if (this.filter.any.content) {
-        filters.push({ key: 'any', label: 'Search', value: this.filter.any.content });
-      }
-      if (this.filter.user.content) {
-        filters.push({ key: 'user', label: 'User', value: this.filter.user.content });
-      }
-      if (this.filter.request_method.content) {
-        filters.push({
-          key: 'request_method',
-          label: 'Method',
-          value: this.filter.request_method.content,
-        });
-      }
-      if (this.filter.status.content) {
-        filters.push({ key: 'status', label: 'Status', value: this.filter.status.content });
-      }
-      if (this.filter.path.content) {
-        filters.push({ key: 'path', label: 'Path', value: this.filter.path.content });
-      }
-      return filters;
-    },
-    removeFiltersButtonVariant() {
-      return this.hasActiveFilters ? 'outline-danger' : 'outline-secondary';
-    },
-    removeFiltersButtonTitle() {
-      return this.hasActiveFilters ? 'Clear all filters' : 'No active filters';
-    },
-  },
-  watch: {
-    // Watch for filter changes (deep required for Vue 3 behavior)
-    // Skip during initialization to prevent multiple API calls
-    filter: {
-      handler() {
-        if (this.isInitializing) return;
-        this.filtered();
-      },
-      deep: true,
-    },
-    // Watch for sortBy changes (deep watch for array)
-    // Skip during initialization to prevent multiple API calls
-    // Only trigger if sort actually changed to prevent resetting currentItemID during pagination
-    sortBy: {
-      handler(newVal) {
-        if (this.isInitializing) return;
-        const newSortColumn = newVal && newVal.length > 0 ? newVal[0].key : 'id';
-        const newSortOrder = newVal && newVal.length > 0 ? newVal[0].order : 'desc';
-        const newSortString = (newSortOrder === 'desc' ? '-' : '+') + newSortColumn;
-        // Only trigger if sort actually changed - prevents resetting currentItemID during pagination
-        if (newSortString !== this.sort) {
-          this.handleSortByOrDescChange();
-        }
-      },
-      deep: true,
-    },
-  },
-  created() {
-    // Lifecycle hooks
-  },
-  mounted() {
-    // Transform input sort string to Bootstrap-Vue-Next array format
-    // sortStringToVariables now returns { sortBy: [{ key: 'column', order: 'asc'|'desc' }] }
-    if (this.sortInput) {
-      const sort_object = this.sortStringToVariables(this.sortInput);
-      this.sortBy = sort_object.sortBy;
-      this.sort = this.sortInput; // Also set the sort string for API calls
-    }
-
-    // Initialize pagination from URL if provided
-    if (this.pageAfterInput && this.pageAfterInput !== '0') {
-      this.currentItemID = parseInt(this.pageAfterInput, 10) || 0;
-    }
-
-    // Load user list for filter dropdown
-    this.loadUserList();
-
-    // Transform input filter string to object and load data
-    // Use $nextTick to ensure Vue reactivity is fully initialized
-    this.$nextTick(() => {
-      if (this.filterInput && this.filterInput !== 'null' && this.filterInput !== '') {
-        // Parse URL filter string into filter object for proper UI state
-        this.filter = this.filterStrToObj(this.filterInput, this.filter);
-        // Also set filter_string so the API call uses the URL filter
-        this.filter_string = this.filterInput;
-      }
-      // Load data first while still in initializing state
-      this.loadData();
-      // Delay marking initialization complete to ensure watchers triggered
-      // by filter/sortBy changes above see isInitializing=true
-      this.$nextTick(() => {
-        this.isInitializing = false;
-      });
-    });
-
-    this.loading = false;
-  },
-  methods: {
-    // Handle row click to open detail drawer
-    handleRowClick(row) {
-      this.selectedLog = row;
-      this.selectedLogIndex = this.items.findIndex((item) => item.id === row.id);
-      this.showLogDetail = true;
-    },
-    // Navigate to previous log in drawer
-    navigateToPreviousLog() {
-      if (this.selectedLogIndex > 0) {
-        this.selectedLogIndex -= 1;
-        this.selectedLog = this.items[this.selectedLogIndex];
-      }
-    },
-    // Navigate to next log in drawer
-    navigateToNextLog() {
-      if (this.selectedLogIndex < this.items.length - 1) {
-        this.selectedLogIndex += 1;
-        this.selectedLog = this.items[this.selectedLogIndex];
-      }
-    },
-    // Load user list for filter dropdown
-    async loadUserList() {
-      try {
-        const data = await listUsersByRole();
-        this.user_options = data.map((item) => ({
-          value: item.user_name,
-          text: `${item.user_name} (${item.user_role})`,
-        }));
-      } catch (_e) {
-        this.makeToast('Failed to load user list', 'Error', 'danger');
-      }
-    },
-    // Debounced loadData to prevent duplicate calls from multiple triggers
-    loadData() {
-      if (this.loadDataDebounceTimer) {
-        clearTimeout(this.loadDataDebounceTimer);
-      }
-      this.loadDataDebounceTimer = setTimeout(() => {
-        this.loadDataDebounceTimer = null;
-        this.doLoadData();
-      }, 50);
-    },
-    // Actual data loading with module-level caching
-    async doLoadData() {
-      const params = {
-        sort: this.sort,
-        filter: this.filter_string,
-        page_after: this.currentItemID,
-        page_size: this.perPage,
-      };
-      this.isBusy = true;
-
-      try {
-        const result = await moduleLogRequestCache.load(params, () => listLogs(params));
-        this.applyApiResponse(result.response);
-
-        // Update URL AFTER API success to prevent component remount during API call
-        if (!result.fromCache) {
-          this.updateBrowserUrl();
-        }
-
-        this.isBusy = false;
-      } catch (error) {
-        this.makeToast(`Error: ${error.message}`, 'Error loading logs', 'danger');
-        this.isBusy = false;
-      }
-    },
-    /**
-     * Apply API response data to component state.
-     * Extracted to allow reuse when skipping duplicate API calls.
-     * @param {Object} data - API response data
-     */
-    applyApiResponse(data) {
-      this.items = data.data;
-      this.totalRows = data.meta[0].totalItems;
-      // this solves an update issue in b-pagination component
-      // based on https://github.com/bootstrap-vue/bootstrap-vue/issues/3541
-      this.$nextTick(() => {
-        this.currentPage = data.meta[0].currentPage;
-      });
-      this.totalPages = data.meta[0].totalPages;
-      this.prevItemID = Number(data.meta[0].prevItemID) || 0;
-      this.currentItemID = Number(data.meta[0].currentItemID) || 0;
-      this.nextItemID = Number(data.meta[0].nextItemID) || 0;
-      this.lastItemID = Number(data.meta[0].lastItemID) || 0;
-      this.executionTime = data.meta[0].executionTime;
-      // Apply fspec from API for column filters (like TablesEntities)
-      // The fspec contains filterable, selectable, selectOptions for each field
-      if (data.meta[0].fspec && data.meta[0].fspec.fspec) {
-        this.fields = data.meta[0].fspec.fspec;
-      }
-
-      const uiStore = useUiStore();
-      uiStore.requestScrollbarUpdate();
-    },
-    // Update browser URL with current table state
-    // Uses history.replaceState instead of router.replace to prevent component remount
-    updateBrowserUrl() {
-      // Don't update URL during initialization - preserves URL params from navigation
-      if (this.isInitializing) return;
-
-      const searchParams = new URLSearchParams();
-
-      if (this.sort) {
-        searchParams.set('sort', this.sort);
-      }
-      if (this.filter_string) {
-        searchParams.set('filter', this.filter_string);
-      }
-      const currentId = Number(this.currentItemID) || 0;
-      if (currentId > 0) {
-        searchParams.set('page_after', String(currentId));
-      }
-      searchParams.set('page_size', String(this.perPage));
-
-      // Use history.replaceState to update URL without triggering Vue Router navigation
-      // This prevents component remount which was causing duplicate API calls
-      const newUrl = `${window.location.pathname}?${searchParams.toString()}`;
-      window.history.replaceState({ ...window.history.state }, '', newUrl);
-    },
-    copyLinkToClipboard() {
-      const urlParam = `sort=${this.sort}&filter=${this.filter_string}&page_after=${this.currentItemID}&page_size=${this.perPage}`;
-      navigator.clipboard.writeText(`${import.meta.env.VITE_URL + this.$route.path}?${urlParam}`);
-    },
-    handleSortByOrDescChange() {
-      this.currentItemID = 0;
-      // Extract sort column and order from array-based sortBy
-      const sortColumn = this.sortBy.length > 0 ? this.sortBy[0].key : 'id';
-      const sortOrder = this.sortBy.length > 0 ? this.sortBy[0].order : 'desc';
-      this.sort = (sortOrder === 'desc' ? '-' : '+') + sortColumn;
-      this.filtered();
-    },
-    // Override handlePageChange to properly update currentItemID and call loadData
-    handlePageChange(value) {
-      if (value === 1) {
-        this.currentItemID = 0;
-      } else if (value === this.totalPages) {
-        this.currentItemID = Number(this.lastItemID) || 0;
-      } else if (value > this.currentPage) {
-        this.currentItemID = Number(this.nextItemID) || 0;
-      } else if (value < this.currentPage) {
-        this.currentItemID = Number(this.prevItemID) || 0;
-      }
-      this.filtered();
-    },
-    // Override handlePerPageChange to reset pagination and reload
-    handlePerPageChange(newPerPage) {
-      this.perPage = parseInt(newPerPage, 10);
-      this.currentItemID = 0;
-      this.filtered();
-    },
-    filtered() {
-      const filter_string_loc = this.filterObjToStr(this.filter);
-
-      if (filter_string_loc !== this.filter_string) {
-        this.filter_string = this.filterObjToStr(this.filter);
-      }
-
-      this.loadData();
-    },
-    removeFilters() {
-      this.filter = createEmptyLogFilter();
-    },
-    removeSearch() {
-      this.filter.any.content = null;
-    },
-    clearFilter(key) {
-      if (this.filter[key]) {
-        this.filter[key].content = null;
-      }
-      this.filtered();
-    },
-    async requestExcel() {
-      this.downloading = true;
-
-      // Warn if large export
-      if (this.totalRows > 30000) {
-        const proceed = confirm(
-          `This export contains ${this.totalRows.toLocaleString()} rows and may take a while. Continue?`
-        );
-        if (!proceed) {
-          this.downloading = false;
-          return;
-        }
-      }
-
-      try {
-        const blob = await listLogsXlsx({
-          page_after: 0,
-          page_size: 'all',
-          filter: this.filter_string,
-          sort: this.sort,
-        });
-
-        // Generate filename with date
-        const date = new Date().toISOString().split('T')[0];
-        const filename = `sysndd_audit_logs_${date}.xlsx`;
-
-        const fileURL = window.URL.createObjectURL(new Blob([blob]));
-        const fileLink = document.createElement('a');
-
-        fileLink.href = fileURL;
-        fileLink.setAttribute('download', filename);
-        document.body.appendChild(fileLink);
-
-        fileLink.click();
-
-        // Cleanup
-        document.body.removeChild(fileLink);
-        window.URL.revokeObjectURL(fileURL);
-
-        this.makeToast(`Exported ${this.totalRows} log entries`, 'Export Complete', 'success');
-      } catch (e) {
-        this.makeToast(extractApiErrorMessage(e, 'Export failed'), 'Export failed', 'danger');
-      }
-
-      this.downloading = false;
-    },
-    truncate(str, n) {
-      return Utils.truncate(str, n);
-    },
-    formatDate(dateStr) {
-      return formatLogDate(dateStr);
-    },
-    // Format relative time using Intl.RelativeTimeFormat (e.g., "2 hours ago")
-    formatRelativeTime(dateStr) {
-      return formatRelativeLogTime(dateStr);
-    },
-    // Format absolute time for tooltip display
-    formatAbsoluteTime(dateStr) {
-      return formatAbsoluteLogTime(dateStr);
-    },
-    // Get Bootstrap variant for HTTP status code badges
-    getStatusVariant(status) {
-      return getLogStatusVariant(status);
-    },
-    getMethodVariant(method) {
-      return getLogMethodVariant(method);
-    },
-    // Format duration with appropriate unit
-    formatDuration(duration) {
-      return formatLogDuration(duration);
-    },
-    // Get CSS class for duration based on performance
-    getDurationClass(duration) {
-      return getLogDurationClass(duration);
-    },
-    // Delete logs with optional age filter
-    async deleteLogs() {
-      this.isDeleting = true;
-      try {
-        const olderThanDays = this.deleteMode === 'all' ? 0 : parseInt(this.deleteMode, 10);
-        const response = await deleteLogsApi({ older_than_days: olderThanDays });
-
-        const deletedCount = response.deleted_count || 0;
-        const message =
-          this.deleteMode === 'all'
-            ? `Successfully deleted ${deletedCount.toLocaleString()} log entries`
-            : `Successfully deleted ${deletedCount.toLocaleString()} log entries older than ${this.deleteMode} days`;
-
-        this.makeToast(message, 'Logs Deleted', 'success');
-        // Closing the modal triggers its @hidden reset (confirm text + mode)
-        this.showDeleteModal = false;
-        // Reset and reload
-        this.currentItemID = 0;
-        this.loadData();
-      } catch (error) {
-        const errorMsg = extractApiErrorMessage(error, 'Failed to delete logs');
-        this.makeToast(`Failed to delete logs: ${errorMsg}`, 'Error', 'danger');
-      } finally {
-        this.isDeleting = false;
-      }
-    },
-  },
-};
+});
 </script>
 
 <style scoped>
@@ -1082,34 +329,8 @@ export default {
   border-radius: 0.2rem;
 }
 
-.log-mobile-filters {
-  margin-top: 0.5rem;
-}
-
 .logs-table {
   padding-bottom: max(1rem, var(--app-footer-height, 48px));
-}
-
-.log-mobile-filters summary {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  min-height: 2rem;
-  color: #0d6efd;
-  font-size: 0.8125rem;
-  font-weight: 700;
-  cursor: pointer;
-}
-
-.log-mobile-filters__grid {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
-}
-
-.log-mobile-filters:not([open]) .log-mobile-filters__grid {
-  display: none;
 }
 
 .logs-loading-state {

--- a/app/src/components/tables/logTableConfig.ts
+++ b/app/src/components/tables/logTableConfig.ts
@@ -1,0 +1,79 @@
+// components/tables/logTableConfig.ts
+//
+// Static column and filter-option configuration for the audit-log table.
+// Extracted from useLogTable so the composable stays focused on behaviour.
+
+export interface LogTableField {
+  key: string;
+  label: string;
+  sortable: boolean;
+  class?: string;
+  thStyle?: Record<string, string>;
+  // Runtime fspec rows from the API carry extra keys (filterable, selectable,
+  // selectOptions, …); the index signature keeps the default config and the
+  // API-overwritten config the same shape.
+  [k: string]: unknown;
+}
+
+export interface LogSelectOption {
+  value: string;
+  text: string;
+}
+
+// Default column definitions. Overwritten at runtime by the API `fspec` when
+// present (see applyApiResponse in useLogTable).
+export const LOG_TABLE_FIELDS: LogTableField[] = [
+  { key: 'id', label: 'ID', sortable: true, class: 'text-center', thStyle: { width: '80px' } },
+  { key: 'timestamp', label: 'Time', sortable: true, thStyle: { width: '120px' } },
+  {
+    key: 'request_method',
+    label: 'Method',
+    sortable: true,
+    class: 'text-center',
+    thStyle: { width: '90px' },
+  },
+  {
+    key: 'status',
+    label: 'Status',
+    sortable: true,
+    class: 'text-center',
+    thStyle: { width: '80px' },
+  },
+  { key: 'path', label: 'Path', sortable: true },
+  {
+    key: 'duration',
+    label: 'Duration',
+    sortable: true,
+    class: 'text-end',
+    thStyle: { width: '90px' },
+  },
+  { key: 'address', label: 'IP', sortable: true, thStyle: { width: '120px' } },
+  { key: 'actions', label: '', sortable: false, class: 'text-center', thStyle: { width: '60px' } },
+];
+
+export const LOG_METHOD_OPTIONS: LogSelectOption[] = [
+  { value: 'GET', text: 'GET' },
+  { value: 'POST', text: 'POST' },
+  { value: 'PUT', text: 'PUT' },
+  { value: 'DELETE', text: 'DELETE' },
+];
+
+export const LOG_STATUS_OPTIONS: LogSelectOption[] = [
+  { value: '200', text: '200 OK' },
+  { value: '201', text: '201 Created' },
+  { value: '307', text: '307 Redirect' },
+  { value: '400', text: '400 Bad Request' },
+  { value: '401', text: '401 Unauthorized' },
+  { value: '403', text: '403 Forbidden' },
+  { value: '404', text: '404 Not Found' },
+  { value: '500', text: '500 Server Error' },
+];
+
+export const LOG_MOBILE_SORT_OPTIONS: LogSelectOption[] = [
+  { value: '-id', text: 'Newest ID first' },
+  { value: '+id', text: 'Oldest ID first' },
+  { value: '-timestamp', text: 'Newest time first' },
+  { value: '+timestamp', text: 'Oldest time first' },
+  { value: '-duration', text: 'Slowest first' },
+  { value: '+duration', text: 'Fastest first' },
+];

--- a/app/src/components/tables/useLogTable.ts
+++ b/app/src/components/tables/useLogTable.ts
@@ -1,0 +1,581 @@
+// components/tables/useLogTable.ts
+//
+// State, data loading, cursor pagination, URL sync, filtering and delete/export
+// orchestration for the audit-log table. Extracted from TablesLogs.vue so the
+// SFC stays a thin shell (the view-logic lives here, the toolbar markup lives in
+// LogFilterToolbar.vue). Composes the shared useTableData state container; the
+// log-specific methods (load, cursor pagination, URL sync) are implemented here
+// because they differ from the generic useTableMethods versions.
+
+import { computed, nextTick, onMounted, ref, watch, type Ref } from 'vue';
+import { useRoute } from 'vue-router';
+// Import composables from the barrel so view specs that mock '@/composables'
+// (e.g. TablesLogs.spec.ts) intercept these the same way the SFC did.
+import { useToast, useUrlParsing, useColorAndSymbols, useText, useTableData } from '@/composables';
+import Utils from '@/assets/js/utils';
+import { useUiStore } from '@/stores/ui';
+import {
+  formatAbsoluteLogTime,
+  formatLogDate,
+  formatLogDuration,
+  formatRelativeLogTime,
+  getLogDurationClass,
+  getLogMethodVariant,
+  getLogStatusVariant,
+} from './logTableFormatters';
+import { extractApiErrorMessage } from '@/utils/api-errors';
+import {
+  listLogs,
+  listLogsXlsx,
+  deleteLogs as deleteLogsApi,
+  type LogListResponse,
+} from '@/api/logging';
+import { listUsersByRole } from '@/api/user';
+import { createLogTableRequestCache } from './logTableRequests';
+import {
+  LOG_TABLE_FIELDS,
+  LOG_METHOD_OPTIONS,
+  LOG_STATUS_OPTIONS,
+  LOG_MOBILE_SORT_OPTIONS,
+} from './logTableConfig';
+
+const moduleLogRequestCache = createLogTableRequestCache();
+
+export interface LogFilterField {
+  content: string | null;
+  join_char: string | null;
+  operator: string;
+}
+
+export type LogFilter = Record<string, LogFilterField>;
+
+// Single source of truth for the empty log-filter shape (used by both the
+// initial filter ref and removeFilters() to avoid drift between the two).
+export function createEmptyLogFilter(): LogFilter {
+  return {
+    any: { content: null, join_char: null, operator: 'contains' },
+    id: { content: null, join_char: null, operator: 'contains' },
+    timestamp: { content: null, join_char: null, operator: 'contains' },
+    address: { content: null, join_char: null, operator: 'contains' },
+    agent: { content: null, join_char: null, operator: 'contains' },
+    host: { content: null, join_char: null, operator: 'contains' },
+    user: { content: null, join_char: null, operator: 'contains' },
+    request_method: { content: null, join_char: ',', operator: 'contains' },
+    path: { content: null, join_char: ',', operator: 'contains' },
+    query: { content: null, join_char: null, operator: 'contains' },
+    post: { content: null, join_char: ',', operator: 'contains' },
+    status: { content: null, join_char: ',', operator: 'contains' },
+    duration: { content: null, join_char: ',', operator: 'contains' },
+    file: { content: null, join_char: ',', operator: 'contains' },
+    modified: { content: null, join_char: ',', operator: 'contains' },
+  };
+}
+
+export interface UseLogTableProps {
+  apiEndpoint?: string;
+  sortInput?: string;
+  filterInput?: string | null;
+  pageAfterInput?: string;
+  pageSizeInput?: number;
+}
+
+interface LogRow {
+  id: number;
+  [key: string]: unknown;
+}
+
+export function useLogTable(props: UseLogTableProps) {
+  const { makeToast } = useToast();
+  const { filterObjToStr, filterStrToObj, sortStringToVariables } = useUrlParsing();
+  const colorAndSymbols = useColorAndSymbols();
+  const text = useText();
+
+  const tableData = useTableData({
+    pageSizeInput: props.pageSizeInput,
+    sortInput: props.sortInput,
+    pageAfterInput: props.pageAfterInput,
+  });
+
+  const route = useRoute();
+
+  // Component-specific filter
+  const filter = ref<LogFilter>(createEmptyLogFilter());
+
+  // ── Local state (was data()) ─────────────────────────────────────────────
+  const isInitializing = ref(true);
+  const loadDataDebounceTimer = ref<ReturnType<typeof setTimeout> | null>(null);
+  const totalPages = ref(0);
+  const user_options = ref<Array<{ value: string; text: string }>>([]);
+  const method_options = LOG_METHOD_OPTIONS;
+  const showLogDetail = ref(false);
+  const selectedLog = ref<LogRow | null>(null);
+  const selectedLogIndex = ref(-1);
+  const fields = ref<Array<Record<string, unknown>>>([...LOG_TABLE_FIELDS]);
+  const fields_details = ref<unknown[]>([]);
+  const status_options = LOG_STATUS_OPTIONS;
+  const mobileSortOptions = LOG_MOBILE_SORT_OPTIONS;
+  const showDeleteModal = ref(false);
+  const deleteMode = ref('all'); // 'all', '3', '7', '14', '30' (days)
+  const isDeleting = ref(false);
+  // Large exports are gated behind a confirmation modal (replaces window.confirm).
+  const showExportModal = ref(false);
+  const LARGE_EXPORT_THRESHOLD = 30000;
+
+  // Pull the table-state refs we reference by name below.
+  const {
+    items,
+    totalRows,
+    currentPage,
+    currentItemID,
+    prevItemID,
+    nextItemID,
+    lastItemID,
+    executionTime,
+    perPage,
+    sortBy,
+    sort,
+    filter_string,
+    downloading,
+    loading,
+    isBusy,
+  } = tableData;
+
+  // ── Computed (was computed) ──────────────────────────────────────────────
+  const mobileSortValue = computed<string>({
+    get() {
+      return sort.value || '-id';
+    },
+    set(value: string) {
+      const sort_object = sortStringToVariables(value);
+      sortBy.value = sort_object.sortBy;
+      sort.value = value;
+      currentItemID.value = 0;
+      filtered();
+    },
+  });
+  const canNavigatePrev = computed(() => selectedLogIndex.value > 0);
+  const canNavigateNext = computed(() => selectedLogIndex.value < items.value.length - 1);
+  const hasActiveFilters = computed(() =>
+    Object.values(filter.value).some((f) => f.content !== null && f.content !== '')
+  );
+  const activeFilters = computed(() => {
+    const filters: Array<{ key: string; label: string; value: string }> = [];
+    if (filter.value.any.content) {
+      filters.push({ key: 'any', label: 'Search', value: filter.value.any.content });
+    }
+    if (filter.value.user.content) {
+      filters.push({ key: 'user', label: 'User', value: filter.value.user.content });
+    }
+    if (filter.value.request_method.content) {
+      filters.push({
+        key: 'request_method',
+        label: 'Method',
+        value: filter.value.request_method.content,
+      });
+    }
+    if (filter.value.status.content) {
+      filters.push({ key: 'status', label: 'Status', value: filter.value.status.content });
+    }
+    if (filter.value.path.content) {
+      filters.push({ key: 'path', label: 'Path', value: filter.value.path.content });
+    }
+    return filters;
+  });
+  const removeFiltersButtonVariant = computed(() =>
+    hasActiveFilters.value ? 'outline-danger' : 'outline-secondary'
+  );
+  const removeFiltersButtonTitle = computed(() =>
+    hasActiveFilters.value ? 'Clear all filters' : 'No active filters'
+  );
+
+  // ── Methods ────────────────────────────────────────────────────────────────
+  function handleRowClick(row: LogRow): void {
+    selectedLog.value = row;
+    selectedLogIndex.value = items.value.findIndex((item) => (item as LogRow).id === row.id);
+    showLogDetail.value = true;
+  }
+  function navigateToPreviousLog(): void {
+    if (selectedLogIndex.value > 0) {
+      selectedLogIndex.value -= 1;
+      selectedLog.value = items.value[selectedLogIndex.value] as LogRow;
+    }
+  }
+  function navigateToNextLog(): void {
+    if (selectedLogIndex.value < items.value.length - 1) {
+      selectedLogIndex.value += 1;
+      selectedLog.value = items.value[selectedLogIndex.value] as LogRow;
+    }
+  }
+
+  async function loadUserList(): Promise<void> {
+    try {
+      const data = await listUsersByRole();
+      user_options.value = data.map((item: { user_name: string; user_role: string }) => ({
+        value: item.user_name,
+        text: `${item.user_name} (${item.user_role})`,
+      }));
+    } catch (_e) {
+      makeToast('Failed to load user list', 'Error', 'danger');
+    }
+  }
+
+  // Debounced loadData to prevent duplicate calls from multiple triggers
+  function loadData(): void {
+    if (loadDataDebounceTimer.value) {
+      clearTimeout(loadDataDebounceTimer.value);
+    }
+    loadDataDebounceTimer.value = setTimeout(() => {
+      loadDataDebounceTimer.value = null;
+      void doLoadData();
+    }, 50);
+  }
+
+  async function doLoadData(): Promise<void> {
+    const params = {
+      sort: sort.value,
+      filter: filter_string.value,
+      page_after: currentItemID.value,
+      page_size: perPage.value,
+    };
+    isBusy.value = true;
+
+    try {
+      const result = await moduleLogRequestCache.load(params, () => listLogs(params));
+      applyApiResponse(result.response);
+
+      // Update URL AFTER API success to prevent component remount during API call
+      if (!result.fromCache) {
+        updateBrowserUrl();
+      }
+      isBusy.value = false;
+    } catch (error) {
+      makeToast(`Error: ${(error as Error).message}`, 'Error loading logs', 'danger');
+      isBusy.value = false;
+    }
+  }
+
+  function applyApiResponse(data: LogListResponse): void {
+    items.value = data.data;
+    const meta = (data.meta as Array<Record<string, unknown>>)[0];
+    totalRows.value = meta.totalItems as number;
+    // this solves an update issue in b-pagination component
+    // based on https://github.com/bootstrap-vue/bootstrap-vue/issues/3541
+    void nextTick(() => {
+      currentPage.value = meta.currentPage as number;
+    });
+    totalPages.value = meta.totalPages as number;
+    prevItemID.value = Number(meta.prevItemID) || 0;
+    currentItemID.value = Number(meta.currentItemID) || 0;
+    nextItemID.value = Number(meta.nextItemID) || 0;
+    lastItemID.value = Number(meta.lastItemID) || 0;
+    executionTime.value = meta.executionTime as number;
+    // Apply fspec from API for column filters (like TablesEntities)
+    const fspec = meta.fspec as { fspec?: Array<Record<string, unknown>> } | undefined;
+    if (fspec && fspec.fspec) {
+      fields.value = fspec.fspec;
+    }
+
+    const uiStore = useUiStore();
+    uiStore.requestScrollbarUpdate();
+  }
+
+  // Update browser URL with current table state. Uses history.replaceState
+  // instead of router.replace to prevent component remount.
+  function updateBrowserUrl(): void {
+    if (isInitializing.value) return;
+
+    const searchParams = new URLSearchParams();
+    if (sort.value) {
+      searchParams.set('sort', sort.value);
+    }
+    if (filter_string.value) {
+      searchParams.set('filter', filter_string.value);
+    }
+    const currentId = Number(currentItemID.value) || 0;
+    if (currentId > 0) {
+      searchParams.set('page_after', String(currentId));
+    }
+    searchParams.set('page_size', String(perPage.value));
+
+    const newUrl = `${window.location.pathname}?${searchParams.toString()}`;
+    window.history.replaceState({ ...window.history.state }, '', newUrl);
+  }
+
+  function copyLinkToClipboard(): void {
+    const urlParam = `sort=${sort.value}&filter=${filter_string.value}&page_after=${currentItemID.value}&page_size=${perPage.value}`;
+    void navigator.clipboard.writeText(`${import.meta.env.VITE_URL + route.path}?${urlParam}`);
+  }
+
+  function handleSortByOrDescChange(): void {
+    currentItemID.value = 0;
+    const sortColumn = sortBy.value.length > 0 ? sortBy.value[0].key : 'id';
+    const sortOrder = sortBy.value.length > 0 ? sortBy.value[0].order : 'desc';
+    sort.value = (sortOrder === 'desc' ? '-' : '+') + sortColumn;
+    filtered();
+  }
+
+  function handleSortUpdate({ sortBy: key, sortDesc }: { sortBy: string; sortDesc: boolean }): void {
+    sortBy.value = [{ key, order: sortDesc ? 'desc' : 'asc' }];
+  }
+
+  function handlePageChange(value: number): void {
+    if (value === 1) {
+      currentItemID.value = 0;
+    } else if (value === totalPages.value) {
+      currentItemID.value = Number(lastItemID.value) || 0;
+    } else if (value > currentPage.value) {
+      currentItemID.value = Number(nextItemID.value) || 0;
+    } else if (value < currentPage.value) {
+      currentItemID.value = Number(prevItemID.value) || 0;
+    }
+    filtered();
+  }
+
+  function handlePerPageChange(newPerPage: number | string): void {
+    perPage.value = parseInt(String(newPerPage), 10);
+    currentItemID.value = 0;
+    filtered();
+  }
+
+  function filtered(): void {
+    const filter_string_loc = filterObjToStr(filter.value);
+    if (filter_string_loc !== filter_string.value) {
+      filter_string.value = filterObjToStr(filter.value);
+    }
+    loadData();
+  }
+
+  function removeFilters(): void {
+    filter.value = createEmptyLogFilter();
+  }
+
+  function removeSearch(): void {
+    filter.value.any.content = null;
+  }
+
+  // Single mutation entry point for the toolbar (props-down / events-up): the
+  // toolbar emits update-filter; the composable owns the filter object.
+  function setFilterField(key: string, value: string | null): void {
+    if (filter.value[key]) {
+      filter.value[key].content = value;
+    }
+    filtered();
+  }
+
+  function clearFilter(key: string): void {
+    if (filter.value[key]) {
+      filter.value[key].content = null;
+    }
+    filtered();
+  }
+
+  // Entry point bound to the toolbar's export button. Large exports open a
+  // confirmation modal (the app's modal language) before downloading; smaller
+  // exports proceed directly.
+  function requestExcel(): void | Promise<void> {
+    if (totalRows.value > LARGE_EXPORT_THRESHOLD) {
+      showExportModal.value = true;
+      return undefined;
+    }
+    return doExportExcel();
+  }
+
+  // Confirmed by the export modal (or reached directly for small exports).
+  async function doExportExcel(): Promise<void> {
+    showExportModal.value = false;
+    downloading.value = true;
+    try {
+      const blob = await listLogsXlsx({
+        page_after: 0,
+        page_size: 'all',
+        filter: filter_string.value,
+        sort: sort.value,
+      });
+
+      const date = new Date().toISOString().split('T')[0];
+      const filename = `sysndd_audit_logs_${date}.xlsx`;
+
+      const fileURL = window.URL.createObjectURL(new Blob([blob]));
+      const fileLink = document.createElement('a');
+      fileLink.href = fileURL;
+      fileLink.setAttribute('download', filename);
+      document.body.appendChild(fileLink);
+      fileLink.click();
+      document.body.removeChild(fileLink);
+      window.URL.revokeObjectURL(fileURL);
+
+      makeToast(`Exported ${totalRows.value} log entries`, 'Export Complete', 'success');
+    } catch (e) {
+      makeToast(extractApiErrorMessage(e, 'Export failed'), 'Export failed', 'danger');
+    }
+    downloading.value = false;
+  }
+
+  function truncate(str: string, n: number): string {
+    return Utils.truncate(str, n);
+  }
+  function formatDate(dateStr: string) {
+    return formatLogDate(dateStr);
+  }
+  function formatRelativeTime(dateStr: string) {
+    return formatRelativeLogTime(dateStr);
+  }
+  function formatAbsoluteTime(dateStr: string) {
+    return formatAbsoluteLogTime(dateStr);
+  }
+  function getStatusVariant(status: number | string) {
+    return getLogStatusVariant(status);
+  }
+  function getMethodVariant(method: string) {
+    return getLogMethodVariant(method);
+  }
+  function formatDuration(duration: number) {
+    return formatLogDuration(duration);
+  }
+  function getDurationClass(duration: number) {
+    return getLogDurationClass(duration);
+  }
+
+  async function deleteLogs(): Promise<void> {
+    isDeleting.value = true;
+    try {
+      const olderThanDays = deleteMode.value === 'all' ? 0 : parseInt(deleteMode.value, 10);
+      const response = await deleteLogsApi({ older_than_days: olderThanDays });
+
+      const deletedCount = response.deleted_count || 0;
+      const message =
+        deleteMode.value === 'all'
+          ? `Successfully deleted ${deletedCount.toLocaleString()} log entries`
+          : `Successfully deleted ${deletedCount.toLocaleString()} log entries older than ${deleteMode.value} days`;
+
+      makeToast(message, 'Logs Deleted', 'success');
+      // Closing the modal triggers its @hidden reset (confirm text + mode)
+      showDeleteModal.value = false;
+      currentItemID.value = 0;
+      loadData();
+    } catch (error) {
+      const errorMsg = extractApiErrorMessage(error, 'Failed to delete logs');
+      makeToast(`Failed to delete logs: ${errorMsg}`, 'Error', 'danger');
+    } finally {
+      isDeleting.value = false;
+    }
+  }
+
+  // ── Watchers ───────────────────────────────────────────────────────────────
+  watch(
+    filter,
+    () => {
+      if (isInitializing.value) return;
+      filtered();
+    },
+    { deep: true }
+  );
+  watch(
+    sortBy as Ref<Array<{ key: string; order: 'asc' | 'desc' }>>,
+    (newVal) => {
+      if (isInitializing.value) return;
+      const newSortColumn = newVal && newVal.length > 0 ? newVal[0].key : 'id';
+      const newSortOrder = newVal && newVal.length > 0 ? newVal[0].order : 'desc';
+      const newSortString = (newSortOrder === 'desc' ? '-' : '+') + newSortColumn;
+      // Only trigger if sort actually changed - prevents resetting currentItemID during pagination
+      if (newSortString !== sort.value) {
+        handleSortByOrDescChange();
+      }
+    },
+    { deep: true }
+  );
+
+  // ── Lifecycle (was mounted) ──────────────────────────────────────────────
+  onMounted(() => {
+    if (props.sortInput) {
+      const sort_object = sortStringToVariables(props.sortInput);
+      sortBy.value = sort_object.sortBy;
+      sort.value = props.sortInput;
+    }
+
+    if (props.pageAfterInput && props.pageAfterInput !== '0') {
+      currentItemID.value = parseInt(props.pageAfterInput, 10) || 0;
+    }
+
+    loadUserList();
+
+    void nextTick(() => {
+      if (props.filterInput && props.filterInput !== 'null' && props.filterInput !== '') {
+        filter.value = filterStrToObj(props.filterInput, filter.value) as LogFilter;
+        filter_string.value = props.filterInput;
+      }
+      loadData();
+      void nextTick(() => {
+        isInitializing.value = false;
+      });
+    });
+
+    loading.value = false;
+  });
+
+  return {
+    // composable passthroughs (spread for template/vm access parity)
+    ...colorAndSymbols,
+    ...text,
+    ...tableData,
+    filterObjToStr,
+    filterStrToObj,
+    sortStringToVariables,
+    // local state
+    filter,
+    isInitializing,
+    loadDataDebounceTimer,
+    totalPages,
+    user_options,
+    method_options,
+    status_options,
+    mobileSortOptions,
+    showLogDetail,
+    selectedLog,
+    selectedLogIndex,
+    fields,
+    fields_details,
+    showDeleteModal,
+    deleteMode,
+    isDeleting,
+    showExportModal,
+    // computed
+    mobileSortValue,
+    canNavigatePrev,
+    canNavigateNext,
+    hasActiveFilters,
+    activeFilters,
+    removeFiltersButtonVariant,
+    removeFiltersButtonTitle,
+    // methods
+    handleRowClick,
+    navigateToPreviousLog,
+    navigateToNextLog,
+    loadUserList,
+    loadData,
+    doLoadData,
+    applyApiResponse,
+    updateBrowserUrl,
+    copyLinkToClipboard,
+    handleSortByOrDescChange,
+    handleSortUpdate,
+    handlePageChange,
+    handlePerPageChange,
+    filtered,
+    removeFilters,
+    removeSearch,
+    setFilterField,
+    clearFilter,
+    requestExcel,
+    doExportExcel,
+    truncate,
+    formatDate,
+    formatRelativeTime,
+    formatAbsoluteTime,
+    getStatusVariant,
+    getMethodVariant,
+    formatDuration,
+    getDurationClass,
+    deleteLogs,
+  };
+}

--- a/app/src/components/ui/ConfirmActionModal.spec.ts
+++ b/app/src/components/ui/ConfirmActionModal.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * ConfirmActionModal contract tests.
+ *
+ * Generic yes/no confirmation modal used in place of native window.confirm().
+ * These pin the v-model visibility contract, the confirm/cancel emits, the
+ * busy-disables-both-buttons behaviour, and the message/slot fallback.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { mount } from '@vue/test-utils';
+import ConfirmActionModal from './ConfirmActionModal.vue';
+
+const stubs = {
+  BModal: {
+    name: 'BModal',
+    template: '<div><slot /><slot name="footer" /></div>',
+    props: ['modelValue', 'title'],
+    emits: ['update:modelValue', 'hidden'],
+  },
+  BButton: { template: '<button v-bind="$attrs"><slot /></button>' },
+  BSpinner: { template: '<span class="spinner" />' },
+};
+
+function mountModal(props = {}) {
+  return mount(ConfirmActionModal, {
+    props: { modelValue: true, title: 'Do the thing?', message: 'Are you sure?', ...props },
+    global: { stubs },
+  });
+}
+
+describe('ConfirmActionModal', () => {
+  it('renders the message prop when no default slot is provided', () => {
+    const wrapper = mountModal({ message: 'This cannot be undone.' });
+    expect(wrapper.text()).toContain('This cannot be undone.');
+  });
+
+  it('emits confirm when the confirm button is clicked', async () => {
+    const wrapper = mountModal();
+    // Footer order: [Cancel, Confirm]
+    await wrapper.findAll('button')[1].trigger('click');
+    expect(wrapper.emitted('confirm')).toHaveLength(1);
+  });
+
+  it('emits cancel and closes when the cancel button is clicked', async () => {
+    const wrapper = mountModal();
+    await wrapper.findAll('button')[0].trigger('click');
+    expect(wrapper.emitted('cancel')).toHaveLength(1);
+    expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
+  });
+
+  it('disables both buttons while busy', () => {
+    const wrapper = mountModal({ busy: true });
+    expect(wrapper.findAll('button')[0].attributes('disabled')).toBeDefined();
+    expect(wrapper.findAll('button')[1].attributes('disabled')).toBeDefined();
+  });
+
+  it('forwards the hidden lifecycle so the parent can reset state', () => {
+    const wrapper = mountModal();
+    wrapper.findComponent({ name: 'BModal' }).vm.$emit('hidden');
+    expect(wrapper.emitted('hidden')).toHaveLength(1);
+  });
+});

--- a/app/src/components/ui/ConfirmActionModal.vue
+++ b/app/src/components/ui/ConfirmActionModal.vue
@@ -1,0 +1,81 @@
+<!-- components/ui/ConfirmActionModal.vue -->
+<!--
+  Generic confirmation modal in the app's modal language (replaces native
+  window.confirm()). Yes/no semantics with a configurable title, message,
+  confirm label, and variant. Visibility is two-way via v-model; the parent
+  keeps it mounted (no v-if) so @hidden can own any reset. Emits `confirm`
+  when the operator accepts and `cancel` when they decline.
+-->
+<template>
+  <BModal
+    :model-value="modelValue"
+    :title="title"
+    :header-bg-variant="headerBgVariant"
+    :header-text-variant="headerTextVariant"
+    centered
+    role="alertdialog"
+    :aria-label="title"
+    @update:model-value="$emit('update:modelValue', $event)"
+    @hidden="$emit('hidden')"
+  >
+    <div v-if="icon" class="text-center mb-3">
+      <i :class="`bi ${icon} ${iconClass} fs-1`" aria-hidden="true" />
+    </div>
+
+    <!-- Default slot allows richer bodies; falls back to the message prop. -->
+    <slot>
+      <p class="mb-0 text-center">{{ message }}</p>
+    </slot>
+
+    <template #footer>
+      <BButton variant="outline-secondary" :disabled="busy" @click="onCancel">
+        {{ cancelLabel }}
+      </BButton>
+      <BButton :variant="confirmVariant" :disabled="busy" @click="$emit('confirm')">
+        <BSpinner v-if="busy" small class="me-1" />
+        {{ confirmLabel }}
+      </BButton>
+    </template>
+  </BModal>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue';
+import { BModal, BButton, BSpinner, type ButtonVariant, type ColorVariant } from 'bootstrap-vue-next';
+
+export default defineComponent({
+  name: 'ConfirmActionModal',
+  components: { BModal, BButton, BSpinner },
+  props: {
+    /** Two-way modal visibility flag. */
+    modelValue: { type: Boolean, default: false },
+    /** Header title. */
+    title: { type: String, default: 'Please confirm' },
+    /** Body copy shown when the default slot is not provided. */
+    message: { type: String, default: '' },
+    /** Confirm-button label. */
+    confirmLabel: { type: String, default: 'Confirm' },
+    /** Cancel-button label. */
+    cancelLabel: { type: String, default: 'Cancel' },
+    /** Confirm-button Bootstrap variant (e.g. 'primary', 'warning', 'danger'). */
+    confirmVariant: { type: String as PropType<ButtonVariant>, default: 'primary' },
+    /** Header background variant. */
+    headerBgVariant: { type: String as PropType<ColorVariant>, default: 'warning' },
+    /** Header text variant. */
+    headerTextVariant: { type: String as PropType<ColorVariant>, default: 'dark' },
+    /** Optional Bootstrap-Icons class shown above the message (e.g. 'bi-exclamation-triangle-fill'). */
+    icon: { type: String, default: '' },
+    /** Icon colour class (e.g. 'text-warning', 'text-danger'). */
+    iconClass: { type: String, default: 'text-warning' },
+    /** Disables both buttons and shows a spinner on confirm while an action runs. */
+    busy: { type: Boolean, default: false },
+  },
+  emits: ['update:modelValue', 'confirm', 'cancel', 'hidden'],
+  methods: {
+    onCancel() {
+      this.$emit('cancel');
+      this.$emit('update:modelValue', false);
+    },
+  },
+});
+</script>

--- a/scripts/code-quality-file-size-baseline.tsv
+++ b/scripts/code-quality-file-size-baseline.tsv
@@ -35,7 +35,6 @@ app/src/components/nddscore/NddScoreGeneTable.vue	822
 app/src/components/small/GenericTable.vue	926
 app/src/components/tables/TablesEntities.vue	861
 app/src/components/tables/TablesGenes.vue	782
-app/src/components/tables/TablesLogs.vue	1160
 app/src/components/tables/TablesPhenotypes.vue	889
 app/src/views/admin/ManageAnnotations.vue	613
 app/src/views/admin/ManageNDDScore.vue	602


### PR DESCRIPTION
Part of the admin-views enhancement program (>9/10). Backlog ref: \`.planning/admin-views-audit-2026-06-14.md\` ("Cross-view backlog" — split TablesLogs.vue; native confirm() → modal).

## What

\`TablesLogs.vue\` was **1160 lines** (~2× the 600-line soft ceiling). This splits it into focused units, leaving the SFC a thin shell like \`ViewLogs.vue\`:

- **\`useLogTable.ts\`** (566) — all log-table behaviour (state, debounced load, cursor pagination, URL sync, filter/delete/export orchestration), composing the shared \`useTableData\` container.
- **\`logTableConfig.ts\`** — static column + filter-option config (sibling to the existing \`logTableFormatters\`/\`logTableRequests\`).
- **\`LogFilterToolbar.vue\`** (240) — the search/filter/pagination toolbar. Props-down / events-up: \`filter\` is read-only, field changes emit \`update-filter (key, value)\`, and the composable owns the filter object (no prop mutation).
- **\`TablesLogs.vue\`** — now **378 lines**, a thin shell wiring the composable + toolbar + table + modals.

Also replaces the large-export \`window.confirm()\` with a reusable **\`ConfirmActionModal\`** (app modal language), gated at 30 000 rows — the second half of the "native dialogs → modals" backlog item (the ManageUser half shipped in #431).

## Notes

- **File-size ratchet:** the \`TablesLogs.vue\` baseline entry is dropped (now under the ceiling); the new files are all < 600. \`make code-quality-audit\` is clean.
- \`ConfirmActionModal\` is a generic primitive that the ManageAnnotations confirmation PR will also reuse.

## Tests

- The existing \`TablesLogs.spec.ts\` (vm-level contract: \`loadUserList\`/\`doLoadData\`/\`requestExcel\`/\`deleteLogs\`/URL-sync after success-not-failure) **passes unchanged** — behaviour is preserved.
- New: \`LogFilterToolbar.spec.ts\` (action emits, pills, mobile sort) and \`ConfirmActionModal.spec.ts\`.
- Full unit suite: 226 files / 1552 pass.

## Verification

\`type-check\` ✓ · \`type-check:strict\` ✓ · \`eslint\` (changed files) ✓ · \`vitest run\` ✓ · \`make code-quality-audit\` ✓