### PR TITLE
fix(#440): self-healing snapshot builds + 'being prepared' UI state

### DIFF
--- a/api/services/analysis-snapshot-refresh-service.R
+++ b/api/services/analysis-snapshot-refresh-service.R
@@ -10,6 +10,15 @@
 # manifest probes from functions/analysis-snapshot-repository.R; all are loaded
 # into the global environment so they resolve at call time.
 
+#' Max attempts for a submitted `analysis_snapshot_refresh` job (#440).
+#'
+#' Heavy snapshot builds (especially `functional_clusters`' recursive STRING
+#' enrichment) can outrun their worker lease under startup contention. The
+#' stale-lease reaper (`async_job_repository_recover_stale`) requeues an expired
+#' lease while `attempt_count < max_attempts`, so > 1 makes the bootstrap
+#' self-healing instead of leaving a permanently-failed `LEASE_EXPIRED` snapshot.
+ANALYSIS_SNAPSHOT_REFRESH_MAX_ATTEMPTS <- 3L
+
 #' Whether the startup snapshot bootstrap is enabled.
 #'
 #' Config gate (issue #420), implemented as an env var to match the repo's
@@ -90,6 +99,7 @@ service_analysis_snapshot_submit_refresh <- function(analysis_type = NULL,
         request_payload = list(analysis_type = at, params = normalized$params),
         queue_name = "default",
         priority = 50L,
+        max_attempts = ANALYSIS_SNAPSHOT_REFRESH_MAX_ATTEMPTS,
         conn = conn
       ),
       error = function(e) list(.error = conditionMessage(e))

--- a/api/tests/testthat/test-unit-analysis-snapshot-bootstrap.R
+++ b/api/tests/testthat/test-unit-analysis-snapshot-bootstrap.R
@@ -53,6 +53,29 @@ test_that("force = TRUE submits every preset regardless of existence", {
   expect_equal(n, 5L)
 })
 
+test_that("submitted snapshot jobs are retryable so an expired lease self-heals (#440)", {
+  captured <- list()
+  fake_submit <- function(job_type, request_payload, ..., max_attempts = 1L) {
+    captured[[length(captured) + 1L]] <<- as.integer(max_attempts)
+    fake_job(paste0("job-", length(captured)))
+  }
+  fake_exists <- function(...) FALSE
+
+  service_analysis_snapshot_submit_refresh(
+    force = TRUE, submit_fn = fake_submit, exists_fn = fake_exists
+  )
+
+  # Every preset must be submitted with > 1 attempt; otherwise a lease that
+  # expires under contention is reaped to a permanent LEASE_EXPIRED failure.
+  expect_gt(ANALYSIS_SNAPSHOT_REFRESH_MAX_ATTEMPTS, 1L)
+  expect_true(length(captured) >= 1L)
+  expect_true(all(vapply(
+    captured,
+    function(x) identical(x, ANALYSIS_SNAPSHOT_REFRESH_MAX_ATTEMPTS),
+    logical(1)
+  )))
+})
+
 test_that("a single analysis_type targets just that preset", {
   fake_submit <- function(job_type, request_payload, ...) fake_job("job-1")
   fake_exists <- function(...) FALSE

--- a/app/src/api/analysis.spec.ts
+++ b/app/src/api/analysis.spec.ts
@@ -229,6 +229,12 @@ describe('isSnapshotPreparingError', () => {
   it('is true for a 503 snapshot_missing problem', () => {
     expect(isSnapshotPreparingError({ response: { status: 503, data: { code: 'snapshot_missing' } } })).toBe(true);
   });
+  it('is true when code is a 1-element array (R/Plumber scalar serialisation) (#440)', () => {
+    // The real API serialises the problem code as ["snapshot_missing"], not a
+    // bare string — the "being prepared" state must still trigger.
+    expect(isSnapshotPreparingError({ response: { status: 503, data: { code: ['snapshot_missing'] } } })).toBe(true);
+    expect(isSnapshotPreparingError({ response: { status: 503, data: { code: ['snapshot_stale'] } } })).toBe(true);
+  });
   it('is true for snapshot_stale and source_version_mismatch', () => {
     expect(isSnapshotPreparingError({ response: { status: 503, data: { code: 'snapshot_stale' } } })).toBe(true);
     expect(isSnapshotPreparingError({ response: { status: 503, data: { code: 'source_version_mismatch' } } })).toBe(true);

--- a/app/src/api/analysis.ts
+++ b/app/src/api/analysis.ts
@@ -38,9 +38,15 @@ export const SNAPSHOT_PREPARING_CODES = [
  * uses in `useNetworkData.ts`.
  */
 export function isSnapshotPreparingError(err: unknown): boolean {
-  const problem = (err as { response?: { status?: number; data?: { code?: string } } })?.response;
+  const problem = (err as { response?: { status?: number; data?: { code?: string | string[] } } })
+    ?.response;
   if (!problem || problem.status !== 503) return false;
-  const code = problem.data?.code;
+  // R/Plumber serialises a bare scalar as a 1-element array, so the problem
+  // `code` arrives as either "snapshot_missing" or ["snapshot_missing"] over
+  // the wire (see `unwrapScalar` in @/api/client). Accept both shapes so the
+  // "being prepared" state actually triggers against the real API (#440).
+  const raw = problem.data?.code;
+  const code = Array.isArray(raw) ? raw[0] : raw;
   return typeof code === 'string'
     && (SNAPSHOT_PREPARING_CODES as readonly string[]).includes(code);
 }

--- a/app/src/components/analyses/AnalyseGeneClusters.spec.ts
+++ b/app/src/components/analyses/AnalyseGeneClusters.spec.ts
@@ -31,10 +31,14 @@ vi.mock('@/api/jobs', () => ({
   getJobStatus: vi.fn(),
 }));
 
-vi.mock('@/api/analysis', () => ({
-  getFunctionalClustering: vi.fn(),
-  getFunctionalClusterSummary: mocks.getFunctionalClusterSummary,
-}));
+vi.mock('@/api/analysis', async () => {
+  const actual = await vi.importActual<typeof import('@/api/analysis')>('@/api/analysis');
+  return {
+    ...actual, // keep the real isSnapshotPreparingError so the preparing-state test is realistic
+    getFunctionalClustering: vi.fn(),
+    getFunctionalClusterSummary: mocks.getFunctionalClusterSummary,
+  };
+});
 
 const getFunctionalClusteringMock = vi.mocked(getFunctionalClustering);
 const submitClusteringMock = vi.mocked(submitClustering);
@@ -294,6 +298,22 @@ describe('AnalyseGeneClusters', () => {
   // serialises `cluster` as a string ("1"), while NetworkVisualization emits
   // numeric cluster ids ([1]). The selection lookups must coerce both sides,
   // otherwise `"1" === 1` is false -> no summary fetch and an empty table.
+  it('shows the "being prepared" state on a snapshot_missing 503 instead of an error toast (#440)', async () => {
+    getFunctionalClusteringMock.mockReset();
+    // Real API shape: 503 with the problem code as a 1-element array.
+    getFunctionalClusteringMock.mockRejectedValue({
+      response: { status: 503, data: { code: ['snapshot_missing'] } },
+    });
+
+    const wrapper = mountComponent();
+    await wrapper.vm.loadClusterData();
+    await flushPromises();
+
+    expect(wrapper.vm.isPreparing).toBe(true);
+    expect(wrapper.vm.loading).toBe(false);
+    expect(wrapper.text()).toContain('This analysis is being prepared');
+  });
+
   it('resolves the summary and table when the API returns cluster as a string and selection is numeric', async () => {
     mocks.getFunctionalClusterSummary.mockResolvedValue({
       summary_json: { summary: 'Cluster 1 summary' },

--- a/app/src/components/analyses/AnalyseGeneClusters.vue
+++ b/app/src/components/analyses/AnalyseGeneClusters.vue
@@ -155,6 +155,20 @@
                 :rows="6"
               />
 
+              <!-- Snapshot still building (503 snapshot_missing) — show a friendly
+                   "being prepared" state instead of a raw error toast (#440). -->
+              <div v-else-if="isPreparing" class="error-state text-center p-4">
+                <i class="bi bi-hourglass-split text-primary fs-1 mb-3 d-block" />
+                <p class="text-muted mb-3">
+                  This analysis is being prepared and will appear here shortly. This can take a
+                  couple of minutes after a deploy or data update.
+                </p>
+                <BButton variant="primary" @click="retryLoad">
+                  <i class="bi bi-arrow-clockwise me-1" />
+                  Check again
+                </BButton>
+              </div>
+
               <!-- GenericTable for main table content -->
               <GenericTable
                 v-else
@@ -379,7 +393,11 @@ import 'splitpanes/dist/splitpanes.css';
 import { getClusterColor } from '@/utils/clusterColors';
 
 // Typed API clients (W5)
-import { getFunctionalClustering, getFunctionalClusterSummary } from '@/api/analysis';
+import {
+  getFunctionalClustering,
+  getFunctionalClusterSummary,
+  isSnapshotPreparingError,
+} from '@/api/analysis';
 import { isApiError } from '@/api/client';
 import { filterFunctionalClusterRows, sortFunctionalClusterRows } from './functionalClusterTable';
 import {
@@ -505,6 +523,9 @@ export default {
       activeSubCluster: 1,
 
       loading: true,
+      // Snapshot still building (503 snapshot_missing) — render a friendly
+      // "being prepared" panel rather than a raw error toast (#440).
+      isPreparing: false,
       loadingStage: 'initializing', // 'initializing' | 'submitting' | 'processing' | 'loading_data'
       loadingProgress: 0,
       estimatedSeconds: 15,
@@ -732,6 +753,7 @@ export default {
     async loadClusterDataSync() {
       this.loadingStage = 'loading_data';
       this.loadingProgress = 50;
+      this.isPreparing = false;
 
       try {
         const data = await getFunctionalClustering({
@@ -749,10 +771,28 @@ export default {
           this.setActiveCluster();
         }
       } catch (e) {
-        this.makeToast(e, 'Error', 'danger');
+        // A snapshot "being prepared" 503 is a transient, expected state — show a
+        // friendly panel instead of a hard error toast (#440), mirroring the
+        // network graph (useNetworkData) and phenotype clusters views.
+        if (isSnapshotPreparingError(e)) {
+          this.isPreparing = true;
+        } else {
+          this.makeToast(e, 'Error', 'danger');
+        }
       } finally {
         this.loading = false;
       }
+    },
+
+    /**
+     * Retry loading the functional clustering snapshot after a "being prepared"
+     * 503. Re-arms the one-shot load guard so the user's "Check again" works.
+     */
+    retryLoad() {
+      this.isPreparing = false;
+      this.loading = true;
+      this.clusterTableLoadStarted = true;
+      this.loadClusterData();
     },
 
     /**

--- a/scripts/code-quality-file-size-baseline.tsv
+++ b/scripts/code-quality-file-size-baseline.tsv
@@ -20,7 +20,7 @@ api/functions/nddscore-import.R	854
 api/functions/omim-functions.R	971
 api/services/entity-service.R	1063
 api/services/re-review-service.R	929
-app/src/components/analyses/AnalyseGeneClusters.vue	1211
+app/src/components/analyses/AnalyseGeneClusters.vue	1251
 app/src/components/analyses/AnalysesCurationUpset.vue	713
 app/src/components/analyses/AnalysesPhenotypeClusters.vue	701
 app/src/components/analyses/NetworkVisualization.vue	1268


### PR DESCRIPTION
Fixes the durability problems behind #440 (the analysis-snapshot 503s that left GeneNetworks broken after a deploy).

## Backend — retryable snapshot jobs (the core fix)

Heavy snapshot builds — especially `functional_clusters`' recursive STRING enrichment — can outrun the worker run-lease (`ASYNC_JOB_RUN_LEASE_SECONDS`, default 900s) under startup contention. Snapshot jobs were submitted with `max_attempts = 1`, so the stale-lease reaper (`async_job_repository_recover_stale`) marked them **permanently `failed (LEASE_EXPIRED)`** with no retry — the snapshot never became `public_ready`.

The reaper **already** requeues an expired lease `WHEN attempt_count < max_attempts THEN 'queued'`; it just never fired because attempts were capped at 1. This PR submits snapshot refresh jobs with `max_attempts = 3` (`ANALYSIS_SNAPSHOT_REFRESH_MAX_ATTEMPTS`), making the bootstrap **self-healing**: a one-off lease overrun is requeued and succeeds once contention clears, instead of leaving a dead snapshot.

## Frontend — "analysis being prepared" state for functional clustering

A `snapshot_missing` 503 on `/GeneNetworks` surfaced as a raw `Request failed with status code 503` toast. This mirrors the existing network-graph (`useNetworkData`) and phenotype-clusters treatment: a friendly "being prepared / Check again" panel.

While wiring it I found a **latent bug**: `isSnapshotPreparingError` only accepted `code` as a bare string, but R/Plumber serialises the problem code as a **1-element array** (`["snapshot_missing"]`). So the guard never matched the real API response — meaning the network/phenotype "preparing" states were also silently inert. Hardened to accept both shapes.

## Tests
- `test-unit-analysis-snapshot-bootstrap.R`: asserts every preset is submitted with `max_attempts > 1`.
- `analysis.spec.ts`: `isSnapshotPreparingError` matches the `["snapshot_missing"]` array shape.
- `AnalyseGeneClusters.spec.ts`: renders the "being prepared" panel (not a toast) on a 503.
- Frontend `eslint` + `vitest` green locally.

## Deferred (tracked in #440)
- **Stagger the startup bootstrap** so the 5 snapshot presets + the PubTator nightly don't all contend at once. The retry above already makes the system self-heal; staggering reduces the contention at its source and is a safer, separate change.
- Heartbeating *inside* the memoised clustering loop (can't thread a progress callback through `memoise()` without polluting its cache key).

Related: #441/#442 (cluster selection), #443 (phenotype summary generation).