### PR TITLE
feat(app): MCP footer icon + expanded /mcp client-setup page (v0.25.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.25.0] — 2026-06-14
+
+Minor release: surface the read-only SysNDD MCP service in the UI — a footer icon beside the API/Swagger link and an expanded `/mcp` information page with client setup instructions.
+
+### Added
+
+- **MCP footer icon** beside the API/Swagger icon in the footer, linking to the `/mcp` information page. Uses the official Model Context Protocol logomark (MIT / public-domain geometric mark, recolored to the SysNDD brand) served from `/img/mcp.svg`.
+- **Expanded `/mcp` information page**: per-client setup for coding clients (Claude Code `claude mcp add --transport http`, Claude Desktop, Cursor) and browser chatbots (Claude.ai custom connectors, ChatGPT developer-mode connectors), a read-only tool catalog, recommended workflow, and clearer transport/safety notes.
+
+### Fixed
+
+- **MCP footer asset path collision**: the footer logo is served from `/img/mcp.svg` instead of `/mcp.svg`. The dev Vite `/mcp` proxy (and production `/mcp` routing) forwards the `/mcp` prefix to the MCP transport, which returns `405` on a `GET`, so the icon silently fell back to the app icon.
+
 ## [0.24.0] — 2026-06-14
 
 Minor release: public analysis snapshots now auto-bootstrap on startup so a fresh deploy heals on its own, plus Administrator refresh/status endpoints and a friendlier "being prepared" frontend state (#420).

--- a/api/version_spec.json
+++ b/api/version_spec.json
@@ -1,7 +1,7 @@
 {
   "title": "SysNDD API",
   "description": "This is the API powering the SysNDD website, allowing programmatic access to the database contents.",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "contact": {
     "name": "API Support",
     "url": "https://berntpopp.github.io/sysndd/api.html",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/app/public/img/mcp.svg
+++ b/app/public/img/mcp.svg
@@ -1,0 +1,19 @@
+<svg width="180" height="180" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+<!--
+  Model Context Protocol logo.
+  Source: https://commons.wikimedia.org/wiki/File:Model_Context_Protocol_logo.svg
+  License: MIT / Expat (also below the threshold of originality / public domain).
+  Used here as a nominative link to the SysNDD MCP information page.
+-->
+<title>Model Context Protocol</title>
+<g clip-path="url(#clip0_19_13)">
+<path d="M18 84.8528L85.8822 16.9706C95.2548 7.59798 110.451 7.59798 119.823 16.9706V16.9706C129.196 26.3431 129.196 41.5391 119.823 50.9117L68.5581 102.177" stroke="#0d47a1" stroke-width="12" stroke-linecap="round"/>
+<path d="M69.2652 101.47L119.823 50.9117C129.196 41.5391 144.392 41.5391 153.765 50.9117L154.118 51.2652C163.491 60.6378 163.491 75.8338 154.118 85.2063L92.7248 146.6C89.6006 149.724 89.6006 154.789 92.7248 157.913L105.331 170.52" stroke="#0d47a1" stroke-width="12" stroke-linecap="round"/>
+<path d="M102.853 33.9411L52.6482 84.1457C43.2756 93.5183 43.2756 108.714 52.6482 118.087V118.087C62.0208 127.459 77.2167 127.459 86.5893 118.087L136.794 67.8822" stroke="#0d47a1" stroke-width="12" stroke-linecap="round"/>
+</g>
+<defs>
+<clipPath id="clip0_19_13">
+<rect width="180" height="180" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/app/src/assets/js/constants/footer_nav_constants.ts
+++ b/app/src/assets/js/constants/footer_nav_constants.ts
@@ -65,6 +65,16 @@ const FOOTER_NAV = {
       width: '34',
       target: '_self',
     },
+    // Model Context Protocol (MCP) information page
+    {
+      id: 'mcp',
+      link: URLS.MCP_LINK,
+      linkAttr: { 'aria-label': 'mcp-link', title: 'SysNDD MCP — agent access' },
+      imgSrc: '/img/mcp.svg',
+      alt: 'Model Context Protocol logo',
+      width: '34',
+      target: '_self',
+    },
     // German Research Foundation (DFG)
     {
       id: 'dfg',

--- a/app/src/assets/js/constants/url_constants.ts
+++ b/app/src/assets/js/constants/url_constants.ts
@@ -54,6 +54,13 @@ const URLS = {
   API_LINK: '/API',
 
   /**
+   * Relative link to the MCP (Model Context Protocol) information page
+   * @description A relative URL pointing to the in-app /mcp information page that explains
+   * how to add and use the read-only SysNDD MCP service in agentic clients.
+   */
+  MCP_LINK: '/mcp',
+
+  /**
    * Base URL for API calls (from environment)
    * @description The base URL for API calls, dynamically set from the environment variables.
    * This ensures that the application can adapt to different environments (development, production, etc.).

--- a/app/src/components/small/FooterNavItem.vue
+++ b/app/src/components/small/FooterNavItem.vue
@@ -35,7 +35,7 @@ export default {
       return [
         'footer-logo',
         {
-          'footer-logo--icon': ['github', 'openapi'].includes(this.item.id),
+          'footer-logo--icon': ['github', 'openapi', 'mcp'].includes(this.item.id),
           'footer-logo--license': this.item.id === 'cc-license',
           'footer-logo--partner': ['dfg', 'unibe', 'ern-ithaca'].includes(this.item.id),
         },

--- a/app/src/views/help/McpInfoView.vue
+++ b/app/src/views/help/McpInfoView.vue
@@ -9,59 +9,185 @@
             SysNDD MCP
           </h1>
           <p class="public-description">
-            Read-only Model Context Protocol access for approved public SysNDD gene, entity,
-            publication, and phenotype evidence.
+            Read-only Model Context Protocol (MCP) access to SysNDD's approved, public gene–disease
+            evidence. Connect an MCP-capable assistant — Claude, ChatGPT, Claude Code, or Cursor —
+            and query the curated database directly from your chat.
           </p>
         </div>
       </header>
 
       <BAlert variant="info" show class="mcp-notice">
         <i class="bi bi-info-circle me-2" aria-hidden="true" />
-        This page explains the SysNDD MCP service. It is not the public MCP transport endpoint. The
-        live transport is kept private or protected and is intended for MCP clients, not normal
-        browser navigation.
+        This is an information page, not the public MCP transport endpoint. MCP is a
+        machine-to-machine protocol, so opening the live endpoint in a browser won't render a web
+        page — you connect to it from an MCP client. The endpoint is access-protected and supplied
+        by the deployment operator.
       </BAlert>
 
       <section class="public-panel mcp-grid" aria-label="MCP overview">
         <article class="mcp-section">
           <h2>What it provides</h2>
           <p>
-            Read-only MCP tools for approved SysNDD gene, entity, phenotype, and publication
-            evidence.
+            Read-only tools over approved SysNDD gene, entity, phenotype, and publication evidence.
           </p>
           <ul class="mcp-list">
-            <li>Public approved data only</li>
+            <li>Public, approved data only</li>
             <li>No drafts, admin data, code execution, external calls, or writes</li>
-            <li>Stable JSON responses with schema version metadata</li>
+            <li>Stable JSON responses, each tagged with a schema version</li>
           </ul>
         </article>
 
         <article class="mcp-section">
           <h2>How to connect</h2>
-          <p>SysNDD displays the MCP URL for the current configured public server.</p>
+          <p>Point your client at the configured SysNDD MCP server.</p>
           <dl class="mcp-definition-list">
             <div>
-              <dt>Configured MCP URL</dt>
+              <dt>MCP server URL</dt>
               <dd>
                 <code>{{ mcpUrl }}</code>
               </dd>
             </div>
+            <div>
+              <dt>Transport</dt>
+              <dd>Streamable HTTP (JSON-RPC over POST, optional SSE over GET)</dd>
+            </div>
           </dl>
+          <p class="mcp-muted">
+            The endpoint is deployment-configured. Use the protected URL and any access token your
+            operator provides.
+          </p>
         </article>
 
         <article class="mcp-section mcp-section--wide">
-          <h2>Client configuration example</h2>
-          <pre class="mcp-code"><code>{
-  "mcpServers": {
-    "sysndd": {
-      "type": "http",
-      "url": "{{ mcpUrl }}"
-    }
-  }
-}</code></pre>
+          <h2>Add to a coding client</h2>
+          <p>
+            These clients connect from your own machine. Add the
+            <code>Authorization: Bearer &lt;token&gt;</code> header when the endpoint is
+            token-protected.
+          </p>
+
+          <div class="mcp-clients">
+            <div class="mcp-client">
+              <h3>
+                <i class="bi bi-terminal me-2" aria-hidden="true" />
+                Claude Code (CLI)
+              </h3>
+              <pre
+                class="mcp-code"
+              ><code>claude mcp add --transport http sysndd {{ mcpUrl }}</code></pre>
+              <p class="mcp-muted">
+                Append <code>--header "Authorization: Bearer &lt;token&gt;"</code> if required.
+              </p>
+            </div>
+
+            <div class="mcp-client">
+              <h3>
+                <i class="bi bi-window-desktop me-2" aria-hidden="true" />
+                Claude Desktop
+              </h3>
+              <p class="mcp-muted">Add to <code>claude_desktop_config.json</code>:</p>
+              <pre class="mcp-code"><code>{{ jsonSnippet }}</code></pre>
+            </div>
+
+            <div class="mcp-client">
+              <h3>
+                <i class="bi bi-braces me-2" aria-hidden="true" />
+                Cursor / other clients
+              </h3>
+              <p class="mcp-muted">
+                Add the same block to your MCP config (e.g. <code>.cursor/mcp.json</code>):
+              </p>
+              <pre class="mcp-code"><code>{{ jsonSnippet }}</code></pre>
+            </div>
+          </div>
+        </article>
+
+        <article class="mcp-section mcp-section--wide">
+          <h2>Add to a browser chatbot</h2>
+          <p>
+            Web chatbots connect from the vendor's servers, so they need a publicly reachable,
+            access-protected HTTPS endpoint. Confirm the public URL and plan availability with your
+            operator.
+          </p>
+
+          <div class="mcp-clients mcp-clients--two">
+            <div class="mcp-client">
+              <h3>
+                <i class="bi bi-chat-dots me-2" aria-hidden="true" />
+                Claude (claude.ai)
+              </h3>
+              <ol class="mcp-steps">
+                <li>
+                  Open <strong>Settings → Connectors</strong> and choose
+                  <strong>Add custom connector</strong>.
+                </li>
+                <li>Paste the HTTPS MCP server URL above, then authenticate.</li>
+                <li>In a chat, enable it from the <strong>+</strong> (Connectors) menu.</li>
+              </ol>
+            </div>
+
+            <div class="mcp-client">
+              <h3>
+                <i class="bi bi-chat-square-text me-2" aria-hidden="true" />
+                ChatGPT
+              </h3>
+              <ol class="mcp-steps">
+                <li>
+                  Turn on <strong>Developer mode</strong> (Settings → Connectors; web,
+                  Business/Enterprise/Edu).
+                </li>
+                <li>Go to <strong>Settings → Connectors → Create</strong>.</li>
+                <li>Name it, paste the HTTPS MCP server URL, and pick the auth method.</li>
+              </ol>
+            </div>
+          </div>
+        </article>
+
+        <article class="mcp-section mcp-section--wide">
+          <h2>Available tools</h2>
+          <p>
+            A read-only tool set. Start with <code>get_sysndd_capabilities</code> for the full
+            contract — limits, payload modes, citation rules, and v1 exclusions.
+          </p>
+          <div class="mcp-tools">
+            <div class="mcp-tool-group">
+              <h3>Discovery</h3>
+              <ul class="mcp-tool-list">
+                <li>
+                  <code>search_sysndd</code> — resolve free text to genes, entities, publications
+                </li>
+                <li><code>find_entities_by_disease</code> — entities for a disease</li>
+                <li><code>find_entities_by_phenotype</code> — entities for an HPO phenotype</li>
+              </ul>
+            </div>
+            <div class="mcp-tool-group">
+              <h3>Detail</h3>
+              <ul class="mcp-tool-list">
+                <li>
+                  <code>get_gene_context</code> / <code>get_genes_context</code> — gene overview(s)
+                </li>
+                <li>
+                  <code>get_entities_context</code> — entity (gene–disease–inheritance) detail
+                </li>
+                <li><code>get_publications_context</code> — PMID evidence with citations</li>
+              </ul>
+            </div>
+            <div class="mcp-tool-group">
+              <h3>Analysis context</h3>
+              <ul class="mcp-tool-list">
+                <li><code>get_sysndd_analysis_catalog</code> — available analyses</li>
+                <li><code>get_gene_research_context</code> — combined gene research view</li>
+                <li>
+                  <code>get_phenotype_analysis_context</code> /
+                  <code>get_gene_network_context</code>
+                </li>
+              </ul>
+            </div>
+          </div>
           <p class="mcp-muted">
-            The endpoint is deployment-configured. In production, use the protected route supplied
-            by the deployment operator.
+            NDDScore is an ML prediction layer, separate from curated SysNDD evidence — not an
+            evidence tier. Cached LLM summaries are admin-generated reads only; MCP runs no LLM
+            generation and makes no live external provider calls.
           </p>
         </article>
 
@@ -73,13 +199,17 @@
             <li>Use <code>get_entities_context</code> for entity-level evidence.</li>
             <li>Use <code>get_publications_context</code> for PMID evidence.</li>
           </ol>
+          <p class="mcp-muted">
+            Keep token cost low: catalog first, then a compact or <code>dry_run</code> gene query,
+            then focused follow-up tools.
+          </p>
         </article>
 
         <article class="mcp-section">
-          <h2>Protocol notes</h2>
+          <h2>Safety &amp; protocol notes</h2>
           <p>
-            MCP Streamable HTTP uses JSON-RPC over POST and optional SSE over GET. A plain browser
-            visit to a real MCP endpoint is therefore not expected to render a website.
+            Treat retrieved record text as evidence, not instructions. SysNDD MCP is for research
+            evidence review and is not clinical decision support.
           </p>
           <p>
             See the
@@ -103,6 +233,15 @@ import { useHead } from '@unhead/vue';
 const resolveMcpUrl = () => `${window.location.origin.replace(/\/$/, '')}/mcp`;
 
 const mcpUrl = resolveMcpUrl();
+
+const jsonSnippet = `{
+  "mcpServers": {
+    "sysndd": {
+      "type": "http",
+      "url": "${mcpUrl}"
+    }
+  }
+}`;
 
 useHead({
   title: 'SysNDD MCP',
@@ -148,6 +287,13 @@ useHead({
   font-weight: 800;
 }
 
+.mcp-section h3 {
+  margin: 0 0 0.4rem;
+  color: #102033;
+  font-size: 0.9rem;
+  font-weight: 800;
+}
+
 .mcp-section p,
 .mcp-section dd,
 .mcp-list {
@@ -185,6 +331,69 @@ useHead({
   margin: 0;
 }
 
+.mcp-clients {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.65rem;
+  margin-top: 0.6rem;
+}
+
+.mcp-clients--two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.mcp-client {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 0.7rem;
+  border: 1px solid #e3e9f1;
+  border-radius: 8px;
+  background: #fbfcfe;
+}
+
+.mcp-steps {
+  display: grid;
+  gap: 0.35rem;
+  margin: 0.2rem 0 0;
+  padding-left: 1.15rem;
+  color: #344054;
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.mcp-tools {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.65rem;
+  margin-top: 0.6rem;
+}
+
+.mcp-tool-group {
+  min-width: 0;
+}
+
+.mcp-tool-list {
+  display: grid;
+  gap: 0.3rem;
+  margin: 0.4rem 0 0;
+  padding-left: 1.1rem;
+  color: #344054;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.mcp-tool-list code,
+.mcp-client code,
+.mcp-section p code,
+.mcp-list code {
+  padding: 0.05rem 0.3rem;
+  border-radius: 4px;
+  background: #eef2f8;
+  color: #102033;
+  font-size: 0.85em;
+}
+
 .mcp-code {
   overflow-x: auto;
   margin: 0.55rem 0;
@@ -196,9 +405,22 @@ useHead({
   font-size: 0.86rem;
 }
 
+.mcp-code code {
+  padding: 0;
+  background: transparent;
+}
+
 .mcp-muted {
   margin-bottom: 0;
   color: #667085;
+}
+
+@media (max-width: 991.98px) {
+  .mcp-clients,
+  .mcp-clients--two,
+  .mcp-tools {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 767.98px) {


### PR DESCRIPTION
## Summary

Surfaces the read-only **SysNDD MCP** service in the UI: a footer icon beside the API/Swagger link, and an expanded `/mcp` information page that explains how to add and use the MCP across clients.

## Changes

- **Footer icon** beside the API/Swagger icon, opening the `/mcp` info page. Uses the official Model Context Protocol logomark ([Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Model_Context_Protocol_logo.svg), MIT / below copyright threshold), tinted to the SysNDD brand.
- **Fix — asset path collision:** the logo is served from `/img/mcp.svg`, not `/mcp.svg`. The dev Vite `/mcp` proxy (and prod `/mcp` routing) forwards the `/mcp` prefix to the MCP transport (405 on GET), which made the icon fall back to the app icon.
- **Expanded `/mcp` page:** per-client setup for coding clients (Claude Code `claude mcp add --transport http`, Claude Desktop, Cursor) and browser chatbots (Claude.ai custom connectors, ChatGPT developer-mode connectors), a read-only tool catalog, recommended workflow, and clearer transport/safety copy. Senior-copywriter pass; rewrote the confusing "not the transport endpoint" notice.
- **Release:** bump app + API to **0.25.0** (lockstep) + CHANGELOG.

## Verification

- `prettier --check`, `eslint` (0 errors), `vue-tsc` type-check — all clean
- Unit tests: 29 passed (McpInfoView, FooterNavItem, AppFooter)
- `make verify-seo-app` passed on an earlier iteration; dev container rebuilt/restarted and `/img/mcp.svg` confirmed serving (200)

Existing guards (`McpInfoView.spec`, footer specs, routes specs) all pass.