### PR TITLE
feat(api): centralize Gemini cost pricing, keyed off the active model

### DIFF
--- a/.planning/admin-views-audit-2026-06-14.md
+++ b/.planning/admin-views-audit-2026-06-14.md
@@ -160,8 +160,16 @@ Status legend: ✅ done in PR #429 · 🔧 in PR #2 (typed-client migration) · 
 ### ManageLLM (6 → target 9.5)
 - ✅ Funct: `/config` 500 fixed; cache per-type cards fixed.  ✅ A11y: WAI-ARIA tablist.
 - 🔧 Code: migrate `useLlmAdmin` onto the typed `llm_admin.ts` (delete dead client + type drift).
-- ⬜ Funct: add a job-cancel action for in-flight regeneration; centralize Gemini pricing with
-  `llm-model-config.R` (cost row currently shows stale "Gemini 2.0 Flash" pricing).
+- ✅ Funct: Gemini cost estimate centralized with `llm-model-config.R` and keyed off the active
+  model (`llm_model_pricing()` + `estimated_cost_model` in `get_cache_statistics()`); the stale
+  hardcoded "Gemini 2.0 Flash" rate is removed.
+- ⬜ Funct (job-cancel) — **absent, documented**: there is **no durable HTTP job-cancel route**.
+  The service layer *does* support cancellation (`async_job_service_cancel()` /
+  `async_job_repository_cancel()` set running jobs to `cancel_requested` and queued jobs to
+  `cancelled`), but no endpoint in `jobs_endpoints.R` exposes it and `useAsyncJob` has no cancel
+  method, so a "Cancel job" action cannot be wired today. Enabling it is a future change: add e.g.
+  `POST /api/jobs/{id}/cancel` → `async_job_service_cancel()`, confirm the worker honours
+  `cancel_requested` mid-job, then add `cancel()` to `useAsyncJob` and a button in `LlmCacheManager`.
 - ⬜ Perf: virtualize/paginate the cache + generation-log tables (TBT 150ms → <50ms).
 
 ### ManageOntology (6 → target 9)

--- a/api/functions/llm-cache-repository.R
+++ b/api/functions/llm-cache-repository.R
@@ -479,9 +479,9 @@ update_validation_status <- function(cache_id, validation_status, validated_by =
 #'   - estimated_cost_usd: Numeric, estimated API cost
 #'
 #' @details
-#' Cost calculation uses Gemini 2.0 Flash pricing:
-#' - $0.075 per 1M input tokens
-#' - $0.30 per 1M output tokens
+#' The cost estimate is keyed off the active Gemini model
+#' (get_default_gemini_model()) using approximate per-1M-token rates from the
+#' central catalog (llm_model_pricing()), not a hardcoded rate.
 #'
 #' @examples
 #' \dontrun{
@@ -529,10 +529,10 @@ get_cache_statistics <- function() {
      WHERE status = 'success'"
   )
 
-  # Calculate estimated cost (Gemini 2.0 Flash pricing)
-  # Input: $0.075 per 1M tokens, Output: $0.30 per 1M tokens
-  input_cost <- (token_stats$total_tokens_input[1] %||% 0) * 0.075 / 1e6
-  output_cost <- (token_stats$total_tokens_output[1] %||% 0) * 0.30 / 1e6
+  # Estimate cost via the active model's catalog pricing (not a hardcoded rate).
+  pricing <- llm_model_pricing(get_default_gemini_model())
+  input_cost <- (token_stats$total_tokens_input[1] %||% 0) * pricing$input_per_million / 1e6
+  output_cost <- (token_stats$total_tokens_output[1] %||% 0) * pricing$output_per_million / 1e6
   estimated_cost_usd <- input_cost + output_cost
 
   list(

--- a/api/functions/llm-model-config.R
+++ b/api/functions/llm-model-config.R
@@ -106,6 +106,12 @@ llm_model_catalog <- function() {
       NA_character_, NA_character_, NA_character_, NA_character_, NA_character_,
       NA_character_, "2026-03-09"
     ),
+    # Approximate USD list prices per 1,000,000 tokens, used only for the
+    # cost ESTIMATE on the LLM admin page (keyed off the active model). These
+    # are tier-based approximations, not billing-grade; adjust to match the
+    # deployment's actual Gemini contract. Tiers: flash, pro, lite.
+    price_input_per_million = c(0.075, 1.25, 0.0375, 0.075, 1.25, 0.0375, 1.25),
+    price_output_per_million = c(0.30, 5.00, 0.15, 0.30, 5.00, 0.15, 5.00),
     stringsAsFactors = FALSE
   )
 }
