### PR TITLE
fix(security): hotfix authenticated RCE, SQLi, and unapproved-curation exposure (v0.29.2)

### DIFF
--- a/.planning/superpowers/plans/2026-07-06-security-bug-scan-fixes-plan.md
+++ b/.planning/superpowers/plans/2026-07-06-security-bug-scan-fixes-plan.md
@@ -1,0 +1,658 @@
+# Security & Bug-Scan Remediation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the three HIGH (hash-endpoint RCE, re-review SQLi, public unapproved-curation exposure), four MEDIUM, and eight LOW defects from the `sysndd-security-bug-scan` review, each by reusing an existing in-repo helper.
+
+**Architecture:** Two PRs. PR 1 (`security/hotfix-rce-sqli-exposure`, current branch) lands the three HIGH fixes fast. PR 2 (`security/hardening-medium-low`, branched from `master` after PR 1 merges) lands MEDIUM + LOW. Every fix is one atomic commit with a guard test; Codex high-effort adversarial review gates each PR.
+
+**Tech Stack:** R 4.x, Plumber, dplyr/dbplyr, DBI/RMariaDB, rlang, httr2, jsonlite, testthat. Design doc: `.planning/superpowers/specs/2026-07-06-security-bug-scan-fixes-design.md`.
+
+## Global Constraints
+
+- **Reuse in-repo helpers; never hand-roll.** Validation → `validate_query_column()` / column allowlists. Errors → classed `stop_for_bad_request()` / `stop_for_unauthorized()` / `stop_for_internal()` (from `core/errors.R`), never bare `stop()` or `return(list(error=e$message))`. External calls → `external_proxy_budget()` / `external_proxy_with_timing()` / `memoise_external_success_only()`. URL segments → `utils::URLencode(x, reserved = TRUE)`.
+- **Namespace masked verbs explicitly:** `dplyr::select` / `dplyr::filter`; `base::get` (never bare `get(..., mode=)` — `config::get` masks it).
+- **Tests are NOT bind-mounted** (`api/tests/`). Run new tests on the host where they don't need the live DB (static/unit guards), or `docker cp` into `sysndd-api-1` and `docker exec … Rscript -e "testthat::test_file('/app/tests/testthat/<file>')"`.
+- **Static guard tests are idiomatic here** (see `test-unit-external-budget-guard.R`, `test-unit-cheap-route-isolation.R`) — prefer a static/source-scan guard when a behavioral test would need a live DB.
+- **Per-PR gate:** `make lint-api` + `make test-api-fast` + the touched guard files; `make test-api` before merge.
+- **Worker restart rule:** worker-executed code (`functions/mondo-functions.R`, `functions/metadata-refresh.R`) is sourced at worker start — restart `worker` / `worker-maintenance` after those changes. API-path fixes (endpoints/repositories/core) are live on API container restart via bind mount.
+- **No new DB migration.** Allowlists derive from the existing schema.
+- **Commit trailer:** end each commit message with `Claude-Session: https://claude.ai/code/session_01Nxo1e69TNWFWXxroYEuWNX`.
+
+---
+
+## File Structure
+
+**PR 1 (HIGH):**
+- `api/functions/data-helpers.R` — reorder validation + drop eval sort (#1).
+- `api/endpoints/hash_endpoints.R` — unchanged (handler already delegates).
+- `api/services/re-review-service.R` — new `re_review_submit_allowed_fields()` + `re_review_filter_submit_fields()` helpers (#2).
+- `api/endpoints/re_review_endpoints.R` — call the allowlist helper (#2).
+- `api/functions/review-repository.R` — new `primary_approved_reviews()` helper (#3).
+- `api/endpoints/entity_endpoints.R` — 5 sites consume the helper + `status_approved` (#3).
+- `api/tests/testthat/test-unit-hash-endpoint-injection.R` — new (#1).
+- `api/tests/testthat/test-unit-re-review-submit-allowlist.R` — new (#2).
+- `api/tests/testthat/test-unit-public-approved-review-guard.R` — new static guard (#3).
+
+**PR 2 (MEDIUM + LOW):**
+- `api/functions/user-repository.R` (#4), `api/services/user-service.R` + `api/endpoints/user_endpoints.R` (#5), `api/functions/job-manager.R` (LOW-1).
+- `api/endpoints/publication_endpoints.R` + `api/functions/publication-endpoint-helpers.R` (#6).
+- `api/functions/llm-endpoint-helpers.R` (#7).
+- `api/endpoints/about_endpoints.R`, `logging_endpoints.R`, `publication_endpoints.R`, `user_endpoints.R` (LOW-2 classed errors).
+- `api/core/logging_sanitizer.R` (LOW-3), `api/core/security.R` (LOW-4), `api/functions/hgnc-functions.R` + `oxo-functions.R` (LOW-5), `api/functions/mondo-functions.R` (LOW-6), `api/functions/metadata-refresh.R` (LOW-7).
+- Matching `test-unit-*` guards per fix.
+
+---
+
+# PR 1 — HIGH fixes (branch `security/hotfix-rce-sqli-exposure`)
+
+## Task 1: #1 — Close the hash-endpoint RCE (validate-first + drop eval)
+
+**Files:**
+- Modify: `api/functions/data-helpers.R` (`post_db_hash`, lines ~205–256)
+- Test: `api/tests/testthat/test-unit-hash-endpoint-injection.R` (create)
+
+**Interfaces:**
+- Consumes: `hash_validate_columns(cols, allowed)` (existing, `functions/hash-repository.R`), `stop_for_bad_request()` (existing).
+- Produces: no signature change to `post_db_hash(json_data, allowed_columns, endpoint)`.
+
+- [ ] **Step 1: Write the failing test**
+
+`api/tests/testthat/test-unit-hash-endpoint-injection.R`:
+
+```r
+# Guard: the hash-create path must validate column tokens BEFORE any
+# expression evaluation, and must never parse a column name as R code (#1 RCE).
+test_that("post_db_hash rejects a non-allowlisted column before any evaluation", {
+  src <- readLines("../../functions/data-helpers.R", warn = FALSE)
+  body <- paste(src, collapse = "\n")
+
+  # (a) No parse_exprs over a column name inside post_db_hash's arrange.
+  expect_false(
+    grepl("arrange\\(!!!rlang::parse_exprs\\(", body),
+    info = "post_db_hash must not parse a column name as an R expression"
+  )
+
+  # (b) hash_validate_columns must appear BEFORE the first arrange() call.
+  first_validate <- regexpr("hash_validate_columns\\(colnames", body)
+  first_arrange  <- regexpr("arrange\\(", body)
+  expect_true(first_validate > 0 && first_arrange > 0)
+  expect_lt(first_validate, first_arrange)
+})
+
+test_that("post_db_hash raises a bad-request error on an unexpected column and runs no shell", {
+  skip_if_not(exists("post_db_hash"), "API not sourced")
+  sentinel <- tempfile()
+  malicious <- stats::setNames(list(1L), paste0("system('touch ", sentinel, "')"))
+  expect_error(
+    post_db_hash(malicious, "symbol,hgnc_id,entity_id", "/api/gene")
+  )
+  expect_false(file.exists(sentinel),
+               info = "injected command must NOT have executed")
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd api && Rscript -e "testthat::test_file('tests/testthat/test-unit-hash-endpoint-injection.R')"`
+Expected: FAIL — the `parse_exprs` grep matches (current code) and validation is after `arrange`.
+
+- [ ] **Step 3: Apply the fix**
+
+In `api/functions/data-helpers.R`, replace the block (currently lines ~220–253):
+
+```r
+  json_tibble <- as_tibble(json_data)
+  json_tibble <- json_tibble %>%
+    arrange(!!!rlang::parse_exprs((json_tibble %>% colnames())[1]))
+
+  json_sort <- toJSON(json_tibble)
+```
+…and (further down) `hash_validate_columns(colnames(json_tibble), allowed_col_list)` at line ~253
+
+with:
+
+```r
+  json_tibble <- as_tibble(json_data)
+
+  # SECURITY (#1): validate column tokens against the allowlist BEFORE any
+  # evaluation, and sort by a column REFERENCE (never parse the name as code).
+  # The old arrange(!!!parse_exprs(colnames[1])) evaluated the first JSON key
+  # as an R expression via dplyr data-masking -> authenticated RCE.
+  hash_validate_columns(colnames(json_tibble), allowed_col_list)
+
+  json_tibble <- json_tibble %>%
+    dplyr::arrange(dplyr::across(dplyr::all_of(colnames(json_tibble)[1])))
+
+  json_sort <- toJSON(json_tibble)
+```
+
+Then delete the now-redundant later `hash_validate_columns(colnames(json_tibble), allowed_col_list)` call (line ~253) so validation happens exactly once, up front (it must precede the no-DB early-return at ~238–250 too).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd api && Rscript -e "testthat::test_file('tests/testthat/test-unit-hash-endpoint-injection.R')"`
+Expected: PASS (static guard passes; behavioral test needs the API sourced — it skips on host, runs in-container).
+
+- [ ] **Step 5: Verify in-container behavioral path**
+
+Run: `docker cp api/tests/testthat/test-unit-hash-endpoint-injection.R sysndd-api-1:/app/tests/testthat/ && docker restart sysndd-api-1 && sleep 8 && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-unit-hash-endpoint-injection.R')"`
+Expected: PASS, no sentinel file.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/functions/data-helpers.R api/tests/testthat/test-unit-hash-endpoint-injection.R
+git commit -m "fix(security): close authenticated RCE in hash-create endpoint (#1)
+
+Validate column tokens before evaluation and sort by column reference
+(across(all_of(...))) instead of parse_exprs(colname), which evaluated the
+first JSON key as R code via dplyr data-masking.
+
+Claude-Session: https://claude.ai/code/session_01Nxo1e69TNWFWXxroYEuWNX"
+```
+
+## Task 2: #2 — Allowlist the re-review submit SET clause (SQLi + self-approval)
+
+**Files:**
+- Modify: `api/services/re-review-service.R` (add helpers)
+- Modify: `api/endpoints/re_review_endpoints.R:29–45`
+- Test: `api/tests/testthat/test-unit-re-review-submit-allowlist.R` (create)
+
+**Interfaces:**
+- Produces: `re_review_submit_allowed_fields()` → character vector of writable columns; `re_review_filter_submit_fields(field_names)` → validated character vector or `stop_for_bad_request` on any out-of-allowlist / non-identifier token.
+
+- [ ] **Step 1: Confirm the legitimate field set**
+
+Run: `grep -rn "submit_json\|re_review_review_saved\|re_review_status_saved\|re_review_submitted" app/src api/services/re-review-service.R`
+Expected: identify exactly which columns the frontend submit sends. The allowlist is the intersection with the table's non-identity, non-approval columns: `re_review_review_saved`, `re_review_status_saved`, `re_review_submitted`, `status_id`, `review_id`, `re_review_batch`. It MUST exclude `re_review_entity_id` (PK/WHERE key), `entity_id`, `re_review_approved`, `approving_user_id` (approval is a Curator-only action — excluding them closes the self-approval mass-assignment). Adjust the vector below to the confirmed frontend set.
+
+- [ ] **Step 2: Write the failing test**
+
+`api/tests/testthat/test-unit-re-review-submit-allowlist.R`:
+
+```r
+test_that("re_review_submit_allowed_fields excludes identity + approval columns", {
+  skip_if_not(exists("re_review_submit_allowed_fields"))
+  allowed <- re_review_submit_allowed_fields()
+  expect_false("re_review_entity_id" %in% allowed)
+  expect_false("re_review_approved"  %in% allowed)
+  expect_false("approving_user_id"   %in% allowed)
+  expect_true("re_review_submitted"  %in% allowed)
+})
+
+test_that("re_review_filter_submit_fields rejects injection + out-of-allowlist keys", {
+  skip_if_not(exists("re_review_filter_submit_fields"))
+  expect_error(
+    re_review_filter_submit_fields("re_review_submitted = SLEEP(5), x")
+  )
+  expect_error(re_review_filter_submit_fields("re_review_approved"))
+  expect_equal(
+    re_review_filter_submit_fields(c("re_review_submitted", "re_review_review_saved")),
+    c("re_review_submitted", "re_review_review_saved")
+  )
+})
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `cd api && Rscript -e "testthat::test_file('tests/testthat/test-unit-re-review-submit-allowlist.R')"`
+Expected: FAIL — helpers not defined.
+
+- [ ] **Step 4: Add the helpers to `api/services/re-review-service.R`**
+
+```r
+#' Columns the re-review submit endpoint is permitted to write.
+#' Excludes identity (PK/FK) and approval columns so a Reviewer cannot inject
+#' SQL identifiers or self-approve via mass assignment (#2).
+re_review_submit_allowed_fields <- function() {
+  c("re_review_review_saved", "re_review_status_saved",
+    "re_review_submitted", "re_review_batch", "status_id", "review_id")
+}
+
+#' Validate + filter submitted field names to the allowlist. Fails loud.
+re_review_filter_submit_fields <- function(field_names) {
+  allowed <- re_review_submit_allowed_fields()
+  for (f in field_names) {
+    validate_query_column(f, allowed) # bare-identifier + allowlist; 400 on fail
+  }
+  field_names
+}
+```
+
+- [ ] **Step 5: Wire the endpoint** — `api/endpoints/re_review_endpoints.R`, replace lines 36–38:
+
+```r
+  fields_to_update <- names(submit_data)[names(submit_data) != "re_review_entity_id"]
+  fields_to_update <- re_review_filter_submit_fields(fields_to_update)   # SECURITY #2
+  set_clause <- paste(paste0(fields_to_update, " = ?"), collapse = ", ")
+  sql <- paste0("UPDATE re_review_entity_connect SET ", set_clause, " WHERE re_review_entity_id = ?")
+```
+
+- [ ] **Step 6: Run to verify it passes**
+
+Run: `cd api && Rscript -e "testthat::test_file('tests/testthat/test-unit-re-review-submit-allowlist.R')"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/services/re-review-service.R api/endpoints/re_review_endpoints.R api/tests/testthat/test-unit-re-review-submit-allowlist.R
+git commit -m "fix(security): allowlist re-review submit fields (SQLi + self-approval) (#2)
+
+Interpolated JSON keys as SQL identifiers allowed identifier injection and
+mass-assignment of re_review_approved/approving_user_id. Restrict to writable
+columns via validate_query_column; reject others with 400.
+
+Claude-Session: https://claude.ai/code/session_01Nxo1e69TNWFWXxroYEuWNX"
+```
+
+## Task 3: #3 — Public reads must be approved-only (shared helper)
+
+**Files:**
+- Modify: `api/functions/review-repository.R` (add `primary_approved_reviews`)
+- Modify: `api/endpoints/entity_endpoints.R` (5 review sites + `/status`)
+- Test: `api/tests/testthat/test-unit-public-approved-review-guard.R` (create)
+
+**Interfaces:**
+- Produces: `primary_approved_reviews(pool, cols = NULL)` → a lazy dbplyr tbl over `ndd_entity_review` filtered `is_primary == 1 & review_approved == 1`, optionally `dplyr::select(all_of(cols))`.
+
+- [ ] **Step 1: Write the failing static guard**
+
+`api/tests/testthat/test-unit-public-approved-review-guard.R`:
+
+```r
+# Guard (#3): every public review-derived read must gate on review_approved,
+# not is_primary alone. Enforced by a source scan of entity_endpoints.R.
+test_that("entity_endpoints.R never filters ndd_entity_review by is_primary alone", {
+  src <- paste(readLines("../../endpoints/entity_endpoints.R", warn = FALSE), collapse = "\n")
+  # No bare `filter(is_primary)` / `filter(... is_primary)` without review_approved
+  bad <- gregexpr("filter\\([^)]*is_primary[^)]*\\)", src)[[1]]
+  if (bad[1] != -1) {
+    for (i in seq_along(bad)) {
+      frag <- substr(src, bad[i], bad[i] + attr(bad, "match.length")[i] - 1)
+      expect_true(grepl("review_approved", frag),
+                  info = paste("is_primary filter without review_approved:", frag))
+    }
+  }
+  succeed()
+})
+
+test_that("primary_approved_reviews carries both predicates", {
+  skip_if_not(exists("primary_approved_reviews"))
+  body <- paste(deparse(body(primary_approved_reviews)), collapse = " ")
+  expect_true(grepl("is_primary", body))
+  expect_true(grepl("review_approved", body))
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd api && Rscript -e "testthat::test_file('tests/testthat/test-unit-public-approved-review-guard.R')"`
+Expected: FAIL — current sites filter `is_primary` only.
+
+- [ ] **Step 3: Add the helper to `api/functions/review-repository.R`**
+
+```r
+#' Lazy tbl of PRIMARY + APPROVED reviews only — the single public-read gate.
+#' Every public/anonymous review-derived read MUST source rows through this so
+#' the `is_primary = 1 AND review_approved = 1` predicate cannot drift (#3).
+#' Mirrors the MCP repo / SEO service / snapshot builder.
+primary_approved_reviews <- function(pool, cols = NULL) {
+  out <- pool %>%
+    dplyr::tbl("ndd_entity_review") %>%
+    dplyr::filter(is_primary == 1 & review_approved == 1)
+  if (!is.null(cols)) out <- out %>% dplyr::select(dplyr::all_of(cols))
+  out
+}
+```
+
+- [ ] **Step 4: Update entity_endpoints.R site 1 (entity list, ~87–90)**
+
+```r
+  ndd_entity_review <- primary_approved_reviews(pool, cols = c("entity_id", "synopsis"))
+```
+
+- [ ] **Step 5: Update sites 2–5** (`/phenotypes` ~590, `/variation` ~659, `/review` ~716, `/publications` ~808)
+
+For each, change the primary-review selection from `filter(entity_id == sysndd_id & is_primary)` to source from the helper, e.g.:
+
+```r
+  primary_review <- primary_approved_reviews(pool) %>%
+    dplyr::filter(entity_id == sysndd_id) %>%
+    dplyr::collect()
+```
+
+and restore `is_active == 1` on the `ndd_review_phenotype_connect` / `ndd_review_variation_ontology_connect` reads in `current_review` mode. (Read each handler and apply; the review_id used downstream now comes only from approved primary rows.)
+
+- [ ] **Step 6: Add `status_approved == 1` to `/status` (~764)**
+
+```r
+  ndd_entity_status <- pool %>% dplyr::tbl("ndd_entity_status") %>%
+    dplyr::filter(entity_id == sysndd_id & is_active == 1 & status_approved == 1)
+```
+
+- [ ] **Step 7: Run guard + smoke**
+
+Run: `cd api && Rscript -e "testthat::test_file('tests/testthat/test-unit-public-approved-review-guard.R')"`
+Expected: PASS. Then `make lint-api`.
+
+- [ ] **Step 8: Behavioral verification (in-container / dev stack)**
+
+With `make docker-dev-db` + API up: create/approve an entity, edit its primary review WITHOUT direct_approval (→ `review_approved=0`), then `GET /api/entity/<id>/review` and the entity list — confirm the unapproved synopsis is NOT returned. Document the check in the PR.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add api/functions/review-repository.R api/endpoints/entity_endpoints.R api/tests/testthat/test-unit-public-approved-review-guard.R
+git commit -m "fix(security): public entity reads approved-only via shared helper (#3)
+
+Public list + /phenotypes,/variation,/review,/publications filtered is_primary
+only, leaking unapproved in-place review edits. Route all 5 through
+primary_approved_reviews() (is_primary=1 AND review_approved=1); add
+status_approved=1 to /status; restore is_active=1 on connect reads.
+
+Claude-Session: https://claude.ai/code/session_01Nxo1e69TNWFWXxroYEuWNX"
+```
+
+## Task 4: PR 1 — Codex high-effort review + verification gate
+
+- [ ] **Step 1:** `make lint-api` → clean.
+- [ ] **Step 2:** `make test-api-fast` → green (includes the three new guards after `docker cp`/rebuild).
+- [ ] **Step 3:** Dispatch Codex at **high** reasoning effort (via the `codex` rescue skill/subagent) with the PR-1 diff and prompt: *"Adversarial security review. For each of the three fixes (hash RCE, re-review SET allowlist, approved-only entity reads): can it still be bypassed? Is any evaluation path or predicate site missed? Any regression?"* Address findings, re-run gates.
+- [ ] **Step 4:** Open PR 1; verify the branch has only the intended commits (`git log --oneline master..HEAD`).
+
+---
+
+# PR 2 — MEDIUM + LOW (branch `security/hardening-medium-low` off `master` after PR 1 merges)
+
+> Create the branch: `git checkout master && git pull && git checkout -b security/hardening-medium-low`
+
+## Task 5: #4 — Allowlist user_update SET clause (MEDIUM)
+
+**Files:** Modify `api/functions/user-repository.R:194–215`; Test `api/tests/testthat/test-unit-user-update-allowlist.R` (create).
+
+- [ ] **Step 1: Failing test**
+
+```r
+test_that("user_update rejects unknown/injection field names", {
+  skip_if_not(exists("user_update"))
+  expect_error(user_update(1, list("user_role = 'x', y" = "z")))   # injection key
+  expect_error(user_update(1, list(bogus_col = "x")))              # unknown col
+})
+```
+
+- [ ] **Step 2:** Run → FAIL. `cd api && Rscript -e "testthat::test_file('tests/testthat/test-unit-user-update-allowlist.R')"`
+
+- [ ] **Step 3: Fix** — in `user_update()`, after stripping password fields, add before building the SET clause:
+
+```r
+  allowed_user_cols <- c("user_name", "email", "orcid", "abbreviation",
+                         "first_name", "family_name", "user_role", "comment",
+                         "terms_agreed", "approved", "rereview_request",
+                         "password_reset_date")
+  field_names <- names(updates)
+  bad <- setdiff(field_names, allowed_user_cols)
+  if (length(bad) > 0) {
+    stop_for_bad_request(paste("Disallowed user field(s):", paste(bad, collapse = ", ")))
+  }
+```
+
+(Keep the existing `set_clause`/`params` lines below, now operating on the validated `field_names`.)
+
+- [ ] **Step 4:** Run → PASS. **Step 5:** Commit `fix(security): allowlist user_update fields (SQLi/mass-assignment) (#4)`.
+
+## Task 6: #5 — Block Curator from demoting Administrators (MEDIUM)
+
+**Files:** Modify `api/services/user-service.R` (add guard helper; call in `user_update_role` ~196 and `user_bulk_assign_role` ~515); Modify `api/endpoints/user_endpoints.R:306–323` (`change_role`); Test `api/tests/testthat/test-unit-role-admin-target-guard.R` (create).
+
+- [ ] **Step 1: Failing test** (unit-test the guard helper):
+
+```r
+test_that("assert_not_targeting_admin blocks non-admin caller on admin targets", {
+  skip_if_not(exists("assert_not_targeting_admin"))
+  # current_roles: a lookup of target user_id -> current role
+  expect_error(assert_not_targeting_admin(
+    requesting_role = "Curator", target_current_roles = c("Administrator")))
+  expect_silent(assert_not_targeting_admin(
+    requesting_role = "Curator", target_current_roles = c("Viewer", "Reviewer")))
+  expect_silent(assert_not_targeting_admin(
+    requesting_role = "Administrator", target_current_roles = c("Administrator")))
+})
+```
+
+- [ ] **Step 2:** Run → FAIL.
+
+- [ ] **Step 3: Add helper to `api/services/user-service.R`:**
+
+```r
+#' A non-Administrator caller may not modify a currently-Administrator target
+#' (mirrors the user_bulk_delete admin shield). (#5)
+assert_not_targeting_admin <- function(requesting_role, target_current_roles) {
+  if (requesting_role != "Administrator" &&
+        any(target_current_roles == "Administrator")) {
+    stop_for_unauthorized("Only an Administrator may modify Administrator accounts.")
+  }
+  invisible(TRUE)
+}
+```
+
+Call it in `user_update_role(user_id, new_role, requesting_role, pool)` and `user_bulk_assign_role(user_ids, new_role, requesting_role, pool)` right after input validation — first `SELECT user_id, user_role FROM user WHERE user_id IN (...)` to get `target_current_roles`, then `assert_not_targeting_admin(requesting_role, roles)`.
+
+- [ ] **Step 4: Wire the `change_role` endpoint** (`user_endpoints.R:306`), which currently calls `user_update` directly — route it through `user_update_role(user_id_role, role_assigned, req$user_role, pool)` so the guard applies, OR add an inline lookup + `assert_not_targeting_admin(req$user_role, current_role)` before the `user_update`.
+
+- [ ] **Step 5:** Run → PASS. **Step 6:** Commit `fix(security): block Curator from demoting Administrators (#5)`.
+
+## Task 7: #6 — Bound public PubTator calls (MEDIUM)
+
+**Files:** Modify `api/endpoints/publication_endpoints.R` (`/pubtator/search` ~126–148, `/pubtator/cache-status` ~680–687); optionally add wrappers to `api/functions/publication-endpoint-helpers.R`; Test `api/tests/testthat/test-unit-pubtator-public-route-guard.R` (create).
+
+- [ ] **Step 1: Gate cache-status (simple, high-value).** In `/pubtator/cache-status` handler, add as the first statement:
+
+```r
+  require_role(req, res, "Curator")   # SECURITY #6: operational cache probe, not public
+```
+
+- [ ] **Step 2: Bound `/pubtator/search`.** Wrap the two live calls so a slow upstream can't pin a worker and repeat hits are free. Add to `api/functions/publication-endpoint-helpers.R` (read `functions/external-proxy-functions.R` for exact `external_proxy_budget` / `external_proxy_with_timing` signatures first):
+
+```r
+# Public, budgeted + memoised PubTator search wrappers (#6). The raw
+# pubtator-client fetchers stay untouched for the worker/batch callers.
+pubtator_public_search <- memoise_external_success_only(function(query, page) {
+  budget <- external_proxy_budget("pubtator")
+  old <- options(timeout = budget$max_seconds); on.exit(options(old), add = TRUE)
+  external_proxy_with_timing("pubtator", function() {
+    list(
+      pmids = pubtator_v3_pmids_from_request(query, page, 1L),
+      total_pages = pubtator_v3_total_pages_from_query(query)
+    )
+  })
+}, source = "pubtator")
+```
+
+Then in `/pubtator/search`, replace the two direct calls with `res_pt <- pubtator_public_search(query, current_page)` and read `res_pt$pmids` / `res_pt$total_pages`.
+
+- [ ] **Step 3: Guard test** — assert both public pubtator routes are gated or budget-wrapped:
+
+```r
+test_that("public pubtator routes are gated or budgeted", {
+  src <- paste(readLines("../../endpoints/publication_endpoints.R", warn=FALSE), collapse="\n")
+  # cache-status handler must require_role
+  cs <- regmatches(src, regexpr("cache-status[\\s\\S]{0,400}", src))
+  expect_true(grepl("require_role", cs))
+})
+```
+
+- [ ] **Step 4:** `make lint-api`; run guard → PASS. **Step 5:** Commit `fix(security): bound public PubTator calls (budget/cache + gate cache-status) (#6)`.
+
+## Task 8: #7 — Public LLM summaries validated-only (MEDIUM)
+
+**Files:** Modify `api/functions/llm-endpoint-helpers.R:52`; Test `api/tests/testthat/test-unit-llm-public-validated-only.R` (create).
+
+- [ ] **Step 1: Failing static guard**
+
+```r
+test_that("public cluster-summary path requires validated summaries", {
+  src <- paste(readLines("../../functions/llm-endpoint-helpers.R", warn=FALSE), collapse="\n")
+  expect_false(grepl("get_cached_summary\\(raw_hash,\\s*require_validated\\s*=\\s*FALSE\\)", src))
+})
+```
+
+- [ ] **Step 2:** Run → FAIL.
+
+- [ ] **Step 3: Fix** — line 52, change `require_validated = FALSE` → `require_validated = TRUE`. Because the query now only returns `validated` rows, the `rejected` special-case (67–76) needs its own explicit lookup so the rejected card still shows. Adjust:
+
+```r
+  cached <- tryCatch(
+    get_cached_summary(raw_hash, require_validated = TRUE),
+    error = function(e) { log_error("Cache lookup failed: {e$message}"); NULL })
+
+  if (!is.null(cached) && nrow(cached) > 0) {
+    return(format_summary_response(cached, cluster_number))   # validated only
+  }
+
+  # A current REJECTED row is terminal (#490): surface the explicit card.
+  rejected <- tryCatch(get_cached_summary(raw_hash, require_validated = FALSE,
+                                          status = "rejected"),
+                       error = function(e) NULL)
+  if (!is.null(rejected) && nrow(rejected) > 0) {
+    return(list(cluster_type = rejected$cluster_type[1],
+                cluster_number = as.integer(cluster_number),
+                validation_status = "rejected", summary_available = FALSE,
+                reason = llm_summary_rejection_reason(rejected), generated = FALSE))
+  }
+  # pending / miss -> being-prepared (unchanged 404 / generation branch below)
+```
+
+(Read `functions/llm-cache-repository.R:get_cached_summary` to confirm it accepts a `status`/rejected filter; if not, add a minimal `require_validated`-style filter for the rejected lookup.)
+
+- [ ] **Step 4:** Run → PASS. **Step 5:** Commit `fix(security): serve only validated LLM summaries on public path (#7)`.
+
+## Task 9: LOW-1 — Scope full job-result reads for maintenance jobs
+
+**Files:** Modify `api/functions/job-manager.R:375–382`; Test extend/new guard.
+
+- [ ] **Step 1:** Add an admin-only set and tighten the predicate:
+
+```r
+ADMIN_ONLY_RESULT_JOB_TYPES <- c("backup_create","backup_restore","nddscore_import",
+  "omim_update","hgnc_update","comparisons_update","ontology_update",
+  "force_apply_ontology","publication_refresh","pubtator_update",
+  "disease_ontology_mapping_refresh")
+
+can_read_full_job_result <- function(job_type, user_role = NULL) {
+  is_admin <- identical(user_role, "Administrator")
+  if (!is.null(job_type) && job_type %in% ADMIN_ONLY_RESULT_JOB_TYPES) return(is_admin)
+  privileged <- !is.null(user_role) && user_role %in% c("Reviewer","Curator","Administrator")
+  if (privileged) return(TRUE)
+  !is.null(job_type) && job_type %in% PUBLIC_FULL_RESULT_JOB_TYPES
+}
+```
+
+- [ ] **Step 2:** Unit test: `can_read_full_job_result("backup_create","Reviewer")` is FALSE; `(...,"Administrator")` TRUE; `("clustering", NULL)` TRUE. **Step 3:** Commit `fix(security): restrict maintenance job-result reads to Administrator (LOW)`.
+
+## Task 10: LOW-2 — Replace raw exception echoes with classed errors
+
+**Files:** `api/endpoints/about_endpoints.R:131,219`, `logging_endpoints.R:272`, `publication_endpoints.R:1088`, `user_endpoints.R:903`.
+
+- [ ] **Step 1:** For each site, replace the pattern
+
+```r
+    error = function(e) { res$status <- 500; list(error = paste("Failed to ...:", e$message)) }
+```
+
+with
+
+```r
+    error = function(e) {
+      log_error("<context>: {e$message}")
+      stop_for_internal("<static client message>")
+    }
+```
+
+so `errorHandler` renders a generic problem+json 500 and the internal detail only goes to the log. (For `user_endpoints.R:903`, the service returns `result$error`; wrap the `return(list(error=...))` similarly.)
+
+- [ ] **Step 2:** Guard test scanning these files for `list(error = paste(` near `e$message` → expect none. **Step 3:** Commit `fix(security): stop echoing raw exception text to clients (LOW)`.
+
+## Task 11: LOW-3 — Harden the logging sanitizer
+
+**Files:** `api/core/logging_sanitizer.R`; extend its unit test.
+
+- [ ] **Step 1:** Substring-match sensitive fields — change line 42:
+
+```r
+      if (grepl("pass|token|secret|jwt|api_key|authorization|hash", tolower(name))) {
+```
+
+- [ ] **Step 2:** Redact the query string in `sanitize_request` — change line 82:
+
+```r
+    QUERY_STRING = if (is.null(req$QUERY_STRING) || req$QUERY_STRING == "") NA_character_ else "[REDACTED]",
+```
+
+- [ ] **Step 3:** Test: `sanitize_object(list(access_token="x"))$access_token == "[REDACTED]"`; `sanitize_request(list(QUERY_STRING="t=secret"))$QUERY_STRING == "[REDACTED]"`. **Step 4:** Commit `fix(security): substring-redact sensitive fields + query string in logs (LOW)`.
+
+## Task 12: LOW-4 — Constant-time legacy password compare
+
+**Files:** `api/core/security.R:93`.
+
+- [ ] **Step 1:** Replace `password_from_db == password_attempt` with a constant-time compare:
+
+```r
+    isTRUE(sodium::sha256(charToRaw(as.character(password_from_db))) ==
+             sodium::sha256(charToRaw(as.character(password_attempt))))
+```
+
+(digest-equality of equal-length hashes; still triggers the existing plaintext→Argon2id upgrade on success.)
+
+- [ ] **Step 2:** Test both-match TRUE / mismatch FALSE. **Step 3:** Commit `fix(security): constant-time legacy password comparison (LOW)`.
+
+## Task 13: LOW-5 — URL-encode external segments (hgnc, oxo)
+
+**Files:** `api/functions/hgnc-functions.R:17,45,79,171`, `api/functions/oxo-functions.R:24`.
+
+- [ ] **Step 1:** Wrap each interpolated segment, e.g. hgnc-functions.R:
+
+```r
+  fromJSON(paste0("http://rest.genenames.org/search/prev_symbol/",
+                  utils::URLencode(symbol_input, reserved = TRUE)))
+```
+
+and oxo-functions.R:24: `..."?fromId=", utils::URLencode(ontology_id, reserved = TRUE)`.
+
+- [ ] **Step 2:** Guard scanning both files: no `paste0("http...", <var>)` without `URLencode`. **Step 3:** Commit `fix(security): URL-encode external URL segments in hgnc/oxo fetchers (LOW)`.
+
+## Task 14: LOW-6 & LOW-7 — mondo timeout + config::get mask
+
+**Files:** `api/functions/mondo-functions.R:72–77`, `api/functions/metadata-refresh.R:38`.
+
+- [ ] **Step 1: mondo** — add a budget-derived timeout to `download_mondo_sssom`, mirroring `download_mondo_sssom_full`:
+
+```r
+      budget <- external_proxy_budget("mondo")
+      response <- httr2::request(sssom_url) %>%
+        httr2::req_timeout(budget$timeout_seconds) %>%
+        httr2::req_retry(max_tries = budget$max_tries, max_seconds = budget$max_seconds, backoff = ~2) %>%
+        httr2::req_error(is_error = ~FALSE) %>%
+        httr2::req_perform()
+```
+
+- [ ] **Step 2: metadata-refresh** — line 38, `get(...)` → `base::get("log_warn", mode = "function")(message)`.
+
+- [ ] **Step 3:** Guard: `test-unit-external-budget-guard.R` already scans `mondo-functions.R`; confirm it still passes. Add a one-line assert that `metadata-refresh.R` uses `base::get`. **Step 4:** Commit `fix(correctness): mondo download timeout + base::get in metadata-refresh (LOW)`. **Restart the worker** to make these live.
+
+## Task 15: PR 2 — Codex high-effort review + verification gate
+
+- [ ] **Step 1:** `make lint-api` + `make test-api-fast` + `make test-api` → green.
+- [ ] **Step 2:** Dispatch Codex at **high** effort with the PR-2 diff: *"Adversarial review of these 4 MEDIUM + 8 LOW security/correctness fixes — completeness of each allowlist/guard, any bypass, any regression, R masking footguns."* Address findings.
+- [ ] **Step 3:** Restart `worker` + `worker-maintenance` (mondo/metadata-refresh are worker-executed). Open PR 2.
+
+---
+
+## Self-Review
+
+**Spec coverage:** #1→T1, #2→T2, #3→T3, PR1 review→T4; #4→T5, #5→T6, #6→T7, #7→T8, LOW-1→T9, LOW-2→T10, LOW-3(F1/F2)→T11, LOW-4(F4)→T12, LOW-5→T13, LOW-6/LOW-7→T14, PR2 review→T15. All spec sections mapped.
+
+**Placeholder scan:** No "TBD/TODO/implement later". Two deliberate read-then-apply steps (T2 confirm frontend field set; T8 confirm `get_cached_summary` rejected filter) carry the concrete before/after and a fallback instruction — bounded, not vague.
+
+**Type consistency:** `primary_approved_reviews(pool, cols)`, `re_review_filter_submit_fields()`, `assert_not_targeting_admin(requesting_role, target_current_roles)`, `can_read_full_job_result(job_type, user_role)`, `pubtator_public_search(query, page)` — names used consistently across their tasks. Commit messages consistent. Guard-test file names match the File Structure map.

--- a/.planning/superpowers/plans/2026-07-06-security-bug-scan-fixes-plan.md
+++ b/.planning/superpowers/plans/2026-07-06-security-bug-scan-fixes-plan.md
@@ -119,7 +119,12 @@ with:
   # evaluation, and sort by a column REFERENCE (never parse the name as code).
   # The old arrange(!!!parse_exprs(colnames[1])) evaluated the first JSON key
   # as an R expression via dplyr data-masking -> authenticated RCE.
-  hash_validate_columns(colnames(json_tibble), allowed_col_list)
+  # hash_validate_columns() raises `hash_column_validation_error` (rlang::abort),
+  # which errorHandler does NOT map -> wrap to a classed 400 (Codex review).
+  tryCatch(
+    hash_validate_columns(colnames(json_tibble), allowed_col_list),
+    hash_column_validation_error = function(e) stop_for_bad_request(conditionMessage(e))
+  )
 
   json_tibble <- json_tibble %>%
     dplyr::arrange(dplyr::across(dplyr::all_of(colnames(json_tibble)[1])))
@@ -162,35 +167,31 @@ Claude-Session: https://claude.ai/code/session_01Nxo1e69TNWFWXxroYEuWNX"
 **Interfaces:**
 - Produces: `re_review_submit_allowed_fields()` → character vector of writable columns; `re_review_filter_submit_fields(field_names)` → validated character vector or `stop_for_bad_request` on any out-of-allowlist / non-identifier token.
 
-- [ ] **Step 1: Confirm the legitimate field set**
+- [ ] **Step 1: Confirm the legitimate field set (Codex-narrowed)**
 
-Run: `grep -rn "submit_json\|re_review_review_saved\|re_review_status_saved\|re_review_submitted" app/src api/services/re-review-service.R`
-Expected: identify exactly which columns the frontend submit sends. The allowlist is the intersection with the table's non-identity, non-approval columns: `re_review_review_saved`, `re_review_status_saved`, `re_review_submitted`, `status_id`, `review_id`, `re_review_batch`. It MUST exclude `re_review_entity_id` (PK/WHERE key), `entity_id`, `re_review_approved`, `approving_user_id` (approval is a Curator-only action — excluding them closes the self-approval mass-assignment). Adjust the vector below to the confirmed frontend set.
+Run: `grep -n "submit_json\|re_review_submitted" app/src/views/review/composables/useReviewActions.ts`
+Expected: the frontend `/re_review/submit` call sends **only `re_review_submitted`** (confirmed at `useReviewActions.ts:80-84`). The saved flags + `review_id`/`status_id` are written by the separate `review_update_re_review_status()` / `status_update_re_review_status()` paths, **not** the submit action. So the allowlist is the single column `re_review_submitted`; every other key (identity, approval, save-flags) is rejected. If a later grep shows the frontend legitimately sends more, widen the vector to exactly that set — never broader.
 
 - [ ] **Step 2: Write the failing test**
 
 `api/tests/testthat/test-unit-re-review-submit-allowlist.R`:
 
 ```r
-test_that("re_review_submit_allowed_fields excludes identity + approval columns", {
+test_that("re_review_submit_allowed_fields is the tight single-column set", {
   skip_if_not(exists("re_review_submit_allowed_fields"))
   allowed <- re_review_submit_allowed_fields()
-  expect_false("re_review_entity_id" %in% allowed)
-  expect_false("re_review_approved"  %in% allowed)
+  expect_setequal(allowed, "re_review_submitted")
+  expect_false("re_review_approved"  %in% allowed)  # no self-approval
   expect_false("approving_user_id"   %in% allowed)
-  expect_true("re_review_submitted"  %in% allowed)
+  expect_false("re_review_entity_id" %in% allowed)  # PK / WHERE key
 })
 
 test_that("re_review_filter_submit_fields rejects injection + out-of-allowlist keys", {
   skip_if_not(exists("re_review_filter_submit_fields"))
-  expect_error(
-    re_review_filter_submit_fields("re_review_submitted = SLEEP(5), x")
-  )
-  expect_error(re_review_filter_submit_fields("re_review_approved"))
-  expect_equal(
-    re_review_filter_submit_fields(c("re_review_submitted", "re_review_review_saved")),
-    c("re_review_submitted", "re_review_review_saved")
-  )
+  expect_error(re_review_filter_submit_fields("re_review_submitted = SLEEP(5), x"))
+  expect_error(re_review_filter_submit_fields("re_review_approved"))      # mass-assignment
+  expect_error(re_review_filter_submit_fields("re_review_review_saved"))  # wrong path
+  expect_equal(re_review_filter_submit_fields("re_review_submitted"), "re_review_submitted")
 })
 ```
 
@@ -203,11 +204,12 @@ Expected: FAIL — helpers not defined.
 
 ```r
 #' Columns the re-review submit endpoint is permitted to write.
-#' Excludes identity (PK/FK) and approval columns so a Reviewer cannot inject
-#' SQL identifiers or self-approve via mass assignment (#2).
+#' The frontend submit action sends only `re_review_submitted`; the save-flags
+#' and review/status IDs are written by review_update_re_review_status() /
+#' status_update_re_review_status(), NOT here. Restricting to this single column
+#' blocks SQL-identifier injection AND self-approval mass-assignment (#2, Codex).
 re_review_submit_allowed_fields <- function() {
-  c("re_review_review_saved", "re_review_status_saved",
-    "re_review_submitted", "re_review_batch", "status_id", "review_id")
+  c("re_review_submitted")
 }
 
 #' Validate + filter submitted field names to the allowlist. Fails loud.
@@ -396,6 +398,7 @@ test_that("user_update rejects unknown/injection field names", {
   if (length(bad) > 0) {
     stop_for_bad_request(paste("Disallowed user field(s):", paste(bad, collapse = ", ")))
   }
+  for (f in field_names) validate_query_column(f, allowed_user_cols)  # bare-ident backstop (Codex)
 ```
 
 (Keep the existing `set_clause`/`params` lines below, now operating on the validated `field_names`.)
@@ -447,27 +450,36 @@ Call it in `user_update_role(user_id, new_role, requesting_role, pool)` and `use
 
 **Files:** Modify `api/endpoints/publication_endpoints.R` (`/pubtator/search` ~126–148, `/pubtator/cache-status` ~680–687); optionally add wrappers to `api/functions/publication-endpoint-helpers.R`; Test `api/tests/testthat/test-unit-pubtator-public-route-guard.R` (create).
 
-- [ ] **Step 1: Gate cache-status (simple, high-value).** In `/pubtator/cache-status` handler, add as the first statement:
+- [ ] **Step 1: Gate cache-status AND budget-wrap its probe.** In `/pubtator/cache-status`, gate first, then bound the live probe (Codex: gating alone still lets an authenticated slow upstream hang a worker):
 
 ```r
   require_role(req, res, "Curator")   # SECURITY #6: operational cache probe, not public
+  ...
+  budget <- external_proxy_budget("pubtator")
+  old <- options(timeout = budget$max_seconds); on.exit(options(old), add = TRUE)
+  total_pages <- external_proxy_with_timing("pubtator", function() {
+    pubtator_v3_total_pages_from_query(query)
+  })
 ```
 
-- [ ] **Step 2: Bound `/pubtator/search`.** Wrap the two live calls so a slow upstream can't pin a worker and repeat hits are free. Add to `api/functions/publication-endpoint-helpers.R` (read `functions/external-proxy-functions.R` for exact `external_proxy_budget` / `external_proxy_with_timing` signatures first):
+- [ ] **Step 2: Bound `/pubtator/search`.** The **primary** DoS fix is the timeout bound + per-request ceiling; memoise is an optional optimization and — per Codex — `memoise_external_success_only(f, cache, source)` **requires an explicit `cache` backend** (2nd positional; see `external-proxy-alphafold.R:167` → `cache = cache_static`). Read `functions/external-proxy-functions.R` (`external_proxy_with_timing(source, expr_fn)` at :225) first, then add to `api/functions/publication-endpoint-helpers.R`:
 
 ```r
-# Public, budgeted + memoised PubTator search wrappers (#6). The raw
+# Public, budget-bounded PubTator search on the request path (#6). The raw
 # pubtator-client fetchers stay untouched for the worker/batch callers.
-pubtator_public_search <- memoise_external_success_only(function(query, page) {
+pubtator_public_search <- function(query, page) {
   budget <- external_proxy_budget("pubtator")
   old <- options(timeout = budget$max_seconds); on.exit(options(old), add = TRUE)
   external_proxy_with_timing("pubtator", function() {
     list(
-      pmids = pubtator_v3_pmids_from_request(query, page, 1L),
+      pmids       = pubtator_v3_pmids_from_request(query, page, 1L),
       total_pages = pubtator_v3_total_pages_from_query(query)
     )
   })
-}, source = "pubtator")
+}
+# OPTIONAL memoise (only if a cache backend is in scope):
+#   pubtator_public_search <- memoise_external_success_only(
+#     pubtator_public_search, cache = cache_static, source = "pubtator")
 ```
 
 Then in `/pubtator/search`, replace the two direct calls with `res_pt <- pubtator_public_search(query, current_page)` and read `res_pt$pmids` / `res_pt$total_pages`.
@@ -487,7 +499,7 @@ test_that("public pubtator routes are gated or budgeted", {
 
 ## Task 8: #7 — Public LLM summaries validated-only (MEDIUM)
 
-**Files:** Modify `api/functions/llm-endpoint-helpers.R:52`; Test `api/tests/testthat/test-unit-llm-public-validated-only.R` (create).
+**Files:** Modify `api/functions/llm-endpoint-helpers.R:52` + `api/functions/llm-cache-repository.R` (add `status` arg to `get_cached_summary`); Test `api/tests/testthat/test-unit-llm-public-validated-only.R` (create).
 
 - [ ] **Step 1: Failing static guard**
 
@@ -524,7 +536,7 @@ test_that("public cluster-summary path requires validated summaries", {
   # pending / miss -> being-prepared (unchanged 404 / generation branch below)
 ```
 
-(Read `functions/llm-cache-repository.R:get_cached_summary` to confirm it accepts a `status`/rejected filter; if not, add a minimal `require_validated`-style filter for the rejected lookup.)
+**Required (Codex-confirmed):** `get_cached_summary()` (`functions/llm-cache-repository.R:119-143`) has **no `status` arg** today, so the validated-only query will no longer return the `rejected` row. This task **must** add an optional `status = NULL` parameter to `get_cached_summary()` (when set, `AND validation_status = ?`) and use `status = "rejected"` for the rejected-card lookup above. Without this, rejected clusters would silently show "being prepared" again — re-introducing the #490 bug. Add a unit test for the new `status` filter on `get_cached_summary()`.
 
 - [ ] **Step 4:** Run → PASS. **Step 5:** Commit `fix(security): serve only validated LLM summaries on public path (#7)`.
 
@@ -553,7 +565,7 @@ can_read_full_job_result <- function(job_type, user_role = NULL) {
 
 ## Task 10: LOW-2 — Replace raw exception echoes with classed errors
 
-**Files:** `api/endpoints/about_endpoints.R:131,219`, `logging_endpoints.R:272`, `publication_endpoints.R:1088`, `user_endpoints.R:903`.
+**Files:** `api/endpoints/about_endpoints.R:131,219`, `logging_endpoints.R:272`, `publication_endpoints.R:1088`, `user_endpoints.R:903` **and the sibling bulk paths `user_endpoints.R:~1030-1044` + `~1106-1113`** (Codex Section B — `return(list(error = e$message))` / `return(list(error = result$error))` in bulk delete/role-assign).
 
 - [ ] **Step 1:** For each site, replace the pattern
 
@@ -596,14 +608,26 @@ so `errorHandler` renders a generic problem+json 500 and the internal detail onl
 
 **Files:** `api/core/security.R:93`.
 
-- [ ] **Step 1:** Replace `password_from_db == password_attempt` with a constant-time compare:
+- [ ] **Step 1:** Replace `password_from_db == password_attempt` with a constant-time compare. **Codex caught a bug in the first draft:** `sha256(a) == sha256(b)` yields a length-32 logical, and `isTRUE()` of that is **always FALSE** (would break legacy login + the upgrade). Reduce to a scalar with `all()`:
 
 ```r
-    isTRUE(sodium::sha256(charToRaw(as.character(password_from_db))) ==
-             sodium::sha256(charToRaw(as.character(password_attempt))))
+    isTRUE(all(
+      sodium::sha256(charToRaw(as.character(password_from_db))) ==
+        sodium::sha256(charToRaw(as.character(password_attempt)))
+    ))
 ```
 
-(digest-equality of equal-length hashes; still triggers the existing plaintext→Argon2id upgrade on success.)
+(equal-length 32-byte hash compare → data-independent; still triggers the existing plaintext→Argon2id upgrade on success.)
+
+- [ ] **Step 1b: Add a regression test** so the always-FALSE bug can't return:
+
+```r
+test_that("legacy plaintext verify returns TRUE on match, FALSE on mismatch", {
+  skip_if_not(exists("verify_password"))
+  expect_true(verify_password("secret123", "secret123"))   # plaintext row
+  expect_false(verify_password("secret123", "wrong"))
+})
+```
 
 - [ ] **Step 2:** Test both-match TRUE / mismatch FALSE. **Step 3:** Commit `fix(security): constant-time legacy password comparison (LOW)`.
 
@@ -641,6 +665,41 @@ and oxo-functions.R:24: `..."?fromId=", utils::URLencode(ontology_id, reserved =
 
 - [ ] **Step 3:** Guard: `test-unit-external-budget-guard.R` already scans `mondo-functions.R`; confirm it still passes. Add a one-line assert that `metadata-refresh.R` uses `base::get`. **Step 4:** Commit `fix(correctness): mondo download timeout + base::get in metadata-refresh (LOW)`. **Restart the worker** to make these live.
 
+## Task 14b: LOW-8 — Defense-in-depth allowlist for review_update (Codex Section B)
+
+**Files:** Modify `api/functions/review-repository.R:214–219` (`review_update`); Test `api/tests/testthat/test-unit-review-update-allowlist.R` (create).
+
+Codex found `review_update()` builds its `SET` clause from `names(updates)` with no allowlist — the same class as #2/#4. The **main** `/api/review/update` path is currently safe (`put_post_db_review` passes a fixed-column `sysnopsis_received` tibble), but `svc_review_update()` and the direct caller at `services/review-service.R:362` pass arbitrary `update_data`, so a future caller could reintroduce SQLi / mass-assignment. Harden the repository itself.
+
+- [ ] **Step 1: Failing test**
+
+```r
+test_that("review_update rejects unknown/injection column names", {
+  skip_if_not(exists("review_update"))
+  expect_error(review_update(1, list("synopsis = x, y" = "z")))  # injection key
+  expect_error(review_update(1, list(bogus_col = "x")))          # unknown col
+})
+```
+
+- [ ] **Step 2:** Run → FAIL.
+
+- [ ] **Step 3: Fix** — inside `review_update()`, before building `set_clause` (line ~217), validate against the writable `ndd_entity_review` columns. Confirm the real writable set by reading `db/migrations/000_initialize_base_schema.sql` for `ndd_entity_review`, then:
+
+```r
+    allowed_review_cols <- c("synopsis", "comment", "review_user_id",
+                             "is_primary", "review_approved", "approving_user_id")
+    col_names <- names(updates)
+    bad <- setdiff(col_names, allowed_review_cols)
+    if (length(bad) > 0) {
+      stop_for_bad_request(paste("Disallowed review field(s):", paste(bad, collapse = ", ")))
+    }
+    for (f in col_names) validate_query_column(f, allowed_review_cols)
+```
+
+(Adjust `allowed_review_cols` to the actual `ndd_entity_review` column list; keep `review_approved`/`approving_user_id` writable here because `review_approve()`/`review_update()` legitimately set them internally.)
+
+- [ ] **Step 4:** Run → PASS. **Step 5:** Commit `fix(security): defense-in-depth allowlist for review_update SET clause (Codex)`.
+
 ## Task 15: PR 2 — Codex high-effort review + verification gate
 
 - [ ] **Step 1:** `make lint-api` + `make test-api-fast` + `make test-api` → green.
@@ -651,8 +710,10 @@ and oxo-functions.R:24: `..."?fromId=", utils::URLencode(ontology_id, reserved =
 
 ## Self-Review
 
-**Spec coverage:** #1→T1, #2→T2, #3→T3, PR1 review→T4; #4→T5, #5→T6, #6→T7, #7→T8, LOW-1→T9, LOW-2→T10, LOW-3(F1/F2)→T11, LOW-4(F4)→T12, LOW-5→T13, LOW-6/LOW-7→T14, PR2 review→T15. All spec sections mapped.
+**Spec coverage:** #1→T1, #2→T2, #3→T3, PR1 review→T4; #4→T5, #5→T6, #6→T7, #7→T8, LOW-1→T9, LOW-2→T10, LOW-3(F1/F2)→T11, LOW-4(F4)→T12, LOW-5→T13, LOW-6/LOW-7→T14, LOW-8 review_update (Codex Section B)→T14b, PR2 review→T15. All spec sections mapped.
 
-**Placeholder scan:** No "TBD/TODO/implement later". Two deliberate read-then-apply steps (T2 confirm frontend field set; T8 confirm `get_cached_summary` rejected filter) carry the concrete before/after and a fallback instruction — bounded, not vague.
+**Codex high-review (2026-07-06) incorporated:** #1 error-class wrap to 400 (T1); #2 narrowed to `re_review_submitted` only (T2); #4 + `validate_query_column` (T5); #6 memoise `cache` arg + budget-wrap cache-status (T7); #7 `status` arg on `get_cached_summary` now required (T8); LOW-2 extended to bulk echo sites (T10); LOW-4 constant-time bug fixed with `all()` (T12); new LOW-8 review_update hardening (T14b). All Section A verdicts were SOUND/GAP-with-fix; no diagnosis was WRONG.
+
+**Placeholder scan:** No "TBD/TODO/implement later". Deliberate read-then-apply steps (T2 confirm frontend field set; T8 add `status` arg; T14b confirm `ndd_entity_review` columns) carry concrete before/after — bounded, not vague.
 
 **Type consistency:** `primary_approved_reviews(pool, cols)`, `re_review_filter_submit_fields()`, `assert_not_targeting_admin(requesting_role, target_current_roles)`, `can_read_full_job_result(job_type, user_role)`, `pubtator_public_search(query, page)` — names used consistently across their tasks. Commit messages consistent. Guard-test file names match the File Structure map.

--- a/.planning/superpowers/specs/2026-07-06-security-bug-scan-fixes-design.md
+++ b/.planning/superpowers/specs/2026-07-06-security-bug-scan-fixes-design.md
@@ -55,8 +55,13 @@ handled at PR close, not per commit.
 - **Fix (two independent barriers):**
   1. **Validate first.** Move `hash_validate_columns(colnames(json_tibble), allowed_col_list)`
      to immediately after `as_tibble(json_data)`, *before* the `arrange` and the
-     no-DB branch, so an unexpected column name is rejected (400, classed error)
-     before anything evaluates it.
+     no-DB branch, so an unexpected column name is rejected before anything
+     evaluates it. **Codex note:** `hash_validate_columns()` raises
+     `rlang::abort(class = "hash_column_validation_error")` — **not** a classed
+     `error_400`, so it would currently fall through to a generic 500. Wrap the
+     call in `tryCatch(..., hash_column_validation_error = \(e)
+     stop_for_bad_request(conditionMessage(e)))` so the rejection maps to a
+     clean 400 via `errorHandler`.
   2. **Remove the eval entirely.** Replace the `parse_exprs` sort with a
      non-eval column reference:
      `arrange(dplyr::across(dplyr::all_of(colnames(json_tibble)[1])))`.
@@ -86,15 +91,17 @@ handled at PR close, not per commit.
 - **Table columns:** `re_review_entity_id`(PK), `entity_id`, `re_review_batch`,
   `re_review_review_saved`, `re_review_status_saved`, `re_review_submitted`,
   `re_review_approved`, `approving_user_id`, `status_id`, `review_id`.
-- **Fix:** intersect `fields_to_update` with an **allowlist of the columns the
-  submit workflow legitimately writes** (a subset of the table's non-identity
-  columns — the exact set confirmed in the plan against the frontend re-review
-  submit payload + `services/re-review-service.R`; approval/identity columns
-  `re_review_approved`/`approving_user_id`/`re_review_entity_id`/`entity_id`
-  excluded). Reject any key outside the allowlist with `stop_for_bad_request`
-  (fail loud). Run each surviving key through `validate_query_column` as a
-  bare-identifier backstop. This closes injection **and** the self-approval
-  mass-assignment. Values remain `unname()`-bound (already correct).
+- **Fix (narrowed per Codex review):** the frontend `/re_review/submit` call
+  (`app/src/views/review/composables/useReviewActions.ts:80-84`) sends **only
+  `re_review_submitted`**; the saved flags and `review_id`/`status_id` are
+  written by the separate `review_update_re_review_status()` /
+  `status_update_re_review_status()` paths, **not** by the submit action. So the
+  allowlist is the single column `re_review_submitted` (identity + approval +
+  save-flag columns all excluded). Reject any other key with
+  `stop_for_bad_request` (fail loud); run the surviving key through
+  `validate_query_column` as a bare-identifier backstop. This closes injection
+  **and** the self-approval / mass-assignment surface with the tightest possible
+  set. Values remain `unname()`-bound (already correct).
 - **Guard test:** an injection key and an out-of-allowlist key (`re_review_approved`)
   are both rejected 400; a legitimate submit still updates. Extend/new
   `test-unit-re-review-submit-allowlist.R`.
@@ -176,15 +183,22 @@ handled at PR close, not per commit.
   and `:687` (`GET /pubtator/cache-status`); both call raw `jsonlite::fromJSON`
   fetchers in `functions/pubtator-client.R` (no budget, no memoise, bypassing
   the #344 per-request external-time ceiling).
-- **Fix (Fork B / recommended):**
-  - `/pubtator/search` (fixed internal query): route the two live calls through
-    `external_proxy_budget("pubtator")`-derived timeout **and** the per-request
-    ceiling wrapper (`external_proxy_with_timing("pubtator", …)`), and memoise
-    the fixed-query result with `memoise_external_success_only(source="pubtator")`
-    so repeat hits are free and a slow upstream can't pin a worker.
+- **Fix (Fork B / recommended, corrected per Codex review):**
+  - `/pubtator/search` (fixed internal query): the **primary** DoS fix is
+    bounding the per-call time — wrap both live calls in
+    `external_proxy_with_timing("pubtator", \() …)` (enforces the #344
+    per-request ceiling) and bound the base download timeout via
+    `options(timeout = external_proxy_budget("pubtator")$max_seconds)` with an
+    `on.exit(options(old))` restore. Memoise is an **optional** optimization:
+    `memoise_external_success_only(f, cache, source)` requires a `cache` backend
+    (2nd positional arg, e.g. `cache = cache_static` as in
+    `external-proxy-alphafold.R:167`) — pass it explicitly if memoising, else
+    skip memoise (the timeout bound alone closes the worker-exhaustion DoS).
   - `/pubtator/cache-status` (user-supplied `query`, operational): **gate to
-    `require_role("Curator")`** and budget-wrap the live `total_pages` probe.
-    This removes the unauthenticated, cache-defeating attack surface.
+    `require_role("Curator")`** **and** budget-wrap the live `total_pages` probe
+    the same way (Codex: gating alone still leaves an authenticated slow-upstream
+    hang; wrap the probe too). This removes the unauthenticated, cache-defeating
+    attack surface and bounds the remaining privileged call.
 - **Note:** the PubTator client stays raw for its worker/batch callers (it has
   its own pacing and is intentionally outside the budget-guard scan set); only
   the **public request path** is wrapped. Add a `test-unit`/route guard that the
@@ -203,6 +217,12 @@ handled at PR close, not per commit.
   card. The Curator+ on-demand generation branch is unchanged (it returns freshly
   generated `pending` to the privileged caller only). Matches the MCP default
   and the file's own comment at :66.
+- **Codex note (required, not optional):** `get_cached_summary()`
+  (`llm-cache-repository.R:119-143`) has **no `status` argument** today. Because
+  the validated-only query no longer returns the `rejected` row, the rejected
+  card needs its own lookup — so this fix **must** add an optional
+  `status`/rejected filter to `get_cached_summary()` and use it for the
+  rejected-card branch, not treat it as a "if needed" fallback.
 - **Guard test:** a `pending` cache row is not served on the public path; a
   `validated` row is; a `rejected` row still yields the rejected card.
 
@@ -213,18 +233,25 @@ handled at PR close, not per commit.
    `Administrator`; keep the public `PUBLIC_FULL_RESULT_JOB_TYPES` fast-path and
    Reviewer/Curator access only for review/curation job types.
 2. **Raw exception echo** (`about_endpoints.R:131,219`, `logging_endpoints.R:272`,
-   `publication_endpoints.R:1088`, `user_endpoints.R:903`) — replace
-   `return(list(error = e$message))` (`res$status <- 500`) with a classed
-   `stop_for_internal(<static message>)` and an internal `log_error(e$message)`;
-   let `errorHandler` render the client response so DB/driver detail never
-   crosses the boundary.
+   `publication_endpoints.R:1088`, `user_endpoints.R:903`, **and per Codex the
+   sibling bulk paths `user_endpoints.R:~1034` + `~1108`** which also
+   `return(list(error = e$message))` / `return(list(error = result$error))`) —
+   replace with a classed `stop_for_internal(<static message>)` and an internal
+   `log_error(e$message)`; let `errorHandler` render the client response so
+   DB/driver detail never crosses the boundary.
 3. **`core/logging_sanitizer.R`** — F1: redact/parse `QUERY_STRING` in
    `sanitize_request()` (currently retained raw). F2: match `SENSITIVE_FIELDS`
    by substring/pattern (`grepl("pass|token|secret|jwt|api_key|authorization|hash", …)`)
    so `access_token`/`refresh_token`/`password_hash` compounds are redacted.
    Extend the sanitizer's existing unit test.
 4. **`core/security.R:93`** — legacy plaintext compare uses `==`; replace with a
-   constant-time comparison (digest-based fixed-time compare) on the legacy path.
+   constant-time comparison on the legacy path. **Codex caught a bug in the
+   first-draft snippet:** `isTRUE(sodium::sha256(a) == sodium::sha256(b))`
+   compares two 32-byte raw vectors → a length-32 logical → `isTRUE()` is
+   **always FALSE**, which would break legacy plaintext login + the
+   plaintext→Argon2id upgrade. Correct form reduces to a scalar:
+   `isTRUE(all(sodium::sha256(charToRaw(as.character(a))) == sodium::sha256(charToRaw(as.character(b)))))`
+   (fixed 32-byte compare → data-independent).
 5. **`functions/hgnc-functions.R:17,45,79,171` + `functions/oxo-functions.R:24`**
    — wrap external URL path/query segments in `utils::URLencode(x, reserved = TRUE)`
    (as `hpo-functions.R` / `ols-functions.R` already do).
@@ -234,6 +261,17 @@ handled at PR close, not per commit.
 7. **`functions/metadata-refresh.R:38`** — `get("log_warn", mode="function")`
    hits the `config::get` mask (always errors → degrades to `warning()`); use
    `base::get("log_warn", mode = "function")`.
+8. **`functions/review-repository.R:217–219`** (new, Codex Section B) —
+   `review_update()` builds its `SET` clause from `names(updates)` without an
+   allowlist, exactly like the `user_update` #4 defect. The **main**
+   `/api/review/update` path is currently safe (`put_post_db_review` passes a
+   fixed-column `sysnopsis_received` tibble), but `svc_review_update()` /
+   direct callers pass arbitrary `update_data` (`services/review-service.R:104,
+   362`), so a future caller could reintroduce SQLi / mass-assignment.
+   Defense-in-depth: allowlist `review_update`'s columns (writable
+   `ndd_entity_review` fields — e.g. `synopsis, comment, review_user_id,
+   is_primary, review_approved` as appropriate) and reject others, mirroring the
+   `user_update` fix. Not currently exploitable via the endpoint → PR 2.
 
 ## 5. Codex high-effort review gate (Fork C)
 

--- a/.planning/superpowers/specs/2026-07-06-security-bug-scan-fixes-design.md
+++ b/.planning/superpowers/specs/2026-07-06-security-bug-scan-fixes-design.md
@@ -1,0 +1,282 @@
+# Security & Bug-Scan Remediation — Design
+
+- **Date:** 2026-07-06
+- **Author:** security bug-scan follow-up (`sysndd-security-bug-scan` skill)
+- **Status:** approved design → implementation planning
+- **Scope:** API (`api/`) only. No frontend changes required except where a
+  server contract that the frontend already consumes is tightened (none change
+  the wire shape in a breaking way).
+
+## 1. Context
+
+A full-surface security + correctness review (six parallel dimension passes:
+authorization, injection, MCP/public data exposure, DoS/external calls,
+secrets/error-leakage, R/Plumber correctness footguns) found three HIGH, four
+MEDIUM, and eight LOW defects. Every HIGH/MEDIUM was verified against live code.
+
+The unifying root cause is the skill's core insight: **almost every finding is
+"a hand-rolled path bypassed a safe helper that already exists in the repo."**
+The RCE and the two SQL-injections bypass the `validate_query_column` /
+allowlist discipline used everywhere else; the data-exposure bug is
+`review_approved = 1` predicate drift versus the MCP repo / SEO service /
+snapshot builder; the DoS bypasses `external_proxy_budget`; the LOW items bypass
+`errorHandler`, `sanitize_request`, `base::get`, and `URLencode`.
+
+Design principle for every fix: **reuse the existing in-repo helper/pattern;
+validate-before-use; fail loud (classed error), not silent.**
+
+## 2. Delivery structure
+
+Two branches / PRs (user-selected: split hotfix first).
+
+| PR | Branch | Findings | Rationale |
+|----|--------|----------|-----------|
+| **PR 1 — hotfix** | `security/hotfix-rce-sqli-exposure` | #1 RCE, #2 re-review SQLi, #3 public data exposure | A live authenticated RCE must leave `master` fast; small diff → rigorous Codex review. |
+| **PR 2 — hardening** | `security/hardening-medium-low` | #4 user_update SQLi, #5 Curator→Admin demotion, #6 PubTator DoS, #7 unvalidated LLM summaries, + 8 LOW items | Lower urgency; larger surface; reviewed as a set. |
+
+Each finding is one atomic commit with its guard test. Release/version bump per
+repo convention (`app/package.json`, `api/version_spec.json`, `CHANGELOG.md`)
+handled at PR close, not per commit.
+
+## 3. PR 1 — HIGH fixes
+
+### 3.1 #1 — Authenticated RCE via the hash endpoint
+
+- **Where:** `api/functions/data-helpers.R` `post_db_hash()` (lines ~220–253),
+  reached from `api/endpoints/hash_endpoints.R:34` (`POST /api/hash/create`).
+- **Mechanism:** `arrange(!!!rlang::parse_exprs((json_tibble %>% colnames())[1]))`
+  parses the **first key of the attacker JSON body** as an R expression and
+  evaluates it via dplyr data-masking in the process environment. The
+  `hash_validate_columns()` allowlist runs at line 253 — *after* the eval, and
+  after the no-DB early-return (238–250). Payload
+  `{"json_data":{"system('…')":[1]}}` → arbitrary shell as the API user.
+- **Reachability:** not in `AUTH_ALLOWLIST` (needs a Bearer token) but the
+  handler has **no `require_role`** → any authenticated user (Viewer+).
+- **Fix (two independent barriers):**
+  1. **Validate first.** Move `hash_validate_columns(colnames(json_tibble), allowed_col_list)`
+     to immediately after `as_tibble(json_data)`, *before* the `arrange` and the
+     no-DB branch, so an unexpected column name is rejected (400, classed error)
+     before anything evaluates it.
+  2. **Remove the eval entirely.** Replace the `parse_exprs` sort with a
+     non-eval column reference:
+     `arrange(dplyr::across(dplyr::all_of(colnames(json_tibble)[1])))`.
+     A column token can never again be interpreted as code, even if the
+     allowlist is ever loosened.
+- **Not doing:** adding a role gate. The hash-create utility legitimately backs
+  shareable filtered-list links for any authenticated user; input hardening
+  fully closes the RCE without a behavior change. (Reachability re-confirmed in
+  the plan.)
+- **Guard test:** a malicious column name (`system('id')`) is rejected with a
+  400 and never evaluated; a valid `symbol`/`hgnc_id`/`entity_id` payload still
+  hashes. New file `test-unit-hash-endpoint-injection.R`.
+
+### 3.2 #2 — SQL injection (+ mass-assignment) via re-review submit
+
+- **Where:** `api/endpoints/re_review_endpoints.R:33–44` (`PUT /api/re_review/submit`,
+  `require_role("Reviewer")`).
+- **Mechanism:** `fields_to_update <- names(submit_data)[…]` — the JSON **keys**
+  are interpolated raw as SQL identifiers into `UPDATE re_review_entity_connect
+  SET <keys> = ?`. Values are bound; identifiers are not. A crafted key
+  (`re_review_submitted = IF((SELECT …),SLEEP(5),0), dummy`) yields valid,
+  placeholder-balanced SQL → time-based blind exfiltration by any Reviewer.
+- **Secondary defect (bonus hardening):** even without injection, an arbitrary
+  key set is a **mass-assignment / self-approval** hole — a Reviewer can set
+  `re_review_approved = 1` or `approving_user_id` (approval is meant to be a
+  separate Curator action).
+- **Table columns:** `re_review_entity_id`(PK), `entity_id`, `re_review_batch`,
+  `re_review_review_saved`, `re_review_status_saved`, `re_review_submitted`,
+  `re_review_approved`, `approving_user_id`, `status_id`, `review_id`.
+- **Fix:** intersect `fields_to_update` with an **allowlist of the columns the
+  submit workflow legitimately writes** (a subset of the table's non-identity
+  columns — the exact set confirmed in the plan against the frontend re-review
+  submit payload + `services/re-review-service.R`; approval/identity columns
+  `re_review_approved`/`approving_user_id`/`re_review_entity_id`/`entity_id`
+  excluded). Reject any key outside the allowlist with `stop_for_bad_request`
+  (fail loud). Run each surviving key through `validate_query_column` as a
+  bare-identifier backstop. This closes injection **and** the self-approval
+  mass-assignment. Values remain `unname()`-bound (already correct).
+- **Guard test:** an injection key and an out-of-allowlist key (`re_review_approved`)
+  are both rejected 400; a legitimate submit still updates. Extend/new
+  `test-unit-re-review-submit-allowlist.R`.
+
+### 3.3 #3 — Public endpoints leak unapproved curation
+
+- **Where (all public, unauthenticated GET — `require_auth` forwards tokenless
+  GETs, `core/middleware.R:94`):** `api/endpoints/entity_endpoints.R`
+  entity-list review join (line ~89) and `/phenotypes` (~590), `/variation`
+  (~659), `/review` (~716), `/publications` (~808).
+- **Mechanism:** these filter `ndd_entity_review` on `is_primary` **only**,
+  omitting `review_approved == 1`. `review_update()`
+  (`functions/review-repository.R:227–232`) resets `review_approved = 0` but
+  leaves `is_primary` untouched, so a `PUT /api/review/update` in-place edit of
+  the current primary review (without `direct_approval`) produces
+  `is_primary = 1, review_approved = 0` with **new, unapproved** content — then
+  served to anonymous visitors. The MCP repo, `seo-service.R:211`, and the
+  snapshot builder all correctly gate on `is_primary = 1 AND review_approved = 1`.
+- **Fix (shared helper — drift-proof, Fork A / recommended):**
+  1. Add a helper `primary_approved_reviews(pool)` (in
+     `functions/review-repository.R` or `functions/entity-helpers.R`) returning
+     the lazy `ndd_entity_review` tbl filtered
+     `is_primary == 1 & review_approved == 1`. All five sites consume it instead
+     of hand-writing `filter(is_primary)`. One predicate, one place, cannot
+     drift again.
+  2. Restore `is_active == 1` on the phenotype/variation connect reads in
+     `current_review` mode (to match the MCP repo).
+  3. Add `status_approved == 1` to `/api/entity/<id>/status`
+     (entity_endpoints.R ~764) — defense-in-depth consistency (the
+     `is_active=1, status_approved=0` state is only reachable by an explicit
+     `is_active=1` status update, hence lower risk, but the invariant should
+     hold uniformly).
+- **Behavior note:** the entity-list join is a `left_join`; adding the predicate
+  means an unapproved primary review simply does not join (synopsis → NA), so
+  the entity still lists but without leaking the unapproved synopsis — correct,
+  and dbplyr-translatable so the fast-path SQL pushdown is unaffected.
+- **Guard test:** seed an entity whose primary review is `review_approved = 0`;
+  assert the public list + the four sub-endpoints exclude its review-derived
+  content. New `test-integration-public-approved-only.R` (or extend an existing
+  entity endpoint test); a unit test on `primary_approved_reviews()` asserts
+  both predicates are present.
+
+## 4. PR 2 — MEDIUM + LOW fixes
+
+### 4.1 #4 — SQL injection via user_update SET clause (MEDIUM)
+
+- **Where:** `api/functions/user-repository.R:206–209`, reached from
+  `PUT /api/user/update` (`user_endpoints.R:888`, `require_role("Administrator")`).
+- **Fix:** in `user_update()`, intersect `field_names` with the updatable `user`
+  columns — `user_name, email, orcid, abbreviation, first_name, family_name,
+  user_role, comment, terms_agreed, approved, rereview_request,
+  password_reset_date` (PK `user_id`, `password`/`user_password_hash`,
+  `created_at` excluded). Reject unknown keys (classed error). Mirrors the
+  already-in-repo allowlist in `ontology_endpoints.R:272–289`.
+- **Guard test:** injection/unknown key rejected; legitimate multi-field update
+  still works.
+
+### 4.2 #5 — Curator can demote Administrators (MEDIUM)
+
+- **Where:** `endpoints/user_endpoints.R:313–322` (`change_role`),
+  `services/user-service.R` `user_update_role` (~196–223) and
+  `user_bulk_assign_role` (~515–533).
+- **Mechanism:** all three block *assigning* the Administrator role but never
+  check the **target's current** role → a Curator can demote any/all
+  Administrators to Viewer. Inconsistent with `user_bulk_delete`, which rejects
+  selections containing admins (`user-service.R:457–461`).
+- **Fix:** add an admin-target guard — when the requesting role is not
+  `Administrator` and any target user's **current** `user_role` is
+  `Administrator`, reject (403, classed `stop_for_unauthorized`). Apply in all
+  three role-mutation paths so they stay consistent; factor the check into one
+  helper to avoid a third copy of the rule.
+- **Guard test:** a Curator demoting an Administrator (single + bulk) → 403;
+  a Curator changing a Viewer→Reviewer still works; an Administrator can still
+  do anything.
+
+### 4.3 #6 — Public synchronous PubTator calls bypass budget/ceiling/cache (MEDIUM)
+
+- **Where:** `endpoints/publication_endpoints.R:134–136` (`GET /pubtator/search`)
+  and `:687` (`GET /pubtator/cache-status`); both call raw `jsonlite::fromJSON`
+  fetchers in `functions/pubtator-client.R` (no budget, no memoise, bypassing
+  the #344 per-request external-time ceiling).
+- **Fix (Fork B / recommended):**
+  - `/pubtator/search` (fixed internal query): route the two live calls through
+    `external_proxy_budget("pubtator")`-derived timeout **and** the per-request
+    ceiling wrapper (`external_proxy_with_timing("pubtator", …)`), and memoise
+    the fixed-query result with `memoise_external_success_only(source="pubtator")`
+    so repeat hits are free and a slow upstream can't pin a worker.
+  - `/pubtator/cache-status` (user-supplied `query`, operational): **gate to
+    `require_role("Curator")`** and budget-wrap the live `total_pages` probe.
+    This removes the unauthenticated, cache-defeating attack surface.
+- **Note:** the PubTator client stays raw for its worker/batch callers (it has
+  its own pacing and is intentionally outside the budget-guard scan set); only
+  the **public request path** is wrapped. Add a `test-unit`/route guard that the
+  public pubtator GET path does not make an unbounded external call.
+- **Guard test:** extend `test-unit-cheap-route-isolation.R`-style coverage for
+  these public routes (budget-wrapped / gated).
+
+### 4.4 #7 — Public serves un-judge-validated LLM summaries (MEDIUM)
+
+- **Where:** `functions/llm-endpoint-helpers.R:52` — public `get_cluster_summary()`
+  calls `get_cached_summary(raw_hash, require_validated = FALSE)` and falls
+  through to serve `pending` rows.
+- **Fix:** pass `require_validated = TRUE` on the public/cache-hit path so only
+  `validated` rows are served; a `pending` row reads as "being prepared" (same
+  as a miss / 404-style being-prepared response); keep the explicit `rejected`
+  card. The Curator+ on-demand generation branch is unchanged (it returns freshly
+  generated `pending` to the privileged caller only). Matches the MCP default
+  and the file's own comment at :66.
+- **Guard test:** a `pending` cache row is not served on the public path; a
+  `validated` row is; a `rejected` row still yields the rejected card.
+
+### 4.5 LOW items (one commit + guard each where a guard is meaningful)
+
+1. **`functions/job-manager.R:375`** `can_read_full_job_result` — scope
+   maintenance/admin job types (backup/nddscore/omim/hgnc/comparisons/…) to
+   `Administrator`; keep the public `PUBLIC_FULL_RESULT_JOB_TYPES` fast-path and
+   Reviewer/Curator access only for review/curation job types.
+2. **Raw exception echo** (`about_endpoints.R:131,219`, `logging_endpoints.R:272`,
+   `publication_endpoints.R:1088`, `user_endpoints.R:903`) — replace
+   `return(list(error = e$message))` (`res$status <- 500`) with a classed
+   `stop_for_internal(<static message>)` and an internal `log_error(e$message)`;
+   let `errorHandler` render the client response so DB/driver detail never
+   crosses the boundary.
+3. **`core/logging_sanitizer.R`** — F1: redact/parse `QUERY_STRING` in
+   `sanitize_request()` (currently retained raw). F2: match `SENSITIVE_FIELDS`
+   by substring/pattern (`grepl("pass|token|secret|jwt|api_key|authorization|hash", …)`)
+   so `access_token`/`refresh_token`/`password_hash` compounds are redacted.
+   Extend the sanitizer's existing unit test.
+4. **`core/security.R:93`** — legacy plaintext compare uses `==`; replace with a
+   constant-time comparison (digest-based fixed-time compare) on the legacy path.
+5. **`functions/hgnc-functions.R:17,45,79,171` + `functions/oxo-functions.R:24`**
+   — wrap external URL path/query segments in `utils::URLencode(x, reserved = TRUE)`
+   (as `hpo-functions.R` / `ols-functions.R` already do).
+6. **`functions/mondo-functions.R:74–77`** `download_mondo_sssom` — add
+   `req_timeout` + `req_retry(max_seconds=…)` derived from
+   `external_proxy_budget("mondo")`, mirroring `download_mondo_sssom_full`.
+7. **`functions/metadata-refresh.R:38`** — `get("log_warn", mode="function")`
+   hits the `config::get` mask (always errors → degrades to `warning()`); use
+   `base::get("log_warn", mode = "function")`.
+
+## 5. Codex high-effort review gate (Fork C)
+
+After each PR's diff is implemented and the local gates pass, run **Codex at
+high reasoning effort** as an adversarial security reviewer via the `codex`
+rescue path: *"Here is the diff for finding X — can the fix be bypassed? Is the
+allowlist/predicate/gate complete? Any regression?"* Address Codex findings
+before merge. Optionally pressure-test this spec/plan with Codex first. Codex
+review is advisory on top of — not a replacement for — the repo's own guard
+tests.
+
+## 6. Testing & verification
+
+- Every finding ships a guard test (named above). Guard-test philosophy matches
+  the repo: a static/unit guard that fails if the fix regresses.
+- Per-PR gate: `make lint-api` + `make test-api-fast` + the touched guard files,
+  then `make test-api` before merge if scope warrants.
+- Container boundary: `api/tests/` is **not** bind-mounted; run new tests via
+  `docker exec … Rscript -e "testthat::test_file('/app/tests/testthat/…')"` after
+  `docker cp`, or on the host where the test does not need the DB.
+- All PR-1 and most PR-2 fixes are API-path (endpoints/repositories/core) → live
+  on API container restart (bind mount). Worker-executed touches (#6 batch side
+  is untouched; `mondo-functions.R`, `metadata-refresh.R`) require a **worker
+  restart** to go live — noted in the plan.
+
+## 7. Non-goals / out of scope
+
+- No broad refactor of the entity endpoints beyond the shared review helper.
+- No change to the public hash-create authorization model (input hardening only).
+- No new DB migration (all fixes are code-level; allowlists are derived from
+  existing schema).
+- Frontend changes are out of scope; no server response wire shape changes in a
+  breaking way (the LLM `pending` path already had a "being prepared" UX; the
+  entity endpoints still return the same fields, just approved-only).
+- Deferred/tracked separately: true heavy/light worker-pool isolation (#154),
+  broader typed-client frontend migration.
+
+## 8. Risks & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| #2/#4 allowlist too narrow → breaks a legitimate submit/update | Derive the writable set from the actual frontend payload + service in the plan; guard test exercises a real legitimate call. |
+| #3 predicate change hides a review that *should* be public | Only rows with `review_approved = 0` are hidden — that is the definition of "not approved"; matches every other public surface. |
+| #6 memoise serves a stale pubtator page | `memoise_external_success_only` caches successes only with the repo's standard TTL; the query is fixed for `/search`. |
+| RCE fix + no-eval `arrange` changes sort output | Sort semantics preserved (`across(all_of(col))` sorts by the same single column); guard test asserts identical hash for a valid payload. |
+| Worker code changed but not restarted → fix not live | Plan's verification step restarts the worker for `mondo`/`metadata-refresh` touches. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.29.2] — 2026-07-07
+
+Security hotfix — authenticated RCE, SQL injection, and public exposure of unapproved curation, plus the adjacent higher-severity paths a Codex high-effort review surfaced.
+
+### Security
+
+- **Closed an authenticated RCE in the hash-create endpoint (#1).** `post_db_hash()` sorted the request tibble with `arrange(!!!rlang::parse_exprs(colnames[1]))`, evaluating the first JSON body key as an R expression via dplyr data-masking — arbitrary code execution for any authenticated user. Column tokens are now validated against the allowlist **before** any evaluation, and the sort uses a column **reference** (`across(all_of(...))`) that can never be parsed as code.
+- **Closed an unauthenticated RCE/SQLi via filter and hash values.** `generate_filter_expressions()` pasted raw filter values — and attacker-stored hash values — into R source that reaches `parse_exprs()`, which public list endpoints then evaluate **in R** after `collect()`. Values are now escaped for the string-literal context (`escape_r_string_literal()`), stored hash column names are validated as bare identifiers, and the direct-path value strip also removes backslashes so a trailing backslash cannot escape the closing quote.
+- **Allowlisted the re-review submit SET clause (#2).** `PUT /api/re_review/submit` interpolated JSON body keys raw as SQL identifiers, allowing identifier injection and mass-assignment of `re_review_approved` / `approving_user_id`. The writable set is now restricted to `re_review_submitted` (explicit membership + bare-identifier backstop); an empty field set is rejected with a 400 instead of malformed SQL.
+- **Public reads are approved-only (#3).** The entity list and `/entity/<id>/{phenotypes,variation,review,publications}` (both `current_review` modes) gated reviews on `is_primary`/`is_active`/`is_reviewed` alone, leaking unapproved in-place review edits (`review_approved = 0, is_primary = 1`). All paths now source rows through a shared `primary_approved_reviews()` helper (`is_primary = 1 AND review_approved = 1`); `/status` adds `status_approved = 1`.
+- **SEO payloads expose approved-primary reviews only.** The public `/api/seo/*` HPO-term, variation-term, and PMID queries gated on `is_active`/`is_reviewed` alone; each now joins `ndd_entity_review` on the approved-primary review.
+- **Phenotype/variant connect views gate `review_approved` (migration 042).** `ndd_review_phenotype_connect_view` and `ndd_review_variant_connect_view` — consumed by the public phenotype/variant browse, count, and correlation endpoints and the entity-list vario filter — filtered `is_active + is_primary` but not `review_approved`. Migration 042 rebuilds both with the approved gate; the `C_Rcommands` mirror is updated in sync.
+
 ## [0.29.1] — 2026-07-06
 
 Cluster-snapshot cache coherence & self-healing analysis deploys (#514) — a production follow-up to the v0.29.0 methodology deploy.

--- a/api/endpoints/entity_endpoints.R
+++ b/api/endpoints/entity_endpoints.R
@@ -596,10 +596,13 @@ function(sysndd_id, current_review = TRUE) {
       filter(review_id %in% ndd_entity_review_list$review_id & is_active == 1) %>%
       collect()
   } else {
-    # Legacy behavior: filter by is_active
+    # Legacy "all reviews" mode is still a PUBLIC read, so it must stay
+    # approved-only: gate active rows to primary + approved review_ids so it
+    # cannot leak unapproved curation (#3, Codex re-review).
+    approved_review_ids <- primary_approved_reviews(pool) %>% dplyr::pull(review_id)
     ndd_review_phenotype_conn_coll <- pool %>%
       tbl("ndd_review_phenotype_connect") %>%
-      filter(is_active == 1) %>%
+      filter(is_active == 1 & review_id %in% approved_review_ids) %>%
       collect()
   }
 
@@ -663,10 +666,12 @@ function(sysndd_id, current_review = TRUE) {
         & entity_id == sysndd_id & is_active == 1) %>%
       collect()
   } else {
-    # Legacy behavior: filter by is_active
+    # Legacy "all reviews" mode is still a PUBLIC read, so it must stay
+    # approved-only (#3, Codex re-review).
+    approved_review_ids <- primary_approved_reviews(pool) %>% dplyr::pull(review_id)
     ndd_review_variation_conn_coll <- pool %>%
       tbl("ndd_review_variation_ontology_connect") %>%
-      filter(is_active == 1 & entity_id == sysndd_id) %>%
+      filter(is_active == 1 & entity_id == sysndd_id & review_id %in% approved_review_ids) %>%
       collect()
   }
 
@@ -806,10 +811,12 @@ function(sysndd_id, current_review = TRUE) {
       filter(review_id %in% ndd_entity_review_list$review_id) %>%
       collect()
   } else {
-    # Legacy behavior: filter by is_reviewed
+    # Legacy "all reviews" mode is still a PUBLIC read, so it must stay
+    # approved-only (#3, Codex re-review).
+    approved_review_ids <- primary_approved_reviews(pool) %>% dplyr::pull(review_id)
     review_publication_join_coll <- pool %>%
       tbl("ndd_review_publication_join") %>%
-      filter(is_reviewed == 1) %>%
+      filter(is_reviewed == 1 & review_id %in% approved_review_ids) %>%
       collect()
   }
 

--- a/api/endpoints/entity_endpoints.R
+++ b/api/endpoints/entity_endpoints.R
@@ -84,10 +84,7 @@ function(req,
   has_vario_filter <- isTRUE(vario_filter_result$has_vario_filter)
 
   # Get review data from database (lazy)
-  ndd_entity_review <- pool %>%
-    tbl("ndd_entity_review") %>%
-    filter(is_primary) %>%
-    dplyr::select(entity_id, synopsis)
+  ndd_entity_review <- primary_approved_reviews(pool, cols = c("entity_id", "synopsis"))
 
   ndd_entity_view_lazy <- pool %>%
     tbl("ndd_entity_view") %>%
@@ -586,20 +583,17 @@ function(req, res) {
 #* @get /<sysndd_id>/phenotypes
 function(sysndd_id, current_review = TRUE) {
   if (current_review) {
-    # Get primary review for this entity
-    ndd_entity_review_collected <- pool %>%
-      tbl("ndd_entity_review") %>%
-      collect()
-
-    ndd_entity_review_list <- ndd_entity_review_collected %>%
-      filter(entity_id == sysndd_id & is_primary) %>%
+    # Get primary + approved review for this entity
+    ndd_entity_review_list <- primary_approved_reviews(pool) %>%
+      dplyr::filter(entity_id == sysndd_id) %>%
       dplyr::select(entity_id, review_id, synopsis, review_date, comment) %>%
-      arrange(review_date)
+      dplyr::arrange(review_date) %>%
+      dplyr::collect()
 
     # Get phenotype connections for the primary review
     ndd_review_phenotype_conn_coll <- pool %>%
       tbl("ndd_review_phenotype_connect") %>%
-      filter(review_id %in% ndd_entity_review_list$review_id) %>%
+      filter(review_id %in% ndd_entity_review_list$review_id & is_active == 1) %>%
       collect()
   } else {
     # Legacy behavior: filter by is_active
@@ -655,20 +649,18 @@ function(sysndd_id, current_review = TRUE) {
 #* @get /<sysndd_id>/variation
 function(sysndd_id, current_review = TRUE) {
   if (current_review) {
-    # Get primary review for this entity
-    ndd_entity_review_collected <- pool %>%
-      tbl("ndd_entity_review") %>%
-      collect()
-
-    ndd_entity_review_list <- ndd_entity_review_collected %>%
-      filter(entity_id == sysndd_id & is_primary) %>%
+    # Get primary + approved review for this entity
+    ndd_entity_review_list <- primary_approved_reviews(pool) %>%
+      dplyr::filter(entity_id == sysndd_id) %>%
       dplyr::select(entity_id, review_id, synopsis, review_date, comment) %>%
-      arrange(review_date)
+      dplyr::arrange(review_date) %>%
+      dplyr::collect()
 
     # Get variation connections for the primary review AND this specific entity
     ndd_review_variation_conn_coll <- pool %>%
       tbl("ndd_review_variation_ontology_connect") %>%
-      filter(review_id %in% ndd_entity_review_list$review_id & entity_id == sysndd_id) %>%
+      filter(review_id %in% ndd_entity_review_list$review_id
+        & entity_id == sysndd_id & is_active == 1) %>%
       collect()
   } else {
     # Legacy behavior: filter by is_active
@@ -713,14 +705,11 @@ function(sysndd_id, current_review = TRUE) {
 #*
 #* @get /<sysndd_id>/review
 function(sysndd_id) {
-  ndd_entity_review_collected <- pool %>%
-    tbl("ndd_entity_review") %>%
-    collect()
-
-  ndd_entity_review_list <- ndd_entity_review_collected %>%
-    filter(entity_id == sysndd_id & is_primary) %>%
+  ndd_entity_review_list <- primary_approved_reviews(pool) %>%
+    dplyr::filter(entity_id == sysndd_id) %>%
     dplyr::select(entity_id, review_id, synopsis, review_date, comment) %>%
-    arrange(review_date)
+    dplyr::arrange(review_date) %>%
+    dplyr::collect()
 
   ndd_entity_review_list_joined <- tibble::as_tibble(sysndd_id) %>%
     dplyr::select(entity_id = value) %>%
@@ -762,7 +751,7 @@ function(sysndd_id) {
     collect()
 
   ndd_entity_status_list <- ndd_entity_status_collected %>%
-    filter(entity_id == sysndd_id & is_active) %>%
+    filter(entity_id == sysndd_id & is_active & status_approved == 1) %>%
     inner_join(entity_status_categories_coll, by = c("category_id")) %>%
     dplyr::select(
       status_id,
@@ -804,15 +793,12 @@ function(sysndd_id) {
 #* @get /<sysndd_id>/publications
 function(sysndd_id, current_review = TRUE) {
   if (current_review) {
-    # Get primary review for this entity
-    ndd_entity_review_collected <- pool %>%
-      tbl("ndd_entity_review") %>%
-      collect()
-
-    ndd_entity_review_list <- ndd_entity_review_collected %>%
-      filter(entity_id == sysndd_id & is_primary) %>%
+    # Get primary + approved review for this entity
+    ndd_entity_review_list <- primary_approved_reviews(pool) %>%
+      dplyr::filter(entity_id == sysndd_id) %>%
       dplyr::select(entity_id, review_id, synopsis, review_date, comment) %>%
-      arrange(review_date)
+      dplyr::arrange(review_date) %>%
+      dplyr::collect()
 
     # Get publication connections for the primary review
     review_publication_join_coll <- pool %>%

--- a/api/endpoints/re_review_endpoints.R
+++ b/api/endpoints/re_review_endpoints.R
@@ -34,6 +34,7 @@ function(req, res) {
 
   # Build parameterized UPDATE query dynamically
   fields_to_update <- names(submit_data)[names(submit_data) != "re_review_entity_id"]
+  fields_to_update <- re_review_filter_submit_fields(fields_to_update) # SECURITY #2
   set_clause <- paste(paste0(fields_to_update, " = ?"), collapse = ", ")
   sql <- paste0("UPDATE re_review_entity_connect SET ", set_clause, " WHERE re_review_entity_id = ?")
 

--- a/api/functions/data-helpers.R
+++ b/api/functions/data-helpers.R
@@ -216,10 +216,22 @@ post_db_hash <- function(
   # then sort it
   # check if the column name is in the allowed identifier list
   # then convert back to JSON and hash it
-  # '!!!' in arrange needed to evaluate the external variable as column name
   json_tibble <- as_tibble(json_data)
+
+  # SECURITY (#1): validate column tokens against the allowlist BEFORE any
+  # evaluation, and sort by a column REFERENCE (never parse the name as code).
+  # The old sort step called parse_exprs(colnames[1]) inside dplyr's arrange
+  # call, evaluating the first JSON key as an R expression via dplyr
+  # data-masking -> authenticated RCE.
+  # hash_validate_columns() raises `hash_column_validation_error` (rlang::abort),
+  # which errorHandler does NOT map -> wrap to a classed 400 (Codex review).
+  tryCatch(
+    hash_validate_columns(colnames(json_tibble), allowed_col_list),
+    hash_column_validation_error = function(e) stop_for_bad_request(conditionMessage(e))
+  )
+
   json_tibble <- json_tibble %>%
-    arrange(!!!rlang::parse_exprs((json_tibble %>% colnames())[1]))
+    dplyr::arrange(dplyr::across(dplyr::all_of(colnames(json_tibble)[1])))
 
   json_sort <- toJSON(json_tibble)
   ## -------------------------------------------------------------------##
@@ -248,9 +260,6 @@ post_db_hash <- function(
       data = json_sort_hash
     ))
   }
-
-  # validate columns using hash repository
-  hash_validate_columns(colnames(json_tibble), allowed_col_list)
 
   # check if hash exists using repository
   hash_already_exists <- hash_exists(json_sort_hash)

--- a/api/functions/migration-manifest.R
+++ b/api/functions/migration-manifest.R
@@ -2,7 +2,7 @@
 #
 # Strict migration manifest validation for startup/readiness.
 
-EXPECTED_LATEST_MIGRATION <- "041_add_analysis_reproducibility.sql"
+EXPECTED_LATEST_MIGRATION <- "042_gate_connect_views_review_approved.sql"
 EXPECTED_MIGRATION_COUNT <- 39L
 
 #' Validate the migration manifest for strict startup/readiness checks

--- a/api/functions/migration-manifest.R
+++ b/api/functions/migration-manifest.R
@@ -3,7 +3,7 @@
 # Strict migration manifest validation for startup/readiness.
 
 EXPECTED_LATEST_MIGRATION <- "042_gate_connect_views_review_approved.sql"
-EXPECTED_MIGRATION_COUNT <- 39L
+EXPECTED_MIGRATION_COUNT <- 40L
 
 #' Validate the migration manifest for strict startup/readiness checks
 #'

--- a/api/functions/response-helpers.R
+++ b/api/functions/response-helpers.R
@@ -41,6 +41,23 @@ validate_query_column <- function(column, allowed_columns = NULL) {
 }
 
 
+#' Escape a value for safe interpolation into a single-quoted R string literal
+#' that is subsequently parsed by `rlang::parse_exprs()`.
+#'
+#' Filter/hash values reach `parse_exprs()` as pasted R source; an unescaped
+#' quote or backslash lets attacker-controlled data break out of the string
+#' literal into executable R / injected SQL (RCE). Backslash is escaped first so
+#' an escaped quote is not itself re-doubled. (#security filter-value injection)
+#'
+#' @param x A value (coerced to character) to embed inside single quotes.
+#' @return The value with backslashes and single quotes escaped.
+escape_r_string_literal <- function(x) {
+  x <- as.character(x)
+  x <- gsub("\\", "\\\\", x, fixed = TRUE)
+  gsub("'", "\\'", x, fixed = TRUE)
+}
+
+
 #' Columns a public list endpoint may sort/filter on, derived from the view.
 #'
 #' Queries the view via the global `pool` connection and returns its column
@@ -248,7 +265,10 @@ generate_filter_expressions <- function(
               sep = "\\,",
               extra = "merge"
             ) %>%
-            mutate(filter_value = str_remove_all(filter_value, "'|\\)"))
+            # SECURITY: strip quote / close-paren / backslash so a direct-path
+            # filter value cannot break out of the single-quoted string literal
+            # (or escape its closing quote) once pasted into parse_exprs().
+            mutate(filter_value = str_remove_all(filter_value, "'|\\)|\\\\"))
         },
         error = function(e) {
           stop(paste("Failed to parse filter expression:", e$message))
@@ -286,10 +306,26 @@ generate_filter_expressions <- function(
       if (filter_string_has_hash && hash_found) {
         table_hash_filter_value <- fromJSON(table_hash_filter$json_text)
 
+        # SECURITY (#CRITICAL): the stored hash column names AND values are
+        # attacker-controlled (POST /api/hash/create body) and are interpolated
+        # into R source that reaches parse_exprs() at the caller. Validate the
+        # column tokens as bare identifiers (a bare word cannot be a call) and
+        # escape the values for the single-quoted literal, so a stored value
+        # cannot break out into executable R / injected SQL (RCE).
+        hash_cols <- colnames(table_hash_filter_value)
+        for (hash_col in hash_cols) {
+          validate_query_column(hash_col, allowed_columns)
+        }
+        hash_values <- vapply(
+          as.list(table_hash_filter_value)[[1]],
+          escape_r_string_literal,
+          character(1)
+        )
+
         filter_list <- paste0(
-          colnames(table_hash_filter_value),
+          hash_cols,
           " %in% c('",
-          str_c(as.list(table_hash_filter_value)[[1]], collapse = "','"),
+          str_c(hash_values, collapse = "','"),
           "')"
         )
       } else if (filter_string_has_hash && !hash_found) {

--- a/api/functions/review-repository.R
+++ b/api/functions/review-repository.R
@@ -16,6 +16,24 @@ library(dplyr)
 library(stringr)
 library(rlang)
 
+#' Lazy tbl of PRIMARY + APPROVED reviews only — the single public-read gate.
+#' Every public/anonymous review-derived read MUST source rows through this so
+#' the `is_primary = 1 AND review_approved = 1` predicate cannot drift (#3).
+#' Mirrors the MCP repo / SEO service / snapshot builder.
+#'
+#' @param pool Database connection pool.
+#' @param cols Optional character vector of columns to select.
+#' @return A lazy dbplyr tbl (not yet collected).
+#'
+#' @export
+primary_approved_reviews <- function(pool, cols = NULL) {
+  out <- pool %>%
+    dplyr::tbl("ndd_entity_review") %>%
+    dplyr::filter(is_primary == 1 & review_approved == 1)
+  if (!is.null(cols)) out <- out %>% dplyr::select(dplyr::all_of(cols))
+  out
+}
+
 #' Find review by ID
 #'
 #' @param review_id Integer review ID

--- a/api/services/re-review-service.R
+++ b/api/services/re-review-service.R
@@ -20,6 +20,11 @@ re_review_submit_allowed_fields <- function() {
 #' which would otherwise let a field literally named "any"/"all" bypass the allowlist.
 re_review_filter_submit_fields <- function(field_names) {
   allowed <- re_review_submit_allowed_fields()
+  # An empty field set would build "UPDATE ... SET  WHERE ..." -> malformed SQL
+  # (a 500 leaking a driver error). Reject it as a clean 400 (Codex LOW).
+  if (length(field_names) == 0L) {
+    stop_for_bad_request("Re-review submit requires at least one updatable field.")
+  }
   bad <- setdiff(field_names, allowed)
   if (length(bad) > 0) {
     stop_for_bad_request(paste("Disallowed re-review submit field(s):", paste(bad, collapse = ", ")))

--- a/api/services/re-review-service.R
+++ b/api/services/re-review-service.R
@@ -4,6 +4,31 @@
 # Functions accept pool as parameter (dependency injection)
 # Handles batch creation, assignment, reassignment, and lifecycle
 
+#' Columns the re-review submit endpoint is permitted to write.
+#' The frontend submit action sends only `re_review_submitted`; the save-flags
+#' and review/status IDs are written by review_update_re_review_status() /
+#' status_update_re_review_status(), NOT here. Restricting to this single column
+#' blocks SQL-identifier injection AND self-approval mass-assignment (#2, Codex).
+re_review_submit_allowed_fields <- function() {
+  c("re_review_submitted")
+}
+
+#' Validate + filter submitted field names to the allowlist. Fails loud.
+#' setdiff() enforces membership explicitly, first: validate_query_column()
+#' alone is not enough, since it special-cases "any"/"all" as always-valid
+#' cross-column tokens (for generate_filter_expressions()/generate_sort_expressions())
+#' which would otherwise let a field literally named "any"/"all" bypass the allowlist.
+re_review_filter_submit_fields <- function(field_names) {
+  allowed <- re_review_submit_allowed_fields()
+  bad <- setdiff(field_names, allowed)
+  if (length(bad) > 0) {
+    stop_for_bad_request(paste("Disallowed re-review submit field(s):", paste(bad, collapse = ", ")))
+  }
+  for (f in field_names) validate_query_column(f, allowed) # bare-identifier backstop
+  field_names
+}
+
+
 #' Build dynamic WHERE clause from batch criteria
 #'
 #' Constructs a SQL WHERE clause from the provided criteria object.

--- a/api/services/seo-service.R
+++ b/api/services/seo-service.R
@@ -192,10 +192,13 @@ gene_ndd_status_sql <- function() "
 "
 
 gene_pmids_sql <- function() "
-  SELECT DISTINCT REPLACE(publication_id, 'PMID:', '') AS pmid
-  FROM ndd_review_publication_join
-  WHERE entity_id IN (SELECT entity_id FROM ndd_entity_view WHERE hgnc_id = ?)
-    AND is_reviewed = 1
+  SELECT DISTINCT REPLACE(rpj.publication_id, 'PMID:', '') AS pmid
+  FROM ndd_review_publication_join rpj
+  JOIN ndd_entity_review er
+    ON rpj.review_id = er.review_id
+    AND er.is_primary = 1 AND er.review_approved = 1
+  WHERE rpj.entity_id IN (SELECT entity_id FROM ndd_entity_view WHERE hgnc_id = ?)
+    AND rpj.is_reviewed = 1
   ORDER BY pmid
 "
 
@@ -217,6 +220,9 @@ entity_review_sql <- function() "
 entity_hpo_sql <- function() "
   SELECT DISTINCT pc.phenotype_id AS id, pl.HPO_term AS label
   FROM ndd_review_phenotype_connect pc
+  JOIN ndd_entity_review er
+    ON pc.review_id = er.review_id
+    AND er.is_primary = 1 AND er.review_approved = 1
   JOIN phenotype_list pl ON pc.phenotype_id = pl.phenotype_id
   WHERE pc.entity_id = ? AND pc.is_active = 1
   ORDER BY pl.HPO_term
@@ -225,14 +231,20 @@ entity_hpo_sql <- function() "
 entity_variation_sql <- function() "
   SELECT DISTINCT vc.vario_id AS id, vl.vario_name AS label
   FROM ndd_review_variation_ontology_connect vc
+  JOIN ndd_entity_review er
+    ON vc.review_id = er.review_id
+    AND er.is_primary = 1 AND er.review_approved = 1
   JOIN variation_ontology_list vl ON vc.vario_id = vl.vario_id
   WHERE vc.entity_id = ? AND vc.is_active = 1
   ORDER BY vl.vario_name
 "
 
 entity_pmids_sql <- function() "
-  SELECT DISTINCT REPLACE(publication_id, 'PMID:', '') AS pmid
-  FROM ndd_review_publication_join
-  WHERE entity_id = ? AND is_reviewed = 1
+  SELECT DISTINCT REPLACE(rpj.publication_id, 'PMID:', '') AS pmid
+  FROM ndd_review_publication_join rpj
+  JOIN ndd_entity_review er
+    ON rpj.review_id = er.review_id
+    AND er.is_primary = 1 AND er.review_approved = 1
+  WHERE rpj.entity_id = ? AND rpj.is_reviewed = 1
   ORDER BY pmid
 "

--- a/api/tests/testthat/test-seo-endpoints.R
+++ b/api/tests/testthat/test-seo-endpoints.R
@@ -75,7 +75,10 @@ make_seo_env <- function() {
       ))
     }
 
-    if (grepl("ndd_entity_review", sql)) {
+    # Match the synopsis query specifically: the HPO/variation/pmid queries now
+    # also reference ndd_entity_review (approved-primary JOIN, #3-seo), so key on
+    # its unique "SELECT synopsis" projection instead of the shared table name.
+    if (grepl("SELECT synopsis", sql)) {
       return(tibble::tibble(synopsis = "Curated CHD8 association.", last_modified = "2026-05-09"))
     }
 

--- a/api/tests/testthat/test-unit-analysis-snapshot-migration.R
+++ b/api/tests/testthat/test-unit-analysis-snapshot-migration.R
@@ -6,7 +6,7 @@ test_that("migration manifest tracks the latest migration", {
   source(file.path("functions", "migration-manifest.R"), local = TRUE)
 
   expect_equal(EXPECTED_LATEST_MIGRATION, "042_gate_connect_views_review_approved.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 39L)
+  expect_equal(EXPECTED_MIGRATION_COUNT, 40L)
 })
 
 test_that("migration 041 adds the reproducibility bundle table", {

--- a/api/tests/testthat/test-unit-analysis-snapshot-migration.R
+++ b/api/tests/testthat/test-unit-analysis-snapshot-migration.R
@@ -5,7 +5,7 @@ withr::defer(setwd(analysis_snapshot_test_wd), testthat::teardown_env())
 test_that("migration manifest tracks the latest migration", {
   source(file.path("functions", "migration-manifest.R"), local = TRUE)
 
-  expect_equal(EXPECTED_LATEST_MIGRATION, "041_add_analysis_reproducibility.sql")
+  expect_equal(EXPECTED_LATEST_MIGRATION, "042_gate_connect_views_review_approved.sql")
   expect_equal(EXPECTED_MIGRATION_COUNT, 39L)
 })
 

--- a/api/tests/testthat/test-unit-connect-views-approved-guard.R
+++ b/api/tests/testthat/test-unit-connect-views-approved-guard.R
@@ -1,0 +1,45 @@
+# tests/testthat/test-unit-connect-views-approved-guard.R
+#
+# Guard (#3 views): ndd_review_phenotype_connect_view and
+# ndd_review_variant_connect_view feed the public phenotype/variant browse,
+# count and correlation endpoints (endpoint-functions.R) and the entity-list
+# vario filter. They must gate is_active = 1 AND is_primary = 1 AND
+# review_approved = 1, or unapproved in-place review edits leak publicly.
+# Migration 042 and the C_Rcommands mirror must stay in sync (Codex PR-1 review).
+#
+# Pure (no database) — source scan; runs on host.
+
+connect_views_migration_path <- function() {
+  file.path(get_api_dir(), "..", "db", "migrations",
+            "042_gate_connect_views_review_approved.sql")
+}
+
+c_rcommands_path <- function() {
+  file.path(get_api_dir(), "..", "db", "C_Rcommands_set-table-connections.R")
+}
+
+test_that("migration 042 gates both connect views on review_approved", {
+  path <- connect_views_migration_path()
+  expect_true(file.exists(path))
+  sql <- paste(readLines(path, warn = FALSE), collapse = "\n")
+
+  expect_match(sql, "VIEW `ndd_review_phenotype_connect_view`", fixed = TRUE)
+  expect_match(sql, "VIEW `ndd_review_variant_connect_view`", fixed = TRUE)
+
+  # Both views must carry all three predicates.
+  n_approved <- length(gregexpr("`review_approved` = 1", sql, fixed = TRUE)[[1]])
+  expect_gte(n_approved, 2)
+  expect_match(sql, "`is_primary` = 1", fixed = TRUE)
+  expect_match(sql, "`is_active` = 1", fixed = TRUE)
+})
+
+test_that("C_Rcommands mirror also gates both connect views on review_approved", {
+  path <- c_rcommands_path()
+  skip_if_not(file.exists(path))
+  src <- paste(readLines(path, warn = FALSE), collapse = "\n")
+
+  # The two connect views in the out-of-band script must stay in sync with the
+  # migration: each adds review_approved to its WHERE clause.
+  n_approved <- length(gregexpr("`review_approved` = 1", src, fixed = TRUE)[[1]])
+  expect_gte(n_approved, 2)
+})

--- a/api/tests/testthat/test-unit-core-views-manifest.R
+++ b/api/tests/testthat/test-unit-core-views-manifest.R
@@ -9,8 +9,8 @@
 source_api_file("functions/migration-manifest.R", local = FALSE)
 source_api_file("functions/migration-runner.R", local = FALSE)
 
-test_that("manifest expects migration 041 as latest", {
-  expect_equal(EXPECTED_LATEST_MIGRATION, "041_add_analysis_reproducibility.sql")
+test_that("manifest expects migration 042 as latest", {
+  expect_equal(EXPECTED_LATEST_MIGRATION, "042_gate_connect_views_review_approved.sql")
   expect_equal(EXPECTED_MIGRATION_COUNT, 39L)
 })
 
@@ -18,7 +18,7 @@ test_that("migration manifest validates against db/migrations", {
   migrations_dir <- file.path(get_api_dir(), "..", "db", "migrations")
   res <- validate_migration_manifest(migrations_dir = migrations_dir)
   expect_true(res$ok)
-  expect_identical(res$latest, "041_add_analysis_reproducibility.sql")
+  expect_identical(res$latest, "042_gate_connect_views_review_approved.sql")
 })
 
 test_that("migration 036 file exists and contains disease_ontology_mapping table", {

--- a/api/tests/testthat/test-unit-core-views-manifest.R
+++ b/api/tests/testthat/test-unit-core-views-manifest.R
@@ -11,7 +11,7 @@ source_api_file("functions/migration-runner.R", local = FALSE)
 
 test_that("manifest expects migration 042 as latest", {
   expect_equal(EXPECTED_LATEST_MIGRATION, "042_gate_connect_views_review_approved.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 39L)
+  expect_equal(EXPECTED_MIGRATION_COUNT, 40L)
 })
 
 test_that("migration manifest validates against db/migrations", {

--- a/api/tests/testthat/test-unit-filter-value-injection.R
+++ b/api/tests/testthat/test-unit-filter-value-injection.R
@@ -1,0 +1,77 @@
+# tests/testthat/test-unit-filter-value-injection.R
+#
+# Guard for the filter/hash VALUE injection (RCE/SQLi) closed alongside the #1
+# hash-column RCE. User-supplied filter values and attacker-stored hash values
+# are pasted into R source that reaches rlang::parse_exprs() at the caller
+# (endpoint-functions.R:64/291/632 filter() runs IN R after collect()), so an
+# unescaped quote/backslash is arbitrary code execution.
+#
+# PURE (no database) — runs on the host:
+#   cd api && Rscript --no-init-file -e \
+#     "testthat::test_file('tests/testthat/test-unit-filter-value-injection.R')"
+
+library(stringr)
+library(dplyr)
+library(tidyr)
+library(tibble)
+library(rlang)
+library(jsonlite)
+
+source_api_file("core/errors.R", local = FALSE)
+source_api_file("functions/response-helpers.R", local = FALSE)
+
+# ---------------------------------------------------------------------------
+# escape_r_string_literal — the core neutralizer
+# ---------------------------------------------------------------------------
+
+test_that("escape_r_string_literal neutralizes string-literal breakout", {
+  payload <- "a'); system('touch /tmp/pwn'); c('"
+  esc <- escape_r_string_literal(payload)
+  expr_str <- paste0("hgnc_id %in% c('", esc, "')")
+  exprs <- rlang::parse_exprs(expr_str)
+
+  # A successful breakout parses into MULTIPLE top-level expressions (the
+  # injected system(...) call). Escaped, it stays a single %in% expression.
+  expect_length(exprs, 1)
+  expect_true(grepl("%in%", paste(deparse(exprs[[1]]), collapse = " ")))
+})
+
+test_that("escape_r_string_literal preserves the value as data (no functional loss)", {
+  payload <- "O'Brien-1a"
+  esc <- escape_r_string_literal(payload)
+  parsed <- rlang::parse_exprs(paste0("x %in% c('", esc, "')"))[[1]]
+  expect_equal(eval(parsed[[3]]), payload)
+})
+
+test_that("escape_r_string_literal escapes backslash before quote", {
+  expect_equal(escape_r_string_literal("a\\b"), "a\\\\b")
+  expect_equal(escape_r_string_literal("a'b"), "a\\'b")
+})
+
+# ---------------------------------------------------------------------------
+# generate_filter_expressions — direct path strips backslash
+# ---------------------------------------------------------------------------
+
+test_that("direct-path filter value cannot retain a backslash", {
+  out <- generate_filter_expressions("contains(symbol,'a\\b')", allowed_columns = NULL)
+  expect_false(any(grepl("\\\\", out)),
+    info = "a backslash in a filter value could escape the closing quote")
+})
+
+# ---------------------------------------------------------------------------
+# Static guard: the hash-expansion path must validate columns and escape values
+# ---------------------------------------------------------------------------
+
+test_that("hash-filter expansion validates columns and escapes stored values", {
+  src <- paste(readLines(file.path(get_api_dir(), "functions", "response-helpers.R"),
+                         warn = FALSE), collapse = "\n")
+  # Stored hash values must be escaped before the paste0(... c('...')).
+  expect_true(grepl("escape_r_string_literal", src),
+    info = "hash-stored values must be escaped before parse_exprs")
+  # Stored hash column names must be validated as bare identifiers.
+  expect_true(grepl("validate_query_column\\(hash_col", src),
+    info = "hash column names must be validated before building the expression")
+  # The raw unescaped paste of as.list(...)[[1]] must be gone.
+  expect_false(grepl("str_c\\(as\\.list\\(table_hash_filter_value\\)", src),
+    info = "raw stored values must not be pasted into the filter expression")
+})

--- a/api/tests/testthat/test-unit-hash-endpoint-injection.R
+++ b/api/tests/testthat/test-unit-hash-endpoint-injection.R
@@ -1,0 +1,29 @@
+# Guard: the hash-create path must validate column tokens BEFORE any
+# expression evaluation, and must never parse a column name as R code (#1 RCE).
+test_that("post_db_hash rejects a non-allowlisted column before any evaluation", {
+  src <- readLines("../../functions/data-helpers.R", warn = FALSE)
+  body <- paste(src, collapse = "\n")
+
+  # (a) No parse_exprs over a column name inside post_db_hash's arrange.
+  expect_false(
+    grepl("arrange\\(!!!rlang::parse_exprs\\(", body),
+    info = "post_db_hash must not parse a column name as an R expression"
+  )
+
+  # (b) hash_validate_columns must appear BEFORE the first arrange() call.
+  first_validate <- regexpr("hash_validate_columns\\(colnames", body)
+  first_arrange  <- regexpr("arrange\\(", body)
+  expect_true(first_validate > 0 && first_arrange > 0)
+  expect_lt(first_validate, first_arrange)
+})
+
+test_that("post_db_hash raises a bad-request error on an unexpected column and runs no shell", {
+  skip_if_not(exists("post_db_hash"), "API not sourced")
+  sentinel <- tempfile()
+  malicious <- stats::setNames(list(1L), paste0("system('touch ", sentinel, "')"))
+  expect_error(
+    post_db_hash(malicious, "symbol,hgnc_id,entity_id", "/api/gene")
+  )
+  expect_false(file.exists(sentinel),
+               info = "injected command must NOT have executed")
+})

--- a/api/tests/testthat/test-unit-public-approved-review-guard.R
+++ b/api/tests/testthat/test-unit-public-approved-review-guard.R
@@ -1,0 +1,22 @@
+# Guard (#3): every public review-derived read must gate on review_approved,
+# not is_primary alone. Enforced by a source scan of entity_endpoints.R.
+test_that("entity_endpoints.R never filters ndd_entity_review by is_primary alone", {
+  src <- paste(readLines("../../endpoints/entity_endpoints.R", warn = FALSE), collapse = "\n")
+  # No bare `filter(is_primary)` / `filter(... is_primary)` without review_approved
+  bad <- gregexpr("filter\\([^)]*is_primary[^)]*\\)", src)[[1]]
+  if (bad[1] != -1) {
+    for (i in seq_along(bad)) {
+      frag <- substr(src, bad[i], bad[i] + attr(bad, "match.length")[i] - 1)
+      expect_true(grepl("review_approved", frag),
+                  info = paste("is_primary filter without review_approved:", frag))
+    }
+  }
+  succeed()
+})
+
+test_that("primary_approved_reviews carries both predicates", {
+  skip_if_not(exists("primary_approved_reviews"))
+  body <- paste(deparse(body(primary_approved_reviews)), collapse = " ")
+  expect_true(grepl("is_primary", body))
+  expect_true(grepl("review_approved", body))
+})

--- a/api/tests/testthat/test-unit-public-approved-review-guard.R
+++ b/api/tests/testthat/test-unit-public-approved-review-guard.R
@@ -20,3 +20,23 @@ test_that("primary_approved_reviews carries both predicates", {
   expect_true(grepl("is_primary", body))
   expect_true(grepl("review_approved", body))
 })
+
+test_that("the current_review=FALSE legacy branches gate on approved reviews", {
+  # The `current_review = FALSE` branches read the connect tables directly
+  # (is_active / is_reviewed). Being public, they must ALSO restrict to
+  # approved-primary review ids, or they leak unapproved curation (Codex
+  # re-review). Each of the three legacy branches must reference the gate.
+  src <- paste(readLines("../../endpoints/entity_endpoints.R", warn = FALSE), collapse = "\n")
+
+  # No connect-table read may filter is_active/is_reviewed without an
+  # approved-primary review gate on the same statement.
+  ungated_active <- grepl("filter\\(is_active == 1\\)\\s*%>%", src)
+  expect_false(ungated_active,
+    info = "a connect read filters is_active == 1 with no approved-review gate")
+  expect_false(grepl("filter\\(is_reviewed == 1\\)\\s*%>%", src),
+    info = "a publication read filters is_reviewed == 1 with no approved-review gate")
+
+  # Each of the 3 legacy branches pulls approved review ids.
+  n_gate <- length(gregexpr("approved_review_ids <- primary_approved_reviews", src)[[1]])
+  expect_gte(n_gate, 3)
+})

--- a/api/tests/testthat/test-unit-re-review-submit-allowlist.R
+++ b/api/tests/testthat/test-unit-re-review-submit-allowlist.R
@@ -1,0 +1,54 @@
+# tests/testthat/test-unit-re-review-submit-allowlist.R
+#
+# Unit tests for the SET-clause allowlist added to the re-review submit path
+# (re_review_submit_allowed_fields() / re_review_filter_submit_fields()).
+#
+# Prior behavior: PUT /api/re_review/submit built the UPDATE ... SET clause
+# from names(submit_data) (attacker-controlled JSON body keys) with values
+# bound via `?` but identifiers interpolated raw into SQL. This allowed
+# SQL-identifier injection AND mass-assignment of re_review_approved /
+# approving_user_id. These tests lock the fix: only the single writable
+# column re_review_submitted may pass, and validate_query_column()'s
+# "any"/"all" bypass token is also rejected via an explicit setdiff check.
+#
+# Pure (no database), so this runs on the host:
+#   cd /home/bernt-popp/development/sysndd/api && \
+#   Rscript --no-init-file -e \
+#     "testthat::test_file('tests/testthat/test-unit-re-review-submit-allowlist.R')"
+
+# errors.R provides stop_for_bad_request(), used by validate_query_column()
+# to signal a 400 instead of a bare stop() the global handler maps to 500.
+source_api_file("core/errors.R", local = FALSE)
+source_api_file("functions/response-helpers.R", local = FALSE)
+
+if (!requireNamespace("logger", quietly = TRUE)) {
+  stop("logger package not available — cannot run re-review-service tests")
+}
+source_api_file("services/re-review-service.R", local = FALSE)
+
+test_that("re_review_submit_allowed_fields is the tight single-column set", {
+  skip_if_not(exists("re_review_submit_allowed_fields"))
+  allowed <- re_review_submit_allowed_fields()
+  expect_setequal(allowed, "re_review_submitted")
+  expect_false("re_review_approved"  %in% allowed)  # no self-approval
+  expect_false("approving_user_id"   %in% allowed)
+  expect_false("re_review_entity_id" %in% allowed)  # PK / WHERE key
+})
+
+test_that("re_review_filter_submit_fields rejects injection + out-of-allowlist keys", {
+  skip_if_not(exists("re_review_filter_submit_fields"))
+  expect_error(re_review_filter_submit_fields("re_review_submitted = SLEEP(5), x"))
+  expect_error(re_review_filter_submit_fields("re_review_approved"))      # mass-assignment
+  expect_error(re_review_filter_submit_fields("re_review_review_saved"))  # wrong path
+  expect_equal(re_review_filter_submit_fields("re_review_submitted"), "re_review_submitted")
+})
+
+test_that("re_review_filter_submit_fields closes the validate_query_column any/all bypass", {
+  skip_if_not(exists("re_review_filter_submit_fields"))
+  # validate_query_column() itself special-cases "any"/"all" as always-valid
+  # (used by generate_filter_expressions/generate_sort_expressions cross-column
+  # tokens). A field literally named "any" or "all" must NOT ride that bypass
+  # into the re-review SET clause allowlist.
+  expect_error(re_review_filter_submit_fields("any"))
+  expect_error(re_review_filter_submit_fields("all"))
+})

--- a/api/tests/testthat/test-unit-re-review-submit-allowlist.R
+++ b/api/tests/testthat/test-unit-re-review-submit-allowlist.R
@@ -52,3 +52,11 @@ test_that("re_review_filter_submit_fields closes the validate_query_column any/a
   expect_error(re_review_filter_submit_fields("any"))
   expect_error(re_review_filter_submit_fields("all"))
 })
+
+test_that("re_review_filter_submit_fields rejects an empty field set (no malformed SQL)", {
+  skip_if_not(exists("re_review_filter_submit_fields"))
+  # A body carrying only re_review_entity_id leaves no updatable field -> the
+  # SET clause would be empty ("UPDATE ... SET  WHERE ...") and 500 with a
+  # driver error. Reject as a clean 400 instead (Codex LOW).
+  expect_error(re_review_filter_submit_fields(character(0)))
+})

--- a/api/tests/testthat/test-unit-seo-approved-only-guard.R
+++ b/api/tests/testthat/test-unit-seo-approved-only-guard.R
@@ -1,0 +1,32 @@
+# tests/testthat/test-unit-seo-approved-only-guard.R
+#
+# Guard (#3 SEO): public /api/seo/* payloads are prerendered for anonymous
+# visitors, so their review-derived content (HPO terms, variation terms, PMIDs)
+# must come ONLY from approved-primary reviews. Previously entity_hpo_sql /
+# entity_variation_sql / entity_pmids_sql / gene_pmids_sql gated on is_active /
+# is_reviewed alone, leaking unapproved in-place review edits (Codex PR-1 review).
+#
+# Pure (no database) — the *_sql() helpers return static strings; runs on host:
+#   cd api && Rscript --no-init-file -e \
+#     "testthat::test_file('tests/testthat/test-unit-seo-approved-only-guard.R')"
+
+source_api_file("services/seo-service.R", local = FALSE)
+
+test_that("every SEO review-derived query gates on review_approved = 1", {
+  review_derived <- c("gene_pmids_sql", "entity_hpo_sql", "entity_variation_sql",
+                      "entity_pmids_sql", "entity_review_sql")
+  for (fn in review_derived) {
+    skip_if_not(exists(fn))
+    sql <- base::get(fn)()
+    expect_true(grepl("review_approved = 1", sql, fixed = TRUE),
+                info = paste(fn, "must gate on review_approved = 1"))
+  }
+})
+
+test_that("SEO connect-table queries reach approval via a review join", {
+  skip_if_not(exists("entity_hpo_sql"))
+  expect_true(grepl("JOIN ndd_entity_review", entity_hpo_sql(), fixed = TRUE))
+  expect_true(grepl("JOIN ndd_entity_review", entity_variation_sql(), fixed = TRUE))
+  expect_true(grepl("JOIN ndd_entity_review", entity_pmids_sql(), fixed = TRUE))
+  expect_true(grepl("JOIN ndd_entity_review", gene_pmids_sql(), fixed = TRUE))
+})

--- a/api/version_spec.json
+++ b/api/version_spec.json
@@ -1,7 +1,7 @@
 {
   "title": "SysNDD API",
   "description": "This is the API powering the SysNDD website, allowing programmatic access to the database contents.",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "contact": {
     "name": "API Support",
     "url": "https://berntpopp.github.io/sysndd/api.html",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/db/C_Rcommands_set-table-connections.R
+++ b/db/C_Rcommands_set-table-connections.R
@@ -680,7 +680,8 @@ rs <- dbSendQuery(sysndd_db, "CREATE OR REPLACE VIEW `sysndd_db`.`ndd_review_phe
         JOIN `ndd_entity_review` ON ((`ndd_review_phenotype_connect`.`review_id` = `ndd_entity_review`.`review_id`)))
     WHERE
         ((`ndd_review_phenotype_connect`.`is_active` = 1)
-            AND (`ndd_entity_review`.`is_primary` = 1));")
+            AND (`ndd_entity_review`.`is_primary` = 1)
+            AND (`ndd_entity_review`.`review_approved` = 1));")
 dbClearResult(rs)
 
 
@@ -703,7 +704,8 @@ rs <- dbSendQuery(sysndd_db, "CREATE OR REPLACE VIEW `sysndd_db`.`ndd_review_var
           ON (`ndd_review_variation_ontology_connect`.`review_id` = `ndd_entity_review`.`review_id`))
     WHERE
         (`ndd_review_variation_ontology_connect`.`is_active` = 1
-         AND `ndd_entity_review`.`is_primary` = 1);")
+         AND `ndd_entity_review`.`is_primary` = 1
+         AND `ndd_entity_review`.`review_approved` = 1);")
 dbClearResult(rs)
 
 

--- a/db/migrations/042_gate_connect_views_review_approved.sql
+++ b/db/migrations/042_gate_connect_views_review_approved.sql
@@ -1,0 +1,70 @@
+-- Migration 042: Gate review-connect views on review_approved (public exposure fix)
+--
+-- Security (Codex PR-1 review): ndd_review_phenotype_connect_view and
+-- ndd_review_variant_connect_view filtered is_active = 1 AND is_primary = 1 but
+-- NOT review_approved = 1. An in-place primary-review edit sets
+-- review_approved = 0 while leaving is_primary = 1 (review-repository.R
+-- review_update()), so the new UNAPPROVED phenotype/variation content leaked
+-- through the public phenotype/variant browse, count, and correlation endpoints
+-- (api/functions/endpoint-functions.R consumes both views) and the entity-list
+-- vario filter -- the same #3 exposure class fixed at the entity endpoints and
+-- the SEO service.
+--
+-- Fix: add `AND ndd_entity_review.review_approved = 1` to both view WHERE
+-- clauses. SELECT bodies are copied verbatim from
+-- db/C_Rcommands_set-table-connections.R with the `sysndd_db`. qualifier
+-- stripped and SQL SECURITY INVOKER added (matching migration 025) so a fresh
+-- DB boots without a specific DEFINER account. Keep this migration and that
+-- script in sync if either view definition changes.
+--
+-- Idempotent: CREATE OR REPLACE VIEW is safe to run multiple times.
+
+CREATE OR REPLACE
+  ALGORITHM = UNDEFINED SQL SECURITY INVOKER
+  VIEW `ndd_review_phenotype_connect_view` AS
+    SELECT
+        `ndd_review_phenotype_connect`.`entity_id` AS `entity_id`,
+        `ndd_review_phenotype_connect`.`review_id` AS `review_id`,
+        `ndd_review_phenotype_connect`.`phenotype_id` AS `phenotype_id`,
+        `ndd_review_phenotype_connect`.`modifier_id` AS `modifier_id`,
+        `phenotype_list`.`HPO_term` AS `HPO_term`,
+        `modifier_list`.`modifier_name` AS `modifier_name`,
+        CONCAT(`modifier_list`.`modifier_name`,
+                ': ',
+                `phenotype_list`.`HPO_term`) AS `modifier_phenotype_name`,
+        CONCAT(`ndd_review_phenotype_connect`.`modifier_id`,
+                '-',
+                `ndd_review_phenotype_connect`.`phenotype_id`) AS `modifier_phenotype_id`,
+        `ndd_review_phenotype_connect`.`phenotype_date` AS `phenotype_date`
+    FROM
+        (((`ndd_review_phenotype_connect`
+        JOIN `modifier_list` ON ((`ndd_review_phenotype_connect`.`modifier_id` = `modifier_list`.`modifier_id`)))
+        JOIN `phenotype_list` ON ((`ndd_review_phenotype_connect`.`phenotype_id` = `phenotype_list`.`phenotype_id`)))
+        JOIN `ndd_entity_review` ON ((`ndd_review_phenotype_connect`.`review_id` = `ndd_entity_review`.`review_id`)))
+    WHERE
+        ((`ndd_review_phenotype_connect`.`is_active` = 1)
+            AND (`ndd_entity_review`.`is_primary` = 1)
+            AND (`ndd_entity_review`.`review_approved` = 1));
+
+CREATE OR REPLACE
+  ALGORITHM = UNDEFINED SQL SECURITY INVOKER
+  VIEW `ndd_review_variant_connect_view` AS
+    SELECT
+        `ndd_review_variation_ontology_connect`.`entity_id` AS `entity_id`,
+        `ndd_review_variation_ontology_connect`.`review_id` AS `review_id`,
+        `ndd_review_variation_ontology_connect`.`vario_id` AS `vario_id`,
+        `ndd_review_variation_ontology_connect`.`modifier_id` AS `modifier_id`,
+        `variation_ontology_list`.`vario_name` AS `vario_name`,
+        CONCAT(`variation_ontology_list`.`vario_name`, ': ', `variation_ontology_list`.`definition`) AS `vario_label`,
+        CONCAT(`ndd_review_variation_ontology_connect`.`modifier_id`, '-', `ndd_review_variation_ontology_connect`.`vario_id`) AS `modifier_variant_id`,
+        `ndd_review_variation_ontology_connect`.`variation_ontology_date` AS `variation_ontology_date`
+    FROM
+        ((`ndd_review_variation_ontology_connect`
+        JOIN `variation_ontology_list`
+          ON (`ndd_review_variation_ontology_connect`.`vario_id` = `variation_ontology_list`.`vario_id`))
+        JOIN `ndd_entity_review`
+          ON (`ndd_review_variation_ontology_connect`.`review_id` = `ndd_entity_review`.`review_id`))
+    WHERE
+        (`ndd_review_variation_ontology_connect`.`is_active` = 1
+         AND `ndd_entity_review`.`is_primary` = 1
+         AND `ndd_entity_review`.`review_approved` = 1);

--- a/scripts/code-quality-file-size-baseline.tsv
+++ b/scripts/code-quality-file-size-baseline.tsv
@@ -4,7 +4,7 @@ api/endpoints/entity_endpoints.R	848
 api/endpoints/jobs_endpoints.R	1011
 api/endpoints/llm_admin_endpoints.R	736
 api/endpoints/publication_endpoints.R	1141
-api/endpoints/re_review_endpoints.R	856
+api/endpoints/re_review_endpoints.R	857
 api/endpoints/statistics_endpoints.R	782
 api/endpoints/user_endpoints.R	1117
 api/functions/async-job-handlers.R	973
@@ -18,7 +18,7 @@ api/functions/migration-runner.R	718
 api/functions/nddscore-import.R	854
 api/functions/omim-functions.R	971
 api/services/entity-service.R	1063
-api/services/re-review-service.R	929
+api/services/re-review-service.R	954
 app/src/components/analyses/AnalyseGeneClusters.vue	1251
 app/src/components/analyses/AnalysesCurationUpset.vue	713
 app/src/components/analyses/AnalysesPhenotypeClusters.vue	701


### PR DESCRIPTION
## Security hotfix — RCE, SQL injection, and public exposure of unapproved curation

Remediates three HIGH findings from the `sysndd-security-bug-scan` review, plus the adjacent **higher-severity, pre-existing** paths a two-round Codex high-effort review surfaced (including an *unauthenticated* RCE the original scope missed). Every fix reuses an existing in-repo helper and ships with a guard test.

### HIGH — original scope
- **#1 Authenticated RCE (hash-create).** `post_db_hash()` ran `arrange(!!!rlang::parse_exprs(colnames[1]))`, evaluating the first JSON body key as R code via dplyr data-masking. Now validates column tokens **before** any evaluation and sorts by a column **reference** (`across(all_of(...))`).
- **#2 Re-review submit SQLi + self-approval.** `PUT /api/re_review/submit` interpolated JSON keys raw as SQL identifiers. Restricted to the single writable column `re_review_submitted` (explicit membership + `validate_query_column` backstop); empty field set → 400.
- **#3 Public exposure of unapproved curation.** Entity list + `/entity/<id>/{phenotypes,variation,review,publications}` (**both** `current_review` modes) gated reviews on `is_primary`/`is_active`/`is_reviewed` alone. All routed through a shared `primary_approved_reviews()` helper (`is_primary=1 AND review_approved=1`); `/status` adds `status_approved=1`.

### Found by Codex adversarial review (same vuln classes, adjacent paths)
- **CRITICAL — unauthenticated filter/hash-value RCE.** `generate_filter_expressions()` pasted raw filter values and attacker-stored hash values into R source reaching `parse_exprs()`, which public list endpoints evaluate **in R** after `collect()`. Values are now escaped (`escape_r_string_literal()`), stored hash columns validated as bare identifiers, and the direct-path strip extended to backslash. *Verified live: a `system('touch …')` filter value now executes nothing (no sentinel), while normal filters still return data.*
- **HIGH — SEO leak.** Public `/api/seo/*` HPO/variation/PMID queries now join `ndd_entity_review` on the approved-primary review.
- **HIGH — connect-view leak (migration 042).** `ndd_review_phenotype_connect_view` / `ndd_review_variant_connect_view` (public phenotype/variant browse, counts, correlations, entity-list vario filter) now gate `review_approved=1`; `C_Rcommands` mirror synced.
- **HIGH — `current_review=FALSE` legacy bypass** + **LOW** migration-count sync.

### Verification
- `make lint-api` clean; `make test-api-fast` green (**FAIL 0, PASS 4640**); 6 new guard test files.
- Live smoke on the running API: migration 042 applied cleanly; phenotype/variant browse and both `current_review` modes return 200; malicious filter value executed nothing.
- **Codex high-effort review: 3 passes → final verdict SHIP**, all six findings CLOSED, no regressions.

https://claude.ai/code/session_01RAg1iWsLKaAMvDk2Yf8WxH
