### PR TITLE
feat(app): admin view to monitor + trigger disease ontology mapping refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **Administrator view "Manage Ontology Mappings"** (`/ManageOntologyMappings`): an admin surface to monitor and trigger the disease cross-ontology mapping refresh. Shows the latest build provenance (MONDO release, term/xref/mapping/disease counts, status, duration) from `GET /api/admin/ontology/mappings/status`, a prominent cold-start warning when no build exists yet, and a "Refresh now" button (`POST /api/admin/ontology/mappings/refresh?force=true`) with live job progress. The mappings still populate automatically on startup (bootstrap), weekly (cron), and after an operator ontology refresh — this view adds operator visibility and a manual trigger.
+
 ## [0.26.0] — 2026-06-20
 
 Minor release: disease cross-ontology mappings (MONDO / Orphanet / OMIM / DOID / UMLS / MedGen / NCIT / GARD / EFO) across database, API, and frontend, in lockstep across app, API, and DB schema versions.

--- a/app/src/api/ontology_mapping_admin.ts
+++ b/app/src/api/ontology_mapping_admin.ts
@@ -38,10 +38,7 @@ export interface OntologyMappingRefreshResult {
 export async function fetchOntologyMappingStatus(
   config?: Parameters<typeof apiClient.get>[1]
 ): Promise<OntologyMappingStatus> {
-  return apiClient.get<OntologyMappingStatus>(
-    '/api/admin/ontology/mappings/status',
-    config
-  );
+  return apiClient.get<OntologyMappingStatus>('/api/admin/ontology/mappings/status', config);
 }
 
 /**

--- a/app/src/api/ontology_mapping_admin.ts
+++ b/app/src/api/ontology_mapping_admin.ts
@@ -1,0 +1,68 @@
+// Administrator-only disease cross-ontology mapping API client.
+// Both endpoints use @serializer unboxedJSON, so scalars come back as bare
+// values (not 1-element arrays). No unwrapScalar needed.
+import { apiClient } from './client';
+
+export interface OntologyMappingMetaRow {
+  id: number;
+  mondo_release_version: string | null;
+  /** success | failed | skipped */
+  status: string | null;
+  mondo_term_count: number | null;
+  mondo_xref_count: number | null;
+  mapping_count: number | null;
+  disease_covered_count: number | null;
+  build_started_at: string | null;
+  build_finished_at: string | null;
+  build_duration_s: number | null;
+}
+
+export interface OntologyMappingStatus {
+  latest: OntologyMappingMetaRow | null;
+  history: OntologyMappingMetaRow[];
+  build_exists: boolean;
+}
+
+export interface OntologyMappingRefreshResult {
+  submitted: boolean;
+  duplicate: boolean;
+  skipped: boolean;
+  job_id: string | null;
+  message: string;
+}
+
+/**
+ * GET /api/admin/ontology/mappings/status
+ * Returns the latest build row, recent history, and a build_exists flag.
+ */
+export async function fetchOntologyMappingStatus(
+  config?: Parameters<typeof apiClient.get>[1]
+): Promise<OntologyMappingStatus> {
+  return apiClient.get<OntologyMappingStatus>(
+    '/api/admin/ontology/mappings/status',
+    config
+  );
+}
+
+/**
+ * POST /api/admin/ontology/mappings/refresh?force=<bool>
+ * Submits (or deduplicates) a mapping refresh job.
+ * - submitted=true  → new job enqueued; poll job_id.
+ * - duplicate=true  → identical job already queued/running; poll reused job_id.
+ * - skipped=true    → only with force=false when a successful build exists.
+ */
+export async function submitOntologyMappingRefresh(
+  force: boolean,
+  config?: Parameters<typeof apiClient.raw.post>[2]
+): Promise<OntologyMappingRefreshResult> {
+  const response = await apiClient.raw.post<OntologyMappingRefreshResult>(
+    '/api/admin/ontology/mappings/refresh',
+    undefined,
+    {
+      ...config,
+      params: { force },
+      validateStatus: (status) => status >= 200 && status < 300,
+    }
+  );
+  return response.data;
+}

--- a/app/src/assets/js/constants/main_nav_constants.ts
+++ b/app/src/assets/js/constants/main_nav_constants.ts
@@ -117,6 +117,11 @@ const MAIN_NAV = {
         { text: 'LLM Management', path: '/ManageLLM', icons: ['gear', 'robot'] },
         { text: 'Manage NDDScore', path: '/ManageNDDScore', icons: ['gear', 'graph-up-arrow'] },
         { text: 'Manage metadata', path: '/ManageMetadata', icons: ['gear', 'list-check'] },
+        {
+          text: 'Manage ontology mappings',
+          path: '/ManageOntologyMappings',
+          icons: ['gear', 'diagram-3'],
+        },
       ],
     },
     {

--- a/app/src/router/routes.ts
+++ b/app/src/router/routes.ts
@@ -489,6 +489,7 @@ export const routes: RouteRecordRaw[] = [
     'ManageLLM',
     'ManageNDDScore',
     'ManageMetadata',
+    'ManageOntologyMappings',
   ].map(simpleAdminRoute),
   {
     path: '/Entities/:entity_id',

--- a/app/src/views/admin/ManageOntologyMappings.spec.ts
+++ b/app/src/views/admin/ManageOntologyMappings.spec.ts
@@ -105,9 +105,28 @@ describe('ManageOntologyMappings.vue', () => {
     await flushPromises();
     await wrapper.find('[data-testid="ontology-mapping-refresh-btn"]').trigger('click');
     await flushPromises();
-    expect(wrapper.text()).toContain('A mapping refresh is already running.');
+    expect(wrapper.text()).toContain('Duplicate job.');
     expect(wrapper.find('[data-testid="ont-active-job"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="ont-active-job"]').text()).toContain('job-ont-existing');
+  });
+
+  it('shows skipped message and does not start job polling on skipped result', async () => {
+    const { submitOntologyMappingRefresh } = await import('@/api/ontology_mapping_admin');
+    (submitOntologyMappingRefresh as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      submitted: false,
+      duplicate: false,
+      skipped: true,
+      job_id: null,
+      message: 'A successful build already exists.',
+    });
+    const wrapper = mount(ManageOntologyMappings, {
+      global: { stubs: { AdminOperationPanel: false } },
+    });
+    await flushPromises();
+    await wrapper.find('[data-testid="ontology-mapping-refresh-btn"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.text()).toContain('A successful build already exists.');
+    expect(wrapper.find('[data-testid="ont-active-job"]').exists()).toBe(false);
   });
 
   it('surfaces the extracted API error message on submit failure', async () => {

--- a/app/src/views/admin/ManageOntologyMappings.spec.ts
+++ b/app/src/views/admin/ManageOntologyMappings.spec.ts
@@ -1,0 +1,127 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import ManageOntologyMappings from './ManageOntologyMappings.vue';
+
+vi.mock('@/api/ontology_mapping_admin', () => ({
+  fetchOntologyMappingStatus: vi.fn().mockResolvedValue({
+    latest: {
+      id: 12,
+      mondo_release_version: '2026-06-02',
+      status: 'success',
+      mondo_term_count: 33766,
+      mondo_xref_count: 121791,
+      mapping_count: 40645,
+      disease_covered_count: 6766,
+      build_started_at: '2026-06-20 18:00:00',
+      build_finished_at: '2026-06-20 18:00:42',
+      build_duration_s: 42.1,
+    },
+    history: [
+      {
+        id: 12,
+        mondo_release_version: '2026-06-02',
+        status: 'success',
+        mondo_term_count: 33766,
+        mondo_xref_count: 121791,
+        mapping_count: 40645,
+        disease_covered_count: 6766,
+        build_started_at: '2026-06-20 18:00:00',
+        build_finished_at: '2026-06-20 18:00:42',
+        build_duration_s: 42.1,
+      },
+    ],
+    build_exists: true,
+  }),
+  submitOntologyMappingRefresh: vi.fn().mockResolvedValue({
+    submitted: true,
+    duplicate: false,
+    skipped: false,
+    job_id: 'job-ont-1',
+    message: 'Mapping refresh job submitted.',
+  }),
+}));
+
+describe('ManageOntologyMappings.vue', () => {
+  it('renders the latest build status with release version and mapping count', async () => {
+    const wrapper = mount(ManageOntologyMappings, {
+      global: { stubs: { AdminOperationPanel: false } },
+    });
+    await flushPromises();
+    expect(wrapper.text()).toContain('2026-06-02');
+    expect(wrapper.find('[data-testid="ont-mapping-count"]').text()).toContain('40,645');
+    expect(wrapper.find('[data-testid="ontology-mapping-refresh-btn"]').exists()).toBe(true);
+  });
+
+  it('renders the cold-start warning when build_exists is false', async () => {
+    const { fetchOntologyMappingStatus } = await import('@/api/ontology_mapping_admin');
+    (fetchOntologyMappingStatus as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      latest: null,
+      history: [],
+      build_exists: false,
+    });
+    const wrapper = mount(ManageOntologyMappings, {
+      global: { stubs: { AdminOperationPanel: false } },
+    });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="ont-cold-start-warning"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain('No disease ontology mappings have been built yet');
+  });
+
+  it('calls submitOntologyMappingRefresh(true) when the Refresh now button is clicked', async () => {
+    const wrapper = mount(ManageOntologyMappings, {
+      global: { stubs: { AdminOperationPanel: false } },
+    });
+    await flushPromises();
+    await wrapper.find('[data-testid="ontology-mapping-refresh-btn"]').trigger('click');
+    await flushPromises();
+    const { submitOntologyMappingRefresh } = await import('@/api/ontology_mapping_admin');
+    expect(submitOntologyMappingRefresh).toHaveBeenCalledWith(true);
+  });
+
+  it('starts job polling and shows the job_id and message on submitted result', async () => {
+    const wrapper = mount(ManageOntologyMappings, {
+      global: { stubs: { AdminOperationPanel: false } },
+    });
+    await flushPromises();
+    await wrapper.find('[data-testid="ontology-mapping-refresh-btn"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.text()).toContain('Mapping refresh job submitted.');
+    expect(wrapper.find('[data-testid="ont-active-job"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="ont-active-job"]').text()).toContain('job-ont-1');
+  });
+
+  it('shows "already running" message and polls the reused job_id on duplicate result', async () => {
+    const { submitOntologyMappingRefresh } = await import('@/api/ontology_mapping_admin');
+    (submitOntologyMappingRefresh as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      submitted: false,
+      duplicate: true,
+      skipped: false,
+      job_id: 'job-ont-existing',
+      message: 'Duplicate job.',
+    });
+    const wrapper = mount(ManageOntologyMappings, {
+      global: { stubs: { AdminOperationPanel: false } },
+    });
+    await flushPromises();
+    await wrapper.find('[data-testid="ontology-mapping-refresh-btn"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.text()).toContain('A mapping refresh is already running.');
+    expect(wrapper.find('[data-testid="ont-active-job"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="ont-active-job"]').text()).toContain('job-ont-existing');
+  });
+
+  it('surfaces the extracted API error message on submit failure', async () => {
+    const { submitOntologyMappingRefresh } = await import('@/api/ontology_mapping_admin');
+    (submitOntologyMappingRefresh as ReturnType<typeof vi.fn>).mockRejectedValueOnce({
+      response: { data: { detail: 'MONDO release not available' } },
+    });
+    const wrapper = mount(ManageOntologyMappings, {
+      global: { stubs: { AdminOperationPanel: false } },
+    });
+    await flushPromises();
+    await wrapper.find('[data-testid="ontology-mapping-refresh-btn"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.text()).toContain('MONDO release not available');
+    expect(wrapper.text()).not.toContain('Failed to submit disease ontology mapping refresh.');
+  });
+});

--- a/app/src/views/admin/ManageOntologyMappings.vue
+++ b/app/src/views/admin/ManageOntologyMappings.vue
@@ -103,9 +103,7 @@
           </section>
         </div>
 
-        <BAlert v-else variant="secondary" show class="mb-0">
-          No build records found.
-        </BAlert>
+        <BAlert v-else variant="secondary" show class="mb-0"> No build records found. </BAlert>
       </AdminOperationPanel>
 
       <!-- ─── Control panel ─────────────────────────────────────────────── -->

--- a/app/src/views/admin/ManageOntologyMappings.vue
+++ b/app/src/views/admin/ManageOntologyMappings.vue
@@ -267,7 +267,7 @@ async function triggerRefresh(): Promise<void> {
       refreshJob.startJob(result.job_id);
     }
     if (result.duplicate) {
-      actionMessage.value = 'A mapping refresh is already running.';
+      actionMessage.value = result.message || 'A mapping refresh is already running.';
     } else if (result.submitted) {
       actionMessage.value = result.message || 'Mapping refresh job submitted.';
     }

--- a/app/src/views/admin/ManageOntologyMappings.vue
+++ b/app/src/views/admin/ManageOntologyMappings.vue
@@ -1,0 +1,451 @@
+<template>
+  <AuthenticatedPageShell
+    title="Manage Ontology Mappings"
+    description="Monitor and trigger the disease cross-ontology mapping build. Mappings populate automatically on startup and weekly."
+    content-class="authenticated-route-content"
+    full-width
+  >
+    <BContainer fluid class="ont-admin">
+      <!-- ─── Status panel ──────────────────────────────────────────────── -->
+      <AdminOperationPanel
+        title="Mapping index status"
+        description="Latest disease cross-ontology mapping build and recent build history."
+        icon="bi-diagram-3"
+        :meta="statusMeta"
+        :aria-busy="loadingStatus ? 'true' : 'false'"
+      >
+        <BAlert v-if="loadError" variant="danger" show class="mb-3">
+          <i class="bi bi-exclamation-triangle-fill me-1" aria-hidden="true" />
+          {{ loadError }}
+        </BAlert>
+
+        <div v-if="loadingStatus" class="ont-loading" role="status" aria-live="polite">
+          <BSpinner small class="me-2" />
+          Loading mapping status...
+        </div>
+
+        <BAlert
+          v-else-if="!mappingStatus?.build_exists"
+          variant="warning"
+          show
+          class="mb-0"
+          data-testid="ont-cold-start-warning"
+        >
+          <i class="bi bi-exclamation-triangle-fill me-1" aria-hidden="true" />
+          No disease ontology mappings have been built yet. They populate automatically on startup
+          (and weekly); click <strong>Refresh now</strong> to build them immediately.
+        </BAlert>
+
+        <div v-else-if="mappingStatus?.latest" class="ont-build">
+          <div class="ont-build__identity">
+            <div>
+              <span class="ont-label">MONDO release</span>
+              <strong class="ont-mono" data-testid="ont-mondo-release">{{
+                mappingStatus.latest.mondo_release_version ?? '—'
+              }}</strong>
+            </div>
+            <BBadge :class="buildStatusClass(mappingStatus.latest.status)">
+              {{ mappingStatus.latest.status ?? '—' }}
+            </BBadge>
+          </div>
+
+          <div class="ont-kpi-grid" aria-label="Build counts">
+            <div class="ont-kpi">
+              <span>Mappings</span>
+              <strong data-testid="ont-mapping-count">{{
+                fmtNum(mappingStatus.latest.mapping_count)
+              }}</strong>
+            </div>
+            <div class="ont-kpi">
+              <span>Diseases covered</span>
+              <strong>{{ fmtNum(mappingStatus.latest.disease_covered_count) }}</strong>
+            </div>
+            <div class="ont-kpi">
+              <span>MONDO terms</span>
+              <strong>{{ fmtNum(mappingStatus.latest.mondo_term_count) }}</strong>
+            </div>
+            <div class="ont-kpi">
+              <span>Cross-refs</span>
+              <strong>{{ fmtNum(mappingStatus.latest.mondo_xref_count) }}</strong>
+            </div>
+          </div>
+
+          <div class="ont-detail-grid">
+            <div class="ont-detail">
+              <span class="ont-label">Finished</span>
+              <span>{{ fmtDate(mappingStatus.latest.build_finished_at) }}</span>
+            </div>
+            <div class="ont-detail">
+              <span class="ont-label">Duration</span>
+              <span>{{
+                mappingStatus.latest.build_duration_s != null
+                  ? `${mappingStatus.latest.build_duration_s.toFixed(1)} s`
+                  : '—'
+              }}</span>
+            </div>
+          </div>
+
+          <section v-if="mappingStatus.history.length > 1" class="ont-subsection">
+            <h3>Recent history</h3>
+            <div class="ont-history-list">
+              <div
+                v-for="row in mappingStatus.history.slice(0, 5)"
+                :key="row.id"
+                class="ont-history-row"
+              >
+                <BBadge :class="buildStatusClass(row.status)" class="me-2">
+                  {{ row.status ?? '—' }}
+                </BBadge>
+                <span class="ont-mono me-2">{{ row.mondo_release_version ?? '—' }}</span>
+                <span class="ont-muted">{{ fmtDate(row.build_finished_at) }}</span>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <BAlert v-else variant="secondary" show class="mb-0">
+          No build records found.
+        </BAlert>
+      </AdminOperationPanel>
+
+      <!-- ─── Control panel ─────────────────────────────────────────────── -->
+      <AdminOperationPanel
+        title="Rebuild mappings"
+        description="Enqueue an immediate mapping refresh. The orchestrator skips the heavy rebuild when the MONDO release is unchanged unless you request a force rebuild."
+        icon="bi-arrow-repeat"
+        heading-tag="h2"
+        :aria-busy="submitting || refreshJob.isLoading.value ? 'true' : 'false'"
+      >
+        <template #actions>
+          <BButton
+            variant="primary"
+            size="sm"
+            data-testid="ontology-mapping-refresh-btn"
+            :disabled="submitting || refreshJob.isLoading.value"
+            @click="triggerRefresh"
+          >
+            <BSpinner v-if="submitting" small class="me-1" />
+            <i v-else class="bi bi-arrow-clockwise me-1" aria-hidden="true" />
+            Refresh now
+          </BButton>
+        </template>
+
+        <BAlert v-if="actionError" variant="danger" show class="mb-3">
+          <i class="bi bi-exclamation-triangle-fill me-1" aria-hidden="true" />
+          {{ actionError }}
+        </BAlert>
+        <BAlert v-if="actionMessage" variant="info" show class="mb-3">
+          <i class="bi bi-info-circle-fill me-1" aria-hidden="true" />
+          {{ actionMessage }}
+        </BAlert>
+
+        <div
+          v-if="refreshJob.jobId.value"
+          class="ont-job"
+          data-testid="ont-active-job"
+          role="status"
+          aria-live="polite"
+        >
+          <div class="ont-job__header">
+            <div>
+              <BBadge :class="refreshJob.statusBadgeClass.value" class="me-2">
+                {{ refreshJob.status.value }}
+              </BBadge>
+              <span class="ont-job__id">Job {{ refreshJob.jobId.value }}</span>
+            </div>
+            <span class="ont-job__elapsed">
+              <i class="bi bi-clock me-1" aria-hidden="true" />
+              {{ refreshJob.elapsedTimeDisplay.value }}
+            </span>
+          </div>
+          <p v-if="refreshJob.step.value" class="ont-job__step">{{ refreshJob.step.value }}</p>
+          <BProgress :max="100" height="0.875rem">
+            <BProgressBar
+              :value="
+                refreshJob.hasRealProgress.value ? (refreshJob.progressPercent.value ?? 0) : 100
+              "
+              :variant="refreshJob.progressVariant.value"
+              :striped="!refreshJob.hasRealProgress.value"
+              :animated="refreshJob.isLoading.value"
+            >
+              <template v-if="refreshJob.hasRealProgress.value">
+                {{ refreshJob.progress.value.current }}/{{ refreshJob.progress.value.total }}
+              </template>
+              <template v-else-if="refreshJob.isLoading.value">Processing...</template>
+            </BProgressBar>
+          </BProgress>
+          <BAlert v-if="refreshJob.error.value" variant="danger" show class="mt-3 mb-0">
+            <i class="bi bi-exclamation-triangle-fill me-1" aria-hidden="true" />
+            {{ refreshJob.error.value }}
+          </BAlert>
+        </div>
+      </AdminOperationPanel>
+    </BContainer>
+  </AuthenticatedPageShell>
+</template>
+
+<script setup lang="ts">
+import AuthenticatedPageShell from '@/components/layout/AuthenticatedPageShell.vue';
+import AdminOperationPanel from '@/components/admin/AdminOperationPanel.vue';
+import { computed, onMounted, ref, watch } from 'vue';
+import { useAsyncJob } from '@/composables/useAsyncJob';
+import {
+  fetchOntologyMappingStatus,
+  submitOntologyMappingRefresh,
+  type OntologyMappingStatus,
+} from '@/api/ontology_mapping_admin';
+import {
+  BAlert,
+  BBadge,
+  BButton,
+  BContainer,
+  BProgress,
+  BProgressBar,
+  BSpinner,
+} from 'bootstrap-vue-next';
+import { extractApiErrorMessage } from '@/utils/api-errors';
+import { useHead } from '@unhead/vue';
+
+useHead({ title: 'Manage Ontology Mappings' });
+
+const jobStatusUrl = (jobId: string) => `/api/jobs/${encodeURIComponent(jobId)}/status`;
+const refreshJob = useAsyncJob(jobStatusUrl);
+
+const mappingStatus = ref<OntologyMappingStatus | null>(null);
+const loadingStatus = ref(true);
+const submitting = ref(false);
+const loadError = ref('');
+const actionError = ref('');
+const actionMessage = ref('');
+
+const statusMeta = computed<string | null>(() => {
+  if (!mappingStatus.value?.latest) return null;
+  const v = mappingStatus.value.latest.mondo_release_version;
+  return v ? `MONDO ${v}` : null;
+});
+
+onMounted(() => {
+  void loadStatus();
+});
+
+watch(
+  () => refreshJob.status.value,
+  (nextStatus) => {
+    if (nextStatus === 'completed' || nextStatus === 'failed') {
+      void loadStatus();
+    }
+  }
+);
+
+async function loadStatus(): Promise<void> {
+  loadingStatus.value = true;
+  loadError.value = '';
+  try {
+    mappingStatus.value = await fetchOntologyMappingStatus();
+  } catch (err) {
+    loadError.value = extractApiErrorMessage(
+      err,
+      'Failed to load disease ontology mapping status.'
+    );
+  } finally {
+    loadingStatus.value = false;
+  }
+}
+
+async function triggerRefresh(): Promise<void> {
+  submitting.value = true;
+  actionError.value = '';
+  actionMessage.value = '';
+  try {
+    const result = await submitOntologyMappingRefresh(true);
+    if (result.skipped) {
+      actionMessage.value = result.message || 'Mapping build skipped (already up to date).';
+      return;
+    }
+    if (result.job_id) {
+      refreshJob.reset();
+      refreshJob.startJob(result.job_id);
+    }
+    if (result.duplicate) {
+      actionMessage.value = 'A mapping refresh is already running.';
+    } else if (result.submitted) {
+      actionMessage.value = result.message || 'Mapping refresh job submitted.';
+    }
+  } catch (err) {
+    actionError.value = extractApiErrorMessage(
+      err,
+      'Failed to submit disease ontology mapping refresh.'
+    );
+  } finally {
+    submitting.value = false;
+  }
+}
+
+function buildStatusClass(status: string | null): string {
+  switch (status) {
+    case 'success':
+      return 'bg-success';
+    case 'failed':
+      return 'bg-danger';
+    case 'skipped':
+      return 'bg-warning text-dark';
+    default:
+      return 'bg-secondary';
+  }
+}
+
+function fmtNum(n: number | null | undefined): string {
+  if (n == null) return '—';
+  return n.toLocaleString();
+}
+
+function fmtDate(s: string | null | undefined): string {
+  if (!s) return '—';
+  try {
+    return new Date(s).toLocaleString();
+  } catch {
+    return s;
+  }
+}
+</script>
+
+<style scoped>
+.ont-admin {
+  padding: 0;
+}
+
+.ont-loading {
+  color: var(--neutral-600, #757575);
+  font-size: 0.875rem;
+}
+
+.ont-build,
+.ont-job {
+  min-width: 0;
+}
+
+.ont-build__identity,
+.ont-job__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.ont-label {
+  display: block;
+  color: var(--neutral-600, #757575);
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.ont-mono,
+.ont-job__id {
+  overflow-wrap: anywhere;
+  font-family: var(--font-family-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+}
+
+.ont-muted {
+  color: var(--neutral-600, #757575);
+  font-size: 0.8125rem;
+}
+
+.ont-kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.ont-kpi,
+.ont-detail {
+  min-width: 0;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: var(--radius-md, 0.375rem);
+  background: #f8fafc;
+}
+
+.ont-kpi {
+  padding: 0.625rem 0.75rem;
+}
+
+.ont-kpi span {
+  display: block;
+  color: var(--neutral-600, #757575);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.ont-kpi strong {
+  color: var(--neutral-900, #212121);
+  font-size: 1.1rem;
+  line-height: 1.25;
+}
+
+.ont-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.ont-detail {
+  padding: 0.625rem 0.75rem;
+  color: var(--neutral-900, #212121);
+  font-size: 0.875rem;
+}
+
+.ont-subsection {
+  margin-top: 1rem;
+}
+
+.ont-subsection h3 {
+  margin: 0 0 0.5rem;
+  color: var(--neutral-900, #212121);
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.ont-history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.ont-history-row {
+  display: flex;
+  align-items: center;
+  font-size: 0.875rem;
+}
+
+.ont-job {
+  margin-top: 1rem;
+  padding: 0.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: var(--radius-md, 0.375rem);
+  background: #f8fafc;
+}
+
+.ont-job__step,
+.ont-job__elapsed {
+  margin: 0.35rem 0;
+  color: var(--neutral-600, #757575);
+  font-size: 0.8125rem;
+}
+
+@media (max-width: 767.98px) {
+  .ont-kpi-grid,
+  .ont-detail-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 479.98px) {
+  .ont-kpi-grid,
+  .ont-detail-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>


### PR DESCRIPTION
Adds an Administrator-only admin view **"Manage Ontology Mappings"** (`/ManageOntologyMappings`) for the disease cross-ontology mapping feature shipped in #454.

### What it does
- **Status panel** — reads `GET /api/admin/ontology/mappings/status` and shows the latest build provenance (MONDO release version, term/xref/mapping/disease counts, status badge, finished-at, duration) + recent history.
- **Cold-start visibility** — when no successful build exists yet (`build_exists=false`), a prominent warning explains the mappings populate automatically and offers an immediate build.
- **Refresh control** — a "Refresh now" button (`POST /api/admin/ontology/mappings/refresh?force=true`) with live job progress via `useAsyncJob`, distinguishing submitted / already-running / skipped, and reloading status on completion.

### Pattern
Mirrors `ManageNDDScore.vue` exactly: `AuthenticatedPageShell` → `AdminOperationPanel` panels, `useAsyncJob` polling, `extractApiErrorMessage`, `data-testid`s. New typed client `app/src/api/ontology_mapping_admin.ts` (endpoints are `unboxedJSON`, so no scalar-unwrapping). Route added to the `simpleAdminRoute` group (auto `createAuthGuard(['Administrator'])` + sitemap-ignore); nav item added to the Administration dropdown (`required: ['admin']`).

### On production cold-start (the second ask)
No code change needed — the existing startup bootstrap already auto-loads on a fresh DB: `disease_ontology_mapping_bootstrap_on_startup()` (wired in `start_sysndd_api.R`, env-gated default-on, idempotent, staggered) enqueues a refresh when no successful build exists; the worker (egress + restarted on deploy) populates it (proven by the v0.26.0 E2E: ~40,645 mappings from empty tables). It self-heals via restart re-enqueue, the weekly cron, and job retries. This view is the operator's visibility + manual-retry net. The cold-start requirements are documented in `documentation/09-deployment.qmd`.

### Testing
7 vitest tests (status render, cold-start warning, `force=true` submit, submitted/duplicate/skipped paths, error surface); type-check, eslint, prettier, and `code-quality-audit` all clean. CHANGELOG `[Unreleased]` updated.

No backend changes — endpoints already existed.