### PR TITLE
fix(security): MEDIUM + LOW hardening — allowlists, authz, DoS, info-leak (v0.29.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.29.3] — 2026-07-07
+
+Security hardening — the MEDIUM + LOW follow-up to the v0.29.2 hotfix (defense-in-depth allowlists, authorization gaps, DoS bounding, and info-leak fixes), plus the adjacent paths a Codex high-effort review surfaced.
+
+### Security
+
+- **Allowlisted the `user_update` and `review_update` SET clauses (#4, LOW-8).** Both built their `UPDATE ... SET` from caller-supplied field names; restrict to writable columns (`setdiff` membership + `validate_query_column`) so injection / mass-assignment of non-updatable columns is rejected with a 400.
+- **A Curator can no longer modify Administrator accounts (#5).** All role-mutation paths (`change_role`, bulk role-assign, `user_update_role`) blocked *assigning* the Administrator role but never checked the *target's current* role, so a Curator could demote any Administrator. `assert_not_targeting_admin()` re-checks the target's current role server-side (403), and it also guards the `/user/approval` and `/user/bulk_approve` paths (a Curator could otherwise activate/delete a pending Administrator).
+- **Public PubTator calls are budget-bounded (#6).** `/pubtator/search` and `/pubtator/cache-status` made live PubTator calls with raw fetchers (internal retry-with-sleep, no budget), so a slow upstream could occupy a worker. Both now cap retries, derive their timeout from `external_proxy_budget('pubtator')`, enforce the per-request external-time ceiling, and surface a NULL upstream result as a degraded 503; `/pubtator/cache-status` is additionally gated to Curator+.
+- **Public LLM cluster summaries are validated-only (#7).** The public serve path served `pending` (un-judge-validated) summaries; it now serves only judge-validated summaries (a pending row reads as "being prepared"), while the terminal `rejected` card is preserved.
+- **Public phenotype-clustering jobs use approved input only (#3).** The public `/api/jobs/phenotype_clustering/submit` path built its review set on `is_primary` alone, so a public clustering job — and the per-cluster phenotype stats in its result — could be derived from unapproved curation. It now gates `review_approved = 1`, matching the served-snapshot path.
+- **Maintenance job results are Administrator-only (LOW-1).** Full `result_json` for the maintenance/external job types (backups, imports, refreshes — including `publication_date_backfill`, `pubtator_enrichment_refresh`, `pubtatornidd_nightly`) is now Administrator-only, kept in sync with `ASYNC_MAINTENANCE_JOB_TYPES`.
+- **Logging sanitizer hardened (LOW-3).** Sensitive field names are matched by substring (`access_token`, `refresh_token`, `password_hash`, `api_key`, …) and the raw request query string is never retained in logs.
+- **Constant-time legacy password comparison (LOW-4).** The legacy plaintext-verify path uses a fixed-length digest compare instead of `==`.
+- **URL-encode external URL segments (LOW-5).** HGNC / OxO fetchers URL-encode interpolated identifier segments.
+
+### Fixed
+
+- **MONDO SSSOM download timeout (LOW-6).** `download_mondo_sssom()` derives its timeout/retry from `external_proxy_budget('mondo')` (it previously had no request timeout).
+- **`metadata-refresh.R` masked-`get` (LOW-7).** Dispatch `log_warn` via `base::get` so the `config::get` mask does not silently degrade the warning.
+
 ## [0.29.2] — 2026-07-07
 
 Security hotfix — authenticated RCE, SQL injection, and public exposure of unapproved curation, plus the adjacent higher-severity paths a Codex high-effort review surfaced.

--- a/api/core/logging_sanitizer.R
+++ b/api/core/logging_sanitizer.R
@@ -39,7 +39,11 @@ sanitize_object <- function(obj) {
   if (is.list(obj) && !is.null(names(obj))) {
     # Named list - check each field name
     sanitized <- lapply(names(obj), function(name) {
-      if (tolower(name) %in% tolower(SENSITIVE_FIELDS)) {
+      # Substring/pattern match so compound field names (access_token,
+      # refresh_token, password_hash, api_key, ...) are also redacted (LOW-3).
+      if (grepl("pass|token|secret|jwt|api_key|authorization|hash",
+                tolower(name)) ||
+            tolower(name) %in% tolower(SENSITIVE_FIELDS)) {
         "[REDACTED]"
       } else {
         sanitize_object(obj[[name]])
@@ -79,7 +83,13 @@ sanitize_request <- function(req) {
   req_safe <- list(
     PATH_INFO = req$PATH_INFO %||% NA_character_,
     REQUEST_METHOD = req$REQUEST_METHOD %||% NA_character_,
-    QUERY_STRING = req$QUERY_STRING %||% NA_character_,
+    # The query string can carry tokens/credentials in legacy transitional
+    # flows; never retain it raw in logs (LOW-3).
+    QUERY_STRING = if (is.null(req$QUERY_STRING) || req$QUERY_STRING == "") {
+      NA_character_
+    } else {
+      "[REDACTED]"
+    },
     REMOTE_ADDR = req$REMOTE_ADDR %||% NA_character_
   )
 

--- a/api/core/security.R
+++ b/api/core/security.R
@@ -89,8 +89,15 @@ verify_password <- function(password_from_db, password_attempt) {
       }
     )
   } else {
-    # Plaintext password - direct comparison (legacy)
-    password_from_db == password_attempt
+    # Plaintext password - constant-time comparison (legacy path, LOW-4).
+    # Hash both sides to a fixed 32-byte digest and compare element-wise so the
+    # compare time does not leak how many leading characters matched. all()
+    # reduces the length-32 logical to a scalar (a bare `==` + isTRUE() on two
+    # raw vectors is length-32 and isTRUE() of that is always FALSE).
+    isTRUE(all(
+      sodium::sha256(charToRaw(as.character(password_from_db))) ==
+        sodium::sha256(charToRaw(as.character(password_attempt)))
+    ))
   }
 }
 

--- a/api/endpoints/jobs_endpoints.R
+++ b/api/endpoints/jobs_endpoints.R
@@ -288,10 +288,15 @@ function(req, res) {
   ndd_entity_view_tbl <- pool %>%
     tbl("ndd_entity_view") %>%
     collect()
+  # SECURITY (#3, Codex PR-2): this is the PUBLIC phenotype-clustering submit
+  # path. Gate the review set on review_approved == 1 (not is_primary alone) so
+  # the clustering input — and the per-cluster phenotype stats it produces —
+  # cannot be derived from UNAPPROVED curation. Mirrors the served-snapshot path
+  # generate_phenotype_cluster_input().
   ndd_entity_review_tbl <- pool %>%
     tbl("ndd_entity_review") %>%
     collect() %>%
-    filter(is_primary == 1) %>%
+    filter(is_primary == 1, review_approved == 1) %>%
     select(review_id)
   ndd_review_phenotype_connect_tbl <- pool %>%
     tbl("ndd_review_phenotype_connect") %>%

--- a/api/endpoints/publication_endpoints.R
+++ b/api/endpoints/publication_endpoints.R
@@ -131,9 +131,16 @@ function(req, res, current_page = 1) {
   max_pages <- 1
   current_page <- as.numeric(current_page)
 
-  pmids_data <- pubtator_v3_pmids_from_request(query, current_page, max_pages)
+  # SECURITY (#6): bound the live PubTator calls by the per-request external-time
+  # ceiling + base download timeout so a slow upstream cannot occupy a worker.
+  res_pt <- pubtator_public_search(query, current_page, max_pages)
+  if (isTRUE(res_pt$error)) {
+    res$status <- res_pt$status %||% 503L
+    return(list(error = "PubTator is temporarily unavailable.", source = "pubtator"))
+  }
+  pmids_data <- res_pt$pmids
   per_page <- 10
-  total_pages <- pubtator_v3_total_pages_from_query(query)
+  total_pages <- res_pt$total_pages
 
   response_data <- list(
     meta = list(
@@ -678,13 +685,23 @@ function(req, res) {
 #*
 #* @get /pubtator/cache-status
 function(req, res, query = "") {
+  # SECURITY (#6): this is an operational cache probe that takes a user-supplied
+  # query and makes a live, cache-defeating PubTator call. Gate it to Curator+
+  # (removes the unauthenticated abuse surface) and budget-wrap the probe.
+  require_role(req, res, "Curator")
+
   if (query == "") {
     res$status <- 400
     return(list(error = "Query parameter is required"))
   }
 
-  # Get total pages from PubTator API
-  total_pages <- pubtator_v3_total_pages_from_query(query)
+  # Get total pages from PubTator API (budget-bounded)
+  probe <- pubtator_public_total_pages(query)
+  if (isTRUE(probe$error)) {
+    res$status <- probe$status %||% 503L
+    return(list(error = "PubTator is temporarily unavailable.", source = "pubtator"))
+  }
+  total_pages <- probe$total_pages
 
   # Check cache
   q_hash <- generate_query_hash(query)

--- a/api/endpoints/user_endpoints.R
+++ b/api/endpoints/user_endpoints.R
@@ -310,6 +310,13 @@ function(req, res, user_id, role_assigned = "Viewer") {
   user_id_role <- as.integer(user_id)
   role_assigned <- as.character(role_assigned)
 
+  # SECURITY (#5): this endpoint calls user_update() directly, so guard the
+  # admin-demotion shield here — a Curator must not modify a currently-
+  # Administrator target (re-checked server-side).
+  if (req$user_role != "Administrator") {
+    assert_not_targeting_admin(req$user_role, user_current_roles(user_id_role, pool))
+  }
+
   if (req$user_role == "Administrator") {
     # Admin can assign any role
     user_update(user_id_role, list(user_role = role_assigned))

--- a/api/endpoints/user_endpoints.R
+++ b/api/endpoints/user_endpoints.R
@@ -209,7 +209,7 @@ function(req, res, user_id = 0, status_approval = FALSE) {
 
   user_table <- pool %>%
     tbl("user") %>%
-    select(user_id, user_name, approved, first_name, family_name, email) %>%
+    select(user_id, user_name, approved, first_name, family_name, email, user_role) %>%
     filter(user_id == user_id_approval) %>%
     collect()
 
@@ -217,6 +217,12 @@ function(req, res, user_id = 0, status_approval = FALSE) {
   if (nrow(user_table) == 0) {
     res$status <- 409
     return(list(error = "User account does not exist."))
+  }
+
+  # SECURITY (#5): a non-Administrator may not approve/reject (activate or
+  # delete) a currently-Administrator target account (demotion/takeover shield).
+  if (req$user_role != "Administrator") {
+    assert_not_targeting_admin(req$user_role, user_table$user_role)
   }
 
   # Early return: already approved
@@ -978,6 +984,12 @@ function(req, res) {
 
   # Convert to integers
   user_ids <- as.integer(user_ids)
+
+  # SECURITY (#5): a non-Administrator may not bulk-approve currently-
+  # Administrator target accounts (takeover shield).
+  if (req$user_role != "Administrator") {
+    assert_not_targeting_admin(req$user_role, user_current_roles(user_ids, pool))
+  }
 
   # Call bulk approve service function
   result <- tryCatch(

--- a/api/functions/hgnc-functions.R
+++ b/api/functions/hgnc-functions.R
@@ -14,7 +14,7 @@
 #'
 #' @export
 hgnc_id_from_prevsymbol <- function(symbol_input) {
-  symbol_request <- fromJSON(paste0("http://rest.genenames.org/search/prev_symbol/", symbol_input))
+  symbol_request <- fromJSON(paste0("http://rest.genenames.org/search/prev_symbol/", utils::URLencode(symbol_input, reserved = TRUE)))
 
   hgnc_id_from_symbol <- as_tibble(symbol_request$response$docs)
 
@@ -42,7 +42,7 @@ hgnc_id_from_prevsymbol <- function(symbol_input) {
 #'
 #' @export
 hgnc_id_from_aliassymbol <- function(symbol_input) {
-  symbol_request <- fromJSON(paste0("http://rest.genenames.org/search/alias_symbol/", symbol_input))
+  symbol_request <- fromJSON(paste0("http://rest.genenames.org/search/alias_symbol/", utils::URLencode(symbol_input, reserved = TRUE)))
 
   hgnc_id_from_symbol <- as_tibble(symbol_request$response$docs)
 
@@ -76,7 +76,7 @@ hgnc_id_from_symbol <- function(symbol_tibble) {
     mutate(symbol = toupper(symbol))
 
   # nolint start: line_length_linter
-  symbol_request <- fromJSON(paste0("http://rest.genenames.org/search/symbol/", str_c(symbol_list_tibble$symbol, collapse = "+OR+")))
+  symbol_request <- fromJSON(paste0("http://rest.genenames.org/search/symbol/", str_c(vapply(symbol_list_tibble$symbol, utils::URLencode, character(1), reserved = TRUE), collapse = "+OR+")))
   # nolint end
 
   hgnc_id_from_symbol <- as_tibble(symbol_request$response$docs)
@@ -168,7 +168,7 @@ symbol_from_hgnc_id <- function(hgnc_id_tibble) {
     mutate(hgnc_id = as.integer(hgnc_id))
 
   # nolint start: line_length_linter
-  hgnc_id_request <- fromJSON(paste0("http://rest.genenames.org/search/hgnc_id/", str_c(hgnc_id_list_tibble$hgnc_id, collapse = "+OR+")))
+  hgnc_id_request <- fromJSON(paste0("http://rest.genenames.org/search/hgnc_id/", str_c(vapply(hgnc_id_list_tibble$hgnc_id, utils::URLencode, character(1), reserved = TRUE), collapse = "+OR+")))
   # nolint end
 
   hgnc_id_from_hgnc_id <- as_tibble(hgnc_id_request$response$docs)

--- a/api/functions/hgnc-functions.R
+++ b/api/functions/hgnc-functions.R
@@ -14,7 +14,10 @@
 #'
 #' @export
 hgnc_id_from_prevsymbol <- function(symbol_input) {
-  symbol_request <- fromJSON(paste0("http://rest.genenames.org/search/prev_symbol/", utils::URLencode(symbol_input, reserved = TRUE)))
+  symbol_request <- fromJSON(paste0(
+    "http://rest.genenames.org/search/prev_symbol/",
+    utils::URLencode(symbol_input, reserved = TRUE)
+  ))
 
   hgnc_id_from_symbol <- as_tibble(symbol_request$response$docs)
 
@@ -42,7 +45,10 @@ hgnc_id_from_prevsymbol <- function(symbol_input) {
 #'
 #' @export
 hgnc_id_from_aliassymbol <- function(symbol_input) {
-  symbol_request <- fromJSON(paste0("http://rest.genenames.org/search/alias_symbol/", utils::URLencode(symbol_input, reserved = TRUE)))
+  symbol_request <- fromJSON(paste0(
+    "http://rest.genenames.org/search/alias_symbol/",
+    utils::URLencode(symbol_input, reserved = TRUE)
+  ))
 
   hgnc_id_from_symbol <- as_tibble(symbol_request$response$docs)
 

--- a/api/functions/job-manager.R
+++ b/api/functions/job-manager.R
@@ -373,17 +373,32 @@ PUBLIC_FULL_RESULT_JOB_TYPES <- c("clustering", "phenotype_clustering")
 #' @param user_role Character role from req$user_role, or NULL if anonymous.
 #' @return Logical.
 # Heavy/admin maintenance job results can carry operational detail (backup
-# paths, import diagnostics, upstream errors), so their full result_json is
-# Administrator-only even for otherwise-privileged Reviewer/Curator roles (LOW-1).
+# paths, import diagnostics, standing queries, corpus IDs, upstream errors), so
+# their full result_json is Administrator-only even for otherwise-privileged
+# Reviewer/Curator roles (LOW-1). This must mirror the canonical maintenance set
+# ASYNC_MAINTENANCE_JOB_TYPES (async-job-service.R); the static list is the
+# complete fallback for minimal/test envs where that constant is not sourced.
 ADMIN_ONLY_RESULT_JOB_TYPES <- c(
-  "backup_create", "backup_restore", "nddscore_import", "omim_update",
+  "publication_date_backfill", "publication_refresh", "pubtator_update",
+  "pubtator_enrichment_refresh", "pubtatornidd_nightly", "omim_update",
   "hgnc_update", "comparisons_update", "ontology_update", "force_apply_ontology",
-  "publication_refresh", "pubtator_update", "disease_ontology_mapping_refresh"
+  "disease_ontology_mapping_refresh", "nddscore_import", "backup_create",
+  "backup_restore"
 )
+
+# Reference the canonical maintenance set at CALL time so the two never drift
+# (async-job-service.R is sourced before job-manager.R), unioned with the static
+# fallback above for envs that source job-manager.R alone (tests).
+admin_only_result_job_types <- function() {
+  if (exists("ASYNC_MAINTENANCE_JOB_TYPES", mode = "character")) {
+    return(base::union(ADMIN_ONLY_RESULT_JOB_TYPES, ASYNC_MAINTENANCE_JOB_TYPES))
+  }
+  ADMIN_ONLY_RESULT_JOB_TYPES
+}
 
 can_read_full_job_result <- function(job_type, user_role = NULL) {
   is_admin <- identical(user_role, "Administrator")
-  if (!is.null(job_type) && job_type %in% ADMIN_ONLY_RESULT_JOB_TYPES) {
+  if (!is.null(job_type) && job_type %in% admin_only_result_job_types()) {
     return(is_admin)
   }
   privileged <- !is.null(user_role) &&

--- a/api/functions/job-manager.R
+++ b/api/functions/job-manager.R
@@ -372,7 +372,20 @@ PUBLIC_FULL_RESULT_JOB_TYPES <- c("clustering", "phenotype_clustering")
 #' @param job_type Character job operation/type.
 #' @param user_role Character role from req$user_role, or NULL if anonymous.
 #' @return Logical.
+# Heavy/admin maintenance job results can carry operational detail (backup
+# paths, import diagnostics, upstream errors), so their full result_json is
+# Administrator-only even for otherwise-privileged Reviewer/Curator roles (LOW-1).
+ADMIN_ONLY_RESULT_JOB_TYPES <- c(
+  "backup_create", "backup_restore", "nddscore_import", "omim_update",
+  "hgnc_update", "comparisons_update", "ontology_update", "force_apply_ontology",
+  "publication_refresh", "pubtator_update", "disease_ontology_mapping_refresh"
+)
+
 can_read_full_job_result <- function(job_type, user_role = NULL) {
+  is_admin <- identical(user_role, "Administrator")
+  if (!is.null(job_type) && job_type %in% ADMIN_ONLY_RESULT_JOB_TYPES) {
+    return(is_admin)
+  }
   privileged <- !is.null(user_role) &&
     user_role %in% c("Reviewer", "Curator", "Administrator")
   if (privileged) {

--- a/api/functions/llm-cache-repository.R
+++ b/api/functions/llm-cache-repository.R
@@ -117,7 +117,8 @@ generate_cluster_hash <- function(identifiers, cluster_type = "functional") {
 #'
 #' @export
 get_cached_summary <- function(cluster_hash, require_validated = FALSE,
-                               prompt_version = LLM_SUMMARY_PROMPT_VERSION) {
+                               prompt_version = LLM_SUMMARY_PROMPT_VERSION,
+                               status = NULL) {
   log_debug("Looking up cached summary for hash: {substr(cluster_hash, 1, 16)}...")
 
   # Bind the prompt/code version into the lookup (#485). A summary cached by a
@@ -132,6 +133,16 @@ get_cached_summary <- function(cluster_hash, require_validated = FALSE,
        WHERE cluster_hash = ? AND is_current = TRUE AND validation_status = 'validated'
          AND prompt_version = ?",
       list(cluster_hash, prompt_version)
+    )
+  } else if (!is.null(status)) {
+    # Explicit status lookup (e.g. the terminal "rejected" card): the
+    # validated-only public path no longer returns non-validated rows, so a
+    # rejected row must be fetched by status. (#7)
+    result <- db_execute_query(
+      "SELECT * FROM llm_cluster_summary_cache
+       WHERE cluster_hash = ? AND is_current = TRUE AND validation_status = ?
+         AND prompt_version = ?",
+      list(cluster_hash, status, prompt_version)
     )
   } else {
     result <- db_execute_query(

--- a/api/functions/llm-endpoint-helpers.R
+++ b/api/functions/llm-endpoint-helpers.R
@@ -47,9 +47,11 @@ get_cluster_summary <- function(cluster_hash, cluster_number, cluster_type, res,
     return(list(message = "cluster_number parameter is required"))
   }
 
-  # Fast path: check cache first
+  # Fast path (SECURITY #7): the public / cache-hit path serves ONLY validated
+  # summaries. A `pending` (not-yet-judged) row must read as "being prepared",
+  # never as a served summary, matching the MCP default (require_validated).
   cached <- tryCatch(
-    get_cached_summary(raw_hash, require_validated = FALSE),
+    get_cached_summary(raw_hash, require_validated = TRUE),
     error = function(e) {
       log_error("Cache lookup failed: {e$message}")
       NULL
@@ -57,24 +59,29 @@ get_cluster_summary <- function(cluster_hash, cluster_number, cluster_type, res,
   )
 
   if (!is.null(cached) && nrow(cached) > 0) {
-    # A current REJECTED row is a TERMINAL serving state (#490): the judge
-    # deterministically rejected this cluster's summary, so it will never
-    # validate no matter how many times it is regenerated. Return HTTP 200 with
-    # an explicit "not available + why" payload instead of a bare 404, which the
-    # frontend could not distinguish from "still generating" (so the cluster was
-    # stuck showing "being prepared" forever). We do NOT auto-promote
-    # rejected -> validated; MCP / public analysis stay validated-only.
-    if (cached$validation_status[1] == "rejected") {
-      return(list(
-        cluster_type = cached$cluster_type[1],
-        cluster_number = as.integer(cluster_number),
-        validation_status = "rejected",
-        summary_available = FALSE,
-        reason = llm_summary_rejection_reason(cached),
-        generated = FALSE
-      ))
-    }
     return(format_summary_response(cached, cluster_number))
+  }
+
+  # A current REJECTED row is a TERMINAL serving state (#490): the judge
+  # deterministically rejected this cluster's summary, so it will never validate
+  # no matter how many times it is regenerated. Return HTTP 200 with an explicit
+  # "not available + why" payload instead of a bare 404, which the frontend could
+  # not distinguish from "still generating". The validated-only lookup above does
+  # not return it, so fetch it explicitly by status. We do NOT auto-promote
+  # rejected -> validated; MCP / public analysis stay validated-only.
+  rejected <- tryCatch(
+    get_cached_summary(raw_hash, require_validated = FALSE, status = "rejected"),
+    error = function(e) NULL
+  )
+  if (!is.null(rejected) && nrow(rejected) > 0) {
+    return(list(
+      cluster_type = rejected$cluster_type[1],
+      cluster_number = as.integer(cluster_number),
+      validation_status = "rejected",
+      summary_available = FALSE,
+      reason = llm_summary_rejection_reason(rejected),
+      generated = FALSE
+    ))
   }
 
   # Cache miss - attempt generation

--- a/api/functions/metadata-refresh.R
+++ b/api/functions/metadata-refresh.R
@@ -35,7 +35,7 @@ metadata_with_foreign_key_checks_disabled <- function(conn, work) {
 metadata_log_foreign_key_restore_failure <- function(message) {
   if (exists("log_warn", mode = "function")) {
     tryCatch(
-      get("log_warn", mode = "function")(message),
+      base::get("log_warn", mode = "function")(message),
       error = function(e) warning(message, call. = FALSE)
     )
   } else {

--- a/api/functions/mondo-functions.R
+++ b/api/functions/mondo-functions.R
@@ -71,8 +71,23 @@ download_mondo_sssom <- function(output_path = "data/mondo_mappings/",
 
   tryCatch(
     {
+      # Derive timeout/retry from the tunable mondo budget so a stalled upstream
+      # cannot hang the worker indefinitely (LOW-6; the old call had req_retry
+      # but no req_timeout). Mirrors download_mondo_sssom_full's generous
+      # batch defaults; never a hardcoded req_timeout literal.
+      budget <- external_proxy_budget(
+        "mondo",
+        default_timeout = 180,
+        default_max = 360,
+        default_tries = 3L
+      )
       response <- httr2::request(sssom_url) %>%
-        httr2::req_retry(max_tries = 3, backoff = ~2) %>%
+        httr2::req_timeout(budget$timeout_seconds) %>%
+        httr2::req_retry(
+          max_tries = budget$max_tries,
+          max_seconds = budget$max_seconds,
+          backoff = ~2
+        ) %>%
         httr2::req_error(is_error = ~FALSE) %>%
         httr2::req_perform()
 

--- a/api/functions/oxo-functions.R
+++ b/api/functions/oxo-functions.R
@@ -21,7 +21,7 @@ require(stringr) # For string manipulation
 #'
 #' @export
 oxo_mapping_from_ontology_id <- function(ontology_id) {
-  url <- paste0("https://www.ebi.ac.uk/spot/oxo/api/mappings?fromId=", ontology_id)
+  url <- paste0("https://www.ebi.ac.uk/spot/oxo/api/mappings?fromId=", utils::URLencode(ontology_id, reserved = TRUE))
 
   # Exponential backoff retry strategy for intermittent OXO API failures
   # Handles Neo4j connection issues on OXO backend (internal server errors)

--- a/api/functions/publication-endpoint-helpers.R
+++ b/api/functions/publication-endpoint-helpers.R
@@ -341,10 +341,17 @@ pubtator_public_search <- function(query, page, max_pages = 1L) {
   old_timeout <- options(timeout = budget$max_seconds)
   on.exit(options(old_timeout), add = TRUE)
   external_proxy_with_timing("pubtator", function() {
-    list(
-      pmids = pubtator_v3_pmids_from_request(query, page, max_pages),
-      total_pages = pubtator_v3_total_pages_from_query(query)
-    )
+    # Public path: cap retries to a single attempt so the raw client's internal
+    # retry-with-sleep loop cannot hold a worker past the budget (Codex #6). The
+    # fetchers return NULL on post-retry failure (not an error), so treat a NULL
+    # result as a degraded upstream rather than a 200 with empty data.
+    pmids <- pubtator_v3_pmids_from_request(query, page, max_pages, max_retries = 0)
+    total_pages <- pubtator_v3_total_pages_from_query(query)
+    if (is.null(pmids) || is.null(total_pages)) {
+      return(list(error = TRUE, status = 503L, source = "pubtator",
+                  message = "PubTator returned no result"))
+    }
+    list(pmids = pmids, total_pages = total_pages)
   })
 }
 
@@ -357,6 +364,11 @@ pubtator_public_total_pages <- function(query) {
   old_timeout <- options(timeout = budget$max_seconds)
   on.exit(options(old_timeout), add = TRUE)
   external_proxy_with_timing("pubtator", function() {
-    list(total_pages = pubtator_v3_total_pages_from_query(query))
+    total_pages <- pubtator_v3_total_pages_from_query(query)
+    if (is.null(total_pages)) {
+      return(list(error = TRUE, status = 503L, source = "pubtator",
+                  message = "PubTator returned no result"))
+    }
+    list(total_pages = total_pages)
   })
 }

--- a/api/functions/publication-endpoint-helpers.R
+++ b/api/functions/publication-endpoint-helpers.R
@@ -321,3 +321,42 @@ build_cursor_links <- function(pag_links, resource_path, sort, filter, fields,
       names_from = "type", values_from = "link"
     )
 }
+
+#' Public, budget-bounded PubTator search for the request path (#6).
+#'
+#' The two public pubtator GET routes make live PubTator calls with raw
+#' jsonlite::fromJSON fetchers (no budget, no memoise), so a slow upstream could
+#' occupy a worker. This wrapper bounds the base download timeout and enforces
+#' the #344 per-request external-time ceiling via external_proxy_with_timing().
+#' The raw pubtator-client fetchers stay untouched for the worker/batch callers
+#' (they have their own pacing and are intentionally outside the budget guard).
+#'
+#' @param query PubTator query string.
+#' @param page Page number to fetch.
+#' @param max_pages Max pages for the pmids request (default 1).
+#' @return A list with `pmids` and `total_pages` (plus timing metadata), or a
+#'   degraded `list(error = TRUE, status = 503L, ...)` on failure / ceiling.
+pubtator_public_search <- function(query, page, max_pages = 1L) {
+  budget <- external_proxy_budget("pubtator")
+  old_timeout <- options(timeout = budget$max_seconds)
+  on.exit(options(old_timeout), add = TRUE)
+  external_proxy_with_timing("pubtator", function() {
+    list(
+      pmids = pubtator_v3_pmids_from_request(query, page, max_pages),
+      total_pages = pubtator_v3_total_pages_from_query(query)
+    )
+  })
+}
+
+#' Public, budget-bounded PubTator total-pages probe for the cache-status route (#6).
+#'
+#' @param query PubTator query string.
+#' @return A list with `total_pages`, or a degraded 503-shaped list on failure.
+pubtator_public_total_pages <- function(query) {
+  budget <- external_proxy_budget("pubtator")
+  old_timeout <- options(timeout = budget$max_seconds)
+  on.exit(options(old_timeout), add = TRUE)
+  external_proxy_with_timing("pubtator", function() {
+    list(total_pages = pubtator_v3_total_pages_from_query(query))
+  })
+}

--- a/api/functions/review-repository.R
+++ b/api/functions/review-repository.R
@@ -216,6 +216,20 @@ review_update <- function(review_id, updates) {
     )
   }
 
+  # SECURITY (defense-in-depth, LOW-8): the SET clause below is built from
+  # names(updates). The main /api/review/update path passes a fixed-column
+  # tibble (synopsis/comment), but svc_review_update() and direct callers pass
+  # arbitrary update_data, so restrict to writable ndd_entity_review columns
+  # before interpolation to prevent SQL-identifier injection / mass-assignment.
+  # entity_id / review_id / review_user_id are already stripped above.
+  allowed_review_cols <- c("synopsis", "comment", "is_primary",
+                           "review_approved", "approving_user_id", "review_date")
+  bad_cols <- setdiff(names(updates), allowed_review_cols)
+  if (length(bad_cols) > 0) {
+    stop_for_bad_request(paste("Disallowed review field(s):", paste(bad_cols, collapse = ", ")))
+  }
+  for (f in names(updates)) validate_query_column(f, allowed_review_cols)
+
   # Escape single quotes in synopsis if present
   if ("synopsis" %in% names(updates)) {
     synopsis <- updates$synopsis

--- a/api/functions/user-repository.R
+++ b/api/functions/user-repository.R
@@ -202,8 +202,23 @@ user_update <- function(user_id, updates) {
     return(0L)
   }
 
-  # Build SET clause dynamically
+  # SECURITY (#4): the SET clause is built from the caller-supplied field names,
+  # so restrict them to writable `user` columns before interpolation. Rejects
+  # SQL-identifier injection AND mass-assignment of non-updatable columns.
+  # (PK user_id, password/user_password_hash, and created_at are excluded.)
+  allowed_user_cols <- c(
+    "user_name", "email", "orcid", "abbreviation", "first_name", "family_name",
+    "user_role", "comment", "terms_agreed", "approved", "rereview_request",
+    "password_reset_date"
+  )
   field_names <- names(updates)
+  bad <- setdiff(field_names, allowed_user_cols)
+  if (length(bad) > 0) {
+    stop_for_bad_request(paste("Disallowed user field(s):", paste(bad, collapse = ", ")))
+  }
+  for (f in field_names) validate_query_column(f, allowed_user_cols)
+
+  # Build SET clause dynamically
   set_clause <- paste(paste0(field_names, " = ?"), collapse = ", ")
 
   sql <- paste0("UPDATE user SET ", set_clause, " WHERE user_id = ?")

--- a/api/services/user-service.R
+++ b/api/services/user-service.R
@@ -192,12 +192,40 @@ user_approve <- function(user_id, approving_user_id, approve, pool) {
 #' }
 #'
 #' @export
+#' A non-Administrator caller may not modify a currently-Administrator target
+#' (demotion shield; mirrors the user_bulk_delete admin protection). (#5)
+#'
+#' @param requesting_role Role of the caller.
+#' @param target_current_roles Character vector of the target user(s)' CURRENT roles.
+#' @return invisible(TRUE), or raises stop_for_unauthorized (403).
+assert_not_targeting_admin <- function(requesting_role, target_current_roles) {
+  if (!identical(requesting_role, "Administrator") &&
+        any(target_current_roles == "Administrator", na.rm = TRUE)) {
+    stop_for_unauthorized("Only an Administrator may modify Administrator accounts.")
+  }
+  invisible(TRUE)
+}
+
+#' Current role(s) of the given target user id(s), read via the pool.
+user_current_roles <- function(user_ids, pool) {
+  pool %>%
+    dplyr::tbl("user") %>%
+    dplyr::filter(user_id %in% !!user_ids) %>%
+    dplyr::pull(user_role)
+}
+
 user_update_role <- function(user_id, new_role, requesting_role, pool) {
   allowed_roles <- c("Administrator", "Curator", "Reviewer", "Viewer")
 
   # Validate new role
   if (!new_role %in% allowed_roles) {
     stop("Invalid role specified")
+  }
+
+  # SECURITY (#5): a non-Administrator may not modify a currently-Administrator
+  # target (demotion shield). Check the target's CURRENT role first.
+  if (!identical(requesting_role, "Administrator")) {
+    assert_not_targeting_admin(requesting_role, user_current_roles(user_id, pool))
   }
 
   # Check permissions
@@ -530,6 +558,12 @@ user_bulk_assign_role <- function(user_ids, new_role, requesting_role, pool) {
   # Check permissions
   if (requesting_role == "Curator" && new_role == "Administrator") {
     stop("Insufficient permissions to assign Administrator role")
+  }
+
+  # SECURITY (#5): a non-Administrator may not modify currently-Administrator
+  # targets (demotion shield).
+  if (!identical(requesting_role, "Administrator")) {
+    assert_not_targeting_admin(requesting_role, user_current_roles(user_ids, pool))
   }
 
   # Execute all role updates in a transaction

--- a/api/tests/testthat/test-unit-external-url-encoding-guard.R
+++ b/api/tests/testthat/test-unit-external-url-encoding-guard.R
@@ -7,13 +7,14 @@
 # Source scan — runs on host.
 
 test_that("hgnc-functions.R URL-encodes every interpolated segment", {
-  src <- readLines(file.path(get_api_dir(), "functions", "hgnc-functions.R"), warn = FALSE)
-  url_lines <- grep("paste0\\(\"http://rest.genenames.org", src, value = TRUE)
-  expect_gt(length(url_lines), 0)
-  for (line in url_lines) {
-    expect_true(grepl("URLencode", line),
-                info = paste("hgnc URL segment not URL-encoded:", trimws(line)))
-  }
+  body <- paste(readLines(file.path(get_api_dir(), "functions", "hgnc-functions.R"),
+                          warn = FALSE), collapse = "\n")
+  # Robust to line-wrapping: there is at least one URLencode per genenames.org
+  # search-URL builder (each interpolated identifier segment is encoded).
+  n_urls <- length(gregexpr("rest.genenames.org/search/", body, fixed = TRUE)[[1]])
+  n_encode <- length(gregexpr("URLencode", body, fixed = TRUE)[[1]])
+  expect_gte(n_urls, 4)
+  expect_gte(n_encode, n_urls)
 })
 
 test_that("oxo-functions.R URL-encodes the fromId segment", {

--- a/api/tests/testthat/test-unit-external-url-encoding-guard.R
+++ b/api/tests/testthat/test-unit-external-url-encoding-guard.R
@@ -1,0 +1,27 @@
+# tests/testthat/test-unit-external-url-encoding-guard.R
+#
+# Guard (LOW-5): external URL path/query segments built from caller input must
+# be URL-encoded (utils::URLencode(x, reserved = TRUE)) so an odd/hostile
+# identifier cannot alter the request, matching hpo-functions / ols-functions.
+#
+# Source scan — runs on host.
+
+test_that("hgnc-functions.R URL-encodes every interpolated segment", {
+  src <- readLines(file.path(get_api_dir(), "functions", "hgnc-functions.R"), warn = FALSE)
+  url_lines <- grep("paste0\\(\"http://rest.genenames.org", src, value = TRUE)
+  expect_gt(length(url_lines), 0)
+  for (line in url_lines) {
+    expect_true(grepl("URLencode", line),
+                info = paste("hgnc URL segment not URL-encoded:", trimws(line)))
+  }
+})
+
+test_that("oxo-functions.R URL-encodes the fromId segment", {
+  src <- readLines(file.path(get_api_dir(), "functions", "oxo-functions.R"), warn = FALSE)
+  from_id_line <- grep("fromId=", src, value = TRUE)
+  expect_gt(length(from_id_line), 0)
+  for (line in from_id_line) {
+    expect_true(grepl("URLencode", line),
+                info = paste("oxo URL segment not URL-encoded:", trimws(line)))
+  }
+})

--- a/api/tests/testthat/test-unit-job-result-access.R
+++ b/api/tests/testthat/test-unit-job-result-access.R
@@ -8,11 +8,22 @@ test_that("anonymous may read full results only for public operations", {
   expect_false(can_read_full_job_result("hgnc_update", user_role = NULL))
 })
 
-test_that("Reviewer+ may read full results for any operation", {
-  expect_true(can_read_full_job_result("backup_create", user_role = "Reviewer"))
-  expect_true(can_read_full_job_result("backup_create", user_role = "Curator"))
+test_that("maintenance/admin job results are Administrator-only (LOW-1)", {
+  # Heavy/admin maintenance results (backups, imports, upstream errors) must be
+  # Administrator-only even for otherwise-privileged Reviewer/Curator roles.
+  expect_false(can_read_full_job_result("backup_create", user_role = "Reviewer"))
+  expect_false(can_read_full_job_result("backup_create", user_role = "Curator"))
+  expect_false(can_read_full_job_result("hgnc_update", user_role = "Curator"))
+  expect_true(can_read_full_job_result("backup_create", user_role = "Administrator"))
   expect_true(can_read_full_job_result("hgnc_update", user_role = "Administrator"))
   expect_false(can_read_full_job_result("backup_create", user_role = "Viewer"))
+})
+
+test_that("Reviewer+ may still read full results for non-maintenance operations", {
+  # Interactive/curation job types (not in ADMIN_ONLY_RESULT_JOB_TYPES) remain
+  # readable by Reviewer/Curator/Administrator.
+  expect_true(can_read_full_job_result("llm_generation", user_role = "Reviewer"))
+  expect_true(can_read_full_job_result("analysis_snapshot_refresh", user_role = "Curator"))
 })
 
 test_that("edge cases: null job_type and unknown roles", {

--- a/api/tests/testthat/test-unit-job-result-access.R
+++ b/api/tests/testthat/test-unit-job-result-access.R
@@ -17,6 +17,13 @@ test_that("maintenance/admin job results are Administrator-only (LOW-1)", {
   expect_true(can_read_full_job_result("backup_create", user_role = "Administrator"))
   expect_true(can_read_full_job_result("hgnc_update", user_role = "Administrator"))
   expect_false(can_read_full_job_result("backup_create", user_role = "Viewer"))
+  # The full maintenance set is covered (Codex PR-2: 3 types were omitted).
+  for (jt in c("publication_date_backfill", "pubtator_enrichment_refresh",
+               "pubtatornidd_nightly", "comparisons_update", "nddscore_import")) {
+    expect_false(can_read_full_job_result(jt, user_role = "Curator"),
+                 info = paste("maintenance type must be admin-only:", jt))
+    expect_true(can_read_full_job_result(jt, user_role = "Administrator"))
+  }
 })
 
 test_that("Reviewer+ may still read full results for non-maintenance operations", {

--- a/api/tests/testthat/test-unit-llm-endpoint-helpers.R
+++ b/api/tests/testthat/test-unit-llm-endpoint-helpers.R
@@ -416,7 +416,22 @@ test_that("get_cluster_summary returns a terminal rejected payload (200), not a 
     summary_json = '{"summary":"x","llm_judge_reasoning":"over-broad, low specificity"}',
     stringsAsFactors = FALSE
   )
-  mockery::stub(get_cluster_summary, "get_cached_summary", function(...) rejected_row)
+  # The public serve path now looks up validated-only first (#7), then fetches
+  # the terminal rejected row explicitly by status. Mirror that: the validated
+  # lookup misses, the status="rejected" lookup returns the row.
+  mockery::stub(
+    get_cluster_summary, "get_cached_summary",
+    function(cluster_hash, require_validated = FALSE, prompt_version = NULL,
+             status = NULL) {
+      if (isTRUE(require_validated)) {
+        return(rejected_row[0, , drop = FALSE])
+      }
+      if (identical(status, "rejected")) {
+        return(rejected_row)
+      }
+      rejected_row[0, , drop = FALSE]
+    }
+  )
 
   result <- get_cluster_summary("abc123", "2", "phenotype", res)
 

--- a/api/tests/testthat/test-unit-llm-public-validated-only.R
+++ b/api/tests/testthat/test-unit-llm-public-validated-only.R
@@ -1,0 +1,29 @@
+# tests/testthat/test-unit-llm-public-validated-only.R
+#
+# Guard (#7): the public / cache-hit cluster-summary path must serve ONLY
+# judge-validated summaries. Previously it looked up with require_validated =
+# FALSE and fell through to serve `pending` (un-judged) rows to anonymous
+# callers. It now serves validated-only and fetches the terminal `rejected`
+# card via an explicit status lookup.
+#
+# Source scan — runs on host.
+
+test_that("public cluster-summary serve path requires validated summaries", {
+  src <- paste(readLines(file.path(get_api_dir(), "functions", "llm-endpoint-helpers.R"),
+                         warn = FALSE), collapse = "\n")
+  # The primary serve lookup must NOT be require_validated = FALSE.
+  expect_false(grepl("get_cached_summary\\(raw_hash,\\s*require_validated\\s*=\\s*FALSE\\)", src),
+               info = "the serve path must not fetch/serve non-validated rows")
+  # It must be require_validated = TRUE.
+  expect_true(grepl("get_cached_summary\\(raw_hash,\\s*require_validated\\s*=\\s*TRUE\\)", src))
+  # The terminal rejected card is fetched explicitly by status.
+  expect_true(grepl('status = "rejected"', src, fixed = TRUE))
+})
+
+test_that("get_cached_summary supports an explicit status filter", {
+  src <- paste(readLines(file.path(get_api_dir(), "functions", "llm-cache-repository.R"),
+                         warn = FALSE), collapse = "\n")
+  # New optional status arg + a parameterized validation_status predicate.
+  expect_true(grepl("status = NULL", src, fixed = TRUE))
+  expect_true(grepl("AND validation_status = ?", src, fixed = TRUE))
+})

--- a/api/tests/testthat/test-unit-logging-sanitizer-hardening.R
+++ b/api/tests/testthat/test-unit-logging-sanitizer-hardening.R
@@ -1,0 +1,31 @@
+# tests/testthat/test-unit-logging-sanitizer-hardening.R
+#
+# Guard (LOW-3): the request-log sanitizer must redact compound sensitive field
+# names (access_token, refresh_token, password_hash, api_key, ...) via a
+# substring/pattern match — an exact SENSITIVE_FIELDS match missed those — and
+# must never retain the raw query string (which can carry tokens in legacy
+# transitional flows).
+#
+# Pure (no database) — runs on host.
+
+library(rlang)
+source_api_file("core/logging_sanitizer.R", local = FALSE)
+
+test_that("compound sensitive field names are redacted (substring match)", {
+  out <- sanitize_object(list(
+    access_token = "a", refresh_token = "b", password_hash = "c",
+    api_key = "d", authorization = "e", jwt_secret = "f", normal_field = "keep"
+  ))
+  for (k in c("access_token", "refresh_token", "password_hash",
+              "api_key", "authorization", "jwt_secret")) {
+    expect_equal(out[[k]], "[REDACTED]", info = paste("not redacted:", k))
+  }
+  expect_equal(out$normal_field, "keep")
+})
+
+test_that("sanitize_request redacts the query string but keeps empty as NA", {
+  redacted <- sanitize_request(list(QUERY_STRING = "token=abc&user=x"))
+  expect_equal(redacted$QUERY_STRING, "[REDACTED]")
+  expect_true(is.na(sanitize_request(list(QUERY_STRING = ""))$QUERY_STRING))
+  expect_true(is.na(sanitize_request(list())$QUERY_STRING))
+})

--- a/api/tests/testthat/test-unit-metadata-refresh-patterns.R
+++ b/api/tests/testthat/test-unit-metadata-refresh-patterns.R
@@ -58,3 +58,13 @@ test_that("admin ontology job submissions do not keep dead inline executors", {
     )
   )
 })
+
+test_that("metadata-refresh.R dispatches log_warn via base::get (config::get mask, LOW-7)", {
+  path <- file.path(get_api_dir(), "functions", "metadata-refresh.R")
+  src <- paste(readLines(path, warn = FALSE), collapse = "\n")
+  # config::get masks base::get (no `mode` arg) in the loaded API/worker env, so
+  # a bare get(name, mode = "function") errors -> the warn silently degrades.
+  expect_match(src, 'base::get("log_warn", mode = "function")', fixed = TRUE)
+  # No bare get("log_warn", mode = ...) remains.
+  expect_false(grepl('[^:]get\\("log_warn", mode', src))
+})

--- a/api/tests/testthat/test-unit-phenotype-clustering-approved-guard.R
+++ b/api/tests/testthat/test-unit-phenotype-clustering-approved-guard.R
@@ -1,0 +1,27 @@
+# tests/testthat/test-unit-phenotype-clustering-approved-guard.R
+#
+# Guard (#3, Codex PR-2): the PUBLIC /api/jobs/phenotype_clustering/submit path
+# builds its review set from ndd_entity_review. It must gate on
+# review_approved == 1 (not is_primary alone), or a public clustering job — and
+# the per-cluster phenotype stats it returns — leaks UNAPPROVED curation, the
+# same class the served-snapshot path already gates.
+#
+# Source scan — runs on host.
+
+test_that("phenotype_clustering submit gates the review set on review_approved", {
+  src <- readLines(file.path(get_api_dir(), "endpoints", "jobs_endpoints.R"), warn = FALSE)
+  body <- paste(src, collapse = "\n")
+
+  # Every ndd_entity_review filter on is_primary in this file must also carry
+  # review_approved (the submit path builds review_id sets for clustering input).
+  matches <- gregexpr("filter\\([^)]*is_primary[^)]*\\)", body)[[1]]
+  if (matches[1] != -1) {
+    lens <- attr(matches, "match.length")
+    for (i in seq_along(matches)) {
+      frag <- substr(body, matches[i], matches[i] + lens[i] - 1)
+      expect_true(grepl("review_approved", frag),
+                  info = paste("is_primary filter without review_approved:", frag))
+    }
+  }
+  succeed()
+})

--- a/api/tests/testthat/test-unit-pubtator-public-route-guard.R
+++ b/api/tests/testthat/test-unit-pubtator-public-route-guard.R
@@ -30,4 +30,9 @@ test_that("pubtator public helpers derive their budget + enforce the request cei
   expect_true(grepl('external_proxy_with_timing("pubtator"', h, fixed = TRUE))
   # No hardcoded req_timeout / options(timeout = <literal>) — must derive from budget.
   expect_true(grepl("options(timeout = budget$max_seconds)", h, fixed = TRUE))
+  # The public search must cap the raw client's internal retry loop so it cannot
+  # hold a worker past the budget, and must treat NULL (post-retry failure) as a
+  # degraded 503, not a 200 with empty data (Codex PR-2 MEDIUM-1).
+  expect_true(grepl("max_retries = 0", h, fixed = TRUE))
+  expect_true(grepl("is.null(pmids)", h, fixed = TRUE))
 })

--- a/api/tests/testthat/test-unit-pubtator-public-route-guard.R
+++ b/api/tests/testthat/test-unit-pubtator-public-route-guard.R
@@ -1,0 +1,33 @@
+# tests/testthat/test-unit-pubtator-public-route-guard.R
+#
+# Guard (#6): the two public pubtator GET routes made live PubTator calls with
+# raw fetchers (no budget, no per-request ceiling). /pubtator/search must route
+# through the budget-bounded helper, and /pubtator/cache-status (user-supplied,
+# cache-defeating query) must be role-gated AND budget-bounded.
+#
+# Source scan — runs on host.
+
+test_that("public pubtator routes are budget-bounded and cache-status is gated", {
+  ep <- paste(readLines(file.path(get_api_dir(), "endpoints", "publication_endpoints.R"),
+                        warn = FALSE), collapse = "\n")
+
+  # Both public routes go through the budget-bounded helpers.
+  expect_true(grepl("pubtator_public_search", ep, fixed = TRUE))
+  expect_true(grepl("pubtator_public_total_pages", ep, fixed = TRUE))
+
+  # The cache-status handler must require a role (operational probe, not public).
+  cs_idx <- regexpr("@get /pubtator/cache-status", ep, fixed = TRUE)
+  expect_gt(cs_idx, 0)
+  cs_block <- substr(ep, cs_idx, cs_idx + 500)
+  expect_true(grepl("require_role", cs_block),
+              info = "/pubtator/cache-status must be role-gated")
+})
+
+test_that("pubtator public helpers derive their budget + enforce the request ceiling", {
+  h <- paste(readLines(file.path(get_api_dir(), "functions", "publication-endpoint-helpers.R"),
+                       warn = FALSE), collapse = "\n")
+  expect_true(grepl('external_proxy_budget("pubtator"', h, fixed = TRUE))
+  expect_true(grepl('external_proxy_with_timing("pubtator"', h, fixed = TRUE))
+  # No hardcoded req_timeout / options(timeout = <literal>) — must derive from budget.
+  expect_true(grepl("options(timeout = budget$max_seconds)", h, fixed = TRUE))
+})

--- a/api/tests/testthat/test-unit-review-update-allowlist.R
+++ b/api/tests/testthat/test-unit-review-update-allowlist.R
@@ -1,0 +1,32 @@
+# tests/testthat/test-unit-review-update-allowlist.R
+#
+# Guard (LOW-8, Codex): review_update() builds its UPDATE ... SET clause from
+# names(updates). The main /api/review/update path passes a fixed-column tibble
+# (safe), but svc_review_update() and direct callers pass arbitrary update_data,
+# so the repository restricts field names to writable ndd_entity_review columns
+# before interpolation (SQL-identifier injection / mass-assignment defense).
+#
+# Pure (rejection runs before db_with_transaction) — runs on host.
+
+source_api_file("core/errors.R", local = FALSE)
+source_api_file("functions/response-helpers.R", local = FALSE)
+if (!requireNamespace("logger", quietly = TRUE)) {
+  stop("logger package not available — cannot run review-repository tests")
+}
+source_api_file("functions/review-repository.R", local = FALSE)
+
+test_that("review_update rejects injection + unknown column names", {
+  skip_if_not(exists("review_update"))
+  expect_error(review_update(1, list("synopsis = x, y" = "z")))  # SQL-identifier injection
+  expect_error(review_update(1, list(bogus_col = "x")))          # unknown column
+  expect_error(review_update(1, list(synopsis = "ok", evil = "y"))) # mixed valid+invalid
+})
+
+test_that("review_update allowlist covers writable columns and excludes protected keys", {
+  skip_if_not(exists("review_update"))
+  body <- paste(deparse(body(review_update)), collapse = " ")
+  expect_true(grepl("allowed_review_cols", body))
+  for (col in c("synopsis", "comment", "review_approved")) {
+    expect_true(grepl(col, body), info = paste("writable column missing:", col))
+  }
+})

--- a/api/tests/testthat/test-unit-role-admin-target-guard.R
+++ b/api/tests/testthat/test-unit-role-admin-target-guard.R
@@ -1,0 +1,40 @@
+# tests/testthat/test-unit-role-admin-target-guard.R
+#
+# Guard (#5): role-mutation paths blocked ASSIGNING the Administrator role but
+# never checked the TARGET's current role, so a Curator could demote any
+# Administrator to Viewer. assert_not_targeting_admin() is the shield (mirrors
+# the user_bulk_delete admin protection) and every role-mutation path uses it.
+#
+# Pure (helper needs no DB) — runs on host.
+
+source_api_file("core/errors.R", local = FALSE)
+source_api_file("functions/response-helpers.R", local = FALSE)
+if (!requireNamespace("logger", quietly = TRUE)) {
+  stop("logger package not available — cannot run user-service tests")
+}
+source_api_file("services/user-service.R", local = FALSE)
+
+test_that("assert_not_targeting_admin blocks a non-admin caller on admin targets", {
+  skip_if_not(exists("assert_not_targeting_admin"))
+  # Curator targeting an Administrator -> 403.
+  expect_error(assert_not_targeting_admin("Curator", c("Administrator")))
+  expect_error(assert_not_targeting_admin("Reviewer", c("Viewer", "Administrator")))
+  # Curator targeting non-admins -> allowed.
+  expect_true(assert_not_targeting_admin("Curator", c("Viewer", "Reviewer")))
+  # A non-existent target (empty role set) does not falsely trip the guard.
+  expect_true(assert_not_targeting_admin("Curator", character(0)))
+  # An Administrator may do anything.
+  expect_true(assert_not_targeting_admin("Administrator", c("Administrator")))
+})
+
+test_that("all three role-mutation paths use the admin-target guard", {
+  us <- paste(readLines(file.path(get_api_dir(), "services", "user-service.R"),
+                        warn = FALSE), collapse = "\n")
+  ue <- paste(readLines(file.path(get_api_dir(), "endpoints", "user_endpoints.R"),
+                        warn = FALSE), collapse = "\n")
+  # user-service.R: helper definition + calls in user_update_role and
+  # user_bulk_assign_role => >= 3 references.
+  expect_gte(length(gregexpr("assert_not_targeting_admin", us)[[1]]), 3)
+  # change_role endpoint (which calls user_update() directly) also guards.
+  expect_true(grepl("assert_not_targeting_admin", ue, fixed = TRUE))
+})

--- a/api/tests/testthat/test-unit-role-admin-target-guard.R
+++ b/api/tests/testthat/test-unit-role-admin-target-guard.R
@@ -35,6 +35,7 @@ test_that("all three role-mutation paths use the admin-target guard", {
   # user-service.R: helper definition + calls in user_update_role and
   # user_bulk_assign_role => >= 3 references.
   expect_gte(length(gregexpr("assert_not_targeting_admin", us)[[1]]), 3)
-  # change_role endpoint (which calls user_update() directly) also guards.
-  expect_true(grepl("assert_not_targeting_admin", ue, fixed = TRUE))
+  # Every account-mutating endpoint that a Curator can reach guards admin
+  # targets: change_role, /user/approval, and bulk_approve (Codex PR-2 LOW-2).
+  expect_gte(length(gregexpr("assert_not_targeting_admin", ue)[[1]]), 3)
 })

--- a/api/tests/testthat/test-unit-user-update-allowlist.R
+++ b/api/tests/testthat/test-unit-user-update-allowlist.R
@@ -1,0 +1,39 @@
+# tests/testthat/test-unit-user-update-allowlist.R
+#
+# Guard (#4): user_update() built its UPDATE ... SET clause from caller-supplied
+# field names, allowing SQL-identifier injection and mass-assignment of
+# non-updatable `user` columns. The allowlist rejects any non-writable key
+# before the SET clause is interpolated.
+#
+# Pure (rejection paths run before db_execute_statement) — runs on host:
+#   cd api && Rscript --no-init-file -e \
+#     "testthat::test_file('tests/testthat/test-unit-user-update-allowlist.R')"
+
+source_api_file("core/errors.R", local = FALSE)
+source_api_file("functions/response-helpers.R", local = FALSE)
+if (!requireNamespace("logger", quietly = TRUE)) {
+  stop("logger package not available — cannot run user-repository tests")
+}
+source_api_file("functions/user-repository.R", local = FALSE)
+
+test_that("user_update rejects injection + unknown field names (before touching the DB)", {
+  skip_if_not(exists("user_update"))
+  expect_error(user_update(1, list("user_role = 'x', y" = "z")))       # SQL-identifier injection
+  expect_error(user_update(1, list(bogus_col = "x")))                  # unknown column
+  expect_error(user_update(1, list(user_id = 2)))                      # PK not writable
+  expect_error(user_update(1, list(created_at = "2020-01-01")))        # immutable
+  expect_error(user_update(1, list(user_name = "ok", evil_col = "y"))) # mixed valid+invalid
+})
+
+test_that("user_update allowlist covers writable columns and excludes PK/password/created_at", {
+  skip_if_not(exists("user_update"))
+  body <- paste(deparse(body(user_update)), collapse = " ")
+  expect_true(grepl("allowed_user_cols", body))
+  for (col in c("user_role", "email", "approved", "password_reset_date")) {
+    expect_true(grepl(col, body), info = paste("writable column missing:", col))
+  }
+  # password fields are stripped earlier; PK + created_at must not be writable.
+  expect_false(grepl('"user_id"', body, fixed = TRUE))
+  expect_false(grepl('"created_at"', body, fixed = TRUE))
+  expect_false(grepl('"password"', body, fixed = TRUE))
+})

--- a/api/version_spec.json
+++ b/api/version_spec.json
@@ -1,7 +1,7 @@
 {
   "title": "SysNDD API",
   "description": "This is the API powering the SysNDD website, allowing programmatic access to the database contents.",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "contact": {
     "name": "API Support",
     "url": "https://berntpopp.github.io/sysndd/api.html",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.29.2",
+  "version": "0.29.3",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Security hardening — MEDIUM + LOW follow-up to the v0.29.2 hotfix

The second half of the `sysndd-security-bug-scan` remediation: 4 MEDIUM + 8 LOW defects, each fixed by reusing an existing in-repo helper and shipped with a guard test. Two rounds of Codex HIGH adversarial review surfaced several adjacent gaps (an unbounded PubTator retry loop, an incomplete admin-only job set, unguarded approval paths, and a public phenotype-clustering leak) — all fixed here.

### MEDIUM
- **#4 / LOW-8 — `user_update` & `review_update` SET allowlists.** Both built `UPDATE … SET` from caller-supplied field names → restricted to writable columns (`setdiff` + `validate_query_column`); injection / mass-assignment rejected 400.
- **#5 — Curator cannot modify Administrators.** All role paths (`change_role`, bulk-assign, `user_update_role`) *and* the approval paths (`/user/approval`, `/user/bulk_approve`) now re-check the target's current role via `assert_not_targeting_admin()` (403). Previously a Curator could demote/activate/delete an Administrator.
- **#6 — Public PubTator DoS.** `/pubtator/search` + `/pubtator/cache-status` now cap retries, derive timeout from `external_proxy_budget('pubtator')`, enforce the #344 per-request ceiling, and return 503 on a NULL upstream; cache-status gated to Curator+.
- **#7 — Public LLM summaries validated-only.** No longer serves `pending` (un-judge-validated) summaries; the terminal `rejected` card is preserved via a new `status` filter on `get_cached_summary`.

### Also found by Codex (same classes, adjacent paths)
- **#3 — Public phenotype-clustering input.** `/api/jobs/phenotype_clustering/submit` built its review set on `is_primary` alone; now gates `review_approved = 1`, matching the served-snapshot path (a public clustering job's per-cluster phenotype stats no longer derive from unapproved curation).
- **LOW-1 completeness** — admin-only maintenance job-result set now covers all `ASYNC_MAINTENANCE_JOB_TYPES`.

### LOW
- Logging sanitizer substring redaction + query-string redaction (LOW-3); constant-time legacy password compare (LOW-4); URL-encode hgnc/oxo segments (LOW-5); MONDO download timeout (LOW-6); `base::get` in metadata-refresh (LOW-7); Administrator-only maintenance job results (LOW-1).

### Verification
- `make lint-api` clean; `make test-api-fast` green (**FAIL 0, PASS 4713**); 12 new/extended guard test files.
- Live smoke: PubTator search bounded 200; entity/analysis paths healthy.
- **Codex high-effort review: 3 passes → final verdict SHIP**, all findings CLOSED, no regressions.

**Deploy note:** restart `worker` / `worker-maintenance` — `mondo-functions.R` and `metadata-refresh.R` are worker-executed.

https://claude.ai/code/session_01RAg1iWsLKaAMvDk2Yf8WxH
