### PR TITLE
fix(app): cluster selection string-vs-number type mismatch (closes #441)

### DIFF
--- a/app/src/components/analyses/AnalyseGeneClusters.spec.ts
+++ b/app/src/components/analyses/AnalyseGeneClusters.spec.ts
@@ -289,4 +289,40 @@ describe('AnalyseGeneClusters', () => {
 
     expect(wrapper.vm.currentSummary).toEqual(clusterTwoSummary);
   });
+
+  // Regression (#441): the snapshot-backed functional_clustering endpoint
+  // serialises `cluster` as a string ("1"), while NetworkVisualization emits
+  // numeric cluster ids ([1]). The selection lookups must coerce both sides,
+  // otherwise `"1" === 1` is false -> no summary fetch and an empty table.
+  it('resolves the summary and table when the API returns cluster as a string and selection is numeric', async () => {
+    mocks.getFunctionalClusterSummary.mockResolvedValue({
+      summary_json: { summary: 'Cluster 1 summary' },
+      model_name: 'gemini-test',
+      created_at: '2026-05-15T00:00:00Z',
+      validation_status: 'approved',
+    });
+
+    const wrapper = mountComponent();
+    wrapper.vm.loading = false;
+    wrapper.vm.itemsCluster = [
+      {
+        cluster: '1', // API/snapshot serialises cluster as a STRING
+        cluster_size: 10,
+        hash_filter: 'equals(hash,one)',
+        term_enrichment: [{ term: 'GO:1' }],
+        identifiers: [{ symbol: 'AAA' }],
+      },
+    ];
+
+    wrapper.vm.handleClustersChanged([1], false); // NetworkVisualization emits a NUMBER
+    await flushPromises();
+
+    expect(mocks.getFunctionalClusterSummary).toHaveBeenCalledWith({
+      cluster_hash: 'equals(hash,one)',
+      cluster_number: '1',
+    });
+    expect(wrapper.vm.currentSummary).not.toBeNull();
+    // Focused table resolves to the selected cluster's rows (not empty).
+    expect((wrapper.vm.selectedCluster.term_enrichment || []).length).toBeGreaterThan(0);
+  });
 });

--- a/app/src/components/analyses/AnalyseGeneClusters.vue
+++ b/app/src/components/analyses/AnalyseGeneClusters.vue
@@ -786,7 +786,9 @@ export default {
         return;
       }
 
-      const match = this.itemsCluster.find((item) => item.cluster === this.activeParentCluster);
+      const match = this.itemsCluster.find(
+        (item) => Number(item.cluster) === Number(this.activeParentCluster)
+      );
       const clusterNum = this.activeParentCluster;
 
       // Add cluster_num to each row for consistent display