@@ -142,7 +148,27 @@ llm_model_metadata <- function(model) {
     status = "unknown",
     allowed = FALSE,
     default = FALSE,
-    shutdown_date = NA_character_
+    shutdown_date = NA_character_,
+    # Fall back to flash-tier rates for cost estimation of unknown models.
+    price_input_per_million = 0.075,
+    price_output_per_million = 0.30
+  )
+}
+
+#' Resolve cost-estimate pricing for a Gemini model
+#'
+#' Returns the approximate USD list price per 1,000,000 input/output tokens
+#' from the central catalog (flash-tier fallback for unknown models). Used only
+#' for the LLM admin cost estimate, keyed off the active model.
+#'
+#' @param model Character Gemini model id.
+#' @return List with `input_per_million` and `output_per_million` numerics.
+#' @export
+llm_model_pricing <- function(model) {
+  meta <- llm_model_metadata(model)
+  list(
+    input_per_million = meta$price_input_per_million %||% 0.075,
+    output_per_million = meta$price_output_per_million %||% 0.30
   )
 }
 

--- a/api/tests/testthat/test-unit-llm-model-config.R
+++ b/api/tests/testthat/test-unit-llm-model-config.R
@@ -31,3 +31,28 @@ test_that("Gemini model catalog marks shut-down preview model invalid", {
   expect_false(meta$allowed)
   expect_equal(meta$status, "shutdown")
 })
+
+test_that("every catalog model carries positive cost-estimate pricing", {
+  source(testthat::test_path("../../functions/llm-model-config.R"), local = TRUE)
+
+  catalog <- llm_model_catalog()
+  expect_true(all(c("price_input_per_million", "price_output_per_million") %in% names(catalog)))
+  expect_true(all(catalog$price_input_per_million > 0))
+  expect_true(all(catalog$price_output_per_million > 0))
+})
+
+test_that("llm_model_pricing keys off the model and falls back for unknown models", {
+  source(testthat::test_path("../../functions/llm-model-config.R"), local = TRUE)
+
+  flash <- llm_model_pricing("gemini-3.5-flash")
+  pro <- llm_model_pricing("gemini-2.5-pro")
+  expect_true(flash$input_per_million > 0 && flash$output_per_million > 0)
+  # Pro-tier costs more than flash-tier (per-token).
+  expect_gt(pro$input_per_million, flash$input_per_million)
+  expect_gt(pro$output_per_million, flash$output_per_million)
+
+  # Unknown models fall back to flash-tier rates, not NA.
+  unknown <- llm_model_pricing("gemini-does-not-exist")
+  expect_equal(unknown$input_per_million, flash$input_per_million)
+  expect_equal(unknown$output_per_million, flash$output_per_million)
+})


### PR DESCRIPTION
Part of the admin-views enhancement program (>9/10). Backlog refs: \`.planning/admin-views-audit-2026-06-14.md\` — ManageLLM item 4a (centralize Gemini pricing) and 4b (job-cancel).

## 4a — centralize Gemini cost pricing

\`get_cache_statistics()\` hardcoded "Gemini 2.0 Flash" rates ($0.075 input / $0.30 output per 1M tokens) for the LLM-admin cost estimate, while the default model is \`gemini-3.5-flash\`.

- \`llm_model_catalog()\` gains \`price_input_per_million\` / \`price_output_per_million\` columns (tier-based approximate USD list prices, documented as operator-tunable, not billing-grade).
- New \`llm_model_pricing(model)\` helper resolves rates from the catalog (flash-tier fallback for unknown models).
- \`get_cache_statistics()\` now computes the estimate from the **active model's** rates via \`get_default_gemini_model()\` — the stale hardcoded rate and "Gemini 2.0 Flash" comment are gone.

The frontend already labels this "Approximate generation spend" and shows the active model separately, so no frontend change is needed.

## 4b — job-cancel (documented as absent)

There is **no durable HTTP job-cancel route**. The service layer *supports* cancellation (\`async_job_service_cancel()\` / \`async_job_repository_cancel()\` → \`cancel_requested\`/\`cancelled\`), but no endpoint exposes it and \`useAsyncJob\` has no \`cancel()\`, so a "Cancel job" action can't be wired today. Recorded in the audit doc as a future change (add \`POST /api/jobs/{id}/cancel\`, confirm the worker honours \`cancel_requested\`, wire the frontend).

## Tests / verification

- New \`llm_model_pricing\` unit tests in \`test-unit-llm-model-config.R\` (every catalog model has positive rates; pricing keys off the model; unknown → flash-tier fallback). Host: 18 pass; default-guard 9 pass.
- Live: restarted the API container; \`GET /api/llm/cache/stats\` → 200 with \`estimated_cost_usd\` computed via the new path (0 in dev DB — no tokens — but the pricing path executed without error).
- \`lintr\` clean (changed R files + test); \`make code-quality-audit\` clean (\`llm-cache-repository.R\` held at its 787 baseline).