### PR TITLE
test(comparisons): fix red 'Test R API (full)' CI lane (parser sourcing)

### DIFF
--- a/api/tests/testthat/test-unit-comparisons-functions.R
+++ b/api/tests/testthat/test-unit-comparisons-functions.R
@@ -24,7 +24,13 @@ library(stringr)
 library(withr)
 library(readr)
 
-# Source functions being tested
+# Source functions being tested. comparisons-parsers.R MUST be sourced
+# explicitly (absolute path) — comparisons-functions.R only guard-sources it via
+# relative paths, which do not resolve in testthat's working directory, so under
+# a full test_dir run (CI) parse_* / standardize_comparison_data can be undefined
+# and every parser test errors ("could not find function"). See the sibling fix
+# for test-external-pubmed.R.
+source(file.path(api_dir, "functions/comparisons-parsers.R"))
 source(file.path(api_dir, "functions/comparisons-functions.R"))
 source(file.path(api_dir, "functions/omim-functions.R"))
 source(file.path(api_dir, "functions/comparisons-sources.R"))


### PR DESCRIPTION
## Summary

The GitHub **"Test R API (full)"** CI lane has been red on master (last green `c195cef9`, 2026-07-03). It runs **only on push-to-master / dispatch, not on PRs** (`if: github.event_name != 'pull_request'`), so the failure was invisible to the PR gate and persisted across merges.

**Root cause:** all 15 failures were in `test-unit-comparisons-functions.R` — `parse_ndd_genehub_csv` / `parse_radboudumc_pdf` / `standardize_comparison_data` "could not find function". The test sourced `comparisons-functions.R` and `comparisons-omim.R` by absolute path but **never sourced `comparisons-parsers.R`**, relying on `comparisons-functions.R`'s guard-source — which uses **relative paths** that don't resolve in testthat's working directory under a full `test_dir` run. It passed standalone/locally (state leak pre-loaded the parsers) but failed in CI's full run.

**Fix:** source `functions/comparisons-parsers.R` explicitly via the absolute `api_dir` path, matching the other four `source()` lines and the sibling `test-external-pubmed.R` fix. Test-only; no runtime change.

## Verification

Dispatched the CI workflow on this branch (`workflow_dispatch` runs the full lane): **`Test R API (full)`: success**, `CI Success`: success (run 28721617167). Also passes locally.

https://claude.ai/code/session_016VcL9en7cdrjvzi1tqMmqT
