### PR TITLE
fix(analysis): rebuild snapshots on schema_version bump + correct refresh-script usage (#483, #484)

### DIFF
--- a/api/functions/analysis-snapshot-repository.R
+++ b/api/functions/analysis-snapshot-repository.R
@@ -384,6 +384,16 @@ analysis_snapshot_status_code <- function(row) {
     return("snapshot_missing")
   }
 
+  # Rebuild on a snapshot-schema bump even when source data is unchanged (#483):
+  # a stored schema_version != the code's ANALYSIS_SNAPSHOT_SCHEMA_VERSION is
+  # treated as not-current (like source_version_mismatch) so it self-heals.
+  expected_schema <- tryCatch(as.character(ANALYSIS_SNAPSHOT_SCHEMA_VERSION)[1], error = function(e) NA_character_)
+  stored_schema <- analysis_snapshot_scalar(row$schema_version, NA_character_)
+  if (!is.na(expected_schema) && !is.na(stored_schema) && nzchar(stored_schema) &&
+    !identical(stored_schema, expected_schema)) {
+    return("schema_version_mismatch")
+  }
+
   source_version <- analysis_snapshot_scalar(row$source_data_version, NA_character_)
   current_version <- if ("current_source_data_version" %in% names(row)) {
     analysis_snapshot_scalar(row$current_source_data_version, NA_character_)

--- a/api/functions/analysis-snapshot-repository.R
+++ b/api/functions/analysis-snapshot-repository.R
@@ -384,16 +384,8 @@ analysis_snapshot_status_code <- function(row) {
     return("snapshot_missing")
   }
 
-  # Rebuild on a snapshot-schema bump even when source data is unchanged (#483):
-  # a stored schema_version != the code's ANALYSIS_SNAPSHOT_SCHEMA_VERSION is
-  # treated as not-current (like source_version_mismatch) so it self-heals.
-  expected_schema <- tryCatch(as.character(ANALYSIS_SNAPSHOT_SCHEMA_VERSION)[1], error = function(e) NA_character_)
-  stored_schema <- analysis_snapshot_scalar(row$schema_version, NA_character_)
-  if (!is.na(expected_schema) && !is.na(stored_schema) && nzchar(stored_schema) &&
-    !identical(stored_schema, expected_schema)) {
-    return("schema_version_mismatch")
-  }
-
+  # Source-data version is the primary freshness signal (more informative when
+  # both differ), so it is checked before the schema-version bump below.
   source_version <- analysis_snapshot_scalar(row$source_data_version, NA_character_)
   current_version <- if ("current_source_data_version" %in% names(row)) {
     analysis_snapshot_scalar(row$current_source_data_version, NA_character_)
@@ -408,6 +400,16 @@ analysis_snapshot_status_code <- function(row) {
     !is.na(source_version) &&
     !identical(as.character(source_version), as.character(current_version))) {
     return("source_version_mismatch")
+  }
+
+  # Rebuild on a snapshot-schema bump even when source data is unchanged (#483):
+  # a stored schema_version != the code's ANALYSIS_SNAPSHOT_SCHEMA_VERSION is
+  # treated as not-current (like source_version_mismatch) so it self-heals.
+  expected_schema <- tryCatch(as.character(ANALYSIS_SNAPSHOT_SCHEMA_VERSION)[1], error = function(e) NA_character_)
+  stored_schema <- analysis_snapshot_scalar(row$schema_version, NA_character_)
+  if (!is.na(expected_schema) && !is.na(stored_schema) && nzchar(stored_schema) &&
+    !identical(stored_schema, expected_schema)) {
+    return("schema_version_mismatch")
   }
 
   stale_after <- analysis_snapshot_scalar(row$stale_after, NA)

--- a/api/scripts/refresh-analysis-snapshots.R
+++ b/api/scripts/refresh-analysis-snapshots.R
@@ -14,11 +14,16 @@
 # public route that triggers a refresh (correct: it is admin/operator-only and
 # heavy), so this script is the operator entry point.
 #
-# Usage (inside the running API or worker container, which already has STRINGdb
-# and the full runtime available):
-#   docker exec sysndd-api-1 Rscript /app/scripts/refresh-analysis-snapshots.R
+# Usage: this file is NOT baked into the API image (`api/.dockerignore` excludes
+# `scripts/`), and the container runs as a non-root user (so `docker cp` into
+# `/app` is denied). Pipe it into the running container's R over stdin — the
+# container already has STRINGdb and the full runtime available:
 #
-# Or via the Make target:  make refresh-analysis-snapshots
+#   make refresh-analysis-snapshots
+#     (which runs: docker exec -i sysndd-api-1 Rscript - < api/scripts/refresh-analysis-snapshots.R)
+#
+# Do NOT use `docker exec sysndd-api-1 Rscript /app/scripts/refresh-analysis-snapshots.R`
+# — that path does not exist in the image (#484).
 #
 # The worker (queue "default") picks up the jobs and runs them; clustering-backed
 # snapshots can take 30-80s each. Re-running while jobs are queued/running returns

--- a/api/tests/testthat/test-unit-analysis-snapshot-repository.R
+++ b/api/tests/testthat/test-unit-analysis-snapshot-repository.R
@@ -52,6 +52,16 @@ test_that("snapshot status helpers classify missing and stale rows", {
   expect_equal(analysis_snapshot_status_code(stale), "snapshot_stale")
   fresh <- list(stale_after = Sys.time() + 60)
   expect_equal(analysis_snapshot_status_code(fresh), "available")
+
+  # #483: a fresh, source-current manifest built under an OLDER snapshot schema
+  # must be flagged for rebuild (was ignored -> served the old-schema snapshot).
+  old_schema <- list(stale_after = Sys.time() + 60, schema_version = "1.0")
+  expect_equal(analysis_snapshot_status_code(old_schema), "schema_version_mismatch")
+  current_schema <- list(
+    stale_after = Sys.time() + 60,
+    schema_version = ANALYSIS_SNAPSHOT_SCHEMA_VERSION
+  )
+  expect_equal(analysis_snapshot_status_code(current_schema), "available")
 })
 
 test_that("analysis_snapshot_public_current is TRUE only for a current (available) snapshot", {

--- a/app/src/api/analysis.ts
+++ b/app/src/api/analysis.ts
@@ -25,6 +25,7 @@ export const SNAPSHOT_PREPARING_CODES = [
   'snapshot_missing',
   'snapshot_stale',
   'source_version_mismatch',
+  'schema_version_mismatch',
 ] as const;
 
 /**


### PR DESCRIPTION
Fixes two post-deploy defects the deployment agent filed against the v0.27.0 analysis-snapshot work (#482).

## #483 — snapshots not rebuilt after `ANALYSIS_SNAPSHOT_SCHEMA_VERSION` bump
`analysis_snapshot_status_code()` classified a manifest only by `source_data_version` + `stale_after`, never `schema_version`. So after a schema bump (1.0→1.1 in #482) with unchanged curation data, every `public_ready` row stayed `available` → the startup bootstrap logged `all presets current, nothing to do` and a non-forced admin refresh deduped; only a *forced* rebuild flipped them to 1.1.

**Fix:** `analysis_snapshot_status_code()` now returns `schema_version_mismatch` when the stored manifest `schema_version` differs from the code's `ANALYSIS_SNAPSHOT_SCHEMA_VERSION`, exactly mirroring the existing `source_version_mismatch` path — so the auto-bootstrap / admin refresh re-enqueue the preset and it **self-heals** on the next deploy. The frontend `SNAPSHOT_PREPARING_CODES` gains the new code so the transient 503 still renders the friendly "being prepared" state instead of a raw error. Guarded by `test-unit-analysis-snapshot-repository.R` (old-schema→mismatch, current-schema→available; the no-`schema_version` case still resolves `available`, so existing rows are unaffected).

## #484 — broken `refresh-analysis-snapshots.R` usage comment
The script header documented `docker exec sysndd-api-1 Rscript /app/scripts/refresh-analysis-snapshots.R`, but `api/.dockerignore` excludes `scripts/` (not in the image) and the container is non-root (`docker cp` into `/app` denied) — the documented recovery command hard-fails during an incident. Corrected the comment to the working stdin form (`make refresh-analysis-snapshots` → `docker exec -i … Rscript - < api/scripts/…`). (I hit this exact error while forcing the v0.27.0 rebuild.)

## Verification
- `make code-quality-audit` clean (kept the repository file under 600 LOC).
- R: `analysis-snapshot-repository.R` lint clean; `test-unit-analysis-snapshot-repository.R` 45 pass (incl. new #483 cases).
- Frontend: `analysis.spec.ts` 14 pass, eslint + type-check clean.

## Deliberately deferred (larger / architectural — separate PRs)
- **#485** — LLM cluster-summary cache keyed only on `cluster_hash` (ignores prompt/code version) → stale summaries + orphaned `is_current` rows after re-clustering. Needs a cache-key version dimension + orphan retirement.
- **#486** — `publication_date_backfill` head-of-line blocks `llm_generation` on the single shared `default` worker queue. Needs queue prioritization/separation.

Closes #483, #484.

🤖 Generated with [Claude Code](https://claude.com/claude-code)