### PR TITLE
fix(#443): persist LLM judge verdict + reasoning on rejected cluster summaries

### DIFF
--- a/api/functions/llm-service.R
+++ b/api/functions/llm-service.R
@@ -167,6 +167,16 @@ get_or_generate_summary <- function(
       }
       summary_with_confidence$derived_confidence <- calculate_derived_confidence(confidence_data, cluster_type)
 
+      # Persist the LLM judge's verdict + reasoning on the rejected row so the
+      # rejection is debuggable (#443). Rejected summaries are never served by
+      # the public endpoint (get_cached_summary requires validation_status =
+      # 'validated'), so this is internal QA metadata embedded in summary_json
+      # rather than a schema change.
+      summary_with_confidence$validation <- list(
+        verdict = result$last_validation$verdict %||% NA_character_,
+        reasoning = result$last_validation$reasoning %||% NA_character_
+      )
+
       cache_id <- save_summary_to_cache(
         cluster_type = cluster_type,
         cluster_number = as.integer(cluster_number),
@@ -178,7 +188,7 @@ get_or_generate_summary <- function(
         validation_status = "rejected"
       )
 
-      log_warn("Saved rejected summary to cache (cache_id={cache_id})")
+      log_warn("Saved rejected summary to cache (cache_id={cache_id}, judge verdict={summary_with_confidence$validation$verdict})")
 
       return(list(
         success = FALSE,

--- a/api/functions/llm-service.R
+++ b/api/functions/llm-service.R
@@ -188,7 +188,7 @@ get_or_generate_summary <- function(
         validation_status = "rejected"
       )
 
-      log_warn("Saved rejected summary to cache (cache_id={cache_id}, judge verdict={summary_with_confidence$validation$verdict})")
+      log_warn("Saved rejected summary to cache (cache_id={cache_id}, verdict persisted)")
 
       return(list(
         success = FALSE,

--- a/api/tests/testthat/test-unit-llm-service-db-access.R
+++ b/api/tests/testthat/test-unit-llm-service-db-access.R
@@ -119,3 +119,51 @@ test_that("on-demand summary generation uses configured default Gemini model", {
   expect_true(result$success)
   expect_equal(captured_model, "gemini-test")
 })
+
+test_that("rejected summaries persist the judge verdict + reasoning for debugging (#443)", {
+  env <- source_llm_service_for_db_access_tests()
+  captured <- new.env()
+
+  env$generate_cluster_hash <- function(...) "reject-hash"
+  env$get_cached_summary <- function(...) NULL
+  env$generate_cluster_summary <- function(cluster_data, cluster_type, model, ...) {
+    list(
+      success = FALSE,
+      error = "validation failed",
+      last_result = list(summary = "Bad summary", tags = c("x")),
+      last_validation = list(
+        verdict = "reject",
+        reasoning = "Molecular terms not grounded in the input."
+      )
+    )
+  }
+  env$calculate_derived_confidence <- function(...) list(score = "low")
+  env$save_summary_to_cache <- function(cluster_type, cluster_number, cluster_hash,
+                                        model_name, prompt_version = "1.0",
+                                        summary_json = NULL, tags = NULL,
+                                        validation_status = "pending") {
+    captured$summary_json <- summary_json
+    captured$validation_status <- validation_status
+    456L
+  }
+
+  result <- env$get_or_generate_summary(
+    cluster_data = list(
+      identifiers = tibble::tibble(hgnc_id = c(1L, 2L)),
+      term_enrichment = tibble::tibble(),
+      cluster_number = 3L
+    ),
+    cluster_type = "functional"
+  )
+
+  expect_false(result$success)
+  expect_equal(result$validation_status, "rejected")
+  expect_equal(captured$validation_status, "rejected")
+  # The judge's reasoning is now embedded in the stored summary_json so a
+  # rejected cluster (which the public endpoint 404s) is debuggable.
+  expect_equal(captured$summary_json$validation$verdict, "reject")
+  expect_equal(
+    captured$summary_json$validation$reasoning,
+    "Molecular terms not grounded in the input."
+  )
+})

--- a/scripts/code-quality-file-size-baseline.tsv
+++ b/scripts/code-quality-file-size-baseline.tsv
@@ -14,7 +14,7 @@ api/functions/endpoint-functions.R	860
 api/functions/llm-batch-generator.R	604
 api/functions/llm-cache-repository.R	787
 api/functions/llm-judge.R	920
-api/functions/llm-service.R	610
+api/functions/llm-service.R	620
 api/functions/migration-runner.R	718
 api/functions/nddscore-import.R	854
 api/functions/omim-functions.R	971


### PR DESCRIPTION
Addresses the debuggability gap in #443.

## Problem

When the LLM-as-judge **rejects** a cluster summary, `get_or_generate_summary` saves the rejected row (`validation_status = 'rejected'`) but **discards the judge's `verdict` + `reasoning`**. A persistently-rejected cluster — e.g. phenotype **cluster 3**, which all 3 generation attempts produced but the judge rejected — is then undebuggable: the public endpoint just 404s and nothing records *why*.

## Fix

Embed the judge's `{verdict, reasoning}` into the stored `summary_json` on the rejected path. Rejected rows are never publicly served (`get_cached_summary` requires `validation_status = 'validated'`), so this is **internal QA metadata** — no schema migration, no change to served payloads.

```r
summary_with_confidence$validation <- list(
  verdict   = result$last_validation$verdict   %||% NA_character_,
  reasoning = result$last_validation$reasoning %||% NA_character_
)
```

Now an operator can `SELECT summary_json->'$.validation' FROM llm_cluster_summary_cache WHERE validation_status='rejected'` to see exactly why a cluster keeps failing and tune the prompt/judge.

## On the "frozen composition" ask in #443

Investigated and **already correct** — no change needed. `analysis_snapshot_trigger_llm_generation` passes `payload$raw` (the snapshot's computed clusters) to `trigger_llm_batch_generation`, and the executor keys the cache on the **precomputed `cluster_row$hash_filter`** (not a recompute). So the summarized composition always matches the served snapshot. The earlier snapshot↔summary `is_current` divergence was a one-time startup-contention artifact (two racing builds), which #440's `max_attempts` retry + bootstrap staggering addresses.

The remaining cluster-3 404 is therefore a **genuine judge verdict** (the summary didn't meet the quality bar), now made debuggable rather than silently lowered.

## Test

`test-unit-llm-service-db-access.R`: stubs a rejected generation with a judge verdict and asserts the persisted `summary_json.validation` carries the verdict + reasoning.

Related: #440 (#444), #441 (#442).