### PR TITLE
feat(app): confirmation modals on heavy ManageAnnotations operations

### DIFF
--- a/app/src/composables/annotations/annotationsConfirmCopy.ts
+++ b/app/src/composables/annotations/annotationsConfirmCopy.ts
@@ -1,0 +1,41 @@
+// composables/annotations/annotationsConfirmCopy.ts
+//
+// Confirmation copy for the heavy / irreversible annotation operations on the
+// ManageAnnotations page. Kept out of the (oversized) SFC; consumed via
+// useConfirmGate + ConfirmActionModal.
+
+import type { ConfirmGateConfig } from '@/composables/useConfirmGate';
+
+export const ONTOLOGY_UPDATE_CONFIRM: ConfirmGateConfig = {
+  title: 'Update ontology annotations?',
+  message:
+    'This starts a background job that refreshes OMIM / MONDO / Disease Ontology ' +
+    'annotations and may auto-fix affected entity versions. Continue?',
+  confirmLabel: 'Update ontology',
+  confirmVariant: 'warning',
+};
+
+export const FORCE_APPLY_CONFIRM: ConfirmGateConfig = {
+  title: 'Force-apply blocked ontology update?',
+  message:
+    'Force-applying overrides the critical-change safety block, applies the new ontology, ' +
+    'and creates a re-review batch for the affected entities. This cannot be undone. Continue?',
+  confirmLabel: 'Force-apply',
+  confirmVariant: 'danger',
+};
+
+export const COMPARISONS_REFRESH_CONFIRM: ConfirmGateConfig = {
+  title: 'Refresh comparisons data?',
+  message: 'This starts a background job that rebuilds the external database comparison tables. Continue?',
+  confirmLabel: 'Refresh comparisons',
+  confirmVariant: 'warning',
+};
+
+export const REFRESH_ALL_PUBLICATIONS_CONFIRM: ConfirmGateConfig = {
+  title: 'Refresh all publications?',
+  message:
+    'This re-fetches metadata for the entire publication corpus from PubMed. It is ' +
+    'rate-limited and may take a long time to complete. Continue?',
+  confirmLabel: 'Refresh all',
+  confirmVariant: 'warning',
+};

