### PR TITLE
feat: server-side 'all' sentinel for publication refresh (drop client corpus pull)

### DIFF
--- a/api/endpoints/admin_endpoints.R
+++ b/api/endpoints/admin_endpoints.R
@@ -857,25 +857,15 @@ function(req, res) {
 #* Returns immediately with job_id. Poll GET /api/jobs/{job_id} for status.
 #* Rate limited to 3 requests/second (NCBI limit without API key).
 #*
-#* Supports two modes:
-#* 1. Explicit PMIDs: Provide a list of PMIDs to refresh
-#* 2. Date filter: Provide not_updated_since to refresh all publications not updated since that date
+#* Supports three modes:
+#* 1. Explicit PMIDs: Provide a `pmids` list to refresh
+#* 2. Date filter: Provide `not_updated_since` (YYYY-MM-DD) to refresh publications older than that
+#* 3. Refresh all: Provide `all=true` to refresh the whole corpus (enumerated server-side)
 #*
-#* # `Request Body`
-#* {
-#*   "pmids": ["PMID:12345678", "PMID:87654321"],
-#*   "not_updated_since": "2024-01-01"
-#* }
+#* Request body: { pmids?: [...], not_updated_since?: "YYYY-MM-DD", all?: true }.
+#* With both a date and pmids, the list is filtered to publications older than the date.
 #*
-#* If not_updated_since is provided without pmids, fetches all publications not updated since that date.
-#* If both are provided, filters the pmids list to only those not updated since that date.
-#*
-#* # `Response (202 Accepted)`
-#* {
-#*   "job_id": "550e8400-e29b-41d4-a716-446655440000",
-#*   "status": "accepted",
-#*   "estimated_seconds": 30
-#* }
+#* Returns 202 Accepted with { job_id, status, estimated_seconds }.
 #*
 #* # `Authorization`
 #* Restricted to Administrator role.
@@ -891,6 +881,7 @@ function(req, res) {
   body <- req$body
   pmids <- body$pmids
   not_updated_since <- body$not_updated_since
+  refresh_all <- isTRUE(body$all)
 
   # Handle date-based filtering
   if (!is.null(not_updated_since) && nzchar(not_updated_since)) {
@@ -939,7 +930,13 @@ function(req, res) {
     }
   }
 
-  # Validate input - at least one PMID required
+  # Opt-in full-corpus refresh: enumerate server-side (client need not fetch all PMIDs).
+  if (refresh_all && (is.null(pmids) || length(pmids) == 0)) {
+    pmids <- db_execute_query("SELECT publication_id FROM publication")$publication_id
+  }
+
+  # Validate input - at least one PMID required. An empty request still 400s
+  # (safety guard); full-corpus refresh requires the explicit all=true flag.
   if (is.null(pmids) || length(pmids) == 0) {
     res$status <- 400
     return(list(error = "No PMIDs provided and no date filter specified"))

--- a/app/src/composables/annotations/useAnnotationsApi.ts
+++ b/app/src/composables/annotations/useAnnotationsApi.ts
@@ -209,34 +209,15 @@ export async function submitComparisonsRefresh(): Promise<JobSubmissionResponse>
 }
 
 export async function submitPublicationRefresh(
-  payload: { not_updated_since: string } | { pmids: unknown[] }
+  // `{ all: true }` asks the server to enumerate the entire publication corpus
+  // server-side (the client no longer fetches every PMID).
+  payload: { not_updated_since: string } | { pmids: unknown[] } | { all: true }
 ): Promise<JobSubmissionResponse> {
   return apiClient.post<JobSubmissionResponse>(
     '/api/admin/publications/refresh',
     payload,
     authRequestConfig()
   );
-}
-
-export async function fetchAllPublicationPmids(): Promise<unknown[]> {
-  const publications: Array<{ publication_id: string | string[] }> = [];
-  let nextUrl: string | null = '/api/publication';
-  let isFirstPage = true;
-  while (nextUrl) {
-    const data = await apiClient.get<{
-      data?: Array<{ publication_id: string | string[] }>;
-      links?: { next?: unknown };
-    }>(nextUrl, {
-      ...authRequestConfig(),
-      params: isFirstPage ? { fields: 'publication_id', page_size: 10000 } : undefined,
-    });
-    const pageRows: Array<{ publication_id: string | string[] }> = data?.data || [];
-    publications.push(...pageRows);
-    const link = data?.links?.next;
-    nextUrl = typeof link === 'string' && link.length > 0 ? link : null;
-    isFirstPage = false;
-  }
-  return publications.map((p) => unwrapValue(p.publication_id));
 }
 
 export type OntologyJobResult =

--- a/app/src/views/admin/ManageAnnotations.vue
+++ b/app/src/views/admin/ManageAnnotations.vue
@@ -527,14 +527,14 @@ async function onRefreshFilteredPublications(): Promise<void> {
 async function onRefreshAllPublications(): Promise<void> {
   publicationRefreshJob.reset();
   try {
-    const pmids = await api.fetchAllPublicationPmids();
-    if (pmids.length === 0) {
-      makeToast('No publications to refresh', 'Info', 'info');
-      return;
-    }
-    const data = await api.submitPublicationRefresh({ pmids });
+    // Server enumerates the full corpus (no client-side PMID fetch).
+    const data = await api.submitPublicationRefresh({ all: true });
     if (data.error) {
       toastFail(data.message || 'Failed to start refresh');
+      return;
+    }
+    if (data.count === 0) {
+      makeToast(data.message || 'No publications to refresh', 'Info', 'info');
       return;
     }
     if (data.status === 'already_running') {


### PR DESCRIPTION
Part of the admin-views enhancement program (>9/10). Backlog ref: \`.planning/admin-views-audit-2026-06-14.md\` — "server-side 'refresh all' sentinel so useAnnotationsApi.fetchAllPublicationPmids no longer pulls the whole corpus to the client" (item 5-backend).

## What

`POST /api/admin/publications/refresh` gains a third mode: **`all: true`** refreshes the entire publication corpus, enumerated **server-side** (`SELECT publication_id FROM publication`). Previously the frontend's "Refresh all publications" pulled every PMID to the client (`fetchAllPublicationPmids` paginating `/api/publication`) and posted them back.

- Backend (`admin_endpoints.R`): extract `refresh_all <- isTRUE(body$all)`; when set and no explicit pmids, enumerate server-side. An empty request **still 400s** — full-corpus refresh requires the explicit flag (safety guard preserved). Worker behaviour is unchanged (it receives the same PMID list, just built server-side).
- Frontend: `onRefreshAllPublications` now posts `{ all: true }`; the client-side `fetchAllPublicationPmids()` is **removed** from `useAnnotationsApi`.

## File-size ratchet

`admin_endpoints.R` was exactly at its 1084-line baseline, so the handler growth is offset by tightening the endpoint docstring to a concise three-mode summary: **1084 → 1081**. `make code-quality-audit` clean.

## Verification

- Live (dev API restarted): empty body `{}` → **400** and bad date → **400** (guards intact); the underlying `SELECT … FROM publication` returns **4689** rows.
- `all=true` was **not** triggered live — it would start a real 4689-PMID PubMed refresh job on dev. The enumeration reuses the already-proven `not_updated_since` server-side path (identical mechanism), and the guard logic is verified.
- `type-check` ✓ · `type-check:strict` ✓ · `eslint` ✓ · `vitest run` (227 files / 1556) ✓ · `make code-quality-audit` ✓ · R `lintr` clean.