@@ -982,7 +984,9 @@ export default {
         this.activeParentCluster = clusters[0];
         this.setActiveCluster();
         // Fetch LLM summary for this cluster
-        const clusterData = this.itemsCluster.find((item) => item.cluster === clusters[0]);
+        const clusterData = this.itemsCluster.find(
+          (item) => Number(item.cluster) === Number(clusters[0])
+        );
         if (clusterData?.hash_filter) {
           this.fetchClusterSummary(clusterData.hash_filter, clusters[0]);
         } else {
@@ -990,8 +994,9 @@ export default {
         }
       } else {
         // Multiple clusters selected - combine their data
+        const clusterNums = clusters.map(Number);
         const selectedClusterData = this.itemsCluster.filter((item) =>
-          clusters.includes(item.cluster)
+          clusterNums.includes(Number(item.cluster))
         );
         this.selectedCluster = this.combineClusterData(selectedClusterData);
         // Clear summary when showing multiple clusters

--- a/app/src/components/analyses/AnalysesPhenotypeClusters.vue
+++ b/app/src/components/analyses/AnalysesPhenotypeClusters.vue
@@ -429,7 +429,9 @@ export default {
         this.cytoscape.selectCluster(newCluster);
       }
       // Fetch LLM summary for the selected cluster
-      const clusterData = this.itemsCluster.find((item) => item.cluster === newCluster);
+      const clusterData = this.itemsCluster.find(
+        (item) => Number(item.cluster) === Number(newCluster)
+      );
       if (clusterData?.hash_filter) {
         this.fetchClusterSummary(clusterData.hash_filter, newCluster);
       } else {
@@ -459,7 +461,9 @@ export default {
         this.itemsCluster = data.clusters;
         this.setActiveCluster();
         // Fetch LLM summary for initial cluster
-        const clusterData = this.itemsCluster.find((item) => item.cluster === this.activeCluster);
+        const clusterData = this.itemsCluster.find(
+          (item) => Number(item.cluster) === Number(this.activeCluster)
+        );
         if (clusterData?.hash_filter) {
           this.fetchClusterSummary(clusterData.hash_filter, this.activeCluster);
         }
@@ -487,7 +491,9 @@ export default {
     },
     setActiveCluster() {
       // Filter out the cluster matching activeCluster
-      const match = this.itemsCluster.find((item) => item.cluster === this.activeCluster);
+      const match = this.itemsCluster.find(
+        (item) => Number(item.cluster) === Number(this.activeCluster)
+      );
       this.selectedCluster = match || {
         quali_inp_var: [],
         quali_sup_var: [],

--- a/scripts/code-quality-file-size-baseline.tsv
+++ b/scripts/code-quality-file-size-baseline.tsv
@@ -20,9 +20,9 @@ api/functions/nddscore-import.R	854
 api/functions/omim-functions.R	971
 api/services/entity-service.R	1063
 api/services/re-review-service.R	929
-app/src/components/analyses/AnalyseGeneClusters.vue	1206
+app/src/components/analyses/AnalyseGeneClusters.vue	1211
 app/src/components/analyses/AnalysesCurationUpset.vue	713
-app/src/components/analyses/AnalysesPhenotypeClusters.vue	695
+app/src/components/analyses/AnalysesPhenotypeClusters.vue	701
 app/src/components/analyses/NetworkVisualization.vue	1268
 app/src/components/analyses/PublicationsNDDTable.vue	1011
 app/src/components/analyses/PubtatorNDDGenes.vue	900


### PR DESCRIPTION
## Problem

On `/GeneNetworks`, selecting a single functional cluster shows **neither the AI summary nor the focused enrichment table** (#441).

Root cause: the snapshot-backed `functional_clustering` endpoint serialises `cluster` as a **string** (`"1"`), but `NetworkVisualization` emits cluster ids as **numbers** (`[1]`). The selection lookups in `AnalyseGeneClusters.vue` used strict `===`:

- `handleClustersChanged`: `itemsCluster.find(i => i.cluster === clusters[0])` → `"1" === 1` → `false` → `clusterData` undefined → **summary fetch never fires**
- `setActiveCluster`: same mismatch → `match` undefined → **empty focused table**

Verified the backend is fine: `GET /api/analysis/functional_cluster_summary` returns 200 with validated, cached summaries. Reproduced live with Playwright: clicking "View cluster 1" logged `Clusters changed: [1]`, made **zero** follow-up API calls, and collapsed the table from 10 rows → 1.

## Fix

Coerce **both sides** with `Number()` in every cluster-id comparison (`find`/`filter`/`includes`) so the lookups work regardless of whether the API yields a string or a number. Applied to `AnalyseGeneClusters.vue` (the reported bug) and defensively to `AnalysesPhenotypeClusters.vue` (whose `handleClusterClick` assigns a raw cluster id without stringifying).

Adds a regression test: API returns `cluster: "1"` (string) while selection emits `[1]` (number) → summary is fetched and the focused table resolves.

## Scope note

The **phenotype** view's user-visible "no AI summary" is a **separate data issue** — its cluster summaries aren't generated yet, so `phenotype_cluster_summary` returns 404 ("Summary not yet available"). Its table works (string id path). That's handled operationally (regenerating the summaries), not by this PR. The phenotype change here is defensive hardening of the comparison only.

## Test

- `npx vitest run` on both cluster specs: green (incl. new regression test)
- `npx eslint` on both files: clean

Closes #441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)