--- a/app/src/composables/annotations/useAnnotationJobReactions.ts
+++ b/app/src/composables/annotations/useAnnotationJobReactions.ts
@@ -1,0 +1,143 @@
+// composables/annotations/useAnnotationJobReactions.ts
+//
+// Reaction layer for the ManageAnnotations async jobs: watches each job's
+// status and, on completion/failure, toasts and refreshes the relevant data.
+// Extracted from ManageAnnotations.vue so the (oversized) SFC stays focused on
+// composition + actions. Behaviour is a faithful port of the inline watchers.
+
+import { watch, type Ref } from 'vue';
+import type { useAsyncJob } from '@/composables/useAsyncJob';
+import useToast from '@/composables/useToast';
+import * as api from './useAnnotationsApi';
+import type { OntologyBlockedState, UserOption } from '@/components/annotations/OntologyAnnotationsCard.vue';
+
+type AsyncJob = ReturnType<typeof useAsyncJob>;
+type MakeToast = ReturnType<typeof useToast>['makeToast'];
+
+export interface AnnotationJobReactionDeps {
+  ontologyJob: AsyncJob;
+  forceApplyJob: AsyncJob;
+  hgncJob: AsyncJob;
+  comparisonsJob: AsyncJob;
+  publicationRefreshJob: AsyncJob;
+  ontologyBlocked: Ref<OntologyBlockedState | null>;
+  forceApplyUserOptions: Ref<UserOption[]>;
+  loadingForceApplyUsers: Ref<boolean>;
+  makeToast: MakeToast;
+  reload: {
+    annotationDates: () => void;
+    jobHistory: () => void;
+    publicationStats: () => void;
+    filteredCount: () => void;
+    comparisonsMetadata: () => void;
+  };
+}
+
+export function useAnnotationJobReactions(deps: AnnotationJobReactionDeps): void {
+  const {
+    ontologyJob,
+    forceApplyJob,
+    hgncJob,
+    comparisonsJob,
+    publicationRefreshJob,
+    ontologyBlocked,
+    forceApplyUserOptions,
+    loadingForceApplyUsers,
+    makeToast,
+    reload,
+  } = deps;
+
+  const toastDone = (msg: string): void => makeToast(msg, 'Success', 'success');
+  const toastFail = (msg: string): void => makeToast(msg, 'Error', 'danger');
+
+  // Ontology update has the Phase-76 "blocked" branch, so it is handled
+  // explicitly rather than via the simple done/fail helper below.
+  watch(
+    () => ontologyJob.status.value,
+    async (newStatus) => {
+      if (newStatus === 'completed') {
+        try {
+          const jobId = ontologyJob.jobId.value;
+          if (jobId) {
+            const result = await api.fetchOntologyJobResult(jobId);
+            if (result && result.kind === 'blocked') {
+              ontologyBlocked.value = result.state;
+              forceApplyUserOptions.value = [];
+              loadingForceApplyUsers.value = true;
+              try {
+                forceApplyUserOptions.value = await api.fetchForceApplyUsers();
+              } catch {
+                forceApplyUserOptions.value = [];
+              } finally {
+                loadingForceApplyUsers.value = false;
+              }
+              makeToast(
+                `Ontology update blocked: ${result.state.critical_count} critical changes`,
+                'Update Blocked',
+                'warning'
+              );
+              reload.jobHistory();
+              return;
+            }
+            const autoFixes = result && result.kind === 'ok' ? result.autoFixesApplied : 0;
+            if (autoFixes > 0) {
+              toastDone(`Ontology updated. ${autoFixes} entity version(s) auto-fixed.`);
+            } else {
+              toastDone('Ontology annotations updated successfully');
+            }
+          }
+        } catch {
+          toastDone('Ontology annotations updated successfully');
+        }
+        reload.annotationDates();
+        reload.jobHistory();
+      } else if (newStatus === 'failed') {
+        toastFail(ontologyJob.error.value || 'Ontology update failed');
+        reload.jobHistory();
+      }
+    }
+  );
+
+  // Simple done/fail reactions for the remaining jobs.
+  function wire(job: AsyncJob, doneMsg: string, failMsg: string, onDone?: () => void): void {
+    watch(
+      () => job.status.value,
+      (newStatus) => {
+        if (newStatus === 'completed') {
+          toastDone(doneMsg);
+          onDone?.();
+          reload.jobHistory();
+        } else if (newStatus === 'failed') {
+          toastFail(job.error.value || failMsg);
+          reload.jobHistory();
+        }
+      }
+    );
+  }
+
+  wire(
+    forceApplyJob,
+    'Ontology force-applied successfully. Re-review batch created for critical entities.',
+    'Force-apply failed',
+    () => {
+      ontologyBlocked.value = null;
+      reload.annotationDates();
+    }
+  );
+  wire(hgncJob, 'HGNC data updated successfully', 'HGNC update failed', reload.annotationDates);
+  wire(
+    publicationRefreshJob,
+    'Publications refreshed successfully',
+    'Publication refresh failed',
+    () => {
+      reload.publicationStats();
+      reload.filteredCount();
+    }
+  );
+  wire(
+    comparisonsJob,
+    'Comparisons data refreshed successfully',
+    'Comparisons refresh failed',
+    reload.comparisonsMetadata
+  );
+}

--- a/app/src/composables/useConfirmGate.spec.ts
+++ b/app/src/composables/useConfirmGate.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * useConfirmGate contract tests.
+ *
+ * Pins the defer-action-behind-confirmation behaviour: request() opens the
+ * gate without running the action, accept() runs the pending action exactly
+ * once, and reset() clears a dismissed gate so it cannot fire later.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { useConfirmGate } from './useConfirmGate';
+
+describe('useConfirmGate', () => {
+  it('opens the gate and stores config without running the action', () => {
+    const gate = useConfirmGate();
+    const action = vi.fn();
+    gate.request({ title: 'T', message: 'M', confirmLabel: 'Go' }, action);
+
+    expect(gate.open.value).toBe(true);
+    expect(gate.config.value.title).toBe('T');
+    expect(gate.config.value.confirmLabel).toBe('Go');
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('runs the pending action once on accept and closes the gate', () => {
+    const gate = useConfirmGate();
+    const action = vi.fn();
+    gate.request({ title: 'T', message: 'M' }, action);
+
+    gate.accept();
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(gate.open.value).toBe(false);
+
+    // A second accept must not re-run the (already consumed) action.
+    gate.accept();
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not run the action after reset (dismissed gate)', () => {
+    const gate = useConfirmGate();
+    const action = vi.fn();
+    gate.request({ title: 'T', message: 'M' }, action);
+
+    gate.reset();
+    gate.accept();
+    expect(action).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/composables/useConfirmGate.ts
+++ b/app/src/composables/useConfirmGate.ts
@@ -1,0 +1,41 @@
+// composables/useConfirmGate.ts
+//
+// Small reusable gate that defers a heavy / irreversible action behind a
+// confirmation modal (pairs with ConfirmActionModal). Call request(config,
+// action) to open the modal; accept() runs the pending action; the @hidden
+// lifecycle should call reset() so a dismissed gate never leaves a stale
+// pending action.
+
+import { ref } from 'vue';
+
+export interface ConfirmGateConfig {
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  confirmVariant?: 'primary' | 'secondary' | 'success' | 'danger' | 'warning' | 'info';
+}
+
+export function useConfirmGate() {
+  const open = ref(false);
+  const config = ref<ConfirmGateConfig>({ title: '', message: '' });
+  let pending: (() => void | Promise<void>) | null = null;
+
+  function request(cfg: ConfirmGateConfig, action: () => void | Promise<void>): void {
+    config.value = cfg;
+    pending = action;
+    open.value = true;
+  }
+
+  function accept(): void {
+    open.value = false;
+    const action = pending;
+    pending = null;
+    void action?.();
+  }
+
+  function reset(): void {
+    pending = null;
+  }
+
+  return { open, config, request, accept, reset };
+}

--- a/app/src/views/admin/ManageAnnotations.spec.ts
+++ b/app/src/views/admin/ManageAnnotations.spec.ts
@@ -262,7 +262,27 @@ const bvnStubs = {
   TableSearchInput: { template: '<input class="search-stub" />' },
   TableDownloadLinkCopyButtons: { template: '<div />' },
   TablePaginationControls: { template: '<div />' },
+  // The shared confirmation gate. Stubbed so tests can accept the gate by
+  // emitting `confirm` directly (the real BModal teleports and is awkward in
+  // jsdom). The view wires `@confirm="acceptConfirm"`, which runs the pending
+  // heavy-op action.
+  ConfirmActionModal: {
+    name: 'ConfirmActionModal',
+    props: ['modelValue', 'title', 'message', 'confirmLabel', 'confirmVariant'],
+    emits: ['update:modelValue', 'confirm', 'cancel', 'hidden'],
+    template: '<div class="confirm-action-modal-stub"><slot /></div>',
+  },
 };
+
+/**
+ * Accept the shared confirmation gate. Heavy operations (ontology update,
+ * force-apply, comparisons refresh, refresh-all) now open ConfirmActionModal
+ * before running; this emits the modal's `confirm` so the pending action fires.
+ */
+async function acceptConfirmGate(wrapper: VueWrapper): Promise<void> {
+  await wrapper.findComponent({ name: 'ConfirmActionModal' }).vm.$emit('confirm');
+  await flushPromises();
+}
 
 async function mountView(): Promise<VueWrapper> {
   const router = buildTestRouter();
@@ -444,7 +464,7 @@ describe('ManageAnnotations — Phase C.C5 functional spec', () => {
     expect(updateOntology, 'Update Ontology Annotations button exists').toBeTruthy();
 
     await updateOntology!.trigger('click');
-    await flushPromises();
+    await acceptConfirmGate(wrapper);
     await vi.advanceTimersByTimeAsync(3000);
     await flushPromises();
 
@@ -546,7 +566,7 @@ describe('ManageAnnotations — Phase C.C5 functional spec', () => {
     expect(ontologyButton, 'expected an "Update Ontology Annotations" button').toBeDefined();
 
     await ontologyButton!.trigger('click');
-    await flushPromises();
+    await acceptConfirmGate(wrapper);
 
     // Walk the polling loop: queued → running → completed+blocked.
     await vi.advanceTimersByTimeAsync(3000); // poll #1 — queued
@@ -685,7 +705,7 @@ describe('ManageAnnotations — Phase C.C5 functional spec', () => {
       'expected an "Update Ontology Annotations" button to trigger the blocked flow'
     ).toBeDefined();
     await ontologyButton!.trigger('click');
-    await flushPromises();
+    await acceptConfirmGate(wrapper);
 
     await vi.advanceTimersByTimeAsync(3000); // poll #1
     await flushPromises();
@@ -707,11 +727,42 @@ describe('ManageAnnotations — Phase C.C5 functional spec', () => {
     ).toBeDefined();
 
     await forceApplyButton!.trigger('click');
-    await flushPromises();
+    await acceptConfirmGate(wrapper);
 
     // The PUT must have been made, with blocked_job_id set to the id we
     // staged — i.e. the Phase 76 contract for force_apply_ontology.
     expect(forceApplyCalls.length).toBe(1);
     expect(forceApplyCalls[0].blockedJobId).toBe(BLOCKED_JOB_ID);
+  });
+
+  // -------------------------------------------------------------------------
+  // Confirmation gate: heavy ops must not fire until the operator accepts.
+  // -------------------------------------------------------------------------
+  it('does not submit the ontology update until the confirmation gate is accepted', async () => {
+    let submitCount = 0;
+    server.use(
+      http.put('/api/admin/update_ontology_async', () => {
+        submitCount += 1;
+        return HttpResponse.json({ job_id: ['ontology-gated'], status: ['accepted'] });
+      }),
+      http.get('/api/jobs/:job_id/status', () =>
+        HttpResponse.json({ job_id: ['ontology-gated'], status: ['completed'], result: [{}] })
+      )
+    );
+
+    const wrapper = await mountView();
+    const ontologyButton = wrapper
+      .findAll('button')
+      .find((b) => b.text().includes('Update Ontology Annotations'));
+    expect(ontologyButton).toBeDefined();
+
+    // Clicking only opens the gate — no submit yet.
+    await ontologyButton!.trigger('click');
+    await flushPromises();
+    expect(submitCount).toBe(0);
+
+    // Accepting the gate runs the pending action — submit fires.
+    await acceptConfirmGate(wrapper);
+    expect(submitCount).toBe(1);
   });
 });

--- a/app/src/views/admin/ManageAnnotations.vue
+++ b/app/src/views/admin/ManageAnnotations.vue
@@ -16,8 +16,10 @@
               :last-updated="annotationDates.omim_update"
               :user-options="forceApplyUserOptions"
               :loading-users="loadingForceApplyUsers"
-              @start-ontology="onStartOntology"
-              @force-apply="onForceApply"
+              @start-ontology="() => requestConfirm(ONTOLOGY_UPDATE_CONFIRM, onStartOntology)"
+              @force-apply="
+                (payload) => requestConfirm(FORCE_APPLY_CONFIRM, () => onForceApply(payload))
+              "
               @dismiss-blocked="dismissBlockedOntology"
             />
           </BCol>
@@ -50,7 +52,7 @@
               :metadata="comparisonsMetadata"
               :loading-metadata="loadingComparisonsMetadata"
               @refresh-metadata="loadComparisonsMetadata"
-              @start-refresh="onStartComparisons"
+              @start-refresh="() => requestConfirm(COMPARISONS_REFRESH_CONFIRM, onStartComparisons)"
             />
           </BCol>
         </BRow>
@@ -70,7 +72,7 @@
               @update:custom-date="(value: string) => (customDate = value)"
               @refresh-stats="loadPublicationStats"
               @refresh-filtered="onRefreshFilteredPublications"
-              @refresh-all="onRefreshAllPublications"
+              @refresh-all="() => requestConfirm(REFRESH_ALL_PUBLICATIONS_CONFIRM, onRefreshAllPublications)"
             />
           </BCol>
         </BRow>
@@ -111,18 +113,44 @@
         </BRow>
       </BContainer>
     </div>
+
+    <!-- Shared confirmation gate for heavy / irreversible operations. Stays
+         mounted (no v-if) so its @hidden lifecycle clears any pending action. -->
+    <ConfirmActionModal
+      v-model="confirmOpen"
+      :title="confirmConfig.title"
+      :message="confirmConfig.message"
+      :confirm-label="confirmConfig.confirmLabel ?? 'Confirm'"
+      :confirm-variant="confirmConfig.confirmVariant ?? 'warning'"
+      :header-bg-variant="confirmConfig.confirmVariant ?? 'warning'"
+      :header-text-variant="confirmConfig.confirmVariant === 'danger' ? 'light' : 'dark'"
+      icon="bi-exclamation-triangle-fill"
+      :icon-class="confirmConfig.confirmVariant === 'danger' ? 'text-danger' : 'text-warning'"
+      @confirm="acceptConfirm"
+      @hidden="resetConfirm"
+    />
   </AuthenticatedPageShell>
 </template>
 
 <script setup lang="ts">
 import AuthenticatedPageShell from '@/components/layout/AuthenticatedPageShell.vue';
+import ConfirmActionModal from '@/components/ui/ConfirmActionModal.vue';
 import { ref, computed, onMounted, watch } from 'vue';
 import { useRoute } from 'vue-router';
+import { useHead } from '@unhead/vue';
 import useToast from '@/composables/useToast';
 import { useAsyncJob } from '@/composables/useAsyncJob';
+import { useConfirmGate } from '@/composables/useConfirmGate';
 import { unwrapValue } from '@/composables/annotations/useAnnotationFormatters';
 import * as api from '@/composables/annotations/useAnnotationsApi';
 import { useJobHistoryPanel } from '@/composables/annotations/useJobHistoryPanel';
+import { useAnnotationJobReactions } from '@/composables/annotations/useAnnotationJobReactions';
+import {
+  ONTOLOGY_UPDATE_CONFIRM,
+  FORCE_APPLY_CONFIRM,
+  COMPARISONS_REFRESH_CONFIRM,
+  REFRESH_ALL_PUBLICATIONS_CONFIRM,
+} from '@/composables/annotations/annotationsConfirmCopy';
 import OntologyAnnotationsCard, {
   type OntologyBlockedState,
   type UserOption,
@@ -148,6 +176,18 @@ import JobHistoryCard from '@/components/annotations/JobHistoryCard.vue';
 // ---------------------------------------------------------------------------
 const route = useRoute();
 const { makeToast } = useToast();
+
+useHead({ title: 'Manage Annotations' });
+
+// Confirmation gate for heavy / irreversible operations (pairs with
+// ConfirmActionModal in the template).
+const {
+  open: confirmOpen,
+  config: confirmConfig,
+  request: requestConfirm,
+  accept: acceptConfirm,
+  reset: resetConfirm,
+} = useConfirmGate();
 
 const jobStatusUrl = (jobId: string): string => `/api/jobs/${encodeURIComponent(jobId)}/status`;
 
@@ -255,120 +295,30 @@ const {
 } = useJobHistoryPanel(route, { onToast: makeToast });
 
 // ---------------------------------------------------------------------------
-// Toast-and-history wiring for each job watcher
+// Toast-and-history wiring: per-job status reactions live in a composable.
 // ---------------------------------------------------------------------------
-function toastDone(msg: string): void {
-  makeToast(msg, 'Success', 'success');
-}
 function toastFail(msg: string): void {
   makeToast(msg, 'Error', 'danger');
 }
 
-watch(
-  () => ontologyJob.status.value,
-  async (newStatus) => {
-    if (newStatus === 'completed') {
-      try {
-        const jobId = ontologyJob.jobId.value;
-        if (jobId) {
-          const result = await api.fetchOntologyJobResult(jobId);
-          if (result && result.kind === 'blocked') {
-            ontologyBlocked.value = result.state;
-            forceApplyUserOptions.value = [];
-            loadingForceApplyUsers.value = true;
-            try {
-              forceApplyUserOptions.value = await api.fetchForceApplyUsers();
-            } catch {
-              forceApplyUserOptions.value = [];
-            } finally {
-              loadingForceApplyUsers.value = false;
-            }
-            makeToast(
-              `Ontology update blocked: ${result.state.critical_count} critical changes`,
-              'Update Blocked',
-              'warning'
-            );
-            loadJobHistory();
-            return;
-          }
-          const autoFixes = result && result.kind === 'ok' ? result.autoFixesApplied : 0;
-          if (autoFixes > 0) {
-            toastDone(`Ontology updated. ${autoFixes} entity version(s) auto-fixed.`);
-          } else {
-            toastDone('Ontology annotations updated successfully');
-          }
-        }
-      } catch {
-        toastDone('Ontology annotations updated successfully');
-      }
-      loadAnnotationDates();
-      loadJobHistory();
-    } else if (newStatus === 'failed') {
-      toastFail(ontologyJob.error.value || 'Ontology update failed');
-      loadJobHistory();
-    }
-  }
-);
-
-watch(
-  () => forceApplyJob.status.value,
-  (newStatus) => {
-    if (newStatus === 'completed') {
-      toastDone(
-        'Ontology force-applied successfully. Re-review batch created for critical entities.'
-      );
-      ontologyBlocked.value = null;
-      loadAnnotationDates();
-      loadJobHistory();
-    } else if (newStatus === 'failed') {
-      toastFail(forceApplyJob.error.value || 'Force-apply failed');
-      loadJobHistory();
-    }
-  }
-);
-
-watch(
-  () => hgncJob.status.value,
-  (newStatus) => {
-    if (newStatus === 'completed') {
-      toastDone('HGNC data updated successfully');
-      loadAnnotationDates();
-      loadJobHistory();
-    } else if (newStatus === 'failed') {
-      toastFail(hgncJob.error.value || 'HGNC update failed');
-      loadJobHistory();
-    }
-  }
-);
-
-watch(
-  () => publicationRefreshJob.status.value,
-  (newStatus) => {
-    if (newStatus === 'completed') {
-      toastDone('Publications refreshed successfully');
-      loadPublicationStats();
-      loadFilteredCount();
-      loadJobHistory();
-    } else if (newStatus === 'failed') {
-      toastFail(publicationRefreshJob.error.value || 'Publication refresh failed');
-      loadJobHistory();
-    }
-  }
-);
-
-watch(
-  () => comparisonsJob.status.value,
-  (newStatus) => {
-    if (newStatus === 'completed') {
-      toastDone('Comparisons data refreshed successfully');
-      loadComparisonsMetadata();
-      loadJobHistory();
-    } else if (newStatus === 'failed') {
-      toastFail(comparisonsJob.error.value || 'Comparisons refresh failed');
-      loadJobHistory();
-    }
-  }
-);
+useAnnotationJobReactions({
+  ontologyJob,
+  forceApplyJob,
+  hgncJob,
+  comparisonsJob,
+  publicationRefreshJob,
+  ontologyBlocked,
+  forceApplyUserOptions,
+  loadingForceApplyUsers,
+  makeToast,
+  reload: {
+    annotationDates: loadAnnotationDates,
+    jobHistory: loadJobHistory,
+    publicationStats: loadPublicationStats,
+    filteredCount: loadFilteredCount,
+    comparisonsMetadata: loadComparisonsMetadata,
+  },
+});
 
 watch(notUpdatedSince, () => {
   if (notUpdatedSince.value) {


### PR DESCRIPTION
Part of the admin-views enhancement program (>9/10). Backlog ref: \`.planning/admin-views-audit-2026-06-14.md\` ("Cross-view backlog" — confirmation modals on heavy/irreversible ManageAnnotations ops).

## What

Adds a **confirmation gate** before the four heavy / irreversible annotation operations, which previously fired immediately on click:

- **Update ontology annotations** (warning)
- **Force-apply** blocked ontology update (danger — it overrides the critical-change safety block and creates a re-review batch)
- **Refresh comparisons data** (warning)
- **Refresh all publications** (warning — re-fetches the whole PubMed corpus)

Implemented with the reusable **\`ConfirmActionModal\`** (shipped in #432) + a new **\`useConfirmGate\`** composable (request → accept/reset). The op handlers are unchanged; the gate wraps them in the template (props-down, no handler rewrites). Also adds the per-view \`<title>\` ("Manage Annotations").

## Keeping the oversized SFC under baseline

\`ManageAnnotations.vue\` was already at its 613-line file-size baseline, so the gate could not be added without offsetting growth. The five job-status → toast/refresh **watchers** are extracted into a cohesive **\`useAnnotationJobReactions\`** composable (faithful port — the Phase-76 ontology blocked-branch behaviour is preserved), and the confirm copy lives in **\`annotationsConfirmCopy.ts\`**. Net: **613 → 563**. \`make code-quality-audit\` is clean.

## Tests

- New \`useConfirmGate.spec.ts\` (opens without running; runs once on accept; reset clears a dismissed gate).
- New ManageAnnotations gate test: clicking does **not** submit until the gate is accepted.
- The existing blocked-alert / force-apply-flow tests now accept the gate (helper) and still assert the downstream contract.
- Full unit suite: 227 files / 1556 pass.

## Verification

\`type-check\` ✓ · \`type-check:strict\` ✓ · \`eslint\` (changed files) ✓ · \`vitest run\` ✓ · \`make code-quality-audit\` ✓