### PR TITLE
docs(skills): repository skills for testing, async jobs, snapshots, MCP, and security review

### DIFF
--- a/.agents/skills/sysndd-analysis-snapshots/SKILL.md
+++ b/.agents/skills/sysndd-analysis-snapshots/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: sysndd-analysis-snapshots
+description: Use when changing gene clustering (STRING/Leiden functional axis or phenotype MCA/HCPC), the analysis snapshot builder or validator, the memoised clustering cache, cache coherence, or LLM cluster summaries — or deploying a clustering change so public endpoints and summaries reflect it
+---
+
+# SysNDD Analysis Snapshots & Cache Coherence
+
+Use this skill before touching clustering, the snapshot builder/validator, the clustering cache, or LLM cluster summaries. This subsystem (#508–#514) is coherence-sensitive: a subtle mistake serves a stale, internally-incoherent snapshot that still activates as public-ready.
+
+## Architecture
+
+- Public endpoints (`/api/analysis/functional_clustering`, `.../phenotype_clustering`) read **activated `analysis_snapshot_*` rows** — not live compute. Nothing public changes until a **snapshot refresh job** (worker) rebuilds and activates a new row.
+- Heavy clustering (`gen_string_clust_obj`, `gen_mca_clust_obj`, `gen_network_edges`) is **memoised to a disk cache on a named volume that SURVIVES redeploys** (`bootstrap/init_cache.R`).
+- The builder reads **membership** from the memoised function; the **validator** (`validate_functional_clusters`, not memoised) recomputes fresh. They are coherent only when both clustered the identical graph with the identical seed.
+
+## The Additivity Lever
+
+`analysis_snapshot_payload_hash` **excludes** `partition_validation` and `reproducibility` (`analysis-snapshot-builder.R`). So new validation metrics are **additive** — they never change `cluster_hash` and never invalidate LLM summaries. Only changes to cluster **membership** (graph construction, STRING channel, MCA hygiene, Leiden/HCPC params) change `cluster_hash`.
+
+## Cache Invalidation — Two Mechanisms
+
+The memoise key is call-args **plus a call-time `.cache_fingerprint`** (`analysis-cache-fingerprint.R`).
+
+- **Code change to clustering inputs/algorithm → bump `CLUSTER_LOGIC_VERSION`.** This is the only thing that changes the key for a code-only change; the data-identity components (STRING channel, exp+db file `size:mtime`, MCA prevalence band) won't. This **supersedes** the manual `CACHE_VERSION` bump for clustering caches (`CACHE_VERSION` nukes *all* memoised `.rds` and still governs other return-shape changes).
+- **Data/channel/prevalence change → self-invalidates** via the fingerprint at call time, no restart needed.
+
+## The Coherence Gate — Do Not Bypass
+
+The builder joins validation onto membership **only** through `analysis_snapshot_join_validated_clusters()` → `analysis_snapshot_assert_partition_coherent()` (`analysis-snapshot-coherence.R`). It refuses to publish (throws → refresh fails → prior public-ready retained) when the visible membership cluster set ≠ the validation set, a visible cluster lacks a stability score, or the membership channel ≠ the validation channel. **Never reintroduce a bare `left_join(clusters, val$per_cluster)`.** `ANALYSIS_SNAPSHOT_REQUIRE_COHERENCE` defaults `true`; setting it `false` to "get a refresh through" re-opens the incoherent-publish hole — bump `CLUSTER_LOGIC_VERSION` instead.
+
+## LLM Summaries
+
+Keyed by per-cluster `cluster_hash` **plus `LLM_SUMMARY_PROMPT_VERSION`** (`llm-summary-config.R`). A membership change changes `cluster_hash`, so old summaries retire and regenerate. **Bump `LLM_SUMMARY_PROMPT_VERSION` only when the prompt or generation/judge logic changes** — not for a clustering change (the hash already handles that; bumping would gratuitously blank untouched clusters).
+
+## Membership-Change Deploy Runbook
+
+1. Ensure the exp+db artifact exists (`api/data/9606.protein.links.expdb.v11.5.min400.txt.gz`) if the functional axis needs it — else clustering silently falls back to the text-mining graph (loud via `warning()` + health flag).
+2. Bump `CLUSTER_LOGIC_VERSION` (only for a code change).
+3. Restart `worker` **and** `worker-maintenance` (worker-executed code; the refresh runs on the worker).
+4. `POST /api/admin/analysis/snapshots/refresh?analysis_type=functional_clusters&force=true` (and `…phenotype_clusters`). **`force` is required** — a non-forced refresh skips a preset whose current snapshot is still `available`.
+5. `POST /api/llm/regenerate?cluster_type=functional&force=true` (and `…phenotype`). **`force` required here too**, else it short-circuits on existing `is_current` rows.
+
+## Verify
+
+- Health endpoint (`health_endpoints.R`): `analysis.cluster_logic_version` == new value, `analysis.expdb_edges_file_present == true`.
+- `GET /api/admin/analysis/snapshots/status`: preset `available`, fresh timestamps.
+- Snapshot refresh job in history is **succeeded, not failed** (a coherence throw shows here — the tell you forgot the version bump).
+- Public endpoint: every visible cluster has a **non-null stability score** (the #514 symptom was `n/a`), metrics agree, and `weight_channel`/`membership_weight_channel == experimental_database`.
+- LLM: summaries map to a **new** `cluster_hash`. In the batch-generation log, "all cached / 0 generated" means membership did **not** change — the change was additive and a forced regen is wasteful.

--- a/.agents/skills/sysndd-api-testing/SKILL.md
+++ b/.agents/skills/sysndd-api-testing/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: sysndd-api-testing
+description: Use when writing, running, or fixing SysNDD R/Plumber API tests (testthat) — including database-writing tests, running a single test inside the API container, mocking external providers, or diagnosing SKIP-vs-PASS, helper-loading, or path-resolution issues
+---
+
+# SysNDD API Testing
+
+Use this skill before adding or running R API tests under `api/tests/testthat/`. The suite is large (200+ files) and has non-obvious container, database, and helper conventions. The authoritative helpers are `helper-db.R`, `helper-paths.R`, and `setup.R`.
+
+## Run Lanes
+
+- `make test-api-fast` — fast PR gate (also what `make pre-commit` runs).
+- `make test-api` — full suite locally.
+- `make ci-local` — closest local mirror of CI (lint + tests with DB). Prefer before handoff.
+- Single file (host): `cd api && Rscript -e "testthat::test_file('tests/testthat/test-unit-foo.R')"`
+- Single file (running container): `docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-foo.R')"`
+
+## Container Boundary (the #1 trap)
+
+`api/tests/` is **not** bind-mounted (only `functions/`, `services/`, `endpoints/`, `core/` are). A new or edited test must be copied in or the image rebuilt:
+
+```bash
+docker cp api/tests/testthat/test-foo.R sysndd-api-1:/app/tests/testthat/test-foo.R
+```
+
+Inside the container the default `sysndd_db_test` config points at a host-published port that the container can't reach, so `skip_if_no_test_db()` **SKIPs**. `get_test_config()` prefers `MYSQL_*` env when `MYSQL_HOST` is set, so pass DB creds to reach the DB service:
+
+```bash
+docker exec -e MYSQL_HOST=mysql -e MYSQL_DATABASE=sysndd_db_test \
+  -e MYSQL_USER=<u> -e MYSQL_PASSWORD=<p> sysndd-api-1 \
+  Rscript -e "testthat::test_file('/app/tests/testthat/test-foo.R')"
+```
+
+**SKIP is not PASS.** Read the summary: `[ FAIL 0 | SKIP 1 ]` means the DB test did not run. Only `PASS n` with `SKIP 0` is a real green.
+
+## Patterns
+
+- **Load code under test:** `source_api_file("services/foo-service.R", local = FALSE)` — resolves `/app` in-container via `get_api_dir()`. `helper-*.R` auto-load through `setup.R`.
+- **DB-writing tests:** wrap in `with_test_db_transaction({ conn <- getOption(".test_db_con"); ... })` — always rolls back. It calls `skip_if_no_test_db()` for you. See AGENTS.md: prefer this or document why rollback is impossible.
+- **Schema setup goes OUTSIDE the transaction.** `CREATE TABLE`/`TRUNCATE` are DDL and auto-commit — they break rollback isolation. Create fixtures on a separate connection first (mirror `ensure_test_user_table()`).
+- **`DBI::dbBind()` with `?` placeholders needs `unname(params)`** (named lists fail silently); positional `params = list(x)` is safe.
+- **Mock external providers**, not `httr2`: PubMed tests stub `pubmed_esearch_count()` / `pubmed_fetch_xml()`; see `helper-mock-apis.R` and `dittodb`.
+
+## Don't Trip the Static Guards
+
+Behavior changes must not break the guard tests that encode invariants: `test-unit-filter-column-allowlist.R`, `test-unit-endpoint-error-handler.R`, `test-unit-external-budget-guard.R`, `test-unit-cheap-route-isolation.R`, `test-unit-analysis-snapshot-coherence.R`, `test-unit-llm-model-default-guard.R`. If your change makes one fail, the change is likely wrong — not the guard.
+
+## Output
+
+Report which lane you ran and paste the real summary line. Never claim green on a run that only SKIPped.

--- a/.agents/skills/sysndd-async-jobs/SKILL.md
+++ b/.agents/skills/sysndd-async-jobs/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: sysndd-async-jobs
+description: Use when adding or changing durable async jobs, worker-executed code, job handlers, queue lanes or priorities in SysNDD — or diagnosing why a submitted job never runs, stays queued, or fails with "No durable async job handler registered"
+---
+
+# SysNDD Async Jobs & Workers
+
+Use this skill before touching any durable background job or worker-executed code. Jobs are durable and MySQL-backed: the web API submits and serves status; a separate **worker** claims and executes. Worker code is sourced **once at worker startup** — a change is not live until the worker restarts.
+
+## Mental Model
+
+- Submit: `create_job()` → `async_job_service_submit()` inserts a row. `job_type` is `VARCHAR(64)` with **no enum and no submit-side allowlist** — a typo or unregistered type inserts fine and only fails later, at execution.
+- Execute: the worker claims by `priority ASC, scheduled_at ASC`, then looks the type up in `async_job_handler_registry` (`async-job-handlers.R`). **Unregistered type → the claimed job hard-fails** with "No durable async job handler registered for '<type>'".
+- Two lanes (#486): `default` (interactive) and `maintenance` (heavy/bulk/external), drained by the `worker` and `worker-maintenance` containers respectively.
+
+## Adding a Durable Job Type
+
+1. **Define the executor** (e.g. `widget_refresh_async(params)`) in a `functions/` file.
+2. **Register the file in `bootstrap/load_modules.R`** (`function_files`). This single loader is used by both the API and the durable worker (`start_async_worker.R`). Adding it only to `setup_workers.R` (mirai legacy parity) is **not** enough — durable jobs do not run on the mirai pool.
+3. **Register the handler** in `async_job_handler_registry`: `run = .async_job_run_passthrough("widget_refresh_async")` (lazy-resolves by name, like `comparisons_update`) or a dedicated runner, plus a `cancel_mode` and `after_success`.
+4. **Route the lane/priority** in `async-job-service.R`: add heavy/external types to `ASYNC_MAINTENANCE_JOB_TYPES` (→ `maintenance` queue, priority 50). Interactive types get priority 10 in `async_job_priority_for_type()`. Lane/priority are resolved at **submit time**, so the submitter must run new code too.
+5. **External calls** inside the job must go through `external_proxy_budget()` / `make_external_request()` (enforced by `test-unit-external-budget-guard.R`) — never a hardcoded `req_timeout()`. An external-heavy **batch** must reset the per-request accumulator per call (see `.pubtatornidd_reset_external_budget()`), and the worker resets it per job (`external_proxy_request_reset()` in `async-job-worker.R`).
+6. **Secrets** used by the job must be added to the `worker` **and** `worker-maintenance` `environment:` maps in `docker-compose.yml`. Compose uses explicit env maps — a bare `.env` value is invisible to the container otherwise.
+
+## Operational — Restart the Worker
+
+After changing worker-executed code (handlers, executors, `load_modules.R`): **restart `worker` and `worker-maintenance`**. Bind-mounted `.R` files are not hot-reloaded inside a running worker. Restart the `api`/submitter too when lane routing or a submit endpoint changed. Local dev runs one `worker` draining `default,maintenance` (`docker-compose.override.yml`); prod keeps the two containers as a deliberate mirror — only `ASYNC_JOB_QUEUES` differs.
+
+## Verify
+
+Submit a job; confirm the worker logs claim it on the expected lane and it completes (not `failed` with the "no handler" message). The two most-missed steps are **registering the handler** and **restarting the worker**.
+
+## Common Mistakes
+
+| Symptom | Cause |
+|---|---|
+| Job inserts but immediately `failed` | Handler not in `async_job_handler_registry` |
+| Handler exists but old behavior runs | Worker not restarted after code change |
+| Function-not-found at run time | New file not added to `bootstrap/load_modules.R` |
+| Heavy job blocks interactive work | Type missing from `ASYNC_MAINTENANCE_JOB_TYPES` (stuck on `default`) |
+| External calls 503 mid-batch | Per-call budget not reset in a batch job |

--- a/.agents/skills/sysndd-external-proxy/SKILL.md
+++ b/.agents/skills/sysndd-external-proxy/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: sysndd-external-proxy
+description: Use when adding or changing an external HTTP provider call in SysNDD (gnomAD, Ensembl, UniProt, AlphaFold, MGI, RGD, PubMed, PubTator, MONDO, JAX/HPO) or touching external-call timeouts, retries, caching, or per-request time budgets
+---
+
+# SysNDD External Proxy Budgets
+
+Use this skill before adding or editing any outbound HTTP call to a gene/literature/ontology provider. The rules exist so one slow upstream cannot occupy a worker for tens of seconds or poison a long-lived cache. All helpers live in `api/functions/external-proxy-functions.R`.
+
+## Every External Call Has a Budget
+
+Derive the timeout/retry window from `external_proxy_budget(api_name, default_timeout =, default_max =, default_tries =)` **or** route the whole call through `make_external_request(url, api_name, throttle_config, ...)`. **Never a hardcoded `req_timeout(<n>)` / `max_seconds = <n>` literal** — this is enforced by `test-unit-external-budget-guard.R` (a bypass was reintroduced once via GeneReviews in #389, which is why the guard exists).
+
+## Cache Only Successes
+
+Wrap fetchers in `memoise_external_success_only(f, cache, source = "<provider>")`, **not** raw `memoise::memoise()`. It caches successful and true not-found responses but **not** transient `list(error = TRUE, ...)` failures, so a blip does not poison the 7/14/30-day caches. Passing `source =` also emits one structured timing log per call:
+
+```
+[external-proxy] ... event=complete status=... elapsed_ms=... cache=hit|miss
+```
+
+`gnomad`/`ensembl`/`uniprot`/`alphafold` use the memoise `source`; `mgi`/`rgd` instead log via the inline `external_proxy_with_timing()` wrapper and **omit** `source` to avoid double-logging.
+
+## Request-Scoped Time Ceiling
+
+`EXTERNAL_PROXY_REQUEST_MAX_SECONDS` (default 15s) is wired into both universal wrappers. Once a request's accumulated external time crosses it, further external calls **short-circuit to a degraded 503** (`request_budget_exceeded = TRUE`) without contacting the upstream. The accumulator is reset **per request** in the `preroute` hook (`bootstrap/mount_endpoints.R`) and **per job** at job start (`external_proxy_request_reset()`, `async-job-worker.R`).
+
+- **Batch jobs** that make many independent provider calls must additionally reset the accumulator **per call** (see `.pubtatornidd_reset_external_budget()` in `pubtator-enrichment-collector.R`), or the ceiling — designed for public request paths — caps the back half of the batch.
+- The `postroute` hook emits `[request-timing] method=… path=… status=… duration_ms=… external_ms=… slow=…` (`slow` over `API_SLOW_REQUEST_MS`, default 2000), so a slow request can be attributed to external time.
+
+## Cheap Routes Stay External-Free
+
+`/health`, `/auth`, `/statistics` must never call an external fetcher — enforced by `test-unit-cheap-route-isolation.R`.
+
+## Known Exceptions
+
+Batch jobs with their own pacing (e.g. `publication_date_backfill`) intentionally keep raw `httr2` retry (429 handling, Retry-After) and are **outside** the guard scan set — do not "fix" them into `external_proxy_budget()`. Per-provider budgets are tunable via env (`EXTERNAL_PROXY_MONDO_*`, etc.).
+
+## Verify
+
+`test-unit-external-budget-guard.R`, `test-unit-external-proxy-budgets.R`, `test-unit-external-slow-provider.R`, `test-unit-cheap-route-isolation.R`, and the router-level `test-integration-slow-provider-isolation.R`.

--- a/.agents/skills/sysndd-frontend-integration/SKILL.md
+++ b/.agents/skills/sysndd-frontend-integration/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: sysndd-frontend-integration
+description: Use when wiring a SysNDD Vue 3 view or component to the backend API, adding a typed API client, handling API errors, or binding backend data into BootstrapVueNext tables and tooltips — especially around Plumber response shapes and BVN table/tooltip quirks
+---
+
+# SysNDD Frontend Integration Boundaries
+
+Use this skill when connecting the frontend to the API or binding backend data into the UI. These are the boundary rules and BootstrapVueNext (BVN) quirks that repeatedly bite. For visual/layout work, use `sysndd-visual-design` instead.
+
+## API Access Goes Through Typed Clients
+
+All backend access goes through the typed clients in `app/src/api/*` (`client.ts` is the shared base). **Do not** add raw `axios` calls in views/components, and **do not** read `localStorage.token` / `localStorage.user` directly. Add or extend a typed client method (with its `.spec.ts`) instead.
+
+## Plumber Response Shapes
+
+- **JSON scalars come back as arrays.** Plumber serializes a scalar as `["abc"]`. Unwrap with `unwrapValue` before feeding a value back into `axios` params — otherwise axios encodes `param[]=value`, which Plumber won't match (e.g. an async `job_id`).
+- **Errors are RFC 9457 problem+json.** Read them via `extractApiErrorMessage(err, fallback)` (`app/src/utils/api-errors.ts`, which prefers `detail` → `title`). Don't hand-parse error response shapes.
+
+## BootstrapVueNext Table & Tooltip Traps
+
+- **Dotted field keys render blank.** BVN `BTable` (and the `GenericTable` wrapper) cannot display a field whose `key` contains a dot: the cell resolver renders blank, and a `#cell-a.b` slot parses as `cell-a` + `.b` modifier. Alias dotted source columns (e.g. MCA stats `p.value`, `v.test`) to flat keys (`p_value`, `v_test`) before binding them as field keys — see `normalizePhenotypeClusterRows()` in `app/src/components/analyses/phenotypeClusterTable.ts`. Keep the original dotted keys on the row if the Excel export header map still reads them.
+- **`v-b-tooltip` is reactive to its binding *value*, not a bound `:title`.** For a tooltip whose text changes (e.g. faceted "filtered/total" counts), bind through the directive value — `v-b-tooltip.hover.bottom="getTooltipText(field)"` — never `:title="getTooltipText(field)"` (that patches `data-original-title` but never re-renders the popover). Static `:title` tooltips whose text never changes are fine. Guard: `app/src/components/tables/columnHeaderTooltipReactivity.spec.ts`.
+
+## Performance
+
+Importing composables from the `@/composables` barrel drags `ngl`/`markdown`/`d3` (~600 KB) onto a route's critical path. On perf-sensitive routes, import composables by their **direct path**, not the barrel.
+
+## Verify
+
+```bash
+cd app && npm run type-check          # (+ npm run type-check:strict for touched scope)
+cd app && npm run test:unit           # or: npx vitest run <spec> / -t "<name>"
+make lint-app                         # ESLint + MSW↔OpenAPI drift check
+```

--- a/.agents/skills/sysndd-mcp-readonly/SKILL.md
+++ b/.agents/skills/sysndd-mcp-readonly/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: sysndd-mcp-readonly
+description: Use when changing the SysNDD read-only MCP sidecar, its tools, repositories, resources, capabilities, schema version, or anything the MCP layer reads or exposes — especially when a product requirement would have MCP write, generate, fetch externally, or surface non-public data
+---
+
+# SysNDD MCP Read-Only Contract
+
+Use this skill before changing the MCP sidecar (`api/start_sysndd_mcp.R`, `api/services/mcp-*.R`, `api/functions/mcp-*.R`). MCP v1 is a **separate, read-only process serving approved public data only**. The contract is safety-critical: violating it can leak curation-in-progress or misrepresent data to LLM clients.
+
+## Hard Invariants — MCP MUST NOT
+
+- Write the DB, call write routes, or execute raw SQL / raw R.
+- Call Gemini or any LLM **generation**. Summaries are **cache-hit-only, admin-generated** reads (`require_validated = TRUE`).
+- Call live external gene providers. Stored external IDs may be shown **only** as `external_reference_identifier`.
+- Expose draft reviews, re-review workflows, admin/user/log/job data, curation comments, or broad export payloads.
+
+When a product ask conflicts with these (e.g. "include the latest review even if unapproved", "generate a summary on cache miss", "present NDDScore as the authoritative classification"), **the invariant wins.** Implement the compliant framing and push the extra need to the authenticated main API (Curator+) or an admin/worker job — never into MCP.
+
+## Approved-Public Enforcement
+
+Repository queries must return only approved public data:
+
+- Active records from `ndd_entity_view`.
+- Review-derived synopsis / phenotype / variation / publication data **only from primary approved reviews**: `is_primary = 1 AND review_approved = 1`. Do not drop these gates to serve "fresher" content.
+
+## Cache Access Is Read-Only
+
+The sidecar binds the same memoised wrapper names as the API and mounts `api_cache` **read-only**. It must not initialize cache versions, clear cache files, compute STRING/phenotype clusters, or write entries. Phenotype correlations are **cache-hit-only** — never call `generate_phenotype_correlations()` on a miss. A fingerprint mismatch may only make MCP **miss**, never serve stale (that is why the exp+db artifact is mounted read-only to MCP).
+
+## Adding or Changing a Tool
+
+- Build it as a **thin composition** of existing read-only repo helpers (see `get_gene_research_context` for the pattern). Register in `mcp-tool-registry.R`; wrap execution in `mcp_tool_safe(...)`.
+- **Label every payload's `data_class`**: `curated_sysndd_evidence`, `curated_derived_analysis`, `ml_prediction`, `llm_generated_summary`, `external_reference_identifier`, or `operational_metadata`. NDDScore is always `ml_prediction`, `not_evidence_tier`, and never alters curated classifications.
+- Recoverable validation failures return a JSON tool result with `schema_version`, `error.code`, and `isError = true` — **not** a raw R error or JSON-RPC `-32603`.
+- Large tools default `response_mode = "compact"` and expose `budget` metadata; keep `schema_version` at the outer envelope only.
+- `MCP_SCHEMA_VERSION` (currently `1.2`) is the compatibility contract — bump additively for a new tool, and keep `get_sysndd_capabilities`, `resources/list`, and `resources/read` aligned. Prompts are **off by default** (`MCP_ENABLE_PROMPTS`); enable only for intentional slash-command prompts.
+
+## Verify
+
+- Healthcheck stays cheap and data-independent: `api/scripts/mcp-healthcheck.R` (initialize + tools/list). The heavier `api/scripts/mcp-smoke.R` exercises real tools for dev/CI.
+- Guard tests: `api/tests/testthat/test-mcp-*.R` (repository, analysis service, publication-context-verified). A new tool needs a unit test asserting approved-only reads and correct `data_class` labels.
+
+## Common Mistakes
+
+| Mistake | Why it's wrong |
+|---|---|
+| Query drops `review_approved = 1` for freshness | Leaks draft/in-progress curation |
+| Generate an LLM summary on cache miss | MCP has no egress/creds and must not write cache; generation is admin/worker-only |
+| Present NDDScore as the evidence verdict | NDDScore is `ml_prediction`, not an evidence tier |
+| Return raw R error on bad input | Clients expect the recoverable JSON error envelope |
+| Add a tool without bumping `MCP_SCHEMA_VERSION` / updating capabilities | Breaks the discovery + compatibility contract |

--- a/.agents/skills/sysndd-migrations-db/SKILL.md
+++ b/.agents/skills/sysndd-migrations-db/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: sysndd-migrations-db
+description: Use when adding or changing a SysNDD DB migration, editing a SQL view (especially ndd_entity_view or the core read views), touching the migration runner or manifest, restoring a database, or diagnosing a startup failure related to migrations
+---
+
+# SysNDD Migrations & DB Views
+
+Use this skill before adding a migration, editing a view, or touching the migration runner. `db/migrations/*.sql` are applied at API startup by the runner using a MySQL advisory lock (`GET_LOCK('sysndd_migration')`, `migration-runner.R`). See `db/migrations/README.md` for specifics.
+
+## Core Rule — Failures Are Meant to Crash Startup
+
+A failing migration is supposed to crash boot. **Do not weaken startup checks to work around it** — fix the migration or the mount. Missing, empty, or stale migration mounts are fatal by design and are a packaging/deployment problem, not something to patch in code.
+
+## Adding a Migration
+
+1. Name it `NNN_snake_case.sql`, contiguous with the current latest (currently `041_add_analysis_reproducibility.sql`). `make lint-api` checks the prefix.
+2. **Bump the manifest** in `api/functions/migration-manifest.R`: `EXPECTED_LATEST_MIGRATION` must equal the new sorted-latest filename, and keep `EXPECTED_MIGRATION_COUNT` in sync. Startup validates the manifest *before* the fast path (`validate_migration_manifest`): the dir must exist, contain SQL files, have the expected latest, and meet the minimum count — all fatal if not.
+3. Migrations are idempotent-friendly where they re-assert schema (e.g. `039` re-asserts columns/types after a drifted restore). Prefer `CREATE TABLE IF NOT EXISTS` / guarded `ALTER` for re-assertable DDL.
+
+## Views Are Mirrored — Change Both Places
+
+The core read views (`ndd_entity_view`, `users_view`, `search_non_alt_loci_view`, `search_disease_ontology_set`) are codified in `025_create_core_views.sql` with `SQL SECURITY INVOKER` so a pristine DB boots. `ndd_entity_view` is later rebuilt by `026_add_entity_last_update.sql` (adds the derived `last_update` column). **The latest `CREATE OR REPLACE VIEW ndd_entity_view` migration is the source of truth and must stay mirrored byte-for-byte** (modulo the `sysndd_db.` schema prefix and the migration's `ALGORITHM`/`SQL SECURITY INVOKER` clause) in `db/C_Rcommands_set-table-connections.R`. Edit a view definition → update both.
+
+## Rollback & Restore Gotchas
+
+- Metadata refreshes needing rollback must **not** use `TRUNCATE` (DDL auto-commits, breaking the transaction). Use `refresh_disease_ontology_set()` / `metadata_with_foreign_key_checks_disabled()` from `metadata-refresh.R`; enforced by `test-unit-metadata-refresh-patterns.R`.
+- A `dbWriteTable`-style DB restore silently drifts schema (narrow auto-sized VARCHARs, `comparison_id` recreated as `DOUBLE` PK without `AUTO_INCREMENT`, dropped columns). Use `make db-restore-latest` then `make db-views-rebuild` to recreate the DEFINER views; the idempotent re-assert migrations (`039`) repair the drift.
+
+## Related
+
+- Never re-add `COPY config.yml` to `api/Dockerfile` — config is a runtime read-only mount only.
+- New job-handler / function files register in `bootstrap/load_modules.R` and need a worker restart — see `sysndd-async-jobs`.
+
+## Verify
+
+Confirm the API starts cleanly (migration runner logs each applied migration), run `make lint-api` (prefix check), and consult `db/migrations/README.md`.

--- a/.agents/skills/sysndd-security-bug-scan/SKILL.md
+++ b/.agents/skills/sysndd-security-bug-scan/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: sysndd-security-bug-scan
+description: Use when reviewing or writing SysNDD code for security vulnerabilities or correctness bugs — authorization/role gates, SQL/expression injection, credential and secret handling, data exposure through public or MCP surfaces, resource-exhaustion/DoS from external calls, error/info leakage, and the repo's known R/Plumber footguns — especially before merging a diff or PR
+---
+
+# SysNDD Security & Bug Scan
+
+A focused **defect + vulnerability** review pass over a diff or PR. Distinct from `sysndd-code-quality` (maintainability) — this hunts for exploitable and correctness-breaking defects. It complements the generic `/security-review` and `/code-review` by encoding SysNDD's specific gates, helpers, and footguns.
+
+Core insight: almost every SysNDD vulnerability is **"bypassed a safe helper that already exists."** For each finding, prefer the in-repo helper over a hand-rolled fix.
+
+## Workflow
+
+1. Scope the diff. For each new/changed **endpoint, DB query, external call, or auth path**, run the relevant checks below.
+2. Flag any hand-rolled code that a listed helper already covers.
+3. Run the guard tests for the touched areas (see Verify) — a failing guard test usually means the change is wrong, not the guard.
+4. Report findings by severity with `file:line` and the concrete in-repo fix; separate must-fix from optional.
+
+## Security Checks
+
+### Authorization & privilege escalation
+- Every write / admin / curation endpoint must call `require_role(req, res, "<Role>")`. Auth is **per-endpoint** (no global deny filter) — a handler with no gate is reachable **unauthenticated**.
+- `direct_approval` escalates the gate to **Curator** server-side; never trust the client flag (re-checked in `svc_status_apply_direct_approval` / `review_apply_direct_approval`). The frontend `hasMinRole` is UX, not a control.
+- Attribution is server-set: `status_user_id <- req$user_id`. Never accept `*_user_id` from the request body.
+
+### Injection (SQL / expression / RCE)
+- User `filter` / `sort` tokens must pass through `validate_query_column()` via `generate_filter_expressions()` / `generate_sort_expressions()` with `allowed_columns_for_view()`. **Never `paste0()` or raw input into `rlang::parse_exprs()`** — over a dbplyr `tbl` that is SQL injection **and** R-side RCE (local partial-eval runs `system(...)` etc.).
+- Parameterize SQL with `?` placeholders + `DBI::dbBind(stmt, unname(params))`. No string-interpolated values.
+- URL-encode external path/query segments: `utils::URLencode(x, reserved = TRUE)`.
+
+### Data exposure (public / MCP)
+- MCP and public reads are **approved-public only**: reviews gated `is_primary = 1 AND review_approved = 1`; records from `ndd_entity_view` (active only). A query dropping these leaks **draft/unapproved** curation. See `sysndd-mcp-readonly`.
+- MCP must not write, generate LLM summaries, or call live external providers.
+
+### Secrets & credentials
+- Auth-sensitive inputs (`/auth/signup`, `/auth/authenticate`, password change) are **JSON body only** — never query string (leaks into access/Traefik logs, browser history).
+- Log through `sanitize_request()` / `sanitize_object()` (`SENSITIVE_FIELDS` redaction in `core/logging_sanitizer.R`); never log tokens, passwords, or secrets.
+- Do not bake `config.yml` / secrets into image layers (no `COPY config.yml` in `api/Dockerfile`; use the runtime mount).
+- Passwords use Argon2id/sodium (`hash_password` / `verify_password` in `core/security.R`); never plaintext comparison.
+
+### Resource exhaustion / DoS
+- Every external HTTP call derives its timeout/retry from `external_proxy_budget()` or `make_external_request()` — **no hardcoded `req_timeout(<n>)`** (enforced by `test-unit-external-budget-guard.R`). Wrap fetchers in `memoise_external_success_only(source = "<provider>")`.
+- Cheap routes (`/health`, `/auth`, `/statistics`) must never call an external fetcher (`test-unit-cheap-route-isolation.R`).
+- Public expensive operations are throttled or cache-only (async submit cap; LLM generation is Curator+ only).
+
+### Error / info leakage
+- Mount every endpoint sub-router via `mount_endpoint()` (attaches the RFC 9457 `errorHandler` + `notFoundHandler`). A bare `plumber::pr_mount(...)` leaks opaque `500`s with internal detail and drops correct status codes. Throw classed errors (`stop_for_bad_request` / `stop_for_unauthorized` / …), not bare `stop()`.
+
+## Correctness Footguns (SysNDD-specific)
+
+- `DBI::dbBind()` with `?` placeholders needs `unname(params)`; named lists fail silently.
+- `dplyr::select` / `filter` are masked (biomaRt/AnnotationDbi) — namespace them explicitly.
+- `config::get` masks `base::get` in the loaded API/worker env — bare `get(x, mode = "function")` errors "unused argument (mode)"; use `base::get` or direct dispatch (`test-unit-base-exists-get-guard.R`).
+- Plumber returns JSON scalars as arrays — unwrap before feeding back into params.
+- Use `inherits(x, "Date")`, not `is.Date()`.
+- Worker-executed code is sourced at worker start — a change is not live until the worker restarts.
+
+## Verify
+
+Run the guard tests for the touched areas, then `make lint-api` and the appropriate test lane:
+
+`test-unit-security.R`, `test-unit-filter-column-allowlist.R`, `test-unit-endpoint-error-handler.R`, `test-endpoint-auth.R` / `test-integration-auth.R`, `test-unit-*-endpoint-guard.R`, `test-unit-external-budget-guard.R`, `test-unit-cheap-route-isolation.R`.
+
+Lead with findings ordered by severity, each with `file:line` and the in-repo fix. If nothing is found, say so and list the checks run plus residual risk.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,9 @@ Focused, cross-LLM skill guides live under `.agents/skills/<name>/SKILL.md`. Rea
 - `sysndd-analysis-snapshots` — clustering, the snapshot builder/validator, the survives-redeploy memoise cache, `CLUSTER_LOGIC_VERSION`, the coherence gate, LLM summaries, and the membership-change deploy runbook.
 - `sysndd-mcp-readonly` — the read-only MCP sidecar contract: approved-public-only reads, no writes/LLM-generation/external calls, `data_class` labels, and the schema-version contract.
 - `sysndd-security-bug-scan` — security + correctness review pass: authorization/role gates, SQL/expression injection, credential and secret handling, public/MCP data exposure, external-call DoS, error/info leakage, and the repo's R/Plumber footguns.
+- `sysndd-migrations-db` — DB migrations and SQL views: the startup migration runner + manifest (`EXPECTED_LATEST_MIGRATION`), advisory locks, `ndd_entity_view`/core-view mirroring, restore drift, and rollback-safe metadata refresh.
+- `sysndd-external-proxy` — outbound provider calls: `external_proxy_budget()`/`make_external_request()`, `memoise_external_success_only`, the per-request time ceiling, batch per-call resets, and cheap-route isolation.
+- `sysndd-frontend-integration` — Vue↔API boundary: typed clients only, Plumber array unwrap, problem+json error extraction, and the BVN dotted-key / tooltip-reactivity table traps.
 
 ## Verify Before Handoff
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Focused, cross-LLM skill guides live under `.agents/skills/<name>/SKILL.md`. Rea
 - `sysndd-async-jobs` — durable MySQL-backed jobs and workers: handler registration, `bootstrap/load_modules.R`, lane/priority routing, the restart-the-worker rule, and external budgets.
 - `sysndd-analysis-snapshots` — clustering, the snapshot builder/validator, the survives-redeploy memoise cache, `CLUSTER_LOGIC_VERSION`, the coherence gate, LLM summaries, and the membership-change deploy runbook.
 - `sysndd-mcp-readonly` — the read-only MCP sidecar contract: approved-public-only reads, no writes/LLM-generation/external calls, `data_class` labels, and the schema-version contract.
+- `sysndd-security-bug-scan` — security + correctness review pass: authorization/role gates, SQL/expression injection, credential and secret handling, public/MCP data exposure, external-call DoS, error/info leakage, and the repo's R/Plumber footguns.
 
 ## Verify Before Handoff
 


### PR DESCRIPTION
## What

Adds **eight** focused, cross-LLM skill guides under `.agents/skills/`, matching the existing `sysndd-code-quality` / `sysndd-visual-design` format, plus the `AGENTS.md` **Repository Skills** index pointing to all ten. Each distills the invariants and traps for one subsystem so agents (any skills-compatible client) find them just-in-time instead of reconstructing from the 75 KB `AGENTS.md` or the code.

## Skills

| Skill | Covers |
|---|---|
| `sysndd-api-testing` | Container test boundary (`tests/` not bind-mounted), `with_test_db_transaction()`, SKIP-vs-PASS trap, path/helper resolution, external mocking, static guard tests |
| `sysndd-async-jobs` | Handler registration, `bootstrap/load_modules.R`, two-lane routing/priority, the restart-the-worker rule, external budgets |
| `sysndd-analysis-snapshots` | `payload_hash` additivity, `CLUSTER_LOGIC_VERSION`, the coherence gate, LLM-summary hashing, the membership-change deploy runbook |
| `sysndd-mcp-readonly` | Read-only + approved-public-only contract, `data_class` labels, recoverable error envelope, schema-version contract |
| `sysndd-security-bug-scan` | Security + correctness review pass: authz/role gates, SQL/expression injection, secret handling, public/MCP data exposure, external-call DoS, error/info leakage, R/Plumber footguns |
| `sysndd-migrations-db` | Startup migration runner + manifest (`EXPECTED_LATEST_MIGRATION`), advisory locks, `ndd_entity_view`/core-view byte-for-byte mirroring, restore drift, rollback-safe metadata refresh |
| `sysndd-external-proxy` | `external_proxy_budget()`/`make_external_request()`, no hardcoded `req_timeout`, `memoise_external_success_only`, per-request time ceiling + batch per-call reset, cheap-route isolation |
| `sysndd-frontend-integration` | Typed clients only, Plumber scalar-as-array unwrap, RFC 9457 problem+json extraction, BVN dotted-key and tooltip-reactivity table traps |

(`sysndd-code-quality` and `sysndd-visual-design` already existed; the index now lists all ten.)

## Approach

- Every anchor (function names, file paths, guard tests) verified against the actual code.
- Validated with the writing-skills RED-baseline method: fresh agents given realistic tasks without the skill, to confirm each closes a real gap and to source the exact content. Finding: this codebase is unusually self-documenting, so a thorough agent recovers these from code — but at ~100 K tokens of exploration each. The skills earn their place as **discovery accelerators, systematic checklists, and safety nets** for the hurried agent and the agent writing the code.
- `sysndd-security-bug-scan` conforms to the [agentskills.io](https://agentskills.io/specification) SKILL.md spec (name matches parent dir, description ≤1024 chars, SKILL.md well under 500 lines); all seven follow the same conventions.

## Note

The `AGENTS.md` Repository Skills section (referencing the four core skills) already merged to `master` with #514/#516; `master` currently has a dangling pointer to files that live on this branch. Merging this PR resolves it and adds the remaining pointers.

https://claude.ai/code/session_01HwgtyYeUPaxueBoAaqe3wv
