### PR TITLE
fix(llm): stop phenotype judge permanently rejecting legitimate clusters (#448)

### DIFF
--- a/api/bootstrap/load_modules.R
+++ b/api/bootstrap/load_modules.R
@@ -121,6 +121,7 @@ bootstrap_load_modules <- function() {
     "functions/llm-rate-limiter.R",
     "functions/llm-types.R",
     "functions/llm-service.R",
+    "functions/llm-judge-prompts.R",
     "functions/llm-judge.R",
     "functions/llm-batch-generator.R",
     "functions/ontology-functions.R",

--- a/api/functions/llm-judge-prompts.R
+++ b/api/functions/llm-judge-prompts.R
@@ -1,0 +1,540 @@
+# functions/llm-judge-prompts.R
+#
+# Judge prompt builders for LLM-as-judge cluster-summary validation.
+# Extracted from functions/llm-judge.R (#448) to keep that file under the
+# code-quality file-size ratchet; these are pure string builders consumed by
+# validate_with_llm_judge(). Sourced before functions/llm-judge.R in
+# bootstrap/load_modules.R. The phenotype builder prefers accept_with_corrections
+# (with corrected_summary) over hard reject for isolated molecular phrasing and
+# allows grounded clinical synthesis of the listed phenotypes (#448).
+
+require(glue)
+
+#' Build judge prompt for FUNCTIONAL cluster validation
+#'
+#' Creates validation prompt for functional clusters which group genes by function.
+#'
+#' @param summary List, the generated summary to validate
+#' @param cluster_data List, the original cluster data
+#'
+#' @return Character string, the formatted judge prompt
+#'
+#' @keywords internal
+build_functional_judge_prompt <- function(summary, cluster_data) {
+  # Extract context for judge
+  genes <- if ("identifiers" %in% names(cluster_data) && "symbol" %in% names(cluster_data$identifiers)) {
+    gene_list <- cluster_data$identifiers$symbol
+    if (length(gene_list) > 20) {
+      paste0(paste(head(gene_list, 15), collapse = ", "), "... (", length(gene_list), " total)")
+    } else {
+      paste(gene_list, collapse = ", ")
+    }
+  } else {
+    "(genes not available)"
+  }
+
+  # Extract top 20 enrichment terms PER CATEGORY for validation
+
+  # CRITICAL: Must match the generation prompt which uses top_n_terms = 20 per category
+  # Previous bug: used slice_head(n=15) globally, so judge only saw 15 terms total
+  # while generator showed 20 per category (potentially 80+ terms)
+  enrichment_terms <- if ("term_enrichment" %in% names(cluster_data) && nrow(cluster_data$term_enrichment) > 0) {
+    cluster_data$term_enrichment %>%
+      dplyr::group_by(category) %>%
+      dplyr::arrange(fdr) %>%
+      dplyr::slice_head(n = 20) %>%
+      dplyr::ungroup() %>%
+      dplyr::mutate(
+        display_name = dplyr::if_else(!is.na(description) & description != "", description, term),
+        term_line = glue::glue("- {category}: {display_name} (FDR: {signif(fdr, 3)})")
+      ) %>%
+      dplyr::pull(term_line) %>%
+      paste(collapse = "\n")
+  } else {
+    "(no enrichment data)"
+  }
+
+  # Extract summary components
+  summary_text <- summary$summary %||% ""
+  key_themes <- if (!is.null(summary$key_themes) && length(summary$key_themes) > 0) {
+    paste(summary$key_themes, collapse = ", ")
+  } else {
+    "(none)"
+  }
+  pathways <- if (!is.null(summary$pathways) && length(summary$pathways) > 0) {
+    paste(summary$pathways, collapse = ", ")
+  } else {
+    "(none)"
+  }
+  self_confidence <- summary$confidence %||% "unknown"
+
+  glue::glue("
+You are a STRICT scientific accuracy validator for AI-generated gene cluster summaries.
+Your task is to DETECT HALLUCINATIONS and verify the summary is accurately grounded in the provided data.
+
+## Original Cluster Data
+**Genes:** {genes}
+
+**Top 20 Enrichment Terms per Category (AUTHORITATIVE SOURCE):**
+{enrichment_terms}
+
+## Generated Summary to Validate
+**Summary text:** {summary_text}
+
+**Key themes:** {key_themes}
+
+**Pathways listed:** {pathways}
+
+**Self-assessed confidence:** {self_confidence}
+
+---
+
+## MANDATORY VERIFICATION CHECKLIST
+
+Complete each verification step before rendering your verdict.
+
+### Step 1: Pathway String Matching (CRITICAL)
+For EACH pathway listed in the summary:
+- Does it appear VERBATIM in the enrichment terms? (YES/NO)
+- If NO, is it a reasonable synonym of an existing term? (YES/NO)
+- If neither, mark as INVENTED
+
+**Scoring:**
+- All pathways appear verbatim = +2 points
+- Minor generalizations only = +1 point
+- Any completely invented pathway = 0 points
+
+### Step 2: Theme Grounding Check
+For EACH key theme, identify which enrichment terms support it.
+- Theme with supporting term(s) = GROUNDED
+- Theme with NO supporting terms = UNGROUNDED
+
+**Scoring:**
+- All themes grounded = +2 points
+- 1-2 ungrounded but reasonable = +1 point
+- 3+ ungrounded themes = 0 points
+
+### Step 3: Invented Term Detection
+List ANY terms, pathways, or mechanisms in the summary that:
+- Do NOT appear in the enrichment terms AND
+- Cannot be directly inferred from the enrichment data
+
+**Scoring:**
+- No invented terms = +2 points
+- 1-2 minor invented terms = +1 point
+- Any significant hallucination = 0 points
+
+### Step 4: Confidence Calibration
+Compare self-assessed confidence to evidence strength:
+- High appropriate if: Multiple terms with FDR < 1E-50
+- Medium appropriate if: Terms with FDR between 1E-10 and 1E-50
+- Low appropriate if: Terms with FDR > 1E-10 or few terms
+
+**Scoring:**
+- Confidence matches evidence = +2 points
+- Off by one level = +1 point
+- Significantly mismatched = 0 points
+
+---
+
+## VERDICT CALCULATION (with Corrections)
+
+**Total your points from Steps 1-4 (maximum 8 points):**
+
+| Points | Verdict | Action |
+|--------|---------|--------|
+| 7-8 | **accept** | Cache as 'validated' |
+| 5-6 | **accept_with_corrections** | Apply corrections, cache as 'validated' |
+| 3-4 | **low_confidence** | Cache as 'pending' for review |
+| 0-2 | **reject** | Do not cache, trigger regeneration |
+
+**IMPORTANT: Prefer accept_with_corrections over reject when possible**
+
+---
+
+## CORRECTION INSTRUCTIONS
+
+For scores 5-6, if issues are correctable:
+1. Set corrections_needed = true
+2. List corrections in corrections_made array
+3. Provide corrected_tags with ONLY valid pathway/functional terms from input
+4. Use verdict = 'accept_with_corrections'
+
+Only REJECT (score 0-2) if:
+- Summary fundamentally misrepresents the cluster
+- Multiple severe hallucinations that can't be corrected
+- Core summary text is inaccurate (not just tags/metadata)
+
+---
+
+## EXAMPLES
+
+### Example: ACCEPT (8 points)
+- 'PI3K-Akt signaling pathway' appears verbatim in KEGG terms (+2)
+- All themes map to specific enrichment terms (+2)
+- No invented terms found (+2)
+- Medium confidence for FDR ~1E-30 terms (+2)
+
+### Example: ACCEPT_WITH_CORRECTIONS (6 points)
+- Pathway name slightly paraphrased but correct meaning (+1)
+- Most themes grounded, one tag not in data - CORRECT IT (+2)
+- One invented term in tags - REMOVE IT (+1)
+- Confidence matches evidence (+2)
+- corrections_made: ['Removed \"axon guidance\" from tags - not in KEGG data']
+
+### Example: LOW_CONFIDENCE (4 points)
+- 'Ras/MAPK cascade' but data shows 'Ras signaling pathway' separately (+1)
+- Most themes grounded, one reasonable inference (+1)
+- One term not in enrichment data (+0)
+- Confidence matches evidence (+2)
+
+### Example: REJECT (2 points)
+- 'Wnt signaling pathway' NOT in enrichment data (+0)
+- 'epigenetic regulation' but no epigenetic terms in data (+0)
+- Multiple invented mechanisms (+0)
+- High confidence despite weak enrichment (+2)
+
+---
+
+## YOUR RESPONSE
+Complete the verification steps, calculate total points, then provide your verdict.
+")
+}
+
+
+#' Build judge prompt for PHENOTYPE cluster validation
+#'
+#' Creates validation prompt for phenotype clusters which group disease entities
+#' by phenotype patterns using v.test scores.
+#'
+#' @param summary List, the generated summary to validate
+#' @param cluster_data List, the original cluster data
+#'
+#' @return Character string, the formatted judge prompt
+#'
+#' @keywords internal
+build_phenotype_judge_prompt <- function(summary, cluster_data) {
+  # Extract phenotype data from quali_inp_var
+  phenotype_terms <- if ("quali_inp_var" %in% names(cluster_data)) {
+    phenotypes_df <- if (is.data.frame(cluster_data$quali_inp_var)) {
+      cluster_data$quali_inp_var
+    } else if (is.list(cluster_data$quali_inp_var)) {
+      dplyr::bind_rows(cluster_data$quali_inp_var)
+    } else {
+      NULL
+    }
+
+    if (!is.null(phenotypes_df) && nrow(phenotypes_df) > 0 &&
+        all(c("variable", "v.test") %in% names(phenotypes_df))) {
+      phenotypes_df %>%
+        dplyr::arrange(dplyr::desc(abs(`v.test`))) %>%
+        dplyr::slice_head(n = 15) %>%
+        dplyr::mutate(
+          direction = dplyr::if_else(`v.test` > 0, "ENRICHED", "DEPLETED"),
+          term_line = glue::glue("- {variable}: v.test={round(`v.test`, 2)} [{direction}]")
+        ) %>%
+        dplyr::pull(term_line) %>%
+        paste(collapse = "\n")
+    } else {
+      "(no phenotype data)"
+    }
+  } else {
+    "(no phenotype data)"
+  }
+
+  # Extract inheritance patterns from quali_sup_var
+  inheritance_terms <- "(no inheritance data)"
+  if ("quali_sup_var" %in% names(cluster_data) && length(cluster_data$quali_sup_var) > 0) {
+    inheritance_df <- if (is.data.frame(cluster_data$quali_sup_var)) {
+      cluster_data$quali_sup_var
+    } else if (is.list(cluster_data$quali_sup_var)) {
+      dplyr::bind_rows(cluster_data$quali_sup_var)
+    } else {
+      NULL
+    }
+
+    if (!is.null(inheritance_df) && nrow(inheritance_df) > 0 &&
+        all(c("variable", "v.test") %in% names(inheritance_df))) {
+      sig_inheritance <- inheritance_df %>%
+        dplyr::filter(abs(`v.test`) > 2) %>%
+        dplyr::arrange(dplyr::desc(`v.test`))
+
+      if (nrow(sig_inheritance) > 0) {
+        inheritance_terms <- sig_inheritance %>%
+          dplyr::mutate(
+            direction = dplyr::if_else(`v.test` > 0, "ENRICHED", "DEPLETED"),
+            term_line = glue::glue("- {variable}: v.test={round(`v.test`, 2)} [{direction}]")
+          ) %>%
+          dplyr::pull(term_line) %>%
+          paste(collapse = "\n")
+      }
+    }
+  }
+
+  # Extract syndromicity metrics from quanti_sup_var
+  syndromicity_terms <- "(no syndromicity data)"
+  if ("quanti_sup_var" %in% names(cluster_data) && length(cluster_data$quanti_sup_var) > 0) {
+    quanti_df <- if (is.data.frame(cluster_data$quanti_sup_var)) {
+      cluster_data$quanti_sup_var
+    } else if (is.list(cluster_data$quanti_sup_var)) {
+      dplyr::bind_rows(cluster_data$quanti_sup_var)
+    } else {
+      NULL
+    }
+
+    if (!is.null(quanti_df) && nrow(quanti_df) > 0 &&
+        all(c("variable", "v.test") %in% names(quanti_df))) {
+      sig_quanti <- quanti_df %>%
+        dplyr::filter(abs(`v.test`) > 2) %>%
+        dplyr::arrange(dplyr::desc(abs(`v.test`)))
+
+      if (nrow(sig_quanti) > 0) {
+        syndromicity_terms <- sig_quanti %>%
+          dplyr::mutate(
+            direction = dplyr::if_else(`v.test` > 0, "HIGHER", "LOWER"),
+            term_line = glue::glue("- {variable}: v.test={round(`v.test`, 2)} [{direction} than average]")
+          ) %>%
+          dplyr::pull(term_line) %>%
+          paste(collapse = "\n")
+      }
+    }
+  }
+
+  # Get entity count
+  entity_count <- if ("identifiers" %in% names(cluster_data)) {
+    nrow(cluster_data$identifiers)
+  } else {
+    "unknown"
+  }
+
+  # Extract summary components (phenotype-specific fields)
+  summary_text <- summary$summary %||% ""
+
+  # Handle both old (key_themes) and new (key_phenotype_themes) field names
+  key_themes <- if (!is.null(summary$key_phenotype_themes) && length(summary$key_phenotype_themes) > 0) {
+    paste(summary$key_phenotype_themes, collapse = ", ")
+  } else if (!is.null(summary$key_themes) && length(summary$key_themes) > 0) {
+    paste(summary$key_themes, collapse = ", ")
+  } else {
+    "(none)"
+  }
+
+  notably_absent <- if (!is.null(summary$notably_absent) && length(summary$notably_absent) > 0) {
+    paste(summary$notably_absent, collapse = ", ")
+  } else {
+    "(not specified)"
+  }
+
+  clinical_pattern <- summary$clinical_pattern %||% "(not specified)"
+  self_confidence <- summary$confidence %||% "unknown"
+
+  # Extract new supplementary fields
+  inheritance_patterns <- if (!is.null(summary$inheritance_patterns) && length(summary$inheritance_patterns) > 0) {
+    paste(summary$inheritance_patterns, collapse = ", ")
+  } else {
+    "(not specified)"
+  }
+
+  syndromicity <- summary$syndromicity %||% "(not specified)"
+
+  glue::glue("
+You are a STRICT validator for AI-generated phenotype cluster summaries.
+Your job is to DETECT HALLUCINATIONS and REJECT inaccurate summaries.
+
+## CRITICAL CONTEXT
+- This cluster contains {entity_count} DISEASE ENTITIES (gene-disease associations)
+- Entities were clustered by PHENOTYPE PATTERNS, NOT by gene function
+- The summary MUST describe CLINICAL PHENOTYPES, not molecular mechanisms
+- v.test interpretation: POSITIVE = phenotype ENRICHED, NEGATIVE = phenotype DEPLETED
+
+---
+
+## SEVERE ERRORS (verdict = 'reject')
+Reject ONLY for these severe, non-correctable errors:
+
+1. **FUNDAMENTALLY MOLECULAR**: The summary's main point is a molecular MECHANISM
+   rather than a clinical phenotype description.
+   - REJECT if: 'these genes drive synaptic signaling and chromatin remodeling'
+   - REJECT if: the summary explains *why* (mechanism) instead of *what* (phenotype)
+
+2. **FABRICATED SPECIFIC PHENOTYPE**: Summary asserts a NEW specific phenotype that
+   is NOT in the input data (and is not a grounded synthesis of listed terms).
+   - REJECT if: summary says 'epilepsy' but no seizure term is in the input
+   - REJECT if: summary says 'cardiac defects' but no heart-related term is in the input
+
+3. **DIRECTION INVERSION**: Summary describes enriched phenotypes as depleted or vice versa
+   - REJECT if: v.test is NEGATIVE but summary says 'strongly associated with' or 'enriched'
+   - REJECT if: v.test is POSITIVE but summary says 'absent' or 'depleted'
+
+---
+
+## GROUNDED CLINICAL SYNTHESIS IS ALLOWED (do NOT treat as fabrication)
+Synthesizing or grouping the LISTED phenotypes into a recognized clinical gestalt
+is grounded clinical synthesis, not hallucination. A cluster defined mostly by
+what is DEPLETED (few enriched terms) can be legitimately summarized by that
+overall character.
+- ALLOWED: describing mild-ID + macrocephaly + behavioral-abnormality enrichment
+  (with strong depletion of severe/profound features) as 'a mild, predominantly
+  non-syndromic neurodevelopmental presentation'.
+- ALLOWED: grouping listed phenotypes into a clinical category (e.g. 'renal and
+  genitourinary features') when those phenotypes appear in the data.
+- The line: it is fabrication ONLY when a NEW specific phenotype absent from the
+  tables is asserted - not when the listed phenotypes are summarized as a whole.
+
+## ISOLATED MOLECULAR PHRASING -> CORRECT, DON'T REJECT
+A molecular-sounding word can appear inside a legitimate clinical phenotype name
+(e.g. 'Elevated circulating creatine kinase concentration') or as an isolated
+slip. When the summary is otherwise grounded clinical prose and the ONLY problem
+is one or two molecular words/phrases, prefer 'accept_with_corrections' and return
+a 'corrected_summary' that rephrases or removes the molecular wording. Reserve
+'reject' for summaries that are FUNDAMENTALLY about mechanism (Severe Error 1).
+
+Molecular-mechanism vocabulary to scrub from prose (NOT from grounded phenotype
+names): gene, protein, pathway, signaling, transcription, chromatin, histone,
+methylation, enzyme, receptor, kinase, mTOR, MAPK, DNA repair, RNA processing,
+cell cycle, 'plays a role in', 'involved in', 'functions in', 'regulates',
+'modulates'.
+
+---
+
+## INPUT DATA (Ground Truth)
+
+### Primary Phenotypes (used for clustering)
+{phenotype_terms}
+
+### Supplementary Data (describes cluster characteristics)
+**Inheritance patterns (from HPO):**
+{inheritance_terms}
+
+**Syndromicity metrics:**
+{syndromicity_terms}
+
+---
+
+## SUMMARY TO VALIDATE
+**Summary text:** {summary_text}
+
+**Key phenotype themes:** {key_themes}
+
+**Notably absent phenotypes:** {notably_absent}
+
+**Clinical pattern:** {clinical_pattern}
+
+**Inheritance patterns:** {inheritance_patterns}
+
+**Syndromicity:** {syndromicity}
+
+**Self-assessed confidence:** {self_confidence}
+
+---
+
+## STEP-BY-STEP VERIFICATION (Complete ALL steps before verdict)
+
+**Step 1 - Molecular-Mechanism Scan (FIRST!):**
+Check whether the summary is fundamentally about a molecular MECHANISM.
+- If the main point is mechanism (Severe Error 1): verdict = 'reject'.
+- If there is only isolated molecular phrasing in otherwise-clinical prose, OR a
+  molecular-sounding word that is part of a grounded phenotype name (e.g.
+  'creatine kinase'): do NOT reject - prefer 'accept_with_corrections' and supply
+  a 'corrected_summary' that rephrases/removes the molecular wording.
+
+**Step 2 - Extract Claims:**
+List every phenotype or clinical term mentioned in the summary.
+
+**Step 3 - Ground Each Claim:**
+For EACH term from Step 2, verify it exists in the input phenotype data (exact or
+semantically equivalent), OR is a grounded clinical synthesis of listed terms.
+Mark a term as FABRICATED only when it asserts a NEW specific phenotype absent
+from the input - not when it summarizes the listed phenotypes as a whole.
+
+**Step 4 - Direction Check:**
+For phenotypes described as enriched, verify v.test > 0.
+For phenotypes described as depleted, verify v.test < 0.
+Mark mismatches as DIRECTION_ERROR.
+
+**Step 5 - Calculate Grounding Score:**
+Grounding % = (number of grounded claims / total claims) x 100
+
+**Step 6 - Inheritance Pattern Check:**
+For each inheritance pattern in the summary:
+- Verify it appears in the inheritance data (quali_sup_var) with |v.test| > 2
+- Standard abbreviations: AD=Autosomal dominant, AR=Autosomal recessive, XL=X-linked, MT=Mitochondrial
+- Mark as INVALID if pattern not in source data
+
+**Step 7 - Syndromicity Check:**
+Compare summary's syndromicity claim against quanti_sup_var data:
+- 'predominantly_syndromic' should match positive v.test for phenotype_non_id_count
+- 'predominantly_id' should match positive v.test for phenotype_id_count
+- 'mixed' is valid if both or neither significant
+- 'unknown' is valid if no syndromicity data
+- Mark as INVALID if mismatch
+
+---
+
+## VERDICT CRITERIA (with Corrections)
+
+**IMPORTANT: Prefer CORRECTING minor issues over REJECTING**
+
+**REJECT (only for SEVERE, non-correctable issues):**
+- Summary is FUNDAMENTALLY about a molecular mechanism (Severe Error 1)
+- Direction inversion in main summary description (Step 4)
+- Grounding score < 50% in main summary
+- Multiple fabricated SPECIFIC phenotypes that fundamentally misrepresent the cluster
+
+**ACCEPT_WITH_CORRECTIONS (correctable issues - PREFER THIS over reject):**
+- Isolated molecular phrasing in otherwise-clinical prose → set corrected_summary
+  with the molecular wording rephrased/removed
+- One over-reaching label or phrase in the main summary → set corrected_summary
+  trimmed to the grounded phenotypes
+- Tags array contains items not in input data → Remove them, list in corrections_made
+- Notably_absent array contains items not in input data → Remove them, list in corrections_made
+- One or two phenotype terms need adjustment → Provide corrected list
+- Main summary is accurate but supporting fields have minor issues
+
+**LOW_CONFIDENCE (moderate issues, no correction possible):**
+- Grounding score 50-79%
+- Uses overly broad syndrome terms that can't be corrected
+- Missing significant phenotypes from top 5 by |v.test|
+
+**ACCEPT (all must be true):**
+- Grounding score >= 80%
+- No molecular/gene content
+- No fabricated phenotypes in main summary
+- Direction interpretation correct
+- All tags and notably_absent items verified in input data
+
+---
+
+## CORRECTION INSTRUCTIONS
+
+If issues are correctable:
+1. Set corrections_needed = true
+2. List each correction in corrections_made array
+3. Provide corrected_tags with ONLY items that appear in the input phenotype data
+4. Provide corrected_notably_absent with ONLY depleted phenotypes (v.test < 0) from input
+5. Provide corrected_inheritance_patterns with ONLY patterns from quali_sup_var with |v.test| > 2
+   - Use standard abbreviations: AD, AR, XL, XLR, XLD, MT, SP
+6. Provide corrected_syndromicity based on quanti_sup_var data
+7. If the MAIN summary text needed wording fixes (isolated molecular phrasing or
+   an over-reaching label), provide corrected_summary with grounded clinical
+   prose; otherwise leave corrected_summary empty
+8. Use verdict = 'accept_with_corrections'
+
+Example correction:
+- corrections_made: ['Removed \"Seizures\" from notably_absent - not in input data',
+  'Corrected inheritance from XL to AR based on source data']
+- corrected_notably_absent: ['Progressive', 'Developmental regression'] (only items with v.test < 0)
+- corrected_inheritance_patterns: ['AR', 'AD'] (only from source data)
+- corrected_syndromicity: 'predominantly_id' (based on positive v.test for phenotype_id_count)
+
+---
+
+## YOUR RESPONSE
+Complete the verification steps, then provide your verdict.
+REMEMBER: Prefer 'accept_with_corrections' (supply a grounded corrected_summary)
+over 'reject' for isolated molecular phrasing or a single over-reaching label.
+Reject ONLY when the summary is fundamentally about a molecular mechanism,
+inverts enrichment direction, fabricates a NEW specific phenotype, or falls below
+50% grounding. Grounded clinical synthesis of the listed phenotypes is acceptable.
+")
+}

--- a/api/functions/llm-judge.R
+++ b/api/functions/llm-judge.R
@@ -32,6 +32,15 @@ if (!exists("save_summary_to_cache", mode = "function")) {
   }
 }
 
+# Load judge prompt builders (extracted to functions/llm-judge-prompts.R, #448).
+# Bootstrap sources that file first; this guard makes llm-judge.R self-sufficient
+# when sourced standalone (e.g. in tests).
+if (!exists("build_phenotype_judge_prompt", mode = "function")) {
+  if (file.exists("functions/llm-judge-prompts.R")) {
+    source("functions/llm-judge-prompts.R", local = TRUE)
+  }
+}
+
 
 #' Type specification for LLM-as-judge validation verdict
 #'
@@ -93,6 +102,16 @@ llm_judge_verdict_type <- ellmer::type_object(
     required = FALSE
   ),
 
+  corrected_summary = ellmer::type_string(
+    "Corrected main summary text. Provide ONLY when verdict is
+     accept_with_corrections AND the main summary needed wording fixes (e.g. an
+     isolated molecular phrase rewritten as a clinical phenotype description, or
+     an over-reaching label trimmed). The corrected text must stay grounded in
+     the input data and contain no molecular/gene/pathway mechanism language.
+     Leave empty when the main summary text needs no change.",
+    required = FALSE
+  ),
+
   reasoning = ellmer::type_string(
     "Brief explanation of assessment including any corrections (2-3 sentences)"
   ),
@@ -103,502 +122,6 @@ llm_judge_verdict_type <- ellmer::type_object(
      low_confidence (concerns but usable), reject (severe hallucinations only)"
   )
 )
-
-
-#' Build judge prompt for FUNCTIONAL cluster validation
-#'
-#' Creates validation prompt for functional clusters which group genes by function.
-#'
-#' @param summary List, the generated summary to validate
-#' @param cluster_data List, the original cluster data
-#'
-#' @return Character string, the formatted judge prompt
-#'
-#' @keywords internal
-build_functional_judge_prompt <- function(summary, cluster_data) {
-  # Extract context for judge
-  genes <- if ("identifiers" %in% names(cluster_data) && "symbol" %in% names(cluster_data$identifiers)) {
-    gene_list <- cluster_data$identifiers$symbol
-    if (length(gene_list) > 20) {
-      paste0(paste(head(gene_list, 15), collapse = ", "), "... (", length(gene_list), " total)")
-    } else {
-      paste(gene_list, collapse = ", ")
-    }
-  } else {
-    "(genes not available)"
-  }
-
-  # Extract top 20 enrichment terms PER CATEGORY for validation
-
-  # CRITICAL: Must match the generation prompt which uses top_n_terms = 20 per category
-  # Previous bug: used slice_head(n=15) globally, so judge only saw 15 terms total
-  # while generator showed 20 per category (potentially 80+ terms)
-  enrichment_terms <- if ("term_enrichment" %in% names(cluster_data) && nrow(cluster_data$term_enrichment) > 0) {
-    cluster_data$term_enrichment %>%
-      dplyr::group_by(category) %>%
-      dplyr::arrange(fdr) %>%
-      dplyr::slice_head(n = 20) %>%
-      dplyr::ungroup() %>%
-      dplyr::mutate(
-        display_name = dplyr::if_else(!is.na(description) & description != "", description, term),
-        term_line = glue::glue("- {category}: {display_name} (FDR: {signif(fdr, 3)})")
-      ) %>%
-      dplyr::pull(term_line) %>%
-      paste(collapse = "\n")
-  } else {
-    "(no enrichment data)"
-  }
-
-  # Extract summary components
-  summary_text <- summary$summary %||% ""
-  key_themes <- if (!is.null(summary$key_themes) && length(summary$key_themes) > 0) {
-    paste(summary$key_themes, collapse = ", ")
-  } else {
-    "(none)"
-  }
-  pathways <- if (!is.null(summary$pathways) && length(summary$pathways) > 0) {
-    paste(summary$pathways, collapse = ", ")
-  } else {
-    "(none)"
-  }
-  self_confidence <- summary$confidence %||% "unknown"
-
-  glue::glue("
-You are a STRICT scientific accuracy validator for AI-generated gene cluster summaries.
-Your task is to DETECT HALLUCINATIONS and verify the summary is accurately grounded in the provided data.
-
-## Original Cluster Data
-**Genes:** {genes}
-
-**Top 20 Enrichment Terms per Category (AUTHORITATIVE SOURCE):**
-{enrichment_terms}
-
-## Generated Summary to Validate
-**Summary text:** {summary_text}
-
-**Key themes:** {key_themes}
-
-**Pathways listed:** {pathways}
-
-**Self-assessed confidence:** {self_confidence}
-
----
-
-## MANDATORY VERIFICATION CHECKLIST
-
-Complete each verification step before rendering your verdict.
-
-### Step 1: Pathway String Matching (CRITICAL)
-For EACH pathway listed in the summary:
-- Does it appear VERBATIM in the enrichment terms? (YES/NO)
-- If NO, is it a reasonable synonym of an existing term? (YES/NO)
-- If neither, mark as INVENTED
-
-**Scoring:**
-- All pathways appear verbatim = +2 points
-- Minor generalizations only = +1 point
-- Any completely invented pathway = 0 points
-
-### Step 2: Theme Grounding Check
-For EACH key theme, identify which enrichment terms support it.
-- Theme with supporting term(s) = GROUNDED
-- Theme with NO supporting terms = UNGROUNDED
-
-**Scoring:**
-- All themes grounded = +2 points
-- 1-2 ungrounded but reasonable = +1 point
-- 3+ ungrounded themes = 0 points
-
-### Step 3: Invented Term Detection
-List ANY terms, pathways, or mechanisms in the summary that:
-- Do NOT appear in the enrichment terms AND
-- Cannot be directly inferred from the enrichment data
-
-**Scoring:**
-- No invented terms = +2 points
-- 1-2 minor invented terms = +1 point
-- Any significant hallucination = 0 points
-
-### Step 4: Confidence Calibration
-Compare self-assessed confidence to evidence strength:
-- High appropriate if: Multiple terms with FDR < 1E-50
-- Medium appropriate if: Terms with FDR between 1E-10 and 1E-50
-- Low appropriate if: Terms with FDR > 1E-10 or few terms
-
-**Scoring:**
-- Confidence matches evidence = +2 points
-- Off by one level = +1 point
-- Significantly mismatched = 0 points
-
----
-
-## VERDICT CALCULATION (with Corrections)
-
-**Total your points from Steps 1-4 (maximum 8 points):**
-
-| Points | Verdict | Action |
-|--------|---------|--------|
-| 7-8 | **accept** | Cache as 'validated' |
-| 5-6 | **accept_with_corrections** | Apply corrections, cache as 'validated' |
-| 3-4 | **low_confidence** | Cache as 'pending' for review |
-| 0-2 | **reject** | Do not cache, trigger regeneration |
-
-**IMPORTANT: Prefer accept_with_corrections over reject when possible**
-
----
-
-## CORRECTION INSTRUCTIONS
-
-For scores 5-6, if issues are correctable:
-1. Set corrections_needed = true
-2. List corrections in corrections_made array
-3. Provide corrected_tags with ONLY valid pathway/functional terms from input
-4. Use verdict = 'accept_with_corrections'
-
-Only REJECT (score 0-2) if:
-- Summary fundamentally misrepresents the cluster
-- Multiple severe hallucinations that can't be corrected
-- Core summary text is inaccurate (not just tags/metadata)
-
----
-
-## EXAMPLES
-
-### Example: ACCEPT (8 points)
-- 'PI3K-Akt signaling pathway' appears verbatim in KEGG terms (+2)
-- All themes map to specific enrichment terms (+2)
-- No invented terms found (+2)
-- Medium confidence for FDR ~1E-30 terms (+2)
-
-### Example: ACCEPT_WITH_CORRECTIONS (6 points)
-- Pathway name slightly paraphrased but correct meaning (+1)
-- Most themes grounded, one tag not in data - CORRECT IT (+2)
-- One invented term in tags - REMOVE IT (+1)
-- Confidence matches evidence (+2)
-- corrections_made: ['Removed \"axon guidance\" from tags - not in KEGG data']
-
-### Example: LOW_CONFIDENCE (4 points)
-- 'Ras/MAPK cascade' but data shows 'Ras signaling pathway' separately (+1)
-- Most themes grounded, one reasonable inference (+1)
-- One term not in enrichment data (+0)
-- Confidence matches evidence (+2)
-
-### Example: REJECT (2 points)
-- 'Wnt signaling pathway' NOT in enrichment data (+0)
-- 'epigenetic regulation' but no epigenetic terms in data (+0)
-- Multiple invented mechanisms (+0)
-- High confidence despite weak enrichment (+2)
-
----
-
-## YOUR RESPONSE
-Complete the verification steps, calculate total points, then provide your verdict.
-")
-}
-
-
-#' Build judge prompt for PHENOTYPE cluster validation
-#'
-#' Creates validation prompt for phenotype clusters which group disease entities
-#' by phenotype patterns using v.test scores.
-#'
-#' @param summary List, the generated summary to validate
-#' @param cluster_data List, the original cluster data
-#'
-#' @return Character string, the formatted judge prompt
-#'
-#' @keywords internal
-build_phenotype_judge_prompt <- function(summary, cluster_data) {
-  # Extract phenotype data from quali_inp_var
-  phenotype_terms <- if ("quali_inp_var" %in% names(cluster_data)) {
-    phenotypes_df <- if (is.data.frame(cluster_data$quali_inp_var)) {
-      cluster_data$quali_inp_var
-    } else if (is.list(cluster_data$quali_inp_var)) {
-      dplyr::bind_rows(cluster_data$quali_inp_var)
-    } else {
-      NULL
-    }
-
-    if (!is.null(phenotypes_df) && nrow(phenotypes_df) > 0 &&
-        all(c("variable", "v.test") %in% names(phenotypes_df))) {
-      phenotypes_df %>%
-        dplyr::arrange(dplyr::desc(abs(`v.test`))) %>%
-        dplyr::slice_head(n = 15) %>%
-        dplyr::mutate(
-          direction = dplyr::if_else(`v.test` > 0, "ENRICHED", "DEPLETED"),
-          term_line = glue::glue("- {variable}: v.test={round(`v.test`, 2)} [{direction}]")
-        ) %>%
-        dplyr::pull(term_line) %>%
-        paste(collapse = "\n")
-    } else {
-      "(no phenotype data)"
-    }
-  } else {
-    "(no phenotype data)"
-  }
-
-  # Extract inheritance patterns from quali_sup_var
-  inheritance_terms <- "(no inheritance data)"
-  if ("quali_sup_var" %in% names(cluster_data) && length(cluster_data$quali_sup_var) > 0) {
-    inheritance_df <- if (is.data.frame(cluster_data$quali_sup_var)) {
-      cluster_data$quali_sup_var
-    } else if (is.list(cluster_data$quali_sup_var)) {
-      dplyr::bind_rows(cluster_data$quali_sup_var)
-    } else {
-      NULL
-    }
-
-    if (!is.null(inheritance_df) && nrow(inheritance_df) > 0 &&
-        all(c("variable", "v.test") %in% names(inheritance_df))) {
-      sig_inheritance <- inheritance_df %>%
-        dplyr::filter(abs(`v.test`) > 2) %>%
-        dplyr::arrange(dplyr::desc(`v.test`))
-
-      if (nrow(sig_inheritance) > 0) {
-        inheritance_terms <- sig_inheritance %>%
-          dplyr::mutate(
-            direction = dplyr::if_else(`v.test` > 0, "ENRICHED", "DEPLETED"),
-            term_line = glue::glue("- {variable}: v.test={round(`v.test`, 2)} [{direction}]")
-          ) %>%
-          dplyr::pull(term_line) %>%
-          paste(collapse = "\n")
-      }
-    }
-  }
-
-  # Extract syndromicity metrics from quanti_sup_var
-  syndromicity_terms <- "(no syndromicity data)"
-  if ("quanti_sup_var" %in% names(cluster_data) && length(cluster_data$quanti_sup_var) > 0) {
-    quanti_df <- if (is.data.frame(cluster_data$quanti_sup_var)) {
-      cluster_data$quanti_sup_var
-    } else if (is.list(cluster_data$quanti_sup_var)) {
-      dplyr::bind_rows(cluster_data$quanti_sup_var)
-    } else {
-      NULL
-    }
-
-    if (!is.null(quanti_df) && nrow(quanti_df) > 0 &&
-        all(c("variable", "v.test") %in% names(quanti_df))) {
-      sig_quanti <- quanti_df %>%
-        dplyr::filter(abs(`v.test`) > 2) %>%
-        dplyr::arrange(dplyr::desc(abs(`v.test`)))
-
-      if (nrow(sig_quanti) > 0) {
-        syndromicity_terms <- sig_quanti %>%
-          dplyr::mutate(
-            direction = dplyr::if_else(`v.test` > 0, "HIGHER", "LOWER"),
-            term_line = glue::glue("- {variable}: v.test={round(`v.test`, 2)} [{direction} than average]")
-          ) %>%
-          dplyr::pull(term_line) %>%
-          paste(collapse = "\n")
-      }
-    }
-  }
-
-  # Get entity count
-  entity_count <- if ("identifiers" %in% names(cluster_data)) {
-    nrow(cluster_data$identifiers)
-  } else {
-    "unknown"
-  }
-
-  # Extract summary components (phenotype-specific fields)
-  summary_text <- summary$summary %||% ""
-
-  # Handle both old (key_themes) and new (key_phenotype_themes) field names
-  key_themes <- if (!is.null(summary$key_phenotype_themes) && length(summary$key_phenotype_themes) > 0) {
-    paste(summary$key_phenotype_themes, collapse = ", ")
-  } else if (!is.null(summary$key_themes) && length(summary$key_themes) > 0) {
-    paste(summary$key_themes, collapse = ", ")
-  } else {
-    "(none)"
-  }
-
-  notably_absent <- if (!is.null(summary$notably_absent) && length(summary$notably_absent) > 0) {
-    paste(summary$notably_absent, collapse = ", ")
-  } else {
-    "(not specified)"
-  }
-
-  clinical_pattern <- summary$clinical_pattern %||% "(not specified)"
-  self_confidence <- summary$confidence %||% "unknown"
-
-  # Extract new supplementary fields
-  inheritance_patterns <- if (!is.null(summary$inheritance_patterns) && length(summary$inheritance_patterns) > 0) {
-    paste(summary$inheritance_patterns, collapse = ", ")
-  } else {
-    "(not specified)"
-  }
-
-  syndromicity <- summary$syndromicity %||% "(not specified)"
-
-  glue::glue("
-You are a STRICT validator for AI-generated phenotype cluster summaries.
-Your job is to DETECT HALLUCINATIONS and REJECT inaccurate summaries.
-
-## CRITICAL CONTEXT
-- This cluster contains {entity_count} DISEASE ENTITIES (gene-disease associations)
-- Entities were clustered by PHENOTYPE PATTERNS, NOT by gene function
-- The summary MUST describe CLINICAL PHENOTYPES, not molecular mechanisms
-- v.test interpretation: POSITIVE = phenotype ENRICHED, NEGATIVE = phenotype DEPLETED
-
----
-
-## AUTOMATIC REJECTION TRIGGERS
-ANY of these errors = immediate verdict of 'reject':
-
-1. **MOLECULAR HALLUCINATION**: Summary mentions genes, proteins, pathways, molecular mechanisms,
-   chromatin, transcription, signaling, enzymes, or any biological mechanism terms
-   - REJECT if: 'genes involved in synaptic function'
-   - REJECT if: 'chromatin remodeling and transcriptional regulation'
-   - REJECT if: 'mitochondrial respiratory chain', 'DNA repair pathways'
-
-2. **FABRICATED PHENOTYPES**: Summary references phenotypes NOT in the input data
-   - REJECT if: summary says 'autism' but input only has 'intellectual disability'
-   - REJECT if: summary says 'epilepsy' but no seizure term in input
-   - REJECT if: summary says 'cardiac defects' but no heart-related term in input
-
-3. **DIRECTION INVERSION**: Summary describes enriched phenotypes as depleted or vice versa
-   - REJECT if: v.test is NEGATIVE but summary says 'strongly associated with' or 'enriched'
-   - REJECT if: v.test is POSITIVE but summary says 'absent' or 'depleted'
-
-4. **SCOPE ERROR**: Summary discusses gene functions when data is about disease phenotypes
-   - REJECT if: mentions what genes 'do' or their 'functions'
-   - ACCEPT if: describes what clinical features patients present with
-
----
-
-## FORBIDDEN TERMS (if present = automatic reject)
-gene, protein, pathway, signaling, transcription, chromatin, histone, methylation,
-enzyme, receptor, kinase, mTOR, MAPK, DNA repair, RNA processing, cell cycle,
-'plays a role in', 'involved in', 'functions in', 'regulates', 'modulates'
-
----
-
-## INPUT DATA (Ground Truth)
-
-### Primary Phenotypes (used for clustering)
-{phenotype_terms}
-
-### Supplementary Data (describes cluster characteristics)
-**Inheritance patterns (from HPO):**
-{inheritance_terms}
-
-**Syndromicity metrics:**
-{syndromicity_terms}
-
----
-
-## SUMMARY TO VALIDATE
-**Summary text:** {summary_text}
-
-**Key phenotype themes:** {key_themes}
-
-**Notably absent phenotypes:** {notably_absent}
-
-**Clinical pattern:** {clinical_pattern}
-
-**Inheritance patterns:** {inheritance_patterns}
-
-**Syndromicity:** {syndromicity}
-
-**Self-assessed confidence:** {self_confidence}
-
----
-
-## STEP-BY-STEP VERIFICATION (Complete ALL steps before verdict)
-
-**Step 1 - Forbidden Term Scan (FIRST!):**
-Check for ANY molecular/gene/pathway terms in the summary.
-If found: Mark as MOLECULAR_HALLUCINATION = automatic reject
-
-**Step 2 - Extract Claims:**
-List every phenotype or clinical term mentioned in the summary.
-
-**Step 3 - Ground Each Claim:**
-For EACH term from Step 2, verify it exists in the input phenotype data (exact or semantically equivalent).
-Mark ungrounded terms as FABRICATED.
-
-**Step 4 - Direction Check:**
-For phenotypes described as enriched, verify v.test > 0.
-For phenotypes described as depleted, verify v.test < 0.
-Mark mismatches as DIRECTION_ERROR.
-
-**Step 5 - Calculate Grounding Score:**
-Grounding % = (number of grounded claims / total claims) x 100
-
-**Step 6 - Inheritance Pattern Check:**
-For each inheritance pattern in the summary:
-- Verify it appears in the inheritance data (quali_sup_var) with |v.test| > 2
-- Standard abbreviations: AD=Autosomal dominant, AR=Autosomal recessive, XL=X-linked, MT=Mitochondrial
-- Mark as INVALID if pattern not in source data
-
-**Step 7 - Syndromicity Check:**
-Compare summary's syndromicity claim against quanti_sup_var data:
-- 'predominantly_syndromic' should match positive v.test for phenotype_non_id_count
-- 'predominantly_id' should match positive v.test for phenotype_id_count
-- 'mixed' is valid if both or neither significant
-- 'unknown' is valid if no syndromicity data
-- Mark as INVALID if mismatch
-
----
-
-## VERDICT CRITERIA (with Corrections)
-
-**IMPORTANT: Prefer CORRECTING minor issues over REJECTING**
-
-**REJECT (only for SEVERE issues):**
-- ANY molecular/gene/pathway term found in main summary text (Step 1)
-- Direction inversion in main summary description (Step 4)
-- Grounding score < 50% in main summary
-- Multiple fabricated claims that fundamentally misrepresent the cluster
-
-**ACCEPT_WITH_CORRECTIONS (correctable issues):**
-- Tags array contains items not in input data → Remove them, list in corrections_made
-- Notably_absent array contains items not in input data → Remove them, list in corrections_made
-- One or two phenotype terms need adjustment → Provide corrected list
-- Main summary is accurate but supporting fields have minor issues
-
-**LOW_CONFIDENCE (moderate issues, no correction possible):**
-- Grounding score 50-79%
-- Uses overly broad syndrome terms that can't be corrected
-- Missing significant phenotypes from top 5 by |v.test|
-
-**ACCEPT (all must be true):**
-- Grounding score >= 80%
-- No molecular/gene content
-- No fabricated phenotypes in main summary
-- Direction interpretation correct
-- All tags and notably_absent items verified in input data
-
----
-
-## CORRECTION INSTRUCTIONS
-
-If issues are correctable:
-1. Set corrections_needed = true
-2. List each correction in corrections_made array
-3. Provide corrected_tags with ONLY items that appear in the input phenotype data
-4. Provide corrected_notably_absent with ONLY depleted phenotypes (v.test < 0) from input
-5. Provide corrected_inheritance_patterns with ONLY patterns from quali_sup_var with |v.test| > 2
-   - Use standard abbreviations: AD, AR, XL, XLR, XLD, MT, SP
-6. Provide corrected_syndromicity based on quanti_sup_var data
-7. Use verdict = 'accept_with_corrections'
-
-Example correction:
-- corrections_made: ['Removed \"Seizures\" from notably_absent - not in input data',
-  'Corrected inheritance from XL to AR based on source data']
-- corrected_notably_absent: ['Progressive', 'Developmental regression'] (only items with v.test < 0)
-- corrected_inheritance_patterns: ['AR', 'AD'] (only from source data)
-- corrected_syndromicity: 'predominantly_id' (based on positive v.test for phenotype_id_count)
-
----
-
-## YOUR RESPONSE
-Complete the verification steps, then provide your verdict.
-REMEMBER: If ANY forbidden molecular terms appear, verdict MUST be 'reject'.
-")
-}
 
 
 #' Validate cluster summary using LLM-as-judge
@@ -702,6 +225,66 @@ validate_with_llm_judge <- function(summary, cluster_data, model = NULL, cluster
 }
 
 
+#' Apply judge corrections to a generated summary.
+#'
+#' When the judge returns `corrections_needed = TRUE`, copy any corrected fields
+#' onto the summary. Beyond the supporting fields (tags / notably_absent /
+#' inheritance_patterns / syndromicity), this also applies `corrected_summary`
+#' to the main summary text (#448) so an otherwise-grounded clinical summary with
+#' an isolated molecular phrase or over-reaching label can be salvaged via
+#' `accept_with_corrections` instead of being permanently rejected. A no-op when
+#' `corrections_needed` is not TRUE.
+#'
+#' @param summary List, the generated summary.
+#' @param judge_result List, the judge verdict (with optional corrected_* fields).
+#' @return The summary list with corrections applied (and corrections metadata).
+#' @export
+apply_judge_corrections <- function(summary, judge_result) {
+  if (!isTRUE(judge_result$corrections_needed)) {
+    return(summary)
+  }
+  log_info("Applying judge corrections to summary")
+
+  # Corrected main summary text (#448): salvage isolated molecular phrasing /
+  # over-reach rather than hard-rejecting an otherwise-grounded summary.
+  cs <- judge_result$corrected_summary
+  if (!is.null(cs) && length(cs) > 0 && nzchar(trimws(as.character(cs[[1]])))) {
+    summary$summary <- as.character(cs[[1]])
+    log_debug("Applied corrected_summary")
+  }
+
+  # Corrected tags
+  if (!is.null(judge_result$corrected_tags) && length(judge_result$corrected_tags) > 0) {
+    summary$tags <- judge_result$corrected_tags
+    log_debug("Applied corrected tags: {paste(judge_result$corrected_tags, collapse=', ')}")
+  }
+
+  # Corrected notably_absent
+  if (!is.null(judge_result$corrected_notably_absent)) {
+    summary$notably_absent <- judge_result$corrected_notably_absent
+    log_debug("Applied corrected notably_absent")
+  }
+
+  # Corrected inheritance_patterns
+  corrected_inh <- judge_result$corrected_inheritance_patterns
+  if (!is.null(corrected_inh) && length(corrected_inh) > 0) {
+    summary$inheritance_patterns <- corrected_inh
+    log_debug("Applied corrected inheritance_patterns")
+  }
+
+  # Corrected syndromicity
+  if (!is.null(judge_result$corrected_syndromicity) &&
+        nzchar(judge_result$corrected_syndromicity)) {
+    summary$syndromicity <- judge_result$corrected_syndromicity
+    log_debug("Applied corrected syndromicity: {judge_result$corrected_syndromicity}")
+  }
+
+  summary$corrections_applied <- TRUE
+  summary$corrections_made <- judge_result$corrections_made
+  summary
+}
+
+
 #' Generate and validate cluster summary with LLM-as-judge
 #'
 #' Complete pipeline: generate summary, validate entities, validate with judge, cache.
@@ -802,41 +385,7 @@ generate_and_validate_with_judge <- function(
   log_info("Judge verdict: {judge_result$verdict} -> validation_status={validation_status}, success={success}")
 
   # Step 4: Add judge metadata to summary
-  summary_with_metadata <- gen_result$summary
-
-  # Apply corrections if judge provided them
-  if (isTRUE(judge_result$corrections_needed)) {
-    log_info("Applying judge corrections to summary")
-
-    # Apply corrected tags if provided
-    if (!is.null(judge_result$corrected_tags) && length(judge_result$corrected_tags) > 0) {
-      summary_with_metadata$tags <- judge_result$corrected_tags
-      log_debug("Applied corrected tags: {paste(judge_result$corrected_tags, collapse=', ')}")
-    }
-
-    # Apply corrected notably_absent if provided
-    if (!is.null(judge_result$corrected_notably_absent)) {
-      summary_with_metadata$notably_absent <- judge_result$corrected_notably_absent
-      log_debug("Applied corrected notably_absent: {paste(judge_result$corrected_notably_absent, collapse=', ')}")
-    }
-
-    # Apply corrected inheritance_patterns if provided
-    corrected_inh <- judge_result$corrected_inheritance_patterns
-    if (!is.null(corrected_inh) && length(corrected_inh) > 0) {
-      summary_with_metadata$inheritance_patterns <- corrected_inh
-      log_debug("Applied corrected inheritance_patterns: {paste(corrected_inh, collapse=', ')}")
-    }
-
-    # Apply corrected syndromicity if provided
-    if (!is.null(judge_result$corrected_syndromicity) && nzchar(judge_result$corrected_syndromicity)) {
-      summary_with_metadata$syndromicity <- judge_result$corrected_syndromicity
-      log_debug("Applied corrected syndromicity: {judge_result$corrected_syndromicity}")
-    }
-
-    # Add corrections metadata
-    summary_with_metadata$corrections_applied <- TRUE
-    summary_with_metadata$corrections_made <- judge_result$corrections_made
-  }
+  summary_with_metadata <- apply_judge_corrections(gen_result$summary, judge_result)
 
   # Add judge verdict and reasoning
   summary_with_metadata$llm_judge_verdict <- judge_result$verdict

--- a/api/functions/llm-types.R
+++ b/api/functions/llm-types.R
@@ -512,6 +512,11 @@ Positive v.test = over-represented; Negative v.test = under-represented.
 
 ### ALLOWED:
 - Grouping phenotypes into categories (e.g., 'genitourinary and renal phenotypes')
+- Synthesize the listed enriched (and strongly depleted) phenotypes into a
+  recognized clinical gestalt - e.g. describing mild ID + macrocephaly +
+  behavioral abnormality (with severe/syndromic features depleted) as 'a mild,
+  predominantly non-syndromic neurodevelopmental presentation'. This is grounded
+  as long as you do NOT assert any NEW specific phenotype absent from the tables.
 - Describing the clinical significance of specific phenotypes
 - Using inheritance pattern data to characterize the cluster
 - Stating uncertainty with phrases like 'The data suggests...'

--- a/api/tests/testthat/test-llm-judge.R
+++ b/api/tests/testthat/test-llm-judge.R
@@ -3,6 +3,7 @@
 
 # Source the required functions
 source_api_file("functions/llm-service.R", local = FALSE)
+source_api_file("functions/llm-judge-prompts.R", local = FALSE)
 source_api_file("functions/llm-judge.R", local = FALSE)
 source_api_file("functions/llm-cache-repository.R", local = FALSE)
 

--- a/api/tests/testthat/test-unit-llm-judge-prompt.R
+++ b/api/tests/testthat/test-unit-llm-judge-prompt.R
@@ -1,0 +1,101 @@
+# tests/testthat/test-unit-llm-judge-prompt.R
+#
+# Unit tests for the #448 phenotype-judge robustness changes:
+# - verdict type advertises corrected_summary
+# - apply_judge_corrections() applies (or skips) corrected_summary + other fields
+# - the phenotype judge prompt allows grounded clinical synthesis and prefers
+#   accept_with_corrections over a hard reject for isolated molecular phrasing,
+#   while keeping the severe-error hard rejects
+# - the phenotype generation prompt permits grounded gestalt synthesis
+#
+# Requires ellmer (the verdict type is built at source time) -> run in the API
+# container: docker exec sysndd-api-1 Rscript -e \
+#   "testthat::test_file('/app/tests/testthat/test-unit-llm-judge-prompt.R')"
+
+source_api_file("functions/llm-judge.R", local = FALSE)
+source_api_file("functions/llm-judge-prompts.R", local = FALSE)
+source_api_file("functions/llm-types.R", local = FALSE)
+
+# --- Task 1: verdict type gains corrected_summary ---------------------------
+
+test_that("verdict type advertises corrected_summary", {
+  props <- names(llm_judge_verdict_type@properties)
+  expect_true("corrected_summary" %in% props)
+  # existing fields preserved
+  expect_true(all(c("verdict", "reasoning", "corrected_tags") %in% props))
+})
+
+# --- Task 2: apply_judge_corrections ----------------------------------------
+
+test_that("apply_judge_corrections rewrites main summary when corrected_summary given", {
+  base <- list(
+    summary = "Genes involved in synaptic signaling drive mild ID.",
+    tags = c("a")
+  )
+  verdict <- list(
+    corrections_needed = TRUE,
+    corrected_summary = "Mild intellectual disability with macrocephaly and behavioral abnormality.",
+    corrections_made = c("Removed molecular phrasing from summary")
+  )
+  out <- apply_judge_corrections(base, verdict)
+  expect_equal(out$summary, "Mild intellectual disability with macrocephaly and behavioral abnormality.")
+  expect_true(isTRUE(out$corrections_applied))
+  expect_equal(out$corrections_made, c("Removed molecular phrasing from summary"))
+})
+
+test_that("apply_judge_corrections leaves summary intact when no corrected_summary", {
+  base <- list(summary = "Original summary", tags = c("a"))
+  verdict <- list(corrections_needed = TRUE, corrected_tags = c("b", "c"))
+  out <- apply_judge_corrections(base, verdict)
+  expect_equal(out$summary, "Original summary")
+  expect_equal(out$tags, c("b", "c"))
+})
+
+test_that("apply_judge_corrections is a no-op when corrections_needed is FALSE", {
+  base <- list(summary = "Original", tags = c("a"))
+  verdict <- list(corrections_needed = FALSE, corrected_summary = "should be ignored")
+  out <- apply_judge_corrections(base, verdict)
+  expect_equal(out$summary, "Original")
+  expect_null(out$corrections_applied)
+})
+
+test_that("apply_judge_corrections ignores blank corrected_summary", {
+  base <- list(summary = "Original", tags = c("a"))
+  verdict <- list(corrections_needed = TRUE, corrected_summary = "   ")
+  out <- apply_judge_corrections(base, verdict)
+  expect_equal(out$summary, "Original")
+})
+
+# --- Task 3: phenotype judge prompt is less brittle but keeps hard rejects ---
+
+test_that("phenotype judge prompt allows grounded synthesis + correction path", {
+  p <- build_phenotype_judge_prompt(
+    summary = list(summary = "x", confidence = "low"),
+    cluster_data = list(identifiers = data.frame(entity_id = 1:3))
+  )
+  # new, softer behavior
+  expect_match(p, "grounded clinical synthesis", fixed = TRUE)
+  expect_match(p, "corrected_summary", fixed = TRUE)
+  expect_match(p, "accept_with_corrections", fixed = TRUE)
+  # hard rejects still present
+  expect_match(p, "Direction inversion", ignore.case = TRUE)
+  expect_match(p, "Grounding score < 50%", fixed = TRUE)
+})
+
+# --- Task 4: generation prompt permits grounded gestalt synthesis -----------
+
+test_that("phenotype generation prompt permits grounded gestalt synthesis", {
+  cd <- list(
+    quali_inp_var = data.frame(
+      variable = c("Macrocephaly", "Intellectual disability, mild", "Behavioral abnormality"),
+      `v.test` = c(3.6, 6.4, 4.15),
+      `p.value` = c(0.01, 0.001, 0.005),
+      check.names = FALSE
+    ),
+    identifiers = data.frame(entity_id = 1:5)
+  )
+  p <- build_phenotype_cluster_prompt(cd)
+  expect_match(p, "synthesize", ignore.case = TRUE)
+  # the molecular guardrails must remain intact
+  expect_match(p, "MUST NOT", fixed = TRUE)
+})

--- a/app/src/components/llm/LlmCacheManager.spec.ts
+++ b/app/src/components/llm/LlmCacheManager.spec.ts
@@ -63,4 +63,62 @@ describe('LlmCacheManager — F2a Bearer-via-interceptor', () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(sawRequest).toBe(true);
   });
+
+  it('renders the judge verdict badge from a rejected summary_json (#448)', async () => {
+    primeAuth();
+    server.use(
+      http.get('*/api/llm/cache/summaries', () =>
+        HttpResponse.json({
+          data: [
+            {
+              cache_id: 7,
+              cluster_type: 'phenotype',
+              cluster_number: 3,
+              model_name: 'gemini-3.5-flash',
+              validation_status: 'rejected',
+              is_current: true,
+              created_at: '2026-06-15 07:53:24',
+              summary_json: {
+                validation: { verdict: 'reject', reasoning: 'Molecular hallucination.' },
+              },
+            },
+          ],
+          total: 1,
+          page: 1,
+          per_page: 20,
+        })
+      )
+    );
+
+    const wrapper = mount(LlmCacheManager, {
+      props: { stats: null },
+      global: {
+        stubs: {
+          BRow: { template: '<div><slot /></div>' },
+          BCol: { template: '<div><slot /></div>' },
+          BCard: { template: '<div><slot name="header" /><slot /><slot name="footer" /></div>' },
+          BButton: { template: '<button><slot /></button>' },
+          BButtonGroup: { template: '<div><slot /></div>' },
+          BBadge: { template: '<span class="badge"><slot /></span>' },
+          // Render the judge_verdict cell scoped slot for each item so the
+          // verdict-badge wiring (summary_json → extractJudgeVerdict → badge) runs.
+          BTable: {
+            props: ['items'],
+            template:
+              '<table><tbody><tr v-for="(it, i) in items" :key="i">' +
+              '<td><slot name="cell(judge_verdict)" :item="it" :value="it.validation_status" /></td>' +
+              '</tr></tbody></table>',
+          },
+          BPagination: { template: '<nav />' },
+          BFormSelect: { template: '<select />' },
+          BModal: { template: '<div />' },
+          'router-link': true,
+        },
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.text()).toContain('reject');
+  });
 });

--- a/app/src/components/llm/LlmCacheManager.vue
+++ b/app/src/components/llm/LlmCacheManager.vue
@@ -112,6 +112,16 @@
             {{ data.value }}
           </BBadge>
         </template>
+        <template #cell(judge_verdict)="data">
+          <BBadge
+            v-if="extractJudgeVerdict(data.item.summary_json).verdict"
+            :variant="verdictVariant(extractJudgeVerdict(data.item.summary_json).verdict)"
+            :title="extractJudgeVerdict(data.item.summary_json).reasoning || ''"
+          >
+            {{ extractJudgeVerdict(data.item.summary_json).verdict }}
+          </BBadge>
+          <span v-else class="text-muted">—</span>
+        </template>
         <template #cell(is_current)="data">
           <BBadge v-if="data.value" variant="success">Current</BBadge>
           <BBadge v-else variant="secondary">Stale</BBadge>
@@ -202,6 +212,27 @@
           </BBadge>
         </div>
 
+        <!-- LLM-as-judge verdict + reasoning (#448) -->
+        <BAlert
+          v-if="selectedVerdict.verdict"
+          :model-value="true"
+          :variant="verdictVariant(selectedVerdict.verdict)"
+          class="mb-3"
+        >
+          <div class="fw-bold mb-1">
+            Judge verdict: {{ selectedVerdict.verdict }}
+          </div>
+          <div v-if="selectedVerdict.reasoning" class="small">
+            {{ selectedVerdict.reasoning }}
+          </div>
+          <div v-if="selectedVerdict.correctionsMade.length" class="mt-2">
+            <small class="fw-bold d-block">Corrections applied:</small>
+            <ul class="small mb-0">
+              <li v-for="(c, i) in selectedVerdict.correctionsMade" :key="i">{{ c }}</li>
+            </ul>
+          </div>
+        </BAlert>
+
         <!-- Summary JSON -->
         <BCard bg-variant="light">
           <template #header>
@@ -217,9 +248,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, onMounted } from 'vue';
+import { ref, reactive, computed, onMounted } from 'vue';
 import { useLlmAdmin } from '@/composables/useLlmAdmin';
 import type { CacheStats, CachedSummary, ClusterType, ValidationStatus } from '@/types/llm';
+import { extractJudgeVerdict, verdictVariant } from '@/utils/llm-verdict';
 
 defineProps<{
   stats: CacheStats | null;
@@ -268,10 +300,15 @@ const fields = [
   { key: 'cluster_number', label: 'Cluster #', sortable: true },
   { key: 'model_name', label: 'Model', sortable: true },
   { key: 'validation_status', label: 'Status', sortable: true },
+  { key: 'judge_verdict', label: 'Judge', sortable: false },
   { key: 'is_current', label: 'Current', sortable: true },
   { key: 'created_at', label: 'Created', sortable: true },
   { key: 'actions', label: 'Actions' },
 ];
+
+// Judge verdict + reasoning for the currently-open detail modal (#448). Reads
+// from either summary_json shape (top-level or nested `validation`).
+const selectedVerdict = computed(() => extractJudgeVerdict(selectedSummary.value?.summary_json));
 
 function statusVariant(status: string) {
   switch (status) {

--- a/app/src/utils/llm-verdict.spec.ts
+++ b/app/src/utils/llm-verdict.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { extractJudgeVerdict, verdictVariant } from './llm-verdict';
+
+describe('extractJudgeVerdict', () => {
+  it('reads top-level accepted shape (array-wrapped, Plumber style)', () => {
+    const r = extractJudgeVerdict({
+      llm_judge_verdict: ['accept_with_corrections'],
+      llm_judge_reasoning: ['Removed hearing impairment; otherwise grounded.'],
+      corrections_made: ['Removed "hearing impairment"'],
+    });
+    expect(r.verdict).toBe('accept_with_corrections');
+    expect(r.reasoning).toContain('hearing');
+    expect(r.correctionsMade).toEqual(['Removed "hearing impairment"']);
+  });
+
+  it('reads top-level scalar shape', () => {
+    const r = extractJudgeVerdict({
+      llm_judge_verdict: 'accept',
+      llm_judge_reasoning: 'Fully grounded.',
+    });
+    expect(r.verdict).toBe('accept');
+    expect(r.reasoning).toBe('Fully grounded.');
+    expect(r.correctionsMade).toEqual([]);
+  });
+
+  it('reads nested rejected shape (#445)', () => {
+    const r = extractJudgeVerdict({
+      validation: { verdict: 'reject', reasoning: 'Molecular hallucination in summary.' },
+    });
+    expect(r.verdict).toBe('reject');
+    expect(r.reasoning).toContain('Molecular');
+  });
+
+  it('prefers the top-level shape when both are present', () => {
+    const r = extractJudgeVerdict({
+      llm_judge_verdict: ['accept'],
+      validation: { verdict: 'reject' },
+    });
+    expect(r.verdict).toBe('accept');
+  });
+
+  it('returns nulls / empty when absent', () => {
+    const r = extractJudgeVerdict({ summary: 'x' });
+    expect(r.verdict).toBeNull();
+    expect(r.reasoning).toBeNull();
+    expect(r.correctionsMade).toEqual([]);
+  });
+
+  it('is null-safe for undefined / null input', () => {
+    expect(extractJudgeVerdict(undefined).verdict).toBeNull();
+    expect(extractJudgeVerdict(null).reasoning).toBeNull();
+  });
+
+  it('treats blank strings as absent', () => {
+    const r = extractJudgeVerdict({ llm_judge_verdict: ['  '], llm_judge_reasoning: [''] });
+    expect(r.verdict).toBeNull();
+    expect(r.reasoning).toBeNull();
+  });
+});
+
+describe('verdictVariant', () => {
+  it('maps verdicts to bootstrap variants', () => {
+    expect(verdictVariant('accept')).toBe('success');
+    expect(verdictVariant('accept_with_corrections')).toBe('info');
+    expect(verdictVariant('low_confidence')).toBe('warning');
+    expect(verdictVariant('reject')).toBe('danger');
+    expect(verdictVariant(null)).toBe('secondary');
+    expect(verdictVariant('unknown')).toBe('secondary');
+  });
+});

--- a/app/src/utils/llm-verdict.ts
+++ b/app/src/utils/llm-verdict.ts
@@ -1,0 +1,67 @@
+// utils/llm-verdict.ts
+//
+// Pure helpers to read the LLM-as-judge verdict + reasoning out of a cached
+// summary's `summary_json`, for the admin LLM cache view (#448).
+//
+// The judge output is persisted in two shapes:
+//   - accepted / accept_with_corrections rows: top-level
+//     `summary_json.llm_judge_verdict` + `summary_json.llm_judge_reasoning`
+//     (+ `corrections_made`).
+//   - rejected rows (#445): nested `summary_json.validation.{verdict,reasoning}`.
+// Plumber wraps JSON scalars in single-element arrays, so values may arrive as
+// `["accept"]` rather than `"accept"`; `unwrap()` normalizes both.
+
+type SummaryJson = Record<string, unknown> | null | undefined;
+
+function unwrap(value: unknown): string | null {
+  if (value == null) return null;
+  if (Array.isArray(value)) return value.length ? unwrap(value[0]) : null;
+  const s = String(value).trim();
+  return s.length ? s : null;
+}
+
+export interface JudgeVerdict {
+  verdict: string | null;
+  reasoning: string | null;
+  correctionsMade: string[];
+}
+
+/**
+ * Extract the judge verdict, reasoning, and applied corrections from a cached
+ * summary's `summary_json`, handling both the top-level (accepted) and nested
+ * `validation` (rejected) shapes. Returns nulls / empty array when absent.
+ */
+export function extractJudgeVerdict(summaryJson: SummaryJson): JudgeVerdict {
+  const j = (summaryJson ?? {}) as Record<string, unknown>;
+  const nested = (j.validation ?? {}) as Record<string, unknown>;
+
+  const verdict = unwrap(j.llm_judge_verdict) ?? unwrap(nested.verdict);
+  const reasoning = unwrap(j.llm_judge_reasoning) ?? unwrap(nested.reasoning);
+
+  const rawCorrections = j.corrections_made;
+  const correctionsMade = Array.isArray(rawCorrections)
+    ? rawCorrections.map((x) => String(x)).filter((s) => s.trim().length > 0)
+    : [];
+
+  return { verdict, reasoning, correctionsMade };
+}
+
+/**
+ * Bootstrap variant for a judge verdict badge/alert. The return type is left to
+ * inference (a literal union) so it satisfies bootstrap-vue-next's `variant`
+ * prop type (`keyof BaseColorVariant`), matching the component's local helpers.
+ */
+export function verdictVariant(verdict: string | null) {
+  switch (verdict) {
+    case 'accept':
+      return 'success';
+    case 'accept_with_corrections':
+      return 'info';
+    case 'low_confidence':
+      return 'warning';
+    case 'reject':
+      return 'danger';
+    default:
+      return 'secondary';
+  }
+}


### PR DESCRIPTION
Closes #448.

## Root cause (data-confirmed against production 2026-06-15)
Phenotype **cluster 3** returns `HTTP 404 {"message":["Summary not found for this cluster"]}` from `/api/analysis/phenotype_cluster_summary` — its generated summary is `validation_status = 'rejected'`. Pulling the live cluster data:

- Cluster 3 (size 502) is the **"mild, predominantly non-syndromic"** cluster: only **4 enriched** phenotypes (mild ID, behavioral abnormality, macrocephaly, ID) against **34 strongly-depleted** syndromic features; `phenotype_non_id_count` v.test = **−23.3**.
- Clusters 2 (541) and 4 (535) are **larger** and pass → the cause is **content-specific, not size**.

The phenotype judge prompt mandated *"ANY forbidden molecular term → verdict MUST be reject"* and treated any interpretive synthesis beyond the 4 verbatim enriched terms as "FABRICATED → reject" — and the verdict type could only correct `tags`/`notably_absent`/`inheritance`/`syndromicity`, **never the main summary text**. So a legitimately-summarizable, sparse, depletion-defined cluster had no correction path and was permanently rejected.

## Fix
**Judge robustness** (no grounding/threshold number is loosened — genuine hallucinations still hard-reject):
- Add optional `corrected_summary` to the verdict type, applied via the new `apply_judge_corrections()` (extracted from `generate_and_validate_with_judge()`), so isolated molecular phrasing / a single over-reaching label is salvaged via `accept_with_corrections` instead of `reject`.
- Reframe `build_phenotype_judge_prompt()`: **grounded clinical synthesis** of the listed phenotypes is explicitly allowed (not fabrication); **isolated molecular phrasing → correct, don't reject**. Hard rejects preserved for *fundamentally molecular* summaries, **direction inversion**, **fabricated specific phenotypes**, and **< 50% grounding**.
- Nudge `build_phenotype_cluster_prompt()` to permit grounded gestalt synthesis.

**Admin surfacing** (asked for in the issue): the admin LLM cache view now shows the judge **verdict + reasoning + corrections** — a `Judge` badge column and a verdict panel in the detail modal — reading **both** persisted shapes (top-level `llm_judge_verdict` for accepted rows, nested `validation.{verdict,reasoning}` for rejected rows from #445) via the pure, fully-tested `extractJudgeVerdict()` helper.

**Refactor:** extracted the two judge prompt builders to `functions/llm-judge-prompts.R` (registered in `bootstrap/load_modules.R`), bringing `llm-judge.R` from 990 → 460 lines, back under the file-size ratchet.

## Tests
- `api/tests/testthat/test-unit-llm-judge-prompt.R` — verdict type has `corrected_summary`; `apply_judge_corrections()` (applies/skips `corrected_summary`, other fields, no-op cases); phenotype judge prompt has the grounded-synthesis + correction guidance **and** keeps the hard-reject rules; generation prompt permits synthesis.
- `app/src/utils/llm-verdict.spec.ts` (8) — dual-shape extraction, array-unwrapping, blank handling, variant mapping.
- `LlmCacheManager.spec.ts` — verdict badge renders from a rejected `summary_json`.
- Existing `test-llm-judge.R` passes (sources the new builders file); `npm run type-check` + lint + `make code-quality-audit` clean.

## Verification note
Live re-validation of cluster 3 requires a **Curator+ regeneration** against production (the public/MCP paths are cache-hit-only). This PR makes the judge accept it; a regeneration after merge confirms it serves.