### PR TITLE
chore(release): v0.23.0 — admin-views UX hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.23.0] — 2026-06-14
+
+Minor release: Administrator-views UX hardening and maintainability (audit follow-through to >9/10).
+
+### Added
+
+- **Per-view document titles** on the Administrator views (ManageUser/Ontology/Annotations/About/Backups/Pubtator/LLM/NDDScore/Metadata/AdminStatistics), via `useHead` — they previously rendered the generic "SysNDD |". Renders e.g. "Manage Users | SysNDD …".
+- **Confirmation modals** replace native browser dialogs in the app's modal language: a `SavePresetModal` for naming a filter preset (was `window.prompt()` in ManageUser), a reusable `ConfirmActionModal` for the large-log-export gate (was `window.confirm()` in the logs table), and a confirmation gate (`useConfirmGate`) before the four heavy/irreversible ManageAnnotations operations (ontology update, force-apply, comparisons refresh, refresh-all).
+- **Server-side "refresh all" for publications** — `POST /api/admin/publications/refresh` accepts `all=true` to enumerate the whole corpus server-side; the client no longer pulls every PMID. An empty request still 400s (safety guard).
+
+### Changed
+
+- **Gemini cost estimate is no longer hardcoded.** The LLM-admin cache cost estimate is centralized in the model catalog (`llm_model_pricing()` with per-model `price_input/output_per_million`) and keyed off the active model (`get_default_gemini_model()`), removing the stale "Gemini 2.0 Flash" rate.
+
+### Internal
+
+- **`TablesLogs.vue` split** (1160 → 378 lines) into a `useLogTable` composable + `LogFilterToolbar` child + `logTableConfig`; file-size baseline ratcheted down.
+- Job-status watchers in ManageAnnotations extracted to `useAnnotationJobReactions`; preset state moved into `useUserData` — both to keep oversized SFCs under the file-size baseline while adding behaviour.
+- Documented that a durable HTTP job-cancel route is absent (the service layer supports cancellation but no endpoint exposes it) — recorded as a future change.
+
 ## [0.22.0] — 2026-06-14
 
 Minor release: PubTatorNDD performance, stability, and automatic nightly updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Minor release: Administrator-views UX hardening and maintainability (audit follo
 
 - **Gemini cost estimate is no longer hardcoded.** The LLM-admin cache cost estimate is centralized in the model catalog (`llm_model_pricing()` with per-model `price_input/output_per_million`) and keyed off the active model (`get_default_gemini_model()`), removing the stale "Gemini 2.0 Flash" rate.
 
+### Fixed
+
+- **Developer-reference version display** (`/API`) rendered the API and Database versions as raw Plumber 1-element arrays (`v[ "0.22.0" ]`) with a stray `[ "unknown" ]` commit badge (the badge guard `!== 'unknown'` never matched the array). The `/api/version` client now unwraps the array-wrapped scalars, so the versions render as plain `v0.22.0` / `v1.0.0` with the commit badge correctly hidden when unknown.
+
 ### Internal
 
 - **`TablesLogs.vue` split** (1160 → 378 lines) into a `useLogTable` composable + `LogFilterToolbar` child + `logTableConfig`; file-size baseline ratcheted down.

--- a/api/version_spec.json
+++ b/api/version_spec.json
@@ -1,7 +1,7 @@
 {
   "title": "SysNDD API",
   "description": "This is the API powering the SysNDD website, allowing programmatic access to the database contents.",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "contact": {
     "name": "API Support",
     "url": "https://berntpopp.github.io/sysndd/api.html",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/app/src/api/version.spec.ts
+++ b/app/src/api/version.spec.ts
@@ -60,6 +60,37 @@ describe('api/version — getVersion', () => {
     expect(result.database).toBeUndefined();
   });
 
+  it('unwraps Plumber 1-element-array scalars (real /api/version shape)', async () => {
+    // The live endpoint (@serializer json, no unboxedJSON) wraps every scalar
+    // in a 1-element array. getVersion() must unwrap so the UI shows "0.22.0"
+    // and the commit-badge guard (`!== 'unknown'`) works.
+    server.use(
+      http.get('/api/version', () =>
+        HttpResponse.json({
+          version: ['0.23.0'],
+          commit: ['unknown'],
+          title: ['SysNDD API'],
+          description: ['desc'],
+          database: {
+            version: ['1.0.0'],
+            commit: ['unknown'],
+            description: ['Initial tracked SysNDD database version (issue #22).'],
+            updated_at: ['2026-06-11 16:23:27'],
+            available: [true],
+          },
+        })
+      )
+    );
+
+    const result = await getVersion();
+    expect(result.version).toBe('0.23.0');
+    expect(result.commit).toBe('unknown');
+    expect(result.title).toBe('SysNDD API');
+    expect(result.database?.version).toBe('1.0.0');
+    expect(result.database?.commit).toBe('unknown');
+    expect(result.database?.available).toBe(true);
+  });
+
   it('throws AxiosError on 500', async () => {
     server.use(
       http.get('/api/version', () => HttpResponse.json({ error: 'boom' }, { status: 500 }))

--- a/app/src/api/version.ts
+++ b/app/src/api/version.ts
@@ -39,11 +39,12 @@ export interface DbVersion {
  * and resolves the git commit hash from `GIT_COMMIT` env var or `git rev-parse`.
  * `commit` falls back to the literal string `"unknown"` if both sources fail.
  *
- * `@serializer json` (no `unboxedJSON`), but the response is a flat list with
- * scalar values that R/Plumber emits as 1-element arrays for plumber's
- * default JSON path; this happens to flatten cleanly to plain strings here
- * because `list()` of named scalars round-trips as `{ key: value }`. Confirmed
- * by inspecting the live response — no `unwrapScalar` needed.
+ * `@serializer json` (no `unboxedJSON`), so R/Plumber emits every scalar as a
+ * 1-element array (`version: ["0.22.0"]`, `commit: ["unknown"]`, and likewise
+ * for the `database` block). `getVersion()` unwraps these to plain scalars so
+ * callers (AppVersionInfo) render `0.22.0` / `unknown` rather than the raw
+ * `["0.22.0"]` / `["unknown"]` (the latter also broke the commit-badge guard,
+ * since `["unknown"] !== "unknown"`).
  *
  * `database` is the issue #22 DB-version block. It is optional in the type so
  * older fixtures and any pre-#22 API still type-check.
@@ -60,13 +61,56 @@ export interface ApiVersion {
 // Helpers
 // ---------------------------------------------------------------------------
 
+// Plumber emits scalars as 1-element arrays on this endpoint; values may also
+// already be plain scalars (test fixtures / a future unboxed serializer), so
+// accept both shapes.
+type MaybeArray<T> = T | T[];
+
+interface RawDbVersion {
+  version?: MaybeArray<string>;
+  commit?: MaybeArray<string>;
+  description?: MaybeArray<string | null>;
+  updated_at?: MaybeArray<string | null>;
+  available?: MaybeArray<boolean>;
+}
+
+interface RawApiVersion {
+  version?: MaybeArray<string>;
+  commit?: MaybeArray<string>;
+  title?: MaybeArray<string>;
+  description?: MaybeArray<string>;
+  database?: RawDbVersion;
+}
+
+function unwrap<T>(value: MaybeArray<T> | null | undefined): T | undefined {
+  if (value == null) return undefined;
+  return Array.isArray(value) ? value[0] : value;
+}
+
 /**
  * GET /api/version
  * Mirrors api/endpoints/version_endpoints.R:16 (handler `@get /`).
  *
- * Public — no auth filter. Throws AxiosError on non-2xx (5xx is the only
- * realistic failure mode for this endpoint).
+ * Public — no auth filter. Unwraps Plumber's 1-element-array scalars. Throws
+ * AxiosError on non-2xx (5xx is the only realistic failure mode here).
  */
 export async function getVersion(config?: AxiosRequestConfig): Promise<ApiVersion> {
-  return apiClient.get<ApiVersion>('/api/version', config);
+  const raw = await apiClient.get<RawApiVersion>('/api/version', config);
+  const result: ApiVersion = {
+    version: unwrap(raw.version) ?? 'unknown',
+    commit: unwrap(raw.commit) ?? 'unknown',
+    title: unwrap(raw.title) ?? '',
+    description: unwrap(raw.description) ?? '',
+  };
+  if (raw.database) {
+    const db = raw.database;
+    result.database = {
+      version: unwrap(db.version) ?? 'unknown',
+      commit: unwrap(db.commit) ?? 'unknown',
+      description: unwrap(db.description) ?? null,
+      updated_at: unwrap(db.updated_at) ?? null,
+      available: unwrap(db.available) ?? false,
+    };
+  }
+  return result;
 }


### PR DESCRIPTION
Release bump for the Administrator-views enhancement program (PRs #431–#435).

Bumps `app/package.json` + `api/version_spec.json` to 0.23.0 and adds the `[0.23.0]` CHANGELOG section.

**Included since 0.22.0:** per-view admin titles; native dialogs → app modals (`SavePresetModal`, `ConfirmActionModal`, `useConfirmGate`); `TablesLogs.vue` split (1160→378) into `useLogTable` + `LogFilterToolbar`; centralized Gemini cost pricing keyed off the active model; server-side `all=true` publication-refresh sentinel; documented absence of a durable job-cancel route.