### PR TITLE
docs(comparisons): fix stale ndd_genehub docstring in normalize_comparison_categories

### DIFF
--- a/api/functions/category-normalization.R
+++ b/api/functions/category-normalization.R
@@ -34,7 +34,11 @@
 #'   - "2" → "Moderate"
 #'   - "3" → "Limited"
 #'   - NA → "Definitive"
-#' - **ndd_genehub**: All entries → "Definitive"
+#' - **ndd_genehub** (NDD GeneHub evidence tiers → normalized scale):
+#'   - "Tier 1", "AR" → "Definitive"
+#'   - "Tier 2" → "Moderate"
+#'   - "Tier 3", "Tier 4", "Missense" → "Limited"
+#'   - any other tier (e.g. "Unclassified") → "Limited"
 #' - **radboudumc_ID**: All entries → "Definitive"
 #' - **SysNDD, omim_ndd, orphanet_id**: Categories unchanged
 #'


### PR DESCRIPTION
## Summary

Comment-only follow-up to #503. The `@details` mapping table in `normalize_comparison_categories()` (`api/functions/category-normalization.R`) still described `ndd_genehub` as **"All entries → Definitive"** — its behavior *before* the #502 tier mapping. The code (and its unit test) actually maps NDD GeneHub evidence tiers to the normalized ClinGen-style scale:

- `Tier 1`, `AR` → **Definitive**
- `Tier 2` → **Moderate**
- `Tier 3`, `Tier 4`, `Missense`, `Unclassified` → **Limited**

The docstring is now synced to the implementation so the next reader isn't misled. No behavior change.

## Verification

- `lintr` on the file: clean.
- `test-unit-category-normalization.R`: **37/37 pass** — it already asserts the differentiated `ndd_genehub` mapping (`Tier 1`/`AR`→Definitive, `Tier 2`→Moderate, `Tier 3`/`Unclassified`→Limited), so the docstring now matches both the code and the test.
- Confirmed live (dev API restarted): the `/api/comparisons/browse` `ndd_genehub` column reports Definitive 548 (Tier 1+AR), Moderate 96 (Tier 2), Limited 932 (Tier 3+Tier 4+Missense) — the mapping behaves exactly as the corrected docstring states.

https://claude.ai/code/session_016VcL9en7cdrjvzi1tqMmqT
