### PR TITLE
docs(planning): #535 P0 security — spec, plans, and Codex adversarial reviews

### DIFF
--- a/.planning/reviews/2026-07-11-security-535-p0-plan-codex-review.md
+++ b/.planning/reviews/2026-07-11-security-535-p0-plan-codex-review.md
@@ -1,0 +1,162 @@
+## Findings
+
+### BLOCKER
+
+1. **S0’s planned implementation cannot make the existing endpoint test files pass.**
+
+The plan changes handler signatures to include `req, res`, but it does not update the existing assertions that require the old signatures:
+
+- [test-endpoint-review.R:612](/home/bernt-popp/development/sysndd/api/tests/testthat/test-endpoint-review.R:612), plus the equivalent assertions at lines 652, 695, and 735, still expect `function(review_id_requested)`.
+- [test-endpoint-status.R:183](/home/bernt-popp/development/sysndd/api/tests/testthat/test-endpoint-status.R:183) still expects `function(status_id_requested)`.
+
+More seriously, existing per-route permission tests still require these routes to remain public:
+
+- [test-endpoint-review.R:626](/home/bernt-popp/development/sysndd/api/tests/testthat/test-endpoint-review.R:626) and analogous phenotype/variation/publication tests beginning at lines 671, 711, and 750 assert no `require_role`.
+- [test-endpoint-status.R:197](/home/bernt-popp/development/sysndd/api/tests/testthat/test-endpoint-status.R:197) asserts no `require_role`.
+
+The plan only replaces the list-route public tests and adds new detail assertions ([S0 plan:31](/home/bernt-popp/development/sysndd/.planning/superpowers/plans/2026-07-11-security-535-s0-endpoint-authz-plan.md:31), [S0 plan:133](/home/bernt-popp/development/sysndd/.planning/superpowers/plans/2026-07-11-security-535-s0-endpoint-authz-plan.md:133)). Consequently, the old and new assertions would directly contradict each other.
+
+**Fix:** explicitly replace all five old review permission assertions, the status-detail assertion, and all five obsolete signature assertions.
+
+2. **S1 puts bulk epoch handling in the wrong layer and loses transaction atomicity.**
+
+The plan names [user-bulk-endpoint-service.R](/home/bernt-popp/development/sysndd/api/services/user-bulk-endpoint-service.R:23) as the modification site and suggests calling `user_bump_session_epoch()` per ID after inspecting bypasses ([S1 plan:200](/home/bernt-popp/development/sysndd/.planning/superpowers/plans/2026-07-11-security-535-s1-session-epoch-refresh-plan.md:200)). That file only delegates. The actual transactional SQL is in:
+
+- Bulk role: [user-service.R:569](/home/bernt-popp/development/sysndd/api/services/user-service.R:569), update at line 576.
+- Bulk approval: [user-service.R:371](/home/bernt-popp/development/sysndd/api/services/user-service.R:371), update at line 400 and password update at line 418.
+- Bulk deletion: [user-service.R:492](/home/bernt-popp/development/sysndd/api/services/user-service.R:492).
+
+The proposed helper has no `conn` argument and uses the global DB helper ([S1 plan:171](/home/bernt-popp/development/sysndd/.planning/superpowers/plans/2026-07-11-security-535-s1-session-epoch-refresh-plan.md:171)). Calling it from the wrapper after `user_bulk_*()` commits creates a durable interval—or process-crash state—where the privilege change is committed but the epoch is not bumped. Calling it from inside `db_with_transaction()` without passing `txn_conn` may use another connection.
+
+Bulk approval is additionally inconsistent with the real schema and auth state: it updates nonexistent `account_status` and `approving_user_id` user columns ([user-service.R:377](/home/bernt-popp/development/sysndd/api/services/user-service.R:377), [user-service.R:400](/home/bernt-popp/development/sysndd/api/services/user-service.R:400)), while authentication checks `approved` ([auth-service.R:47](/home/bernt-popp/development/sysndd/api/services/auth-service.R:47)); the base user schema has `approved` but neither bulk column ([000_initialize_base_schema.sql:282](/home/bernt-popp/development/sysndd/db/migrations/000_initialize_base_schema.sql:282)).
+
+**Fix:** modify the SQL in `user-service.R` itself. Each role/approval/password mutation must update the state and `session_epoch = session_epoch + 1` in the same SQL statement and transaction. Bulk approval must use the actual `approved` schema. Hard deletion needs no preceding bump because DB-backed refresh rejects a missing user.
+
+3. **The new S1 DB tests use a fixture helper that cannot insert into the actual schema.**
+
+The proposed tests call `user_create()` ([S1 plan:117](/home/bernt-popp/development/sysndd/.planning/superpowers/plans/2026-07-11-security-535-s1-session-epoch-refresh-plan.md:117), [S1 plan:243](/home/bernt-popp/development/sysndd/.planning/superpowers/plans/2026-07-11-security-535-s1-session-epoch-refresh-plan.md:243)). That repository function inserts into `user_email` ([user-repository.R:157](/home/bernt-popp/development/sysndd/api/functions/user-repository.R:157)), but the table column is `email` ([000_initialize_base_schema.sql:286](/home/bernt-popp/development/sysndd/db/migrations/000_initialize_base_schema.sql:286)). These tests will fail before exercising epochs.
+
+**Fix:** seed test users with parameterized SQL using the actual columns, or first correct and independently test `user_create()`. Do not let an unrelated broken helper invalidate the security regression tests.
+
+### HIGH
+
+4. **S1’s separate state update and epoch bump permits refresh/revocation races.**
+
+The proposed `user_update()` sequence executes the privilege update and then a separate epoch update ([S1 plan:181](/home/bernt-popp/development/sysndd/.planning/superpowers/plans/2026-07-11-security-535-s1-session-epoch-refresh-plan.md:181)). The password path is likewise two statements ([S1 plan:193](/home/bernt-popp/development/sysndd/.planning/superpowers/plans/2026-07-11-security-535-s1-session-epoch-refresh-plan.md:193)).
+
+A concurrent refresh can read the old role/epoch just before a demotion, then mint an old-role token after the demotion commits. Since `require_auth` does not check the epoch, that token remains usable until expiry. This violates the stated immediate refresh-revocation property under concurrency.
+
+**Fix:** fold the epoch increment into the exact mutation statement. Then treat the refresh DB read as the linearization point: a refresh either reads the complete old row before the atomic mutation or the complete new row after it. Add a deterministic concurrency/transaction test if feasible.
+
+5. **S0 still exposes approved review/status comments through anonymous entity endpoints.**
+
+The S0 goal explicitly includes comments, and its split strategy says anonymous responses should drop comment/workflow fields ([design spec:130](/home/bernt-popp/development/sysndd/.planning/superpowers/specs/2026-07-11-security-hardening-535-design.md:130)). Yet public entity routes have no auth gate:
+
+- [entity_endpoints.R:284](/home/bernt-popp/development/sysndd/api/endpoints/entity_endpoints.R:284)
+- [entity_endpoints.R:299](/home/bernt-popp/development/sysndd/api/endpoints/entity_endpoints.R:299)
+
+Their services return `comment`:
+
+- Approved-primary review comment: [entity-read-endpoint-service.R:333](/home/bernt-popp/development/sysndd/api/services/entity-read-endpoint-service.R:333).
+- Active-approved status comment: [entity-read-endpoint-service.R:354](/home/bernt-popp/development/sysndd/api/services/entity-read-endpoint-service.R:354), selected at line 372.
+
+These paths do not leak drafts, because their approval predicates are correct, but they still expose comments if those are curator workflow notes. The plan’s assertion that the entity family can remain wholly untouched is therefore broader than the source supports.
+
+**Fix:** decide explicitly whether approved review/status comments are public editorial content or private workflow metadata. If private, remove them from anonymous entity responses or provide Reviewer+ enriched responses. If intentionally public, narrow the S0 goal/spec so it does not claim all comments are protected.
+
+6. **The planned S0 tests do not prove the acceptance criterion.**
+
+The proposed behavioral tests cover only review detail and status detail ([S0 plan:227](/home/bernt-popp/development/sysndd/.planning/superpowers/plans/2026-07-11-security-535-s0-endpoint-authz-plan.md:227)). Source grep merely proves that a matching string exists somewhere in a handler; it does not prove Plumber execution, denial before query, or a body free of leaked rows. The live checks cover only a subset and inspect status codes, not response bodies ([S0 plan:273](/home/bernt-popp/development/sysndd/.planning/superpowers/plans/2026-07-11-security-535-s0-endpoint-authz-plan.md:273)).
+
+A green plan could still leave:
+
+- Review list, phenotype, variation, or publication behavior untested.
+- A gate after data access.
+- A custom error handler that returns sensitive body data with 403.
+- Missing Reviewer positive controls.
+- Plumber signature/binding failures.
+
+**Fix:** add behavioral denial tests for all seven gated GET routes, with a DB/query sentinel; assert 403 and an empty/non-sensitive body. Add Reviewer positive controls for list, detail, and each review subresource. Add mounted-router or HTTP-level tests that exercise actual Plumber binding.
+
+7. **The S1 “current role” test does not demonstrate role-current minting.**
+
+The test creates an Administrator, mints an Administrator token, performs no role change, refreshes, and asserts Administrator ([S1 plan:271](/home/bernt-popp/development/sysndd/.planning/superpowers/plans/2026-07-11-security-535-s1-session-epoch-refresh-plan.md:271)). An implementation that loads only approval/epoch but reuses the token’s role would pass.
+
+The test suite also omits several cases required by the spec: explicit demotion, password change, deleted user, malformed/missing user ID, and a normal refresh proving DB-derived non-role claims. The self-review nevertheless claims broader coverage ([S1 plan:394](/home/bernt-popp/development/sysndd/.planning/superpowers/plans/2026-07-11-security-535-s1-session-epoch-refresh-plan.md:394)).
+
+**Fix:** add:
+
+- A direct test-only DB role change without an epoch change, then assert refresh mints the DB role. This isolates “DB-derived claims.”
+- Production-path demotion and deactivation tests asserting rejection after epoch bump.
+- Password-change and deleted-user rejection.
+- Tests showing role, name/email, and epoch are taken from the DB row.
+- An assertion that the endpoint returns 401 rather than merely “some error.”
+
+### MEDIUM
+
+8. **The proposed refresh query ignores the repository’s documented masking footgun.**
+
+The plan explicitly recommends unqualified `tbl`, `filter`, and `collect` ([S1 plan:350](/home/bernt-popp/development/sysndd/.planning/superpowers/plans/2026-07-11-security-535-s1-session-epoch-refresh-plan.md:350)). The runtime loads many packages, including biomaRt and STRINGdb ([init_libraries.R:40](/home/bernt-popp/development/sysndd/api/bootstrap/init_libraries.R:40), [init_libraries.R:59](/home/bernt-popp/development/sysndd/api/bootstrap/init_libraries.R:59)), and this repository specifically treats masked dplyr verbs as a correctness hazard.
+
+`filter(user_id == !!uid)` is otherwise valid tidy evaluation, and `dplyr::rename` is available. `%||%`, `stop_for_bad_request`, and `stop_for_unauthorized` are already used in the auth service, so those are in scope.
+
+**Fix:** use `dplyr::tbl`, `dplyr::filter(.data$user_id == !!uid)`, `dplyr::rename`, and `dplyr::collect`. Validate that `claims$user_id` converts to one finite, positive integer before querying.
+
+9. **The migration guard update is incomplete as written.**
+
+The migration SQL’s `information_schema.COLUMNS` check and prepared conditional DDL are valid MySQL patterns. Count 41 is correct because there are currently 40 SQL migrations.
+
+However, the plan only instructs changing the latest-name expectation at the top of each guard test ([S1 plan:32](/home/bernt-popp/development/sysndd/.planning/superpowers/plans/2026-07-11-security-535-s1-session-epoch-refresh-plan.md:32)). Existing tests also assert:
+
+- Count 40 at [test-unit-core-views-manifest.R:14](/home/bernt-popp/development/sysndd/api/tests/testthat/test-unit-core-views-manifest.R:14).
+- Returned latest name at [test-unit-core-views-manifest.R:21](/home/bernt-popp/development/sysndd/api/tests/testthat/test-unit-core-views-manifest.R:21).
+- Count 40 at [test-unit-analysis-snapshot-migration.R:9](/home/bernt-popp/development/sysndd/api/tests/testthat/test-unit-analysis-snapshot-migration.R:9).
+
+**Fix:** enumerate all four stale assertions in the plan. No additional independent minimum-count constant was found beyond `EXPECTED_MIGRATION_COUNT`.
+
+### LOW
+
+10. **The S0 router-role description is factually wrong, although consumer compatibility remains safe.**
+
+The plan says both approval queues are router-gated to Administrator/Curator/Reviewer ([S0 plan:7](/home/bernt-popp/development/sysndd/.planning/superpowers/plans/2026-07-11-security-535-s0-endpoint-authz-plan.md:7)). They are actually Curator+:
+
+- [routes.ts:435](/home/bernt-popp/development/sysndd/app/src/router/routes.ts:435)
+- [routes.ts:442](/home/bernt-popp/development/sysndd/app/src/router/routes.ts:442)
+
+They do send Bearer tokens: both resolve to `apiClient.raw` ([ApproveStatus.vue:77](/home/bernt-popp/development/sysndd/app/src/views/curate/ApproveStatus.vue:77), [useApproveReviewController.ts:68](/home/bernt-popp/development/sysndd/app/src/views/curate/composables/useApproveReviewController.ts:68)), and the shared interceptor injects the token ([client.ts:69](/home/bernt-popp/development/sysndd/app/src/api/client.ts:69)). Gating the API at Reviewer+ therefore will not break these consumers.
+
+**Fix:** correct the plan narrative to “the current approval views are Curator+, while the API intentionally admits Reviewer+.”
+
+11. **Legacy no-`sepoch` compatibility creates a bounded replay window, not an epoch bypass.**
+
+A legacy token for an epoch-0 user is accepted and can be replayed until its original expiry; each refreshed token gains `sepoch=0`. Once the user’s epoch is bumped, the legacy token maps to 0 and is rejected. This does not bypass demotion/deactivation revocation, but it preserves replay of pre-deployment tokens during their remaining lifetime.
+
+**Fix:** document the bounded compatibility window. If zero legacy acceptance is required, initialize existing users to epoch 1 or enforce a deployment-time `iat` cutoff.
+
+## Confirmed points
+
+- Only four review detail/subresource handlers lack `req, res`; the review list already has both ([review_endpoints.R:33](/home/bernt-popp/development/sysndd/api/endpoints/review_endpoints.R:33)). Status detail lacks them ([status_endpoints.R:168](/home/bernt-popp/development/sysndd/api/endpoints/status_endpoints.R:168)).
+- Adding named `req, res` arguments is consistent with existing Plumber path handlers, such as [status_endpoints.R:320](/home/bernt-popp/development/sysndd/api/endpoints/status_endpoints.R:320); it should not disturb path-parameter binding.
+- No additional GET route was missed in these two endpoint files. `_list` is the only intentionally public status GET and reads only `ndd_entity_status_categories_list` ([status_endpoints.R:228](/home/bernt-popp/development/sysndd/api/endpoints/status_endpoints.R:228)). `approve/all` is not an extra GET; approval matches the gated PUT route.
+- Migration 042 correctly gates the public phenotype and variation connect views on primary and approved review state ([042_gate_connect_views_review_approved.sql:44](/home/bernt-popp/development/sysndd/db/migrations/042_gate_connect_views_review_approved.sql:44), [042_gate_connect_views_review_approved.sql:67](/home/bernt-popp/development/sysndd/db/migrations/042_gate_connect_views_review_approved.sql:67)).
+- Other inspected public data paths were approval-gated: entity review/status content, MCP repository queries, and SEO queries. Re-review and user-identity surfaces have endpoint role gates.
+- Initial approval’s approval bump plus password bump would double-increment; that is harmless but should preferably be one atomic account-initialization update.
+- Stamping `password_reset_date` does not trigger the proposed `user_update` bump, which is correct. The actual password reset/change uses `user_update_password()` ([user-password-profile-endpoint-service.R:272](/home/bernt-popp/development/sysndd/api/services/user-password-profile-endpoint-service.R:272)) and should bump atomically.
+- Deferring distinct rotating refresh tokens is defensible for the narrow P0 refresh criterion. Epoch checking in every `require_auth` call is also not a strict co-dependency, provided the one-hour access-token residual is explicitly accepted. Atomic state+epoch mutation is a co-dependency and cannot be deferred.
+
+## Corrections to apply before implementation
+
+1. Rewrite the S0 test tasks to update every obsolete signature and public-permission assertion.
+2. Add behavioral and mounted-router tests for all seven gated GET routes, including body non-disclosure and Reviewer positive controls.
+3. Classify entity review/status comments as public or private; strip them for anonymous users if they are workflow notes.
+4. Move bulk epoch work into `user-service.R`, where the transactional SQL actually lives.
+5. Make privilege, approval, and password changes increment the epoch in the same SQL statement and transaction.
+6. Correct bulk approval to use the real `approved` schema; do not build epoch logic atop nonexistent `account_status` fields.
+7. Give any reusable epoch helper an explicit `conn` parameter, or inline the atomic increment into mutation SQL.
+8. Replace the broken `user_create()` fixture dependency in new tests.
+9. Expand S1 tests to cover real demotion, deactivation, password change, deletion, DB-derived claims, and error status.
+10. Namespace all dplyr/dbplyr verbs in `auth_refresh` and validate the decoded user ID.
+11. Update every latest-migration and migration-count assertion, including the returned `res$latest`.
+12. Document the concurrency linearization guarantee, legacy-token window, access-token residual, and the precise boundary of deferred S1b work.
+
+This was a static, read-only review. Per request, I did not edit files, run tests, or start services.

--- a/.planning/superpowers/plans/2026-07-11-security-535-s0-endpoint-authz-plan.md
+++ b/.planning/superpowers/plans/2026-07-11-security-535-s0-endpoint-authz-plan.md
@@ -1,0 +1,306 @@
+# S0 — Endpoint Authorization (#535 P0-1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop anonymous callers from reading draft/unapproved curation rows, curator identities, roles, comments, and workflow state through `/api/review` and `/api/status` by gating every draft-exposing GET route at Reviewer+.
+
+**Architecture:** These two endpoint families are curation surfaces whose only consumers are the authenticated approval queues (`ApproveReview.vue`, `ApproveStatus.vue`) which call through the Bearer-authenticated `apiClient` singleton and are router-gated to Administrator/Curator/Reviewer. Add `require_role(req, res, "Reviewer")` to each draft-exposing GET handler (the established pattern already used by write/approve routes and the whole `re_review` family). Detail/subresource handlers must first have `req, res` added to their signatures. Public approved curation data continues to flow through the already approved-gated `/api/entity/*` family, untouched.
+
+**Tech Stack:** R / Plumber REST API, testthat. `require_role` from `api/core/middleware.R` (Viewer<Reviewer<Curator<Administrator, hierarchy-aware). Tests use handler-extraction sandboxes with a stubbed `require_role`.
+
+## Global Constraints
+
+- Keep every touched file **< 600 lines** (`make code-quality-audit` ratchet). `review_endpoints.R` and `status_endpoints.R` are well under; the edits are small.
+- Endpoint sub-routers are mounted via `mount_endpoint()`; classed errors (`stop_for_unauthorized`/`error_403` from `require_role`) map to RFC 9457 problem+json. Do not add bare `pr_mount`.
+- `require_role(req, res, min_role)` raises `error_forbidden` (403) for insufficient role and, because `require_auth` (`middleware.R:94-97`) forwards anonymous GETs with `req$user_role == NULL`, an anonymous caller hits `user_level = 0 < required` → 403. (Anonymous non-GET already 401s upstream; these are GET routes.)
+- Gate at **`"Reviewer"`** (admits Reviewer/Curator/Administrator) — matches the approval-queue router guard and lets Reviewers see the draft queue they must approve.
+- Tests run in the API container (the `api/tests/` dir is **not** bind-mounted): `docker cp` the changed test files into `sysndd-api-1:/app/tests/testthat/` then `docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/<file>')"`, or run `make test-api-fast`. Do not assume host `Rscript` has a test DB.
+
+---
+
+### Task 1: Gate the review list + detail + subresource GET routes at Reviewer+
+
+**Files:**
+- Modify: `api/endpoints/review_endpoints.R` (list handler at `:34`; detail `:385`; `/phenotypes` `:439`; `/variation` `:481`; `/publications` `:523`)
+- Test: `api/tests/testthat/test-endpoint-review.R`
+
+**Interfaces:**
+- Consumes: `require_role(req, res, min_role)` (already in scope in the endpoint runtime; stubbed in tests).
+- Produces: five review GET handlers that call `require_role(req, res, "Reviewer")` as their first statement; the four detail/subresource handlers now take `function(req, res, review_id_requested)`.
+
+- [ ] **Step 1: Invert the existing "public read" permission test and add detail-route permission assertions**
+
+In `api/tests/testthat/test-endpoint-review.R`, replace the block titled
+`"GET / review list: permission — public read (no require_role)"` (around `:200`) with:
+
+```r
+test_that("GET / review list: permission — requires Reviewer+ (require_role gate present)", {
+  with_test_db_transaction({
+    src <- review_source()
+    dec_idx <- grep("^#\\*\\s+@get\\s+/\\s*$", src)[[1L]]
+    next_decorator <- grep("^#\\*\\s+@(get|post|put|delete)\\b", src)
+    next_after <- next_decorator[next_decorator > dec_idx][[1L]]
+    body_blob <- paste(src[dec_idx:(next_after - 1L)], collapse = "\n")
+    expect_true(
+      grepl("require_role\\(\\s*req\\s*,\\s*res\\s*,\\s*\"Reviewer\"", body_blob),
+      info = "GET /review must gate at Reviewer+ (draft/curator-identity exposure)."
+    )
+  })
+})
+
+test_that("GET /<review_id> + subresources: permission — each gates at Reviewer+", {
+  with_test_db_transaction({
+    src <- review_source()
+    for (dec in c("^#\\*\\s+@get\\s+/<review_id_requested>\\s*$",
+                  "^#\\*\\s+@get\\s+/<review_id_requested>/phenotypes\\s*$",
+                  "^#\\*\\s+@get\\s+/<review_id_requested>/variation\\s*$",
+                  "^#\\*\\s+@get\\s+/<review_id_requested>/publications\\s*$")) {
+      dec_idx <- grep(dec, src)[[1L]]
+      nexts <- grep("^#\\*\\s+@(get|post|put|delete)\\b", src)
+      after <- nexts[nexts > dec_idx][[1L]]
+      body_blob <- paste(src[dec_idx:(after - 1L)], collapse = "\n")
+      expect_true(
+        grepl("require_role\\(\\s*req\\s*,\\s*res\\s*,\\s*\"Reviewer\"", body_blob),
+        info = paste("Missing Reviewer+ gate on", dec)
+      )
+    }
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they FAIL**
+
+Run: `docker cp api/tests/testthat/test-endpoint-review.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-endpoint-review.R')"`
+Expected: FAIL — the handlers do not yet contain `require_role(req, res, "Reviewer")`.
+
+- [ ] **Step 3: Add `require_role` to the list handler**
+
+In `api/endpoints/review_endpoints.R`, the list handler at `:34`:
+
+```r
+#* @get /
+function(req, res, filter_review_approved = FALSE) {
+  require_role(req, res, "Reviewer")
+
+  # Ensure logical
+  filter_review_approved <- as.logical(filter_review_approved)
+```
+
+- [ ] **Step 4: Widen detail/subresource signatures and add the gate**
+
+For each of the four handlers (`:385`, `:439`, `:481`, `:523`), change the signature from
+`function(review_id_requested) {` to add `req, res` and gate. Example for `:385`:
+
+```r
+#* @get /<review_id_requested>
+function(req, res, review_id_requested) {
+  require_role(req, res, "Reviewer")
+
+  review_id_requested <- URLdecode(review_id_requested) %>%
+```
+
+Apply the identical two-line change (`req, res` in signature + `require_role(req, res, "Reviewer")` as first statement) to `/phenotypes` (`:439`), `/variation` (`:481`), and `/publications` (`:523`).
+
+- [ ] **Step 5: Run the tests to verify they PASS**
+
+Run: `docker cp api/tests/testthat/test-endpoint-review.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-endpoint-review.R')"`
+Expected: PASS (all blocks; no new skips beyond the pre-existing DB-gated ones).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/endpoints/review_endpoints.R api/tests/testthat/test-endpoint-review.R
+git commit -m "fix(security): gate /api/review draft-exposing GET routes at Reviewer+ (#535 P0-1)"
+```
+
+---
+
+### Task 2: Gate the status list + detail GET routes at Reviewer+ (keep `_list` category vocab public)
+
+**Files:**
+- Modify: `api/endpoints/status_endpoints.R` (list handler at `:27`; detail `:168`; leave `_list` `:228` public with a justifying comment)
+- Test: `api/tests/testthat/test-endpoint-status.R`
+
+**Interfaces:**
+- Consumes: `require_role(req, res, min_role)`.
+- Produces: status list + detail handlers gated at Reviewer+; detail handler takes `function(req, res, status_id_requested)`.
+
+- [ ] **Step 1: Verify `_list` exposes only vocabulary (decide public vs gate)**
+
+Run: `sed -n '228,268p' api/endpoints/status_endpoints.R`
+Expected: the `_list` handler reads only `ndd_entity_status_categories_list` (a category lookup, no curation rows, no `user` join, no `approving_user`/`comment`). It is consumed by public entity-create option loaders. **Decision:** keep `_list` public. If this inspection instead shows any draft/identity/`user`-join exposure, gate it at Reviewer+ too and note the deviation in the commit.
+
+- [ ] **Step 2: Invert the existing status "public read" test and add the detail assertion**
+
+In `api/tests/testthat/test-endpoint-status.R`, replace the block titled
+`"GET / status list: permission — public read (no require_role)"` (around `:156`) with:
+
+```r
+test_that("GET / status list: permission — requires Reviewer+ (require_role gate present)", {
+  with_test_db_transaction({
+    src <- status_source()
+    dec_idx <- grep("^#\\*\\s+@get\\s+/\\s*$", src)[[1L]]
+    next_dec <- grep("^#\\*\\s+@(get|post|put|delete)\\b", src)
+    after <- next_dec[next_dec > dec_idx][[1L]]
+    body_blob <- paste(src[dec_idx:(after - 1L)], collapse = "\n")
+    expect_true(
+      grepl("require_role\\(\\s*req\\s*,\\s*res\\s*,\\s*\"Reviewer\"", body_blob),
+      info = "GET /status must gate at Reviewer+ (draft/curator-identity exposure)."
+    )
+  })
+})
+
+test_that("GET /<status_id>: permission — gates at Reviewer+", {
+  with_test_db_transaction({
+    src <- status_source()
+    dec_idx <- grep("^#\\*\\s+@get\\s+/<status_id_requested>\\s*$", src)[[1L]]
+    next_dec <- grep("^#\\*\\s+@(get|post|put|delete)\\b", src)
+    after <- next_dec[next_dec > dec_idx][[1L]]
+    body_blob <- paste(src[dec_idx:(after - 1L)], collapse = "\n")
+    expect_true(
+      grepl("require_role\\(\\s*req\\s*,\\s*res\\s*,\\s*\"Reviewer\"", body_blob),
+      info = "GET /status/<id> must gate at Reviewer+."
+    )
+  })
+})
+```
+
+- [ ] **Step 3: Run tests to verify they FAIL**
+
+Run: `docker cp api/tests/testthat/test-endpoint-status.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-endpoint-status.R')"`
+Expected: FAIL — handlers lack the gate.
+
+- [ ] **Step 4: Add the gate to the status list handler**
+
+`api/endpoints/status_endpoints.R:27`:
+
+```r
+#* @get /
+function(req, res, filter_status_approved = FALSE) {
+  require_role(req, res, "Reviewer")
+
+  filter_status_approved <- as.logical(filter_status_approved)
+```
+
+- [ ] **Step 5: Widen the detail signature and add the gate**
+
+`api/endpoints/status_endpoints.R:168`:
+
+```r
+#* @get /<status_id_requested>
+function(req, res, status_id_requested) {
+  require_role(req, res, "Reviewer")
+
+  status_id_requested <- URLdecode(status_id_requested) %>%
+```
+
+Add a one-line comment above the `_list` handler at `:228` documenting why it stays public:
+
+```r
+#* Public: returns only the status-category vocabulary (ndd_entity_status_categories_list);
+#* no draft rows, curator identities, or approval state. Consumed by public entity-create option loaders.
+#* @get _list
+```
+
+- [ ] **Step 6: Run tests to verify they PASS**
+
+Run: `docker cp api/tests/testthat/test-endpoint-status.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-endpoint-status.R')"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/endpoints/status_endpoints.R api/tests/testthat/test-endpoint-status.R
+git commit -m "fix(security): gate /api/status draft-exposing GET routes at Reviewer+ (#535 P0-1)"
+```
+
+---
+
+### Task 3: Add behavioral anonymous-denial + Reviewer-allow tests (defense against regression)
+
+**Files:**
+- Test: `api/tests/testthat/test-endpoint-review.R`, `api/tests/testthat/test-endpoint-status.R`
+
+**Interfaces:**
+- Consumes: `extract_review_handler(decorator_regex, envir)` / `make_review_sandbox(...)` and the analogous status helpers already defined in each test file; a `deny_role` stub that sets `res$status <- 403L` and `stop("forbidden")` (mirroring `require_role`).
+
+- [ ] **Step 1: Add a behavioral permission test for the review detail handler**
+
+Append to `api/tests/testthat/test-endpoint-review.R`. This extracts the real handler, injects a `require_role` stub that denies, and asserts the handler stops with 403 before touching data — proving the gate is the first statement:
+
+```r
+test_that("GET /<review_id> behavioral: anonymous/insufficient role blocked with 403", {
+  with_test_db_transaction({
+    deny <- function(req, res, min_role) { res$status <- 403L; stop("forbidden") }
+    env <- new.env(parent = globalenv())
+    env$require_role <- deny
+    env$pool <- structure(list(), class = "FAIL_IF_QUERIED")  # any DB touch would error
+    handler <- extract_review_handler("^#\\*\\s+@get\\s+/<review_id_requested>\\s*$", env)
+    res <- new.env(); res$status <- 200L
+    expect_error(handler(req = list(), res = res, review_id_requested = "1"), "forbidden")
+    expect_equal(res$status, 403L)
+  })
+})
+```
+
+- [ ] **Step 2: Add the analogous behavioral test for the status detail handler**
+
+Append to `api/tests/testthat/test-endpoint-status.R` using its `extract_status_handler` helper (mirror the block above, decorator `"^#\\*\\s+@get\\s+/<status_id_requested>\\s*$"`, param `status_id_requested = "1"`).
+
+- [ ] **Step 3: Run both files to verify PASS**
+
+Run: `docker cp api/tests/testthat/test-endpoint-review.R sysndd-api-1:/app/tests/testthat/ && docker cp api/tests/testthat/test-endpoint-status.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-endpoint-review.R'); testthat::test_file('/app/tests/testthat/test-endpoint-status.R')"`
+Expected: PASS. (If `extract_status_handler`/`make_status_sandbox` names differ, grep the status test file for the actual helper names and use those — do not invent new helpers.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add api/tests/testthat/test-endpoint-review.R api/tests/testthat/test-endpoint-status.R
+git commit -m "test(security): behavioral 403 coverage for gated review/status GET routes (#535 P0-1)"
+```
+
+---
+
+### Task 4: Live verification + full gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Confirm the file-size ratchet is green**
+
+Run: `make code-quality-audit`
+Expected: PASS.
+
+- [ ] **Step 2: Live end-to-end check (fully-loaded API env — catches masking the unit sandbox can't)**
+
+With the dev stack up (`make dev` or the running `sysndd-api-1` + Traefik), verify:
+- Anonymous `GET /api/review/` and `GET /api/status/` → **403** problem+json.
+- Anonymous `GET /api/review/1`, `/api/review/1/phenotypes`, `GET /api/status/1` → **403**.
+- With a Reviewer JWT (mint per the repo recipe: `config::get("sysndd_db")` secret + `auth_generate_token`), the same routes → **200** with data.
+- `GET /api/status/_list` (no token) → **200** category vocabulary (unchanged).
+
+```bash
+# anonymous (expect 403)
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost/api/review/
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost/api/status/
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost/api/review/1/phenotypes
+# public vocab (expect 200)
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost/api/status/_list
+# reviewer token (expect 200)
+curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $REVIEWER_JWT" http://localhost/api/review/
+```
+
+- [ ] **Step 3: Run the fast API PR gate**
+
+Run: `make test-api-fast`
+Expected: PASS; the two endpoint test files' inverted/new blocks run (not skipped) against the dev DB.
+
+- [ ] **Step 4: Update docs if needed**
+
+If the OpenAPI decorators encode `@response`, ensure the gated routes document `@response 403`. No behavior doc change beyond that; the public data surface is unchanged.
+
+## Self-Review
+
+- **Spec coverage:** S0 §4 requirements — public routes no longer expose drafts (gated at Reviewer+), draft detail/subresource routes gated, anonymous cannot enumerate IDs/comments/identities (403), tests inverted + anonymous-denial added, `_list` verified. Covered by Tasks 1–4.
+- **Escalation gate (spec §4):** verified in this session — no anonymous/OpenAPI/MCP/SEO consumer of these lists; only authenticated approval queues consume them via `apiClient`. So "gate at Reviewer+" applies; no split needed.
+- **Placeholder scan:** none — all edits show exact code; the only conditional is the `_list` public-vs-gate decision, which Task 2 Step 1 resolves by inspection with an explicit fallback.
+- **Type/name consistency:** `require_role(req, res, "Reviewer")` used verbatim throughout; detail signatures consistently `function(req, res, <id>_requested)`.

--- a/.planning/superpowers/plans/2026-07-11-security-535-s0-endpoint-authz-plan.md
+++ b/.planning/superpowers/plans/2026-07-11-security-535-s0-endpoint-authz-plan.md
@@ -2,80 +2,59 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Stop anonymous callers from reading draft/unapproved curation rows, curator identities, roles, comments, and workflow state through `/api/review` and `/api/status` by gating every draft-exposing GET route at Reviewer+.
+**Goal:** Stop anonymous callers from reading **draft/unapproved** curation rows and **curator identities** (names, roles, comments, workflow state) through `/api/review` and `/api/status` by gating every draft-exposing GET route at Reviewer+. (Scope note: whether *approved* review/status `comment` text exposed through the separate, approval-gated `/api/entity/*` routes is public-editorial or private-workflow is a distinct product decision tracked as a program follow-up — see §Scope boundary — and is NOT part of S0.)
 
-**Architecture:** These two endpoint families are curation surfaces whose only consumers are the authenticated approval queues (`ApproveReview.vue`, `ApproveStatus.vue`) which call through the Bearer-authenticated `apiClient` singleton and are router-gated to Administrator/Curator/Reviewer. Add `require_role(req, res, "Reviewer")` to each draft-exposing GET handler (the established pattern already used by write/approve routes and the whole `re_review` family). Detail/subresource handlers must first have `req, res` added to their signatures. Public approved curation data continues to flow through the already approved-gated `/api/entity/*` family, untouched.
+**Architecture:** These two families are curation surfaces whose only consumers are the authenticated approval queues (`ApproveReview.vue`, `ApproveStatus.vue`) which call through the Bearer-authenticated `apiClient` singleton (`apiClient.raw`) and are router-gated to **Curator+**. Add `require_role(req, res, "Reviewer")` (admits Reviewer/Curator/Administrator) to each draft-exposing GET handler — the established pattern used by the write/approve routes here and by the whole `re_review` family. The four review detail/subresource handlers and the status detail handler are currently `function(<id>)` with **no `req, res`**; each signature must first be widened to `function(req, res, <id>)`. Public approved curation data continues through the already approval-gated `/api/entity/*` family, untouched.
 
-**Tech Stack:** R / Plumber REST API, testthat. `require_role` from `api/core/middleware.R` (Viewer<Reviewer<Curator<Administrator, hierarchy-aware). Tests use handler-extraction sandboxes with a stubbed `require_role`.
+**Tech Stack:** R / Plumber REST API, testthat. `require_role` from `api/core/middleware.R` (Viewer<Reviewer<Curator<Administrator, hierarchy-aware). Tests extract the handler function literal into a sandbox with a stubbed `require_role`.
 
 ## Global Constraints
 
-- Keep every touched file **< 600 lines** (`make code-quality-audit` ratchet). `review_endpoints.R` and `status_endpoints.R` are well under; the edits are small.
-- Endpoint sub-routers are mounted via `mount_endpoint()`; classed errors (`stop_for_unauthorized`/`error_403` from `require_role`) map to RFC 9457 problem+json. Do not add bare `pr_mount`.
-- `require_role(req, res, min_role)` raises `error_forbidden` (403) for insufficient role and, because `require_auth` (`middleware.R:94-97`) forwards anonymous GETs with `req$user_role == NULL`, an anonymous caller hits `user_level = 0 < required` → 403. (Anonymous non-GET already 401s upstream; these are GET routes.)
-- Gate at **`"Reviewer"`** (admits Reviewer/Curator/Administrator) — matches the approval-queue router guard and lets Reviewers see the draft queue they must approve.
-- Tests run in the API container (the `api/tests/` dir is **not** bind-mounted): `docker cp` the changed test files into `sysndd-api-1:/app/tests/testthat/` then `docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/<file>')"`, or run `make test-api-fast`. Do not assume host `Rscript` has a test DB.
+- Keep every touched file **< 600 lines** (`make code-quality-audit`). Both endpoint files are well under.
+- `require_role(req, res, min_role)` raises `error_forbidden` (403). Anonymous GETs reach the handler with `req$user_role == NULL` (middleware forwards them), so `require_role` computes `user_level = 0 < required` → **403**. Errors map to RFC 9457 problem+json via `mount_endpoint()`.
+- Gate at **`"Reviewer"`** — matches the approval-queue consumers (Curator+ ⊂ Reviewer+) and lets Reviewers see the draft queue they approve.
+- The `api/tests/` dir is **not** bind-mounted into the container. Run tests via: `docker cp <file> sysndd-api-1:/app/tests/testthat/` then `docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/<file>')"`. The dev stack (incl. `sysndd_mysql_test`) is up, so `with_test_db_transaction` blocks RUN (do not assume skip).
+
+## Scope boundary (Codex review, HIGH-5)
+
+`GET /api/entity/<id>/review` and `.../status` (`entity_endpoints.R:284,299`) are anonymous but **approval-gated** (`primary_approved_reviews()`), and they return the approved primary review/status `comment` (`entity-read-endpoint-service.R:333,354`). They do **not** leak drafts or identities. Whether an *approved* `comment` is public editorial content or private workflow metadata is a product decision. **S0 does not change these** — it is recorded as program item **S8-follow-up: "classify approved review/status comment visibility"**. The spec's earlier "entity family wholly untouched/safe" wording is narrowed accordingly.
 
 ---
 
-### Task 1: Gate the review list + detail + subresource GET routes at Reviewer+
+### Task 1: Gate the review list + detail + subresource GET routes at Reviewer+ (and fix ALL obsolete assertions)
 
 **Files:**
-- Modify: `api/endpoints/review_endpoints.R` (list handler at `:34`; detail `:385`; `/phenotypes` `:439`; `/variation` `:481`; `/publications` `:523`)
+- Modify: `api/endpoints/review_endpoints.R` (list `:34`; detail `:385`; `/phenotypes` `:439`; `/variation` `:481`; `/publications` `:523`)
 - Test: `api/tests/testthat/test-endpoint-review.R`
 
 **Interfaces:**
-- Consumes: `require_role(req, res, min_role)` (already in scope in the endpoint runtime; stubbed in tests).
-- Produces: five review GET handlers that call `require_role(req, res, "Reviewer")` as their first statement; the four detail/subresource handlers now take `function(req, res, review_id_requested)`.
+- Produces: five review GET handlers whose first statement is `require_role(req, res, "Reviewer")`; the four detail/subresource handlers now take `function(req, res, review_id_requested)`.
 
-- [ ] **Step 1: Invert the existing "public read" permission test and add detail-route permission assertions**
+- [ ] **Step 1: Invert every obsolete permission AND signature assertion (write the failing expectations first)**
 
-In `api/tests/testthat/test-endpoint-review.R`, replace the block titled
-`"GET / review list: permission — public read (no require_role)"` (around `:200`) with:
+In `api/tests/testthat/test-endpoint-review.R`:
+
+(a) **Permission blocks** — the `"...: permission — public read (no require_role)"` blocks for all five GET routes (list `:200`, `/<review_id>` `:626`, `/phenotypes` `:671`, `/variation` `:711`, `/publications` `:750`) each assert `expect_false(grepl("require_role\\(", body_blob))`. For each: rename the title `— public read (no require_role)` → `— requires Reviewer+`, and change the assertion to:
 
 ```r
-test_that("GET / review list: permission — requires Reviewer+ (require_role gate present)", {
-  with_test_db_transaction({
-    src <- review_source()
-    dec_idx <- grep("^#\\*\\s+@get\\s+/\\s*$", src)[[1L]]
-    next_decorator <- grep("^#\\*\\s+@(get|post|put|delete)\\b", src)
-    next_after <- next_decorator[next_decorator > dec_idx][[1L]]
-    body_blob <- paste(src[dec_idx:(next_after - 1L)], collapse = "\n")
     expect_true(
       grepl("require_role\\(\\s*req\\s*,\\s*res\\s*,\\s*\"Reviewer\"", body_blob),
-      info = "GET /review must gate at Reviewer+ (draft/curator-identity exposure)."
+      info = "This GET route must gate at Reviewer+ (draft/curator-identity exposure)."
     )
-  })
-})
-
-test_that("GET /<review_id> + subresources: permission — each gates at Reviewer+", {
-  with_test_db_transaction({
-    src <- review_source()
-    for (dec in c("^#\\*\\s+@get\\s+/<review_id_requested>\\s*$",
-                  "^#\\*\\s+@get\\s+/<review_id_requested>/phenotypes\\s*$",
-                  "^#\\*\\s+@get\\s+/<review_id_requested>/variation\\s*$",
-                  "^#\\*\\s+@get\\s+/<review_id_requested>/publications\\s*$")) {
-      dec_idx <- grep(dec, src)[[1L]]
-      nexts <- grep("^#\\*\\s+@(get|post|put|delete)\\b", src)
-      after <- nexts[nexts > dec_idx][[1L]]
-      body_blob <- paste(src[dec_idx:(after - 1L)], collapse = "\n")
-      expect_true(
-        grepl("require_role\\(\\s*req\\s*,\\s*res\\s*,\\s*\"Reviewer\"", body_blob),
-        info = paste("Missing Reviewer+ gate on", dec)
-      )
-    }
-  })
-})
 ```
 
-- [ ] **Step 2: Run the tests to verify they FAIL**
+(b) **Signature blocks** — the "happy path — decorator surface present" blocks at `:612`, `:652`, `:695`, `:735` assert `expect_match(sig_line, "^function\\(review_id_requested\\)")`. Change each to:
+
+```r
+    expect_match(sig_line, "^function\\(req, res, review_id_requested\\)")
+```
+
+- [ ] **Step 2: Run to verify FAIL**
 
 Run: `docker cp api/tests/testthat/test-endpoint-review.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-endpoint-review.R')"`
-Expected: FAIL — the handlers do not yet contain `require_role(req, res, "Reviewer")`.
+Expected: FAIL — handlers still lack the gate and still use the old signature.
 
-- [ ] **Step 3: Add `require_role` to the list handler**
-
-In `api/endpoints/review_endpoints.R`, the list handler at `:34`:
+- [ ] **Step 3: Add the gate to the list handler (`:34`)**
 
 ```r
 #* @get /
@@ -86,10 +65,9 @@ function(req, res, filter_review_approved = FALSE) {
   filter_review_approved <- as.logical(filter_review_approved)
 ```
 
-- [ ] **Step 4: Widen detail/subresource signatures and add the gate**
+- [ ] **Step 4: Widen the four detail/subresource signatures and add the gate**
 
-For each of the four handlers (`:385`, `:439`, `:481`, `:523`), change the signature from
-`function(review_id_requested) {` to add `req, res` and gate. Example for `:385`:
+For `:385`, `:439`, `:481`, `:523`, change `function(review_id_requested) {` to `function(req, res, review_id_requested) {` and insert `require_role(req, res, "Reviewer")` as the first statement. Example (`:385`):
 
 ```r
 #* @get /<review_id_requested>
@@ -99,12 +77,10 @@ function(req, res, review_id_requested) {
   review_id_requested <- URLdecode(review_id_requested) %>%
 ```
 
-Apply the identical two-line change (`req, res` in signature + `require_role(req, res, "Reviewer")` as first statement) to `/phenotypes` (`:439`), `/variation` (`:481`), and `/publications` (`:523`).
-
-- [ ] **Step 5: Run the tests to verify they PASS**
+- [ ] **Step 5: Run to verify PASS**
 
 Run: `docker cp api/tests/testthat/test-endpoint-review.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-endpoint-review.R')"`
-Expected: PASS (all blocks; no new skips beyond the pre-existing DB-gated ones).
+Expected: PASS.
 
 - [ ] **Step 6: Commit**
 
@@ -115,64 +91,32 @@ git commit -m "fix(security): gate /api/review draft-exposing GET routes at Revi
 
 ---
 
-### Task 2: Gate the status list + detail GET routes at Reviewer+ (keep `_list` category vocab public)
+### Task 2: Gate the status list + detail GET routes at Reviewer+ (keep `_list` public)
 
 **Files:**
-- Modify: `api/endpoints/status_endpoints.R` (list handler at `:27`; detail `:168`; leave `_list` `:228` public with a justifying comment)
+- Modify: `api/endpoints/status_endpoints.R` (list `:27`; detail `:168`; `_list` `:228` stays public)
 - Test: `api/tests/testthat/test-endpoint-status.R`
 
 **Interfaces:**
-- Consumes: `require_role(req, res, min_role)`.
 - Produces: status list + detail handlers gated at Reviewer+; detail handler takes `function(req, res, status_id_requested)`.
 
-- [ ] **Step 1: Verify `_list` exposes only vocabulary (decide public vs gate)**
+- [ ] **Step 1: Verify `_list` exposes only vocabulary**
 
 Run: `sed -n '228,268p' api/endpoints/status_endpoints.R`
-Expected: the `_list` handler reads only `ndd_entity_status_categories_list` (a category lookup, no curation rows, no `user` join, no `approving_user`/`comment`). It is consumed by public entity-create option loaders. **Decision:** keep `_list` public. If this inspection instead shows any draft/identity/`user`-join exposure, gate it at Reviewer+ too and note the deviation in the commit.
+Expected: `_list` reads only `ndd_entity_status_categories_list` (no `user` join, no drafts, no `approving_user`/`comment`). Keep it public. (Codex confirmed this is the only intentionally-public status GET.)
 
-- [ ] **Step 2: Invert the existing status "public read" test and add the detail assertion**
+- [ ] **Step 2: Invert the status list + detail permission and signature assertions; LEAVE `_list` public**
 
-In `api/tests/testthat/test-endpoint-status.R`, replace the block titled
-`"GET / status list: permission — public read (no require_role)"` (around `:156`) with:
+In `api/tests/testthat/test-endpoint-status.R`:
+- Permission blocks: invert list `:156` and detail `:197` (rename title, `expect_false(...)` → `expect_true(grepl("require_role\\(\\s*req\\s*,\\s*res\\s*,\\s*\"Reviewer\"", body_blob), info=...)`). **Leave the `_list` block `:245` as `expect_false`** (stays public).
+- Signature block: the detail "happy path" block at `:183` asserts `expect_match(sig_line, "^function\\(status_id_requested\\)")`; change to `expect_match(sig_line, "^function\\(req, res, status_id_requested\\)")`.
 
-```r
-test_that("GET / status list: permission — requires Reviewer+ (require_role gate present)", {
-  with_test_db_transaction({
-    src <- status_source()
-    dec_idx <- grep("^#\\*\\s+@get\\s+/\\s*$", src)[[1L]]
-    next_dec <- grep("^#\\*\\s+@(get|post|put|delete)\\b", src)
-    after <- next_dec[next_dec > dec_idx][[1L]]
-    body_blob <- paste(src[dec_idx:(after - 1L)], collapse = "\n")
-    expect_true(
-      grepl("require_role\\(\\s*req\\s*,\\s*res\\s*,\\s*\"Reviewer\"", body_blob),
-      info = "GET /status must gate at Reviewer+ (draft/curator-identity exposure)."
-    )
-  })
-})
-
-test_that("GET /<status_id>: permission — gates at Reviewer+", {
-  with_test_db_transaction({
-    src <- status_source()
-    dec_idx <- grep("^#\\*\\s+@get\\s+/<status_id_requested>\\s*$", src)[[1L]]
-    next_dec <- grep("^#\\*\\s+@(get|post|put|delete)\\b", src)
-    after <- next_dec[next_dec > dec_idx][[1L]]
-    body_blob <- paste(src[dec_idx:(after - 1L)], collapse = "\n")
-    expect_true(
-      grepl("require_role\\(\\s*req\\s*,\\s*res\\s*,\\s*\"Reviewer\"", body_blob),
-      info = "GET /status/<id> must gate at Reviewer+."
-    )
-  })
-})
-```
-
-- [ ] **Step 3: Run tests to verify they FAIL**
+- [ ] **Step 3: Run to verify FAIL**
 
 Run: `docker cp api/tests/testthat/test-endpoint-status.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-endpoint-status.R')"`
-Expected: FAIL — handlers lack the gate.
+Expected: FAIL.
 
-- [ ] **Step 4: Add the gate to the status list handler**
-
-`api/endpoints/status_endpoints.R:27`:
+- [ ] **Step 4: Add the gate to the status list handler (`:27`)**
 
 ```r
 #* @get /
@@ -182,9 +126,7 @@ function(req, res, filter_status_approved = FALSE) {
   filter_status_approved <- as.logical(filter_status_approved)
 ```
 
-- [ ] **Step 5: Widen the detail signature and add the gate**
-
-`api/endpoints/status_endpoints.R:168`:
+- [ ] **Step 5: Widen the detail signature and gate (`:168`); document `_list` stays public (`:228`)**
 
 ```r
 #* @get /<status_id_requested>
@@ -193,16 +135,14 @@ function(req, res, status_id_requested) {
 
   status_id_requested <- URLdecode(status_id_requested) %>%
 ```
-
-Add a one-line comment above the `_list` handler at `:228` documenting why it stays public:
-
+Add above `:228`:
 ```r
 #* Public: returns only the status-category vocabulary (ndd_entity_status_categories_list);
 #* no draft rows, curator identities, or approval state. Consumed by public entity-create option loaders.
 #* @get _list
 ```
 
-- [ ] **Step 6: Run tests to verify they PASS**
+- [ ] **Step 6: Run to verify PASS**
 
 Run: `docker cp api/tests/testthat/test-endpoint-status.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-endpoint-status.R')"`
 Expected: PASS.
@@ -216,91 +156,105 @@ git commit -m "fix(security): gate /api/status draft-exposing GET routes at Revi
 
 ---
 
-### Task 3: Add behavioral anonymous-denial + Reviewer-allow tests (defense against regression)
+### Task 3: Behavioral denial tests for ALL seven gated GET routes (deny-before-query + body non-disclosure)
 
 **Files:**
 - Test: `api/tests/testthat/test-endpoint-review.R`, `api/tests/testthat/test-endpoint-status.R`
 
 **Interfaces:**
-- Consumes: `extract_review_handler(decorator_regex, envir)` / `make_review_sandbox(...)` and the analogous status helpers already defined in each test file; a `deny_role` stub that sets `res$status <- 403L` and `stop("forbidden")` (mirroring `require_role`).
+- Consumes: `extract_review_handler(decorator_regex, envir)` / `extract_status_handler(...)` (grep the status file for its actual extractor name and use it — do not invent one).
+- Produces: a behavioral 403 test per gated route proving the gate fires **before** any DB access (a sentinel `pool` that errors if queried), for all 5 review routes + 2 status routes (list + detail).
 
-- [ ] **Step 1: Add a behavioral permission test for the review detail handler**
+- [ ] **Step 1: Add a query-sentinel behavioral denial test per review route**
 
-Append to `api/tests/testthat/test-endpoint-review.R`. This extracts the real handler, injects a `require_role` stub that denies, and asserts the handler stops with 403 before touching data — proving the gate is the first statement:
+Append to `api/tests/testthat/test-endpoint-review.R`. The sentinel `pool` is an object whose use as a dbplyr source errors, proving the handler stops at `require_role` before touching data:
 
 ```r
-test_that("GET /<review_id> behavioral: anonymous/insufficient role blocked with 403", {
+test_that("review GET routes: anonymous/insufficient role is denied BEFORE any DB access (403)", {
   with_test_db_transaction({
     deny <- function(req, res, min_role) { res$status <- 403L; stop("forbidden") }
-    env <- new.env(parent = globalenv())
-    env$require_role <- deny
-    env$pool <- structure(list(), class = "FAIL_IF_QUERIED")  # any DB touch would error
-    handler <- extract_review_handler("^#\\*\\s+@get\\s+/<review_id_requested>\\s*$", env)
-    res <- new.env(); res$status <- 200L
-    expect_error(handler(req = list(), res = res, review_id_requested = "1"), "forbidden")
-    expect_equal(res$status, 403L)
+    # decorator -> (id-arg?) for each gated GET route
+    routes <- list(
+      list(dec = "^#\\*\\s+@get\\s+/\\s*$",                                  args = list()),
+      list(dec = "^#\\*\\s+@get\\s+/<review_id_requested>\\s*$",             args = list(review_id_requested = "1")),
+      list(dec = "^#\\*\\s+@get\\s+/<review_id_requested>/phenotypes\\s*$",  args = list(review_id_requested = "1")),
+      list(dec = "^#\\*\\s+@get\\s+/<review_id_requested>/variation\\s*$",   args = list(review_id_requested = "1")),
+      list(dec = "^#\\*\\s+@get\\s+/<review_id_requested>/publications\\s*$",args = list(review_id_requested = "1"))
+    )
+    for (r in routes) {
+      env <- new.env(parent = globalenv())
+      env$require_role <- deny
+      # sentinel: any dbplyr use errors, so a green test proves deny-before-query
+      env$pool <- structure(list(), class = "SENTINEL_DB")
+      handler <- extract_review_handler(r$dec, env)
+      res <- new.env(); res$status <- 200L
+      call_args <- c(list(req = list(), res = res), r$args)
+      expect_error(do.call(handler, call_args), "forbidden", info = r$dec)
+      expect_equal(res$status, 403L)
+    }
   })
 })
 ```
 
-- [ ] **Step 2: Add the analogous behavioral test for the status detail handler**
+- [ ] **Step 2: Add the analogous status behavioral test (list + detail; NOT `_list`)**
 
-Append to `api/tests/testthat/test-endpoint-status.R` using its `extract_status_handler` helper (mirror the block above, decorator `"^#\\*\\s+@get\\s+/<status_id_requested>\\s*$"`, param `status_id_requested = "1"`).
+Append to `api/tests/testthat/test-endpoint-status.R` using its extractor, for routes
+`"^#\\*\\s+@get\\s+/\\s*$"` (list, no id arg) and `"^#\\*\\s+@get\\s+/<status_id_requested>\\s*$"`
+(`status_id_requested = "1"`). Do **not** include `_list` (it is public by design).
 
 - [ ] **Step 3: Run both files to verify PASS**
 
 Run: `docker cp api/tests/testthat/test-endpoint-review.R sysndd-api-1:/app/tests/testthat/ && docker cp api/tests/testthat/test-endpoint-status.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-endpoint-review.R'); testthat::test_file('/app/tests/testthat/test-endpoint-status.R')"`
-Expected: PASS. (If `extract_status_handler`/`make_status_sandbox` names differ, grep the status test file for the actual helper names and use those — do not invent new helpers.)
+Expected: PASS. If the extractor evaluates the whole body eagerly and the deny stub's `stop()` is reached first, the sentinel `pool` is never touched (proving deny-before-query). If a route's handler references helpers not stubbed in `env`, add minimal stubs to `env` (mirror the existing `make_review_sandbox` stub set) — but the deny path must still short-circuit first.
 
 - [ ] **Step 4: Commit**
 
 ```bash
 git add api/tests/testthat/test-endpoint-review.R api/tests/testthat/test-endpoint-status.R
-git commit -m "test(security): behavioral 403 coverage for gated review/status GET routes (#535 P0-1)"
+git commit -m "test(security): deny-before-query 403 coverage for all gated review/status GET routes (#535 P0-1)"
 ```
 
 ---
 
-### Task 4: Live verification + full gate
+### Task 4: Live verification (Reviewer positive control + anonymous body non-disclosure) + gate
 
 **Files:** none (verification only)
 
-- [ ] **Step 1: Confirm the file-size ratchet is green**
+- [ ] **Step 1: File-size ratchet**
 
 Run: `make code-quality-audit`
 Expected: PASS.
 
-- [ ] **Step 2: Live end-to-end check (fully-loaded API env — catches masking the unit sandbox can't)**
+- [ ] **Step 2: Restart API so the endpoint edits are live, then anonymous denial + body inspection**
 
-With the dev stack up (`make dev` or the running `sysndd-api-1` + Traefik), verify:
-- Anonymous `GET /api/review/` and `GET /api/status/` → **403** problem+json.
-- Anonymous `GET /api/review/1`, `/api/review/1/phenotypes`, `GET /api/status/1` → **403**.
-- With a Reviewer JWT (mint per the repo recipe: `config::get("sysndd_db")` secret + `auth_generate_token`), the same routes → **200** with data.
-- `GET /api/status/_list` (no token) → **200** category vocabulary (unchanged).
-
+The container bind-mounts `api/endpoints`, so edits are live after a restart:
 ```bash
-# anonymous (expect 403)
-curl -s -o /dev/null -w "%{http_code}\n" http://localhost/api/review/
-curl -s -o /dev/null -w "%{http_code}\n" http://localhost/api/status/
-curl -s -o /dev/null -w "%{http_code}\n" http://localhost/api/review/1/phenotypes
-# public vocab (expect 200)
-curl -s -o /dev/null -w "%{http_code}\n" http://localhost/api/status/_list
-# reviewer token (expect 200)
-curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $REVIEWER_JWT" http://localhost/api/review/
+docker compose restart api
+# Anonymous → 403 with a problem+json body that contains NO draft rows / identities:
+for p in /api/review/ /api/status/ /api/review/1 /api/review/1/phenotypes /api/review/1/variation /api/review/1/publications /api/status/1; do
+  echo -n "$p -> "; curl -s -o /tmp/body.$$ -w "%{http_code}" "http://localhost$p"; echo " body: $(head -c 200 /tmp/body.$$)"; done
+# Public vocab still 200:
+curl -s -o /dev/null -w "/api/status/_list -> %{http_code}\n" http://localhost/api/status/_list
 ```
+Expected: all seven gated routes → **403**, body is problem+json (`application/problem+json`, `title`/`detail` about privileges), **no** `synopsis`/`comment`/`review_user_name`/`approving_user_name`. `_list` → **200**.
 
-- [ ] **Step 3: Run the fast API PR gate**
+- [ ] **Step 3: Reviewer positive control**
+
+Mint a Reviewer JWT (repo recipe: `config::get("sysndd_db")` secret coerced + `auth_generate_token`), then:
+```bash
+for p in /api/review/ /api/review/1 /api/status/; do
+  echo -n "$p -> "; curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $REVIEWER_JWT" "http://localhost$p"; done
+```
+Expected: **200** (data returned). This proves the gate admits Reviewer+ and does not over-block the approval queues.
+
+- [ ] **Step 4: Fast API PR gate**
 
 Run: `make test-api-fast`
-Expected: PASS; the two endpoint test files' inverted/new blocks run (not skipped) against the dev DB.
-
-- [ ] **Step 4: Update docs if needed**
-
-If the OpenAPI decorators encode `@response`, ensure the gated routes document `@response 403`. No behavior doc change beyond that; the public data surface is unchanged.
+Expected: PASS; the inverted/new blocks run (not skipped) against the dev DB.
 
 ## Self-Review
 
-- **Spec coverage:** S0 §4 requirements — public routes no longer expose drafts (gated at Reviewer+), draft detail/subresource routes gated, anonymous cannot enumerate IDs/comments/identities (403), tests inverted + anonymous-denial added, `_list` verified. Covered by Tasks 1–4.
-- **Escalation gate (spec §4):** verified in this session — no anonymous/OpenAPI/MCP/SEO consumer of these lists; only authenticated approval queues consume them via `apiClient`. So "gate at Reviewer+" applies; no split needed.
-- **Placeholder scan:** none — all edits show exact code; the only conditional is the `_list` public-vs-gate decision, which Task 2 Step 1 resolves by inspection with an explicit fallback.
-- **Type/name consistency:** `require_role(req, res, "Reviewer")` used verbatim throughout; detail signatures consistently `function(req, res, <id>_requested)`.
+- **Spec coverage (S0 §4):** drafts/identities no longer anonymous (gated, Task 1–2), all obsolete permission+signature assertions inverted (Codex BLOCKER-1, Task 1–2), behavioral deny-before-query for all seven routes + Reviewer positive control + body non-disclosure (Codex HIGH-6, Task 3–4), `_list` kept public with justification.
+- **Scope boundary:** approved-comment exposure via entity endpoints explicitly out of S0 and recorded as a follow-up (Codex HIGH-5).
+- **Placeholder scan:** none — exact code and commands. The one adaptive point (status extractor helper name) has a grep-and-match instruction.
+- **Type/name consistency:** `require_role(req, res, "Reviewer")` and `function(req, res, <id>_requested)` used identically throughout. Router-consumer note corrected to **Curator+** (Codex LOW-10).

--- a/.planning/superpowers/plans/2026-07-11-security-535-s1-session-epoch-refresh-plan.md
+++ b/.planning/superpowers/plans/2026-07-11-security-535-s1-session-epoch-refresh-plan.md
@@ -105,7 +105,9 @@ git commit -m "feat(db): add user.session_epoch for revocable token refresh (#53
 - Test: `api/tests/testthat/test-unit-user-session-epoch.R` (new)
 
 **Interfaces:**
-- Produces: every SQL statement that changes `user_role`, `approved`, or `password` also sets `session_epoch = session_epoch + 1` in the **same statement** (atomic; no separate helper). Bulk delete needs no bump (a missing user is rejected by `auth_refresh`).
+- Produces: every SQL statement that changes `user_role`, `approved`, or `password` also sets `session_epoch = session_epoch + 1` in the **same statement** (atomic; no separate helper). Bulk delete needs no bump (a missing user is rejected by `auth_refresh`). `user_update`/`user_update_password` gain an optional trailing `conn = NULL` forwarded to `db_execute_statement(..., conn = conn)` so tests can drive them on the rolled-back test transaction (backward compatible — existing callers pass args positionally, and `db_execute_statement` already accepts `conn`).
+
+**Connection reality (verified):** `db_execute_statement(sql, params, conn = NULL)` uses the **global app pool** when `conn` is NULL; `with_test_db_transaction`'s connection (`getOption(".test_db_con")`) is NOT consulted. So the tests here pass `conn = con` explicitly; `auth_refresh` (Task 3) already takes `pool` as an argument, so the same `con` is passed there.
 
 - [ ] **Step 1: Write the failing tests (parameterized SQL fixtures — real `email` column)**
 
@@ -126,8 +128,7 @@ test_that("user_update on user_role bumps epoch atomically (single statement)", 
     con <- getOption(".test_db_con")
     uid <- .seed_user(con, role = "Reviewer")
     before <- .epoch(con, uid)
-    # user_update uses the global db helper; point it at the txn connection for the test
-    withr::with_options(list(.test_db_con = con), user_update(uid, list(user_role = "Viewer")))
+    user_update(uid, list(user_role = "Viewer"), conn = con)   # conn = the rolled-back txn
     expect_equal(.epoch(con, uid) - before, 1)
   })
 })
@@ -137,7 +138,7 @@ test_that("user_update on approved bumps epoch", {
     con <- getOption(".test_db_con")
     uid <- .seed_user(con, approved = 1L)
     before <- .epoch(con, uid)
-    withr::with_options(list(.test_db_con = con), user_update(uid, list(approved = 0)))
+    user_update(uid, list(approved = 0), conn = con)
     expect_equal(.epoch(con, uid) - before, 1)
   })
 })
@@ -147,7 +148,7 @@ test_that("user_update on a non-privilege field does NOT bump epoch", {
     con <- getOption(".test_db_con")
     uid <- .seed_user(con)
     before <- .epoch(con, uid)
-    withr::with_options(list(.test_db_con = con), user_update(uid, list(abbreviation = "EN")))
+    user_update(uid, list(abbreviation = "EN"), conn = con)
     expect_equal(.epoch(con, uid), before)
   })
 })
@@ -157,21 +158,25 @@ test_that("user_update_password bumps epoch", {
     con <- getOption(".test_db_con")
     uid <- .seed_user(con)
     before <- .epoch(con, uid)
-    withr::with_options(list(.test_db_con = con), user_update_password(uid, "newhash"))
+    user_update_password(uid, "newhash", conn = con)
     expect_equal(.epoch(con, uid) - before, 1)
   })
 })
 ```
-Note: `user_update`/`user_update_password` resolve their connection through `db_execute_statement`. Confirm `db_execute_statement` honors `getOption(".test_db_con")` in test mode; if it does not (it uses the app pool), the fixtures must instead assert against the **app pool** with an explicit cleanup `withr::defer(DBI::dbExecute(pool, "DELETE FROM user WHERE user_id = ?", params=list(uid)))`. Grep `api/functions/database-functions.R` for `db_execute_statement` to confirm the connection source before finalizing, and use whichever keeps the test isolated.
+These pass `conn = con` so the seed, mutation, and assertion all run on the single rolled-back transaction connection (Step 3/4 add the `conn` parameter). `db_execute_query`/`db_execute_statement` in `.seed_user`/`.epoch` also accept `conn` — call them as `db_execute_query(sql, params, conn = con)` if you route the fixture through the repo helpers instead of raw `DBI::dbExecute(con, ...)`.
 
 - [ ] **Step 2: Run to verify FAIL**
 
 Run: `docker cp api/tests/testthat/test-unit-user-session-epoch.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-unit-user-session-epoch.R')"`
 Expected: FAIL — mutations do not yet bump.
 
-- [ ] **Step 3: Fold the increment into `user_update()`'s SET clause**
+- [ ] **Step 3: Add `conn` forwarding + fold the increment into `user_update()`'s SET clause**
 
-In `api/functions/user-repository.R`, `user_update()` — after `set_clause` is built, before the `sql <- paste0(...)`:
+In `api/functions/user-repository.R`, change the `user_update` signature to accept an optional connection:
+```r
+user_update <- function(user_id, updates, conn = NULL) {
+```
+After `set_clause` is built, before the `sql <- paste0(...)`:
 ```r
   set_clause <- paste(paste0(field_names, " = ?"), collapse = ", ")
   # #535 P0-2: privilege/state change atomically revokes outstanding sessions.
@@ -180,14 +185,19 @@ In `api/functions/user-repository.R`, `user_update()` — after `set_clause` is 
   }
   sql <- paste0("UPDATE user SET ", set_clause, " WHERE user_id = ?")
 ```
-(`session_epoch = session_epoch + 1` is a fixed literal — no new `?` placeholder, `params` unchanged. It is not caller-supplied, so it bypasses the field allowlist safely.)
+And forward the connection in the final call:
+```r
+  db_execute_statement(sql, as.list(params), conn = conn)
+```
+(`session_epoch = session_epoch + 1` is a fixed literal — no new `?` placeholder, `params` unchanged, and not caller-supplied, so it bypasses the field allowlist safely. `conn` defaults `NULL` → the existing global-pool behavior, so no caller changes.)
 
-- [ ] **Step 4: Fold the increment into `user_update_password()`**
+- [ ] **Step 4: Add `conn` forwarding + fold the increment into `user_update_password()`**
 
-Change its statement to:
+Change the signature to `user_update_password <- function(user_id, password_hash, conn = NULL) {`, the statement to:
 ```r
   sql <- "UPDATE user SET password = ?, session_epoch = session_epoch + 1 WHERE user_id = ?"
 ```
+and forward: `db_execute_statement(sql, list(password_hash, user_id), conn = conn)` (match the existing param order/shape).
 
 - [ ] **Step 5: Fold the increment into the bulk mutations in `user-service.R`**
 
@@ -268,7 +278,7 @@ test_that("refresh REJECTED after a real demotion (epoch bump via user_update)",
     con <- getOption(".test_db_con"); cfg <- .cfg()
     uid <- .seed(con, role = "Curator")
     tok <- .mint(con, uid, cfg)
-    withr::with_options(list(.test_db_con = con), user_update(uid, list(user_role = "Viewer")))  # bumps epoch
+    user_update(uid, list(user_role = "Viewer"), conn = con)   # bumps epoch atomically
     expect_error(auth_refresh(tok, con, cfg), regexp = "revoked|unauthor", ignore.case = TRUE)
   })
 })
@@ -278,7 +288,7 @@ test_that("refresh REJECTED for a deactivated user", {
     con <- getOption(".test_db_con"); cfg <- .cfg()
     uid <- .seed(con, role = "Reviewer", approved = 1L)
     tok <- .mint(con, uid, cfg)
-    withr::with_options(list(.test_db_con = con), user_update(uid, list(approved = 0)))
+    user_update(uid, list(approved = 0), conn = con)
     expect_error(auth_refresh(tok, con, cfg), regexp = "not active|revoked|unauthor", ignore.case = TRUE)
   })
 })
@@ -287,7 +297,7 @@ test_that("refresh REJECTED after a password change (epoch bump)", {
   with_test_db_transaction({
     con <- getOption(".test_db_con"); cfg <- .cfg()
     uid <- .seed(con); tok <- .mint(con, uid, cfg)
-    withr::with_options(list(.test_db_con = con), user_update_password(uid, "newhash"))
+    user_update_password(uid, "newhash", conn = con)
     expect_error(auth_refresh(tok, con, cfg), regexp = "revoked|unauthor", ignore.case = TRUE)
   })
 })
@@ -301,7 +311,7 @@ test_that("refresh REJECTED for a deleted user", {
   })
 })
 ```
-(If `user_update`/`user_update_password` do not honor `.test_db_con`, mutate directly with `DBI::dbExecute(con, "UPDATE user SET user_role='Viewer', session_epoch = session_epoch + 1 WHERE user_id=?", ...)` to simulate the atomic bump — the point of these tests is `auth_refresh`'s reaction to a bumped epoch, not re-testing Task 2.)
+(These pass `conn = con` (Task 2 added the parameter), so the mutation and `auth_refresh`'s DB read share the one rolled-back connection. Equivalent fallback if needed: mutate directly with `DBI::dbExecute(con, "UPDATE user SET user_role='Viewer', session_epoch = session_epoch + 1 WHERE user_id=?", params=list(uid))` — the point of these tests is `auth_refresh`'s reaction to a bumped epoch, not re-testing Task 2.)
 
 - [ ] **Step 2: Run to verify FAIL**
 

--- a/.planning/superpowers/plans/2026-07-11-security-535-s1-session-epoch-refresh-plan.md
+++ b/.planning/superpowers/plans/2026-07-11-security-535-s1-session-epoch-refresh-plan.md
@@ -1,0 +1,397 @@
+# S1 — Session-Epoch Role-Current, Revocable Refresh (#535 P0-2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make JWT refresh reflect current account state — a demoted/deactivated user (or any user whose session epoch was bumped) cannot refresh stale privileges, and a refreshed token carries the role loaded from the database.
+
+**Architecture:** Add a `session_epoch` integer to the `user` table. Tokens carry the epoch as a `sepoch` claim. `auth_refresh()` stops trusting the presented token: it loads the current user by id from the DB pool, requires `approved == 1`, requires the token's `sepoch` to equal the user's current `session_epoch`, and mints the new token with role + fields taken from the DB row. Any admin action that changes privilege or account state (`user_role`/`approved` via `user_update`, password via `user_update_password`, plus bulk paths and delete) increments `session_epoch`, immediately invalidating outstanding refresh capability. Backend + one additive migration only — no frontend change (the SPA keeps its single-token model; `/api/auth/refresh` still takes the token from the `Authorization` header and returns a bare token string).
+
+**Tech Stack:** R / Plumber, MySQL, testthat. `jose` JWT. `dplyr`/`dbplyr` DB access. Migration runner applies `db/migrations/*.sql` at startup with a manifest guard.
+
+## Global Constraints
+
+- Keep every touched file **< 600 lines** (`make code-quality-audit`). `auth-service.R` (224 lines) and `user-repository.R` have headroom.
+- Additive migration only; **no** change to existing tables/columns. Idempotent DDL (restore-drift safe, matching migrations 039/042).
+- After the migration, bump BOTH `EXPECTED_LATEST_MIGRATION` and `EXPECTED_MIGRATION_COUNT` in `api/functions/migration-manifest.R:5-6` and the two guard tests that assert the latest migration name (`test-unit-analysis-snapshot-migration.R:8`, `test-unit-core-views-manifest.R:13`). A stale manifest is a **fatal startup error** by design — do not weaken it.
+- Worker parity: no worker-executed code changes here, but `auth-service.R` is sourced by the API at startup — an API restart picks it up (bind-mounted).
+- Auth secrets stay out of query strings (CLAUDE.md). `/api/auth/refresh` already reads the token from the `Authorization` header — keep it there; do **not** move the token to a query param.
+- Tests that load a user run against the test DB in-container: `docker cp` the test file into `sysndd-api-1:/app/tests/testthat/` then `docker exec sysndd-api-1 Rscript -e "testthat::test_file(...)"`, or `make test-api-fast`. `with_test_db_transaction()` auto-rolls-back and `skip_if_no_test_db()` skips on DB-less hosts.
+
+---
+
+### Task 1: Migration — add `user.session_epoch` and bump the manifest
+
+**Files:**
+- Create: `db/migrations/043_add_user_session_epoch.sql`
+- Modify: `api/functions/migration-manifest.R:5-6`
+- Modify: `api/tests/testthat/test-unit-analysis-snapshot-migration.R:8`, `api/tests/testthat/test-unit-core-views-manifest.R:13`
+
+**Interfaces:**
+- Produces: a `session_epoch INT NOT NULL DEFAULT 0` column on `user`, and a manifest whose latest migration is `043_add_user_session_epoch.sql` (count 41).
+
+- [ ] **Step 1: Update the manifest guard tests to expect 043 (write the failing expectation first)**
+
+In `api/tests/testthat/test-unit-analysis-snapshot-migration.R:8` and
+`api/tests/testthat/test-unit-core-views-manifest.R:13`, change the expected string:
+
+```r
+expect_equal(EXPECTED_LATEST_MIGRATION, "043_add_user_session_epoch.sql")
+```
+
+- [ ] **Step 2: Run one guard test to verify it FAILS**
+
+Run: `docker cp api/tests/testthat/test-unit-core-views-manifest.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-unit-core-views-manifest.R')"`
+Expected: FAIL — manifest still says `042_...`.
+
+- [ ] **Step 3: Write the migration**
+
+Create `db/migrations/043_add_user_session_epoch.sql`:
+
+```sql
+-- Migration 043: add user.session_epoch for revocable, role-current token refresh (#535 P0-2)
+--
+-- Every issued JWT carries the user's session_epoch as a `sepoch` claim. auth_refresh()
+-- rejects a token whose sepoch != the user's current session_epoch, so bumping the epoch
+-- (on demotion, deactivation, admin edit, password change, delete) immediately revokes
+-- outstanding refresh capability. Additive, idempotent (restore-drift safe).
+
+SET @col_exists := (
+  SELECT COUNT(*) FROM information_schema.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user' AND COLUMN_NAME = 'session_epoch'
+);
+SET @ddl := IF(@col_exists = 0,
+  'ALTER TABLE `user` ADD COLUMN `session_epoch` INT NOT NULL DEFAULT 0',
+  'SELECT 1');
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+```
+
+- [ ] **Step 4: Bump the manifest constants**
+
+`api/functions/migration-manifest.R:5-6`:
+
+```r
+EXPECTED_LATEST_MIGRATION <- "043_add_user_session_epoch.sql"
+EXPECTED_MIGRATION_COUNT <- 41L
+```
+
+- [ ] **Step 5: Apply the migration and verify the column + guard tests pass**
+
+Run: `docker exec sysndd-api-1 Rscript -e "source('/app/start_sysndd_api.R')"` is heavy; instead restart the API container so the startup runner applies 043, then verify:
+```bash
+docker compose restart api
+docker exec sysndd-api-1 Rscript -e "library(DBI); con <- DBI::dbConnect(RMariaDB::MariaDB(), group='sysndd_db'); print(DBI::dbGetQuery(con, \"SHOW COLUMNS FROM user LIKE 'session_epoch'\"))"
+docker cp api/tests/testthat/test-unit-core-views-manifest.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-unit-core-views-manifest.R')"
+```
+Expected: the column exists; the manifest guard test PASSES. (If the container's DB group differs, use the repo's documented connect recipe.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add db/migrations/043_add_user_session_epoch.sql api/functions/migration-manifest.R api/tests/testthat/test-unit-analysis-snapshot-migration.R api/tests/testthat/test-unit-core-views-manifest.R
+git commit -m "feat(db): add user.session_epoch for revocable token refresh (#535 P0-2)"
+```
+
+---
+
+### Task 2: Repository — `user_bump_session_epoch()` and wire it into privilege mutations
+
+**Files:**
+- Modify: `api/functions/user-repository.R` (add helper; call inside `user_update()` and `user_update_password()`)
+- Modify: `api/services/user-bulk-endpoint-service.R` (bulk role/approve/delete paths that bypass `user_update`)
+- Test: `api/tests/testthat/test-unit-user-session-epoch.R` (new)
+
+**Interfaces:**
+- Produces: `user_bump_session_epoch(user_id)` → integer affected rows; increments `session_epoch` by 1 for one user. Called automatically by `user_update()` when the update touches `user_role` or `approved`, and by `user_update_password()`.
+
+- [ ] **Step 1: Write the failing test for the helper and the auto-bump**
+
+Create `api/tests/testthat/test-unit-user-session-epoch.R`:
+
+```r
+library(testthat)
+
+test_that("user_bump_session_epoch increments the user's epoch by 1", {
+  with_test_db_transaction({
+    # insert a throwaway user; user_create signature per user-repository.R
+    uid <- user_create(list(user_name = "epoch_tester", user_email = "epoch@test.local",
+                            user_password_hash = "x", user_role = "Viewer"))
+    before <- pool %>% tbl("user") %>% filter(user_id == !!uid) %>% collect()
+    user_bump_session_epoch(uid)
+    after <- pool %>% tbl("user") %>% filter(user_id == !!uid) %>% collect()
+    expect_equal(as.numeric(after$session_epoch[1]) - as.numeric(before$session_epoch[1]), 1)
+  })
+})
+
+test_that("user_update on user_role auto-bumps the epoch", {
+  with_test_db_transaction({
+    uid <- user_create(list(user_name = "epoch_role", user_email = "role@test.local",
+                            user_password_hash = "x", user_role = "Reviewer"))
+    before <- pool %>% tbl("user") %>% filter(user_id == !!uid) %>% collect()
+    user_update(uid, list(user_role = "Viewer"))
+    after <- pool %>% tbl("user") %>% filter(user_id == !!uid) %>% collect()
+    expect_gt(as.numeric(after$session_epoch[1]), as.numeric(before$session_epoch[1]))
+  })
+})
+
+test_that("user_update on a non-privilege field does NOT bump the epoch", {
+  with_test_db_transaction({
+    uid <- user_create(list(user_name = "epoch_name", user_email = "name@test.local",
+                            user_password_hash = "x", user_role = "Viewer"))
+    before <- pool %>% tbl("user") %>% filter(user_id == !!uid) %>% collect()
+    user_update(uid, list(abbreviation = "EN"))
+    after <- pool %>% tbl("user") %>% filter(user_id == !!uid) %>% collect()
+    expect_equal(as.numeric(after$session_epoch[1]), as.numeric(before$session_epoch[1]))
+  })
+})
+```
+
+Note: if `user_create`'s exact field names differ, grep `api/functions/user-repository.R` for the `user_create` signature (Task 2 reads it) and match it — do not invent fields.
+
+- [ ] **Step 2: Run to verify FAIL**
+
+Run: `docker cp api/tests/testthat/test-unit-user-session-epoch.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-unit-user-session-epoch.R')"`
+Expected: FAIL — `user_bump_session_epoch` undefined; `user_update` does not bump.
+
+- [ ] **Step 3: Add the helper to `user-repository.R`**
+
+Add near `user_update` in `api/functions/user-repository.R`:
+
+```r
+#' Increment a user's session epoch (revokes outstanding refresh capability).
+#'
+#' Every issued JWT carries the user's session_epoch as a `sepoch` claim; a
+#' refresh whose sepoch != the current epoch is rejected (see auth_refresh).
+#' Call this whenever a privilege- or account-state change must invalidate a
+#' user's outstanding sessions.
+#'
+#' @param user_id Integer user ID.
+#' @return Integer affected-row count.
+user_bump_session_epoch <- function(user_id) {
+  db_execute_statement(
+    "UPDATE user SET session_epoch = session_epoch + 1 WHERE user_id = ?",
+    list(user_id)
+  )
+}
+```
+
+- [ ] **Step 4: Auto-bump inside `user_update()` and `user_update_password()`**
+
+In `user_update()`, immediately before the final `db_execute_statement(sql, as.list(params))` return,
+capture the result and bump when a privilege/state field changed:
+
+```r
+  affected <- db_execute_statement(sql, as.list(params))
+  if (any(c("user_role", "approved") %in% field_names)) {
+    user_bump_session_epoch(user_id)
+  }
+  affected
+}
+```
+
+In `user_update_password()`, after its `UPDATE user SET password = ...` executes, add:
+
+```r
+  user_bump_session_epoch(user_id)
+```
+(place it after the password `db_execute_statement(...)` call, before returning its result).
+
+- [ ] **Step 5: Cover bulk paths that bypass `user_update`**
+
+Run: `grep -nE 'user_bulk_assign_role|user_bulk_approve|UPDATE .*user|user_update\(|user_delete' api/services/user-bulk-endpoint-service.R api/functions/user-repository.R`
+For any bulk role-change / approve / delete path that issues its own `UPDATE user`/delete **without**
+going through `user_update`, add a `user_bump_session_epoch(<uid>)` for each affected user id
+(vectorize with `lapply(user_ids, user_bump_session_epoch)`). If bulk paths route through
+`user_update`, no extra call is needed (the auto-bump covers them) — document which case held in the
+commit message.
+
+- [ ] **Step 6: Run the epoch tests to verify PASS**
+
+Run: `docker cp api/tests/testthat/test-unit-user-session-epoch.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-unit-user-session-epoch.R')"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/functions/user-repository.R api/services/user-bulk-endpoint-service.R api/tests/testthat/test-unit-user-session-epoch.R
+git commit -m "feat(auth): bump user.session_epoch on privilege/state changes (#535 P0-2)"
+```
+
+---
+
+### Task 3: Auth service — carry `sepoch` in tokens and make `auth_refresh` DB-backed and role-current
+
+**Files:**
+- Modify: `api/services/auth-service.R` (`auth_generate_token` `:175-199`, `auth_refresh` `:140-164`)
+- Test: `api/tests/testthat/test-unit-auth-refresh-epoch.R` (new)
+
+**Interfaces:**
+- Consumes: `user_bump_session_epoch()` (Task 2), `auth_validate_token()`, `auth_generate_token()`, `pool`, `dw` (config).
+- Produces: `auth_generate_token(user, config)` tokens include `sepoch = user$session_epoch %||% 0`; `auth_refresh(refresh_token, pool, config)` loads the current user, enforces `approved == 1` and `sepoch` match, and mints role/fields from the DB row.
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Create `api/tests/testthat/test-unit-auth-refresh-epoch.R`:
+
+```r
+library(testthat)
+
+# Uses the fully-loaded API env (auth-service.R sourced). Runs against the test DB.
+test_that("auth_refresh rejects a token whose sepoch is stale (revoked session)", {
+  with_test_db_transaction({
+    uid <- user_create(list(user_name = "refresh_epoch", user_email = "re@test.local",
+                            user_password_hash = "x", user_role = "Curator"))
+    user_update(uid, list(approved = 1))  # bumps epoch to >=1
+    user <- pool %>% tbl("user") %>% filter(user_id == !!uid) %>%
+      dplyr::rename(user_created = created_at) %>% collect()
+    user <- user[1, ]
+    token <- auth_generate_token(user, dw)$access_token
+    # Simulate a privilege change AFTER the token was minted:
+    user_bump_session_epoch(uid)
+    expect_error(auth_refresh(token, pool, dw), regexp = "revoked|not active|Invalid|unauthor",
+                 ignore.case = TRUE)
+  })
+})
+
+test_that("auth_refresh rejects a deactivated user", {
+  with_test_db_transaction({
+    uid <- user_create(list(user_name = "refresh_deact", user_email = "de@test.local",
+                            user_password_hash = "x", user_role = "Reviewer"))
+    user_update(uid, list(approved = 1))
+    user <- pool %>% tbl("user") %>% filter(user_id == !!uid) %>%
+      dplyr::rename(user_created = created_at) %>% collect()
+    token <- auth_generate_token(user[1, ], dw)$access_token
+    user_update(uid, list(approved = 0))  # deactivate (also bumps epoch)
+    expect_error(auth_refresh(token, pool, dw), regexp = "not active|revoked|unauthor",
+                 ignore.case = TRUE)
+  })
+})
+
+test_that("auth_refresh mints the CURRENT role from the DB (role-current)", {
+  with_test_db_transaction({
+    uid <- user_create(list(user_name = "refresh_role", user_email = "rr@test.local",
+                            user_password_hash = "x", user_role = "Administrator"))
+    user_update(uid, list(approved = 1))
+    user <- pool %>% tbl("user") %>% filter(user_id == !!uid) %>%
+      dplyr::rename(user_created = created_at) %>% collect()
+    token <- auth_generate_token(user[1, ], dw)$access_token
+    new_token <- auth_refresh(token, pool, dw)
+    claims <- auth_validate_token(new_token, dw)
+    expect_equal(claims$user_role, "Administrator")
+    expect_equal(as.numeric(claims$sepoch),
+                 as.numeric((pool %>% tbl("user") %>% filter(user_id == !!uid) %>% collect())$session_epoch[1]))
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify FAIL**
+
+Run: `docker cp api/tests/testthat/test-unit-auth-refresh-epoch.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-unit-auth-refresh-epoch.R')"`
+Expected: FAIL — `sepoch` not in claims; `auth_refresh` does not load the DB / check epoch.
+
+- [ ] **Step 3: Add the `sepoch` claim to `auth_generate_token`**
+
+In `api/services/auth-service.R`, inside `jose::jwt_claim(...)` (`:179`), add:
+
+```r
+    orcid = user$orcid,
+    sepoch = user$session_epoch %||% 0,
+    iat = as.numeric(Sys.time()),
+```
+
+- [ ] **Step 4: Rewrite `auth_refresh` to be DB-backed, role-current, and epoch-checked**
+
+Replace the body of `auth_refresh` (`:140-164`) with:
+
+```r
+auth_refresh <- function(refresh_token, pool, config) {
+  if (missing(refresh_token) || is.null(refresh_token) || nchar(refresh_token) == 0) {
+    stop_for_bad_request("refresh_token is required")
+  }
+
+  claims <- auth_validate_token(refresh_token, config)
+  if (is.null(claims)) {
+    stop_for_unauthorized("Invalid refresh token")
+  }
+  if (is.null(claims$exp) || claims$exp < as.numeric(Sys.time())) {
+    stop_for_unauthorized("Refresh token has expired")
+  }
+
+  # Load CURRENT account state — never trust the presented token's claims.
+  uid <- as.integer(claims$user_id)
+  user <- pool %>%
+    tbl("user") %>%
+    filter(user_id == !!uid) %>%
+    dplyr::rename(user_created = created_at) %>%
+    collect()
+  if (nrow(user) == 0) {
+    stop_for_unauthorized("User no longer exists")
+  }
+  user <- user[1, ]
+  if (is.null(user$approved) || user$approved != 1) {
+    stop_for_unauthorized("Account is not active")
+  }
+
+  # Revocation gate: the token's epoch must match the user's current epoch.
+  token_epoch <- as.numeric(claims$sepoch %||% 0)
+  current_epoch <- as.numeric(user$session_epoch %||% 0)
+  if (token_epoch != current_epoch) {
+    stop_for_unauthorized("Session has been revoked. Please sign in again.")
+  }
+
+  # Mint a fresh token with role + claim fields taken from the DB row.
+  token <- auth_generate_token(user, config)
+  logger::log_info("Token refreshed", user_id = user$user_id)
+  token$access_token
+}
+```
+
+Verify `stop_for_bad_request`/`stop_for_unauthorized` and `%||%` are already used in this file (they are — `auth_signin` uses them). Keep `filter`/`tbl`/`collect` unqualified to match `auth_signin`'s style in the same file.
+
+- [ ] **Step 5: Run the refresh tests to verify PASS**
+
+Run: `docker compose restart api && docker cp api/tests/testthat/test-unit-auth-refresh-epoch.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-unit-auth-refresh-epoch.R')"`
+Expected: PASS. (Restart so the API sources the new `auth-service.R`.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/services/auth-service.R api/tests/testthat/test-unit-auth-refresh-epoch.R
+git commit -m "fix(security): make token refresh DB-backed, role-current, epoch-revocable (#535 P0-2)"
+```
+
+---
+
+### Task 4: Regression sweep, live verification, and gate
+
+**Files:** none (verification); update docs if refresh semantics are documented.
+
+- [ ] **Step 1: Ensure no existing auth test asserts the OLD stale-claims behavior**
+
+Run: `grep -rnE 'auth_refresh|does not use the DB|refresh' api/tests/testthat/test-endpoint-auth.R api/tests/testthat/*auth* 2>/dev/null`
+If any test asserts that `auth_refresh` ignores the pool / reissues old claims, update it to the new contract (a comment in the old code said it "explicitly does not use the DB pool"; any test encoding that must be inverted).
+
+- [ ] **Step 2: File-size + full API gate**
+
+Run: `make code-quality-audit && make test-api-fast`
+Expected: PASS; the three new test files run (not skipped) against the dev DB, migration 043 applied, manifest guard green.
+
+- [ ] **Step 3: Live end-to-end refresh check (fully-loaded env)**
+
+With the dev stack up and a Curator/Admin account:
+- Sign in (`POST /api/auth/authenticate`), capture the token.
+- `GET /api/auth/refresh` with `Authorization: Bearer <token>` → **200**, a new token whose decoded `user_role` matches the DB and `sepoch` matches the user's current epoch.
+- As an admin, demote that user (`PUT /api/user/change_role`), then retry refresh with the OLD token → **401** ("Session has been revoked").
+- Deactivate a user (`PUT /api/user/approval` unapprove), retry refresh → **401**.
+
+- [ ] **Step 4: Docs**
+
+If `documentation/08-development.qmd` or `09-deployment.qmd` documents the refresh flow or token lifetime, note: refresh now loads current account state and enforces `session_epoch`; demotion/deactivation/password-change immediately revoke refresh. Note the residual (§S1 residual risk): the current access token remains valid until `config$token_expiry` (3600s); immediate access-token revocation (epoch check in `require_auth`) and distinct rotating tokens are the deferred S1b follow-up.
+
+## Self-Review
+
+- **Spec coverage (S1 §5):** epoch column (Task 1), tokens carry epoch (Task 3.3), refresh loads current user + role + approved + epoch (Task 3.4), revoke-on-change via bump (Task 2), no frontend change (verified — header-carried token, bare-string response), tests for demotion/deactivation/role-current/normal (Task 3) + bump coverage (Task 2). Residual documented (Task 4.4).
+- **Placeholder scan:** none — migration, helper, and auth_refresh bodies are complete. The two adaptive steps (2.1 `user_create` fields, 2.5 bulk paths) include explicit grep-and-match instructions, not vague TODOs.
+- **Type/name consistency:** `user_bump_session_epoch(user_id)` used identically in repository + tests; `sepoch` claim name consistent across `auth_generate_token`/`auth_refresh`/tests; `session_epoch` column name consistent across migration/repository/auth-service.
+- **Compat:** legacy tokens (no `sepoch`) → `%||% 0`; refresh works while user epoch is 0, correctly rejects once epoch > 0. Additive migration; manifest bumped with guard tests.

--- a/.planning/superpowers/plans/2026-07-11-security-535-s1-session-epoch-refresh-plan.md
+++ b/.planning/superpowers/plans/2026-07-11-security-535-s1-session-epoch-refresh-plan.md
@@ -2,59 +2,62 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make JWT refresh reflect current account state — a demoted/deactivated user (or any user whose session epoch was bumped) cannot refresh stale privileges, and a refreshed token carries the role loaded from the database.
+**Goal:** Make JWT refresh reflect current account state — a demoted/deactivated/epoch-bumped user cannot refresh stale privileges; a refresh either mints a token whose role/claims come from the DB, or is rejected (forcing re-login).
 
-**Architecture:** Add a `session_epoch` integer to the `user` table. Tokens carry the epoch as a `sepoch` claim. `auth_refresh()` stops trusting the presented token: it loads the current user by id from the DB pool, requires `approved == 1`, requires the token's `sepoch` to equal the user's current `session_epoch`, and mints the new token with role + fields taken from the DB row. Any admin action that changes privilege or account state (`user_role`/`approved` via `user_update`, password via `user_update_password`, plus bulk paths and delete) increments `session_epoch`, immediately invalidating outstanding refresh capability. Backend + one additive migration only — no frontend change (the SPA keeps its single-token model; `/api/auth/refresh` still takes the token from the `Authorization` header and returns a bare token string).
+**Architecture:** Add a `session_epoch` integer to the `user` table. Every issued JWT carries the epoch as a `sepoch` claim. `auth_refresh()` stops trusting the presented token: it loads the current user by id from the DB, requires `approved == 1`, requires `sepoch == user.session_epoch`, and mints the new token from the DB row. Any privilege/state mutation increments `session_epoch` **in the same SQL statement and transaction** as the mutation (atomic — no separate bump), so a concurrent refresh reads either the whole old row (old epoch, still refreshable) or the whole new row (new epoch, old token rejected). The refresh DB read is the linearization point.
 
-**Tech Stack:** R / Plumber, MySQL, testthat. `jose` JWT. `dplyr`/`dbplyr` DB access. Migration runner applies `db/migrations/*.sql` at startup with a manifest guard.
+**Design choice (make explicit):** on a privilege/state change the epoch increments, so an outstanding token's `sepoch` no longer matches → **refresh is REJECTED and the user must re-login** (not silently downgraded). This is stronger than "mint the new role on refresh" and fully satisfies the acceptance criterion ("Demoted/deactivated users cannot refresh stale privileges"). Minting role/claims from the DB is defense-in-depth for any hypothetical mutation path that does not bump the epoch. Backend + one additive migration only — **no frontend change** (the SPA keeps its single-token model; `/api/auth/refresh` still reads the token from the `Authorization` header and returns a bare token string).
+
+**Tech Stack:** R / Plumber, MySQL, testthat. `jose` JWT. dplyr/dbplyr DB access (namespace verbs — masking hazard). Migration runner with a manifest guard.
 
 ## Global Constraints
 
-- Keep every touched file **< 600 lines** (`make code-quality-audit`). `auth-service.R` (224 lines) and `user-repository.R` have headroom.
-- Additive migration only; **no** change to existing tables/columns. Idempotent DDL (restore-drift safe, matching migrations 039/042).
-- After the migration, bump BOTH `EXPECTED_LATEST_MIGRATION` and `EXPECTED_MIGRATION_COUNT` in `api/functions/migration-manifest.R:5-6` and the two guard tests that assert the latest migration name (`test-unit-analysis-snapshot-migration.R:8`, `test-unit-core-views-manifest.R:13`). A stale manifest is a **fatal startup error** by design — do not weaken it.
-- Worker parity: no worker-executed code changes here, but `auth-service.R` is sourced by the API at startup — an API restart picks it up (bind-mounted).
-- Auth secrets stay out of query strings (CLAUDE.md). `/api/auth/refresh` already reads the token from the `Authorization` header — keep it there; do **not** move the token to a query param.
-- Tests that load a user run against the test DB in-container: `docker cp` the test file into `sysndd-api-1:/app/tests/testthat/` then `docker exec sysndd-api-1 Rscript -e "testthat::test_file(...)"`, or `make test-api-fast`. `with_test_db_transaction()` auto-rolls-back and `skip_if_no_test_db()` skips on DB-less hosts.
+- Keep every touched file **< 600 lines** (`make code-quality-audit`).
+- Additive migration only; **no** change to existing tables/columns. Idempotent DDL (restore-drift safe).
+- Bump `EXPECTED_LATEST_MIGRATION` **and** `EXPECTED_MIGRATION_COUNT` (`migration-manifest.R:5-6`) **and all four stale guard assertions** (Codex MEDIUM-9): `test-unit-core-views-manifest.R` name `:13`, count `:14`, `res$latest` `:21`; `test-unit-analysis-snapshot-migration.R` name `:8`, count `:9`. A stale manifest is a **fatal startup error** by design — do not weaken it.
+- **Namespace all dplyr/dbplyr verbs** in `auth_refresh` (`dplyr::tbl`, `dplyr::filter(.data$user_id == !!uid)`, `dplyr::rename`, `dplyr::collect`) — the loaded env masks dplyr verbs (biomaRt/STRINGdb). `%||%`, `stop_for_bad_request`, `stop_for_unauthorized` are already in `auth-service.R` scope.
+- Auth token stays in the `Authorization` header (never a query string). `/api/auth/refresh` already does this — keep it.
+- Tests run against the test DB in-container. `with_test_db_transaction` exposes the txn connection via `getOption(".test_db_con")`; pass **that connection as the `pool` argument** to `auth_refresh`/`auth_generate_token` so insert + read + refresh share one rolled-back connection. Seed users with **parameterized SQL using real columns** (`email`, not `user_email` — `user_create()` is broken, Codex BLOCKER-3). Build a test config `cfg <- list(secret = get_test_config("secret"), token_expiry = 3600)`.
 
 ---
 
-### Task 1: Migration — add `user.session_epoch` and bump the manifest
+### Task 1: Migration — add `user.session_epoch` and bump ALL manifest assertions
 
 **Files:**
 - Create: `db/migrations/043_add_user_session_epoch.sql`
 - Modify: `api/functions/migration-manifest.R:5-6`
-- Modify: `api/tests/testthat/test-unit-analysis-snapshot-migration.R:8`, `api/tests/testthat/test-unit-core-views-manifest.R:13`
+- Modify: `api/tests/testthat/test-unit-core-views-manifest.R` (`:13,:14,:21`), `api/tests/testthat/test-unit-analysis-snapshot-migration.R` (`:8,:9`)
 
-**Interfaces:**
-- Produces: a `session_epoch INT NOT NULL DEFAULT 0` column on `user`, and a manifest whose latest migration is `043_add_user_session_epoch.sql` (count 41).
+- [ ] **Step 1: Update ALL four guard assertions to expect 043 / count 41 (write failing expectations first)**
 
-- [ ] **Step 1: Update the manifest guard tests to expect 043 (write the failing expectation first)**
-
-In `api/tests/testthat/test-unit-analysis-snapshot-migration.R:8` and
-`api/tests/testthat/test-unit-core-views-manifest.R:13`, change the expected string:
-
+`test-unit-core-views-manifest.R`:
 ```r
-expect_equal(EXPECTED_LATEST_MIGRATION, "043_add_user_session_epoch.sql")
+  expect_equal(EXPECTED_LATEST_MIGRATION, "043_add_user_session_epoch.sql")   # :13
+  expect_equal(EXPECTED_MIGRATION_COUNT, 41L)                                 # :14
+  ...
+  expect_identical(res$latest, "043_add_user_session_epoch.sql")              # :21
+```
+`test-unit-analysis-snapshot-migration.R`:
+```r
+  expect_equal(EXPECTED_LATEST_MIGRATION, "043_add_user_session_epoch.sql")   # :8
+  expect_equal(EXPECTED_MIGRATION_COUNT, 41L)                                 # :9
 ```
 
-- [ ] **Step 2: Run one guard test to verify it FAILS**
+- [ ] **Step 2: Run to verify FAIL**
 
 Run: `docker cp api/tests/testthat/test-unit-core-views-manifest.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-unit-core-views-manifest.R')"`
-Expected: FAIL — manifest still says `042_...`.
+Expected: FAIL (manifest still 042/40).
 
 - [ ] **Step 3: Write the migration**
 
 Create `db/migrations/043_add_user_session_epoch.sql`:
-
 ```sql
 -- Migration 043: add user.session_epoch for revocable, role-current token refresh (#535 P0-2)
 --
--- Every issued JWT carries the user's session_epoch as a `sepoch` claim. auth_refresh()
--- rejects a token whose sepoch != the user's current session_epoch, so bumping the epoch
--- (on demotion, deactivation, admin edit, password change, delete) immediately revokes
--- outstanding refresh capability. Additive, idempotent (restore-drift safe).
-
+-- Every issued JWT carries the user's session_epoch as a `sepoch` claim. auth_refresh() rejects a
+-- token whose sepoch != the user's current session_epoch. Privilege/state mutations increment the
+-- epoch in the same statement, so demotion/deactivation/password-change/role-change immediately
+-- revoke outstanding refresh capability. Additive, idempotent (restore-drift safe).
 SET @col_exists := (
   SELECT COUNT(*) FROM information_schema.COLUMNS
   WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user' AND COLUMN_NAME = 'session_epoch'
@@ -66,147 +69,133 @@ PREPARE stmt FROM @ddl;
 EXECUTE stmt;
 DEALLOCATE PREPARE stmt;
 ```
+(Default `0`; existing sessions keep working until first bump — see §Compatibility. Do NOT initialize existing users to 1 unless the operator wants a forced logout of all pre-deploy sessions.)
 
 - [ ] **Step 4: Bump the manifest constants**
 
 `api/functions/migration-manifest.R:5-6`:
-
 ```r
 EXPECTED_LATEST_MIGRATION <- "043_add_user_session_epoch.sql"
 EXPECTED_MIGRATION_COUNT <- 41L
 ```
 
-- [ ] **Step 5: Apply the migration and verify the column + guard tests pass**
+- [ ] **Step 5: Apply + verify column and guard tests**
 
-Run: `docker exec sysndd-api-1 Rscript -e "source('/app/start_sysndd_api.R')"` is heavy; instead restart the API container so the startup runner applies 043, then verify:
 ```bash
-docker compose restart api
+docker compose restart api   # startup runner applies 043
 docker exec sysndd-api-1 Rscript -e "library(DBI); con <- DBI::dbConnect(RMariaDB::MariaDB(), group='sysndd_db'); print(DBI::dbGetQuery(con, \"SHOW COLUMNS FROM user LIKE 'session_epoch'\"))"
-docker cp api/tests/testthat/test-unit-core-views-manifest.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-unit-core-views-manifest.R')"
+docker cp api/tests/testthat/test-unit-core-views-manifest.R sysndd-api-1:/app/tests/testthat/ && docker cp api/tests/testthat/test-unit-analysis-snapshot-migration.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-unit-core-views-manifest.R'); testthat::test_file('/app/tests/testthat/test-unit-analysis-snapshot-migration.R')"
 ```
-Expected: the column exists; the manifest guard test PASSES. (If the container's DB group differs, use the repo's documented connect recipe.)
+Expected: column present; both guard files PASS.
 
 - [ ] **Step 6: Commit**
 
 ```bash
-git add db/migrations/043_add_user_session_epoch.sql api/functions/migration-manifest.R api/tests/testthat/test-unit-analysis-snapshot-migration.R api/tests/testthat/test-unit-core-views-manifest.R
+git add db/migrations/043_add_user_session_epoch.sql api/functions/migration-manifest.R api/tests/testthat/test-unit-core-views-manifest.R api/tests/testthat/test-unit-analysis-snapshot-migration.R
 git commit -m "feat(db): add user.session_epoch for revocable token refresh (#535 P0-2)"
 ```
 
 ---
 
-### Task 2: Repository — `user_bump_session_epoch()` and wire it into privilege mutations
+### Task 2: Increment `session_epoch` atomically inside every privilege/state mutation
 
 **Files:**
-- Modify: `api/functions/user-repository.R` (add helper; call inside `user_update()` and `user_update_password()`)
-- Modify: `api/services/user-bulk-endpoint-service.R` (bulk role/approve/delete paths that bypass `user_update`)
+- Modify: `api/functions/user-repository.R` (`user_update()` `:194`, `user_update_password()` `:252`)
+- Modify: `api/services/user-service.R` (bulk role UPDATE `~:576`, bulk approval UPDATE `~:400`)
 - Test: `api/tests/testthat/test-unit-user-session-epoch.R` (new)
 
 **Interfaces:**
-- Produces: `user_bump_session_epoch(user_id)` → integer affected rows; increments `session_epoch` by 1 for one user. Called automatically by `user_update()` when the update touches `user_role` or `approved`, and by `user_update_password()`.
+- Produces: every SQL statement that changes `user_role`, `approved`, or `password` also sets `session_epoch = session_epoch + 1` in the **same statement** (atomic; no separate helper). Bulk delete needs no bump (a missing user is rejected by `auth_refresh`).
 
-- [ ] **Step 1: Write the failing test for the helper and the auto-bump**
+- [ ] **Step 1: Write the failing tests (parameterized SQL fixtures — real `email` column)**
 
 Create `api/tests/testthat/test-unit-user-session-epoch.R`:
-
 ```r
 library(testthat)
 
-test_that("user_bump_session_epoch increments the user's epoch by 1", {
+.seed_user <- function(con, role = "Viewer", approved = 0L) {
+  DBI::dbExecute(con,
+    "INSERT INTO user (user_name, email, password, user_role, approved, session_epoch) VALUES (?,?,?,?,?,0)",
+    params = list(paste0("epoch_", as.integer(runif(1, 1, 1e8))), paste0("e", as.integer(runif(1,1,1e8)), "@t.local"), "x", role, approved))
+  DBI::dbGetQuery(con, "SELECT LAST_INSERT_ID() AS id")$id[1]
+}
+.epoch <- function(con, uid) DBI::dbGetQuery(con, "SELECT session_epoch FROM user WHERE user_id = ?", params = list(uid))$session_epoch[1]
+
+test_that("user_update on user_role bumps epoch atomically (single statement)", {
   with_test_db_transaction({
-    # insert a throwaway user; user_create signature per user-repository.R
-    uid <- user_create(list(user_name = "epoch_tester", user_email = "epoch@test.local",
-                            user_password_hash = "x", user_role = "Viewer"))
-    before <- pool %>% tbl("user") %>% filter(user_id == !!uid) %>% collect()
-    user_bump_session_epoch(uid)
-    after <- pool %>% tbl("user") %>% filter(user_id == !!uid) %>% collect()
-    expect_equal(as.numeric(after$session_epoch[1]) - as.numeric(before$session_epoch[1]), 1)
+    con <- getOption(".test_db_con")
+    uid <- .seed_user(con, role = "Reviewer")
+    before <- .epoch(con, uid)
+    # user_update uses the global db helper; point it at the txn connection for the test
+    withr::with_options(list(.test_db_con = con), user_update(uid, list(user_role = "Viewer")))
+    expect_equal(.epoch(con, uid) - before, 1)
   })
 })
 
-test_that("user_update on user_role auto-bumps the epoch", {
+test_that("user_update on approved bumps epoch", {
   with_test_db_transaction({
-    uid <- user_create(list(user_name = "epoch_role", user_email = "role@test.local",
-                            user_password_hash = "x", user_role = "Reviewer"))
-    before <- pool %>% tbl("user") %>% filter(user_id == !!uid) %>% collect()
-    user_update(uid, list(user_role = "Viewer"))
-    after <- pool %>% tbl("user") %>% filter(user_id == !!uid) %>% collect()
-    expect_gt(as.numeric(after$session_epoch[1]), as.numeric(before$session_epoch[1]))
+    con <- getOption(".test_db_con")
+    uid <- .seed_user(con, approved = 1L)
+    before <- .epoch(con, uid)
+    withr::with_options(list(.test_db_con = con), user_update(uid, list(approved = 0)))
+    expect_equal(.epoch(con, uid) - before, 1)
   })
 })
 
-test_that("user_update on a non-privilege field does NOT bump the epoch", {
+test_that("user_update on a non-privilege field does NOT bump epoch", {
   with_test_db_transaction({
-    uid <- user_create(list(user_name = "epoch_name", user_email = "name@test.local",
-                            user_password_hash = "x", user_role = "Viewer"))
-    before <- pool %>% tbl("user") %>% filter(user_id == !!uid) %>% collect()
-    user_update(uid, list(abbreviation = "EN"))
-    after <- pool %>% tbl("user") %>% filter(user_id == !!uid) %>% collect()
-    expect_equal(as.numeric(after$session_epoch[1]), as.numeric(before$session_epoch[1]))
+    con <- getOption(".test_db_con")
+    uid <- .seed_user(con)
+    before <- .epoch(con, uid)
+    withr::with_options(list(.test_db_con = con), user_update(uid, list(abbreviation = "EN")))
+    expect_equal(.epoch(con, uid), before)
+  })
+})
+
+test_that("user_update_password bumps epoch", {
+  with_test_db_transaction({
+    con <- getOption(".test_db_con")
+    uid <- .seed_user(con)
+    before <- .epoch(con, uid)
+    withr::with_options(list(.test_db_con = con), user_update_password(uid, "newhash"))
+    expect_equal(.epoch(con, uid) - before, 1)
   })
 })
 ```
-
-Note: if `user_create`'s exact field names differ, grep `api/functions/user-repository.R` for the `user_create` signature (Task 2 reads it) and match it — do not invent fields.
+Note: `user_update`/`user_update_password` resolve their connection through `db_execute_statement`. Confirm `db_execute_statement` honors `getOption(".test_db_con")` in test mode; if it does not (it uses the app pool), the fixtures must instead assert against the **app pool** with an explicit cleanup `withr::defer(DBI::dbExecute(pool, "DELETE FROM user WHERE user_id = ?", params=list(uid)))`. Grep `api/functions/database-functions.R` for `db_execute_statement` to confirm the connection source before finalizing, and use whichever keeps the test isolated.
 
 - [ ] **Step 2: Run to verify FAIL**
 
 Run: `docker cp api/tests/testthat/test-unit-user-session-epoch.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-unit-user-session-epoch.R')"`
-Expected: FAIL — `user_bump_session_epoch` undefined; `user_update` does not bump.
+Expected: FAIL — mutations do not yet bump.
 
-- [ ] **Step 3: Add the helper to `user-repository.R`**
+- [ ] **Step 3: Fold the increment into `user_update()`'s SET clause**
 
-Add near `user_update` in `api/functions/user-repository.R`:
-
+In `api/functions/user-repository.R`, `user_update()` — after `set_clause` is built, before the `sql <- paste0(...)`:
 ```r
-#' Increment a user's session epoch (revokes outstanding refresh capability).
-#'
-#' Every issued JWT carries the user's session_epoch as a `sepoch` claim; a
-#' refresh whose sepoch != the current epoch is rejected (see auth_refresh).
-#' Call this whenever a privilege- or account-state change must invalidate a
-#' user's outstanding sessions.
-#'
-#' @param user_id Integer user ID.
-#' @return Integer affected-row count.
-user_bump_session_epoch <- function(user_id) {
-  db_execute_statement(
-    "UPDATE user SET session_epoch = session_epoch + 1 WHERE user_id = ?",
-    list(user_id)
-  )
-}
-```
-
-- [ ] **Step 4: Auto-bump inside `user_update()` and `user_update_password()`**
-
-In `user_update()`, immediately before the final `db_execute_statement(sql, as.list(params))` return,
-capture the result and bump when a privilege/state field changed:
-
-```r
-  affected <- db_execute_statement(sql, as.list(params))
+  set_clause <- paste(paste0(field_names, " = ?"), collapse = ", ")
+  # #535 P0-2: privilege/state change atomically revokes outstanding sessions.
   if (any(c("user_role", "approved") %in% field_names)) {
-    user_bump_session_epoch(user_id)
+    set_clause <- paste0(set_clause, ", session_epoch = session_epoch + 1")
   }
-  affected
-}
+  sql <- paste0("UPDATE user SET ", set_clause, " WHERE user_id = ?")
 ```
+(`session_epoch = session_epoch + 1` is a fixed literal — no new `?` placeholder, `params` unchanged. It is not caller-supplied, so it bypasses the field allowlist safely.)
 
-In `user_update_password()`, after its `UPDATE user SET password = ...` executes, add:
+- [ ] **Step 4: Fold the increment into `user_update_password()`**
 
+Change its statement to:
 ```r
-  user_bump_session_epoch(user_id)
+  sql <- "UPDATE user SET password = ?, session_epoch = session_epoch + 1 WHERE user_id = ?"
 ```
-(place it after the password `db_execute_statement(...)` call, before returning its result).
 
-- [ ] **Step 5: Cover bulk paths that bypass `user_update`**
+- [ ] **Step 5: Fold the increment into the bulk mutations in `user-service.R`**
 
-Run: `grep -nE 'user_bulk_assign_role|user_bulk_approve|UPDATE .*user|user_update\(|user_delete' api/services/user-bulk-endpoint-service.R api/functions/user-repository.R`
-For any bulk role-change / approve / delete path that issues its own `UPDATE user`/delete **without**
-going through `user_update`, add a `user_bump_session_epoch(<uid>)` for each affected user id
-(vectorize with `lapply(user_ids, user_bump_session_epoch)`). If bulk paths route through
-`user_update`, no extra call is needed (the auto-bump covers them) — document which case held in the
-commit message.
+- Bulk role change UPDATE (`~:576`): `UPDATE user SET user_role = ?, session_epoch = session_epoch + 1 WHERE user_id = ?` (still inside `db_with_transaction(txn_conn)` — atomic).
+- Bulk approval UPDATE (`~:400`): append `, session_epoch = session_epoch + 1` to the existing `UPDATE user SET ...` statement. **Caveat (Codex BLOCKER-2):** that statement writes `account_status`/`approving_user_id`, which the base schema does not have (`approved` is the real column). Run `grep -rn account_status db/migrations/*.sql` first: if a migration added `account_status`, add the epoch clause to that statement as-is; if not, the statement is a **pre-existing bug** independent of S1 — add the epoch clause anyway (harmless), and record a follow-up item "fix bulk-approval account_status→approved schema mismatch". Do NOT expand this P0 PR to rewrite bulk approval.
+- Bulk delete: no change (a deleted user's refresh is rejected because the row is gone).
 
-- [ ] **Step 6: Run the epoch tests to verify PASS**
+- [ ] **Step 6: Run epoch tests + bulk verification to PASS**
 
 Run: `docker cp api/tests/testthat/test-unit-user-session-epoch.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-unit-user-session-epoch.R')"`
 Expected: PASS.
@@ -214,96 +203,121 @@ Expected: PASS.
 - [ ] **Step 7: Commit**
 
 ```bash
-git add api/functions/user-repository.R api/services/user-bulk-endpoint-service.R api/tests/testthat/test-unit-user-session-epoch.R
-git commit -m "feat(auth): bump user.session_epoch on privilege/state changes (#535 P0-2)"
+git add api/functions/user-repository.R api/services/user-service.R api/tests/testthat/test-unit-user-session-epoch.R
+git commit -m "feat(auth): atomically bump user.session_epoch on privilege/state mutations (#535 P0-2)"
 ```
 
 ---
 
-### Task 3: Auth service — carry `sepoch` in tokens and make `auth_refresh` DB-backed and role-current
+### Task 3: Carry `sepoch` in tokens; make `auth_refresh` DB-backed, role-current, epoch-revocable
 
 **Files:**
-- Modify: `api/services/auth-service.R` (`auth_generate_token` `:175-199`, `auth_refresh` `:140-164`)
+- Modify: `api/services/auth-service.R` (`auth_generate_token` `:175`, `auth_refresh` `:140`)
 - Test: `api/tests/testthat/test-unit-auth-refresh-epoch.R` (new)
 
 **Interfaces:**
-- Consumes: `user_bump_session_epoch()` (Task 2), `auth_validate_token()`, `auth_generate_token()`, `pool`, `dw` (config).
-- Produces: `auth_generate_token(user, config)` tokens include `sepoch = user$session_epoch %||% 0`; `auth_refresh(refresh_token, pool, config)` loads the current user, enforces `approved == 1` and `sepoch` match, and mints role/fields from the DB row.
+- Consumes: `auth_validate_token()`, `auth_generate_token()`, a `pool`/connection and `config` with `$secret`.
+- Produces: tokens include `sepoch = user$session_epoch %||% 0`; `auth_refresh(refresh_token, pool, config)` (signature UNCHANGED — the existing `test-unit-auth-service.R:217` signature test stays green) loads the current user, enforces `approved == 1` + `sepoch` match, mints from the DB row.
 
-- [ ] **Step 1: Write the failing integration tests**
+- [ ] **Step 1: Write failing integration tests (con-as-pool pattern; real fixtures)**
 
 Create `api/tests/testthat/test-unit-auth-refresh-epoch.R`:
-
 ```r
 library(testthat)
 
-# Uses the fully-loaded API env (auth-service.R sourced). Runs against the test DB.
-test_that("auth_refresh rejects a token whose sepoch is stale (revoked session)", {
+.cfg <- function() list(secret = get_test_config("secret"), token_expiry = 3600L)
+.seed <- function(con, role = "Curator", approved = 1L) {
+  DBI::dbExecute(con,
+    "INSERT INTO user (user_name, email, password, user_role, approved, session_epoch) VALUES (?,?,?,?,?,0)",
+    params = list(paste0("ar_", as.integer(runif(1,1,1e8))), paste0("ar", as.integer(runif(1,1,1e8)), "@t.local"), "x", role, approved))
+  DBI::dbGetQuery(con, "SELECT LAST_INSERT_ID() AS id")$id[1]
+}
+.mint <- function(con, uid, cfg) {
+  u <- con %>% dplyr::tbl("user") %>% dplyr::filter(.data$user_id == !!uid) %>%
+    dplyr::rename(user_created = created_at) %>% dplyr::collect()
+  auth_generate_token(u[1, ], cfg)$access_token
+}
+
+test_that("token carries sepoch and normal refresh succeeds with DB-derived claims", {
   with_test_db_transaction({
-    uid <- user_create(list(user_name = "refresh_epoch", user_email = "re@test.local",
-                            user_password_hash = "x", user_role = "Curator"))
-    user_update(uid, list(approved = 1))  # bumps epoch to >=1
-    user <- pool %>% tbl("user") %>% filter(user_id == !!uid) %>%
-      dplyr::rename(user_created = created_at) %>% collect()
-    user <- user[1, ]
-    token <- auth_generate_token(user, dw)$access_token
-    # Simulate a privilege change AFTER the token was minted:
-    user_bump_session_epoch(uid)
-    expect_error(auth_refresh(token, pool, dw), regexp = "revoked|not active|Invalid|unauthor",
-                 ignore.case = TRUE)
+    con <- getOption(".test_db_con"); cfg <- .cfg()
+    uid <- .seed(con, role = "Curator")
+    tok <- .mint(con, uid, cfg)
+    claims0 <- auth_validate_token(tok, cfg); expect_equal(as.numeric(claims0$sepoch), 0)
+    newtok <- auth_refresh(tok, con, cfg)
+    claims <- auth_validate_token(newtok, cfg)
+    expect_equal(claims$user_role, "Curator")
+    expect_equal(as.numeric(claims$sepoch), .epoch <- DBI::dbGetQuery(con, "SELECT session_epoch FROM user WHERE user_id=?", params=list(uid))$session_epoch[1])
   })
 })
 
-test_that("auth_refresh rejects a deactivated user", {
+test_that("refresh mints the CURRENT DB role (role-current) — isolate by changing role WITHOUT bumping epoch", {
   with_test_db_transaction({
-    uid <- user_create(list(user_name = "refresh_deact", user_email = "de@test.local",
-                            user_password_hash = "x", user_role = "Reviewer"))
-    user_update(uid, list(approved = 1))
-    user <- pool %>% tbl("user") %>% filter(user_id == !!uid) %>%
-      dplyr::rename(user_created = created_at) %>% collect()
-    token <- auth_generate_token(user[1, ], dw)$access_token
-    user_update(uid, list(approved = 0))  # deactivate (also bumps epoch)
-    expect_error(auth_refresh(token, pool, dw), regexp = "not active|revoked|unauthor",
-                 ignore.case = TRUE)
+    con <- getOption(".test_db_con"); cfg <- .cfg()
+    uid <- .seed(con, role = "Administrator")
+    tok <- .mint(con, uid, cfg)              # token role = Administrator, sepoch = 0
+    # raw update: change role but keep epoch 0 so the token still validates
+    DBI::dbExecute(con, "UPDATE user SET user_role = 'Viewer' WHERE user_id = ?", params = list(uid))
+    newtok <- auth_refresh(tok, con, cfg)
+    expect_equal(auth_validate_token(newtok, cfg)$user_role, "Viewer")  # minted from DB, not the token
   })
 })
 
-test_that("auth_refresh mints the CURRENT role from the DB (role-current)", {
+test_that("refresh REJECTED after a real demotion (epoch bump via user_update)", {
   with_test_db_transaction({
-    uid <- user_create(list(user_name = "refresh_role", user_email = "rr@test.local",
-                            user_password_hash = "x", user_role = "Administrator"))
-    user_update(uid, list(approved = 1))
-    user <- pool %>% tbl("user") %>% filter(user_id == !!uid) %>%
-      dplyr::rename(user_created = created_at) %>% collect()
-    token <- auth_generate_token(user[1, ], dw)$access_token
-    new_token <- auth_refresh(token, pool, dw)
-    claims <- auth_validate_token(new_token, dw)
-    expect_equal(claims$user_role, "Administrator")
-    expect_equal(as.numeric(claims$sepoch),
-                 as.numeric((pool %>% tbl("user") %>% filter(user_id == !!uid) %>% collect())$session_epoch[1]))
+    con <- getOption(".test_db_con"); cfg <- .cfg()
+    uid <- .seed(con, role = "Curator")
+    tok <- .mint(con, uid, cfg)
+    withr::with_options(list(.test_db_con = con), user_update(uid, list(user_role = "Viewer")))  # bumps epoch
+    expect_error(auth_refresh(tok, con, cfg), regexp = "revoked|unauthor", ignore.case = TRUE)
+  })
+})
+
+test_that("refresh REJECTED for a deactivated user", {
+  with_test_db_transaction({
+    con <- getOption(".test_db_con"); cfg <- .cfg()
+    uid <- .seed(con, role = "Reviewer", approved = 1L)
+    tok <- .mint(con, uid, cfg)
+    withr::with_options(list(.test_db_con = con), user_update(uid, list(approved = 0)))
+    expect_error(auth_refresh(tok, con, cfg), regexp = "not active|revoked|unauthor", ignore.case = TRUE)
+  })
+})
+
+test_that("refresh REJECTED after a password change (epoch bump)", {
+  with_test_db_transaction({
+    con <- getOption(".test_db_con"); cfg <- .cfg()
+    uid <- .seed(con); tok <- .mint(con, uid, cfg)
+    withr::with_options(list(.test_db_con = con), user_update_password(uid, "newhash"))
+    expect_error(auth_refresh(tok, con, cfg), regexp = "revoked|unauthor", ignore.case = TRUE)
+  })
+})
+
+test_that("refresh REJECTED for a deleted user", {
+  with_test_db_transaction({
+    con <- getOption(".test_db_con"); cfg <- .cfg()
+    uid <- .seed(con); tok <- .mint(con, uid, cfg)
+    DBI::dbExecute(con, "DELETE FROM user WHERE user_id = ?", params = list(uid))
+    expect_error(auth_refresh(tok, con, cfg), regexp = "no longer exists|unauthor", ignore.case = TRUE)
   })
 })
 ```
+(If `user_update`/`user_update_password` do not honor `.test_db_con`, mutate directly with `DBI::dbExecute(con, "UPDATE user SET user_role='Viewer', session_epoch = session_epoch + 1 WHERE user_id=?", ...)` to simulate the atomic bump — the point of these tests is `auth_refresh`'s reaction to a bumped epoch, not re-testing Task 2.)
 
 - [ ] **Step 2: Run to verify FAIL**
 
 Run: `docker cp api/tests/testthat/test-unit-auth-refresh-epoch.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-unit-auth-refresh-epoch.R')"`
-Expected: FAIL — `sepoch` not in claims; `auth_refresh` does not load the DB / check epoch.
+Expected: FAIL — no `sepoch` claim; `auth_refresh` doesn't load DB / check epoch.
 
 - [ ] **Step 3: Add the `sepoch` claim to `auth_generate_token`**
 
-In `api/services/auth-service.R`, inside `jose::jwt_claim(...)` (`:179`), add:
-
+In `jose::jwt_claim(...)` (`:179`), add after `orcid = user$orcid,`:
 ```r
-    orcid = user$orcid,
     sepoch = user$session_epoch %||% 0,
-    iat = as.numeric(Sys.time()),
 ```
 
-- [ ] **Step 4: Rewrite `auth_refresh` to be DB-backed, role-current, and epoch-checked**
+- [ ] **Step 4: Rewrite `auth_refresh` (DB-backed, role-current, epoch-checked; namespaced dplyr)**
 
 Replace the body of `auth_refresh` (`:140-164`) with:
-
 ```r
 auth_refresh <- function(refresh_token, pool, config) {
   if (missing(refresh_token) || is.null(refresh_token) || nchar(refresh_token) == 0) {
@@ -318,13 +332,19 @@ auth_refresh <- function(refresh_token, pool, config) {
     stop_for_unauthorized("Refresh token has expired")
   }
 
+  # Validate the subject id before querying.
+  uid <- suppressWarnings(as.integer(claims$user_id))
+  if (length(uid) != 1L || is.na(uid) || uid <= 0L) {
+    stop_for_unauthorized("Invalid refresh token")
+  }
+
   # Load CURRENT account state — never trust the presented token's claims.
-  uid <- as.integer(claims$user_id)
+  # Namespace dplyr verbs: the loaded runtime masks them (biomaRt/STRINGdb).
   user <- pool %>%
-    tbl("user") %>%
-    filter(user_id == !!uid) %>%
+    dplyr::tbl("user") %>%
+    dplyr::filter(.data$user_id == !!uid) %>%
     dplyr::rename(user_created = created_at) %>%
-    collect()
+    dplyr::collect()
   if (nrow(user) == 0) {
     stop_for_unauthorized("User no longer exists")
   }
@@ -333,26 +353,23 @@ auth_refresh <- function(refresh_token, pool, config) {
     stop_for_unauthorized("Account is not active")
   }
 
-  # Revocation gate: the token's epoch must match the user's current epoch.
+  # Revocation gate: token epoch must match the user's current epoch.
   token_epoch <- as.numeric(claims$sepoch %||% 0)
   current_epoch <- as.numeric(user$session_epoch %||% 0)
   if (token_epoch != current_epoch) {
     stop_for_unauthorized("Session has been revoked. Please sign in again.")
   }
 
-  # Mint a fresh token with role + claim fields taken from the DB row.
   token <- auth_generate_token(user, config)
   logger::log_info("Token refreshed", user_id = user$user_id)
   token$access_token
 }
 ```
 
-Verify `stop_for_bad_request`/`stop_for_unauthorized` and `%||%` are already used in this file (they are — `auth_signin` uses them). Keep `filter`/`tbl`/`collect` unqualified to match `auth_signin`'s style in the same file.
-
-- [ ] **Step 5: Run the refresh tests to verify PASS**
+- [ ] **Step 5: Run refresh tests to PASS**
 
 Run: `docker compose restart api && docker cp api/tests/testthat/test-unit-auth-refresh-epoch.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-unit-auth-refresh-epoch.R')"`
-Expected: PASS. (Restart so the API sources the new `auth-service.R`.)
+Expected: PASS. Also re-run the existing suite: `docker cp api/tests/testthat/test-unit-auth-service.R sysndd-api-1:/app/tests/testthat/ && docker exec sysndd-api-1 Rscript -e "testthat::test_file('/app/tests/testthat/test-unit-auth-service.R')"` — the `sepoch` claim is additive, and the `auth_refresh`/`auth_generate_token` signatures are unchanged, so it stays green (fix any assertion that encoded the old "does not use the DB" behavior).
 
 - [ ] **Step 6: Commit**
 
@@ -363,35 +380,32 @@ git commit -m "fix(security): make token refresh DB-backed, role-current, epoch-
 
 ---
 
-### Task 4: Regression sweep, live verification, and gate
+### Task 4: Regression sweep, live verification, docs, gate
 
-**Files:** none (verification); update docs if refresh semantics are documented.
+- [ ] **Step 1: Ensure no existing test asserts the old stale-claims refresh behavior**
 
-- [ ] **Step 1: Ensure no existing auth test asserts the OLD stale-claims behavior**
-
-Run: `grep -rnE 'auth_refresh|does not use the DB|refresh' api/tests/testthat/test-endpoint-auth.R api/tests/testthat/*auth* 2>/dev/null`
-If any test asserts that `auth_refresh` ignores the pool / reissues old claims, update it to the new contract (a comment in the old code said it "explicitly does not use the DB pool"; any test encoding that must be inverted).
+Run: `grep -rnE 'auth_refresh|does not use the DB|reissue|same.*token|refresh' api/tests/testthat/test-unit-auth-service.R api/tests/testthat/test-endpoint-auth.R api/tests/testthat/test-integration-auth.R`
+Fix any assertion that requires `auth_refresh` to ignore the pool / reuse old claims. Confirm the `auth_refresh has correct signature` test (`test-unit-auth-service.R:217`) still passes (signature unchanged).
 
 - [ ] **Step 2: File-size + full API gate**
 
 Run: `make code-quality-audit && make test-api-fast`
-Expected: PASS; the three new test files run (not skipped) against the dev DB, migration 043 applied, manifest guard green.
+Expected: PASS; migration 043 applied, all guard + new tests run.
 
 - [ ] **Step 3: Live end-to-end refresh check (fully-loaded env)**
 
 With the dev stack up and a Curator/Admin account:
-- Sign in (`POST /api/auth/authenticate`), capture the token.
-- `GET /api/auth/refresh` with `Authorization: Bearer <token>` → **200**, a new token whose decoded `user_role` matches the DB and `sepoch` matches the user's current epoch.
-- As an admin, demote that user (`PUT /api/user/change_role`), then retry refresh with the OLD token → **401** ("Session has been revoked").
-- Deactivate a user (`PUT /api/user/approval` unapprove), retry refresh → **401**.
+- Sign in (`POST /api/auth/authenticate`), capture the token; `GET /api/auth/refresh` with `Authorization: Bearer <token>` → **200**, decoded token `user_role` matches the DB, `sepoch` matches the user's epoch.
+- Admin demote that user (`PUT /api/user/change_role`), retry refresh with the OLD token → **401** ("Session has been revoked").
+- Deactivate (`PUT /api/user/approval` unapprove), retry → **401**.
 
 - [ ] **Step 4: Docs**
 
-If `documentation/08-development.qmd` or `09-deployment.qmd` documents the refresh flow or token lifetime, note: refresh now loads current account state and enforces `session_epoch`; demotion/deactivation/password-change immediately revoke refresh. Note the residual (§S1 residual risk): the current access token remains valid until `config$token_expiry` (3600s); immediate access-token revocation (epoch check in `require_auth`) and distinct rotating tokens are the deferred S1b follow-up.
+In `documentation/09-deployment.qmd` (and `08-development.qmd` if it documents auth): refresh now loads current account state and enforces `session_epoch`; demotion/deactivation/password-change/role-change immediately revoke refresh (force re-login). Document the residuals: (a) the current **access** token remains valid until `config$token_expiry` (3600s) — immediate access revocation (epoch check in `require_auth`) is deferred; (b) a **legacy pre-deploy token** (no `sepoch`, epoch 0) is refreshable until its own expiry unless the operator initializes existing users to epoch 1 at deploy; (c) distinct rotating refresh tokens (theft resistance) are the deferred **S1b** follow-up.
 
 ## Self-Review
 
-- **Spec coverage (S1 §5):** epoch column (Task 1), tokens carry epoch (Task 3.3), refresh loads current user + role + approved + epoch (Task 3.4), revoke-on-change via bump (Task 2), no frontend change (verified — header-carried token, bare-string response), tests for demotion/deactivation/role-current/normal (Task 3) + bump coverage (Task 2). Residual documented (Task 4.4).
-- **Placeholder scan:** none — migration, helper, and auth_refresh bodies are complete. The two adaptive steps (2.1 `user_create` fields, 2.5 bulk paths) include explicit grep-and-match instructions, not vague TODOs.
-- **Type/name consistency:** `user_bump_session_epoch(user_id)` used identically in repository + tests; `sepoch` claim name consistent across `auth_generate_token`/`auth_refresh`/tests; `session_epoch` column name consistent across migration/repository/auth-service.
-- **Compat:** legacy tokens (no `sepoch`) → `%||% 0`; refresh works while user epoch is 0, correctly rejects once epoch > 0. Additive migration; manifest bumped with guard tests.
+- **Spec coverage (S1 §5):** epoch column + full manifest bump (Task 1, Codex MEDIUM-9), atomic in-statement epoch increment on role/approved/password + bulk (Task 2, Codex BLOCKER-2/HIGH-4), DB-backed role-current epoch-checked refresh with namespaced dplyr + id validation (Task 3, Codex MEDIUM-8), tests for normal/role-current-isolated/demotion/deactivation/password/deleted-user (Task 3, Codex HIGH-7) with working fixtures (Codex BLOCKER-3), residuals documented (Task 4, Codex LOW-11).
+- **Design choice documented:** privilege change → reject refresh (force re-login); mint-from-DB is defense-in-depth; role-current isolated by a raw non-epoch-bumping DB update.
+- **Placeholder scan:** none — migration, mutation edits, and `auth_refresh` body are complete. The two adaptive points (db_execute_statement connection source; bulk-approval `account_status`) have explicit grep-and-decide instructions.
+- **Type/name consistency:** `session_epoch` / `sepoch` used identically across migration, mutations, `auth_generate_token`, `auth_refresh`, and tests. `auth_refresh(refresh_token, pool, config)` signature unchanged (keeps `test-unit-auth-service.R:217` green).

--- a/.planning/superpowers/specs/2026-07-11-security-hardening-535-design.md
+++ b/.planning/superpowers/specs/2026-07-11-security-hardening-535-design.md
@@ -51,13 +51,19 @@ refresh flow. This audit (post-#521) and a fresh re-read of current `master` con
 findings remain open. There are currently **no open PRs or branches** targeting #535.
 
 **Frontend consumption (load-bearing for the P0-1 design):** the `/api/review` and `/api/status`
-**list** endpoints have *no* current frontend consumer (`listReviews`/`listStatus` are unused
-outside `api/review.ts`/`api/status.ts`). The detail/subresource routes are consumed only by
-**authenticated curation/review** composables — `useReviewForm.ts`, `useReviewData.ts`,
-`useStatusForm.ts`. Public approved curation data reaches the browser through the already
+**list** endpoints *are* consumed — by the **authenticated approval queues**
+`ApproveReview.vue` (via `useApproveReviewController.ts:246`, `getAxios().get('/api/review')`) and
+`ApproveStatus.vue:126` (`ax().get('/api/status')`). Both use raw axios calls (which is why a
+typed-client grep for `listReviews`/`listStatus` misses them), but crucially `ax()`/`getAxios()`
+resolve to **`apiClient.raw`** — the *same* authenticated singleton whose request interceptor injects
+the `Bearer` token on every call — and both views are **router-gated** to
+Administrator/Curator/Reviewer (`createAuthGuard([...])`). The per-id detail/subresource routes are
+consumed only by authenticated curation/review composables (`useReviewForm.ts`, `useReviewData.ts`,
+`useStatusForm.ts`). Public approved curation data reaches the browser through the already
 approved-gated `/api/entity/*` family (e.g. `GET /api/entity/<id>/review`, a *different* endpoint).
-This means these two endpoint families are **curation surfaces**, and gating them behind Reviewer+
-does not break any known public page.
+**Conclusion:** these two families are curation surfaces whose only consumers are authenticated
+Reviewer+ views sending a Bearer token, so gating the routes at Reviewer+ is safe and needs **no**
+frontend change.
 
 ## 3. Program decomposition (sequenced slices)
 
@@ -104,6 +110,14 @@ Routes to gate at **Reviewer+**:
   Curator/Reviewer; add the guard if any is missing (the audit did not flag them, but the plan must
   confirm rather than assume).
 
+**Handler-signature constraint (spec-stage Codex finding, verified).** The list handlers already
+take `function(req, res, ...)`, but every detail/subresource handler is currently
+`function(review_id_requested)` / `function(status_id_requested)` — **no `req`/`res` params**. Adding
+`require_role(req, res, "Reviewer")` therefore requires first widening each signature to
+`function(req, res, <id>)`. Plumber binds `req`/`res` and path params by name, so this is safe, but
+omitting it throws `object 'req' not found` at runtime. The plan must change all five signatures
+(`review` `<id>`, `.../phenotypes`, `.../variation`, `.../publications`; `status` `<id>`).
+
 Routes that may stay public (verify in plan):
 - `GET /api/status/_list` returns only the status *category* vocabulary
   (`ndd_entity_status_categories_list`), no curation rows or identities. Keep public **only if**
@@ -139,53 +153,77 @@ A refresh operation reflects the **current** account state: a deactivated or dem
 mint fresh privileges, refresh tokens are distinct from access tokens, rotate on use, and can be
 revoked.
 
-### Design
-1. **Distinct tokens.** `auth_generate_token()` mints two different JWTs:
-   - *access token*: short `exp` (`config$token_expiry`, default 3600s), `typ="access"`, carries the
-     role claims as today.
-   - *refresh token*: longer `exp` (new `config$refresh_token_expiry`, default e.g. 30 days),
-     `typ="refresh"`, carries `user_id` + a server-generated **`jti`** and **nothing role-bearing**
-     that a stale copy could trust.
-2. **Server-side revocation store.** New migration `db/migrations/043_add_refresh_tokens.sql` (next
-   after the current latest `042_gate_connect_views_review_approved.sql`; bump
-   `EXPECTED_LATEST_MIGRATION` + the two manifest guard tests) adds a
-   `refresh_token` table: `jti` (PK, indexed), `user_id`, `issued_at`, `expires_at`, `revoked_at`
-   (nullable), `rotated_to_jti` (nullable, for reuse detection), `user_agent`/`ip` optional. On
-   sign-in, insert the issued `jti`.
-3. **Refresh flow (`auth_refresh`)** now:
-   - Decode + signature-verify the refresh JWT; require `typ="refresh"`.
-   - Look up its `jti` in `refresh_token`. Reject if missing, `revoked_at` set, or expired.
-   - **Reuse detection:** if the `jti` was already rotated (`rotated_to_jti` set), treat as replay —
-     revoke the whole chain for that user and reject.
-   - **Load current user by `user_id` from the DB.** Require `approved == 1` (active). Mint the new
-     access token's role **from the DB row**, not the token.
-   - **Rotate:** mark the old `jti` `revoked_at`/`rotated_to_jti`, issue a new refresh `jti`, return
-     new access + new refresh token.
-4. **Revoke on account change.** When a user is demoted, deactivated, or deleted (admin user
-   endpoints), revoke all their outstanding refresh `jti`s. Deactivation/demotion then prevents any
-   further refresh immediately.
-5. **Frontend coordination.** The auth store must store and send the refresh token to
-   `/api/auth/refresh`, accept the rotated refresh token in the response, and replace it. Today the
-   endpoint returns only a string access token; the response shape becomes
-   `{ access_token, refresh_token, token_type, expires_in }`. Keep a transitional path so an
-   in-flight legacy session degrades gracefully (forces re-login rather than 500).
+### Design refinement (from code investigation)
+The audit's literal prescription — distinct rotating refresh tokens with a `jti` revocation store —
+is a large change with real frontend risk: today the SPA stores **one** token, `/api/auth/refresh`
+is a **`GET`** that returns a bare token string, and `refresh()` is a **proactive, user-initiated
+session extension** (`LogoutCountdownBadge.vue`, `IconPairDropdownMenu.vue`), *not* an on-401
+auto-retry. The actual vulnerability is narrower and sharper: **a demoted/deactivated user can
+refresh stale privileges indefinitely because refresh never re-checks the DB.** That precise hole is
+closed by a **session-epoch** mechanism that is backend + one-column-migration only, needs **zero
+frontend changes**, and is far lower risk. S1 does that now; the token-distinctness/rotation
+defense-in-depth becomes **S1b** (its own human-reviewed PR).
 
-### Tests
-- Refresh after **demotion** → new access token carries the *new* (lower) role.
-- Refresh after **deactivation** → rejected.
-- **Replay:** using a rotated (old) refresh token → rejected and chain revoked.
-- **Rotation:** each refresh returns a new refresh `jti`; old one no longer works.
-- **Expiry:** expired refresh token rejected; expired access token still refreshable within refresh
-  window.
-- **Distinctness:** access token ≠ refresh token; access token cannot be used at `/refresh` (`typ`
-  mismatch) and refresh token cannot authenticate a normal protected route.
+### S1 (implement now) — session-epoch role-current, revocable refresh
+1. **Epoch column.** Migration `db/migrations/043_add_user_session_epoch.sql` (next after
+   `042_...`; bump `EXPECTED_LATEST_MIGRATION` + the two manifest guard tests
+   `test-unit-analysis-snapshot-migration.R`, `test-unit-core-views-manifest.R`) adds
+   `user.session_epoch INT NOT NULL DEFAULT 0`. Additive, no FK/collation traps.
+2. **Tokens carry the epoch.** `auth_generate_token()` adds a `sepoch` claim = the user's current
+   `session_epoch`. (Access and refresh remain the same token in S1 — distinctness is S1b.)
+3. **Refresh becomes DB-backed and role-current.** `auth_refresh(refresh_token, pool, config)` now:
+   decode + verify signature and `exp` → **load the user by `user_id` from `pool`** → require
+   `approved == 1` → require the token's `sepoch == user.session_epoch` → mint a **new token with
+   `user_role` and all claim fields taken from the DB row** (not the old token) and the current
+   `sepoch`. Any failure → `stop_for_unauthorized` (frontend proactively logs out). This closes the
+   exact finding: a demoted user's refreshed token carries the *new* role; a deactivated or
+   epoch-bumped user cannot refresh at all.
+4. **Revoke on account change** via one helper `user_bump_session_epoch(pool, user_id)`:
+   `UPDATE user SET session_epoch = session_epoch + 1 WHERE user_id = ?`. Call it from every admin
+   privilege/state change that must invalidate outstanding sessions — `change_role`,
+   `approval` (unapprove/deactivate), `update`, `delete`/`bulk_delete`/`bulk_approve`, and password
+   change/reset. Any incremented epoch immediately blocks refresh for that user.
+5. **No frontend change.** The SPA keeps its single-token model; `/api/auth/refresh` keeps returning
+   a bare token string. Only the *server-side* behavior changes. (Frontend role display can lag until
+   next login if an admin self-demotes and self-refreshes — cosmetic, not the vulnerability, and the
+   server enforces the real role on every request.)
+
+### S1 residual risk (documented, not left silent)
+- The epoch is checked **at refresh**, not on every authenticated request. A demoted user's *current
+  access token* stays valid until it expires (`config$token_expiry`, 3600s). The acceptance
+  criterion is specifically about *refresh* ("Demoted/deactivated users cannot refresh stale
+  privileges"), which S1 fully satisfies; refresh is blocked immediately. Adding the `sepoch` check
+  to `require_auth` would make access revocation immediate too, at the cost of a DB lookup per
+  *authenticated* request (anonymous GETs — the bulk of traffic — are unaffected). This is a
+  deliberate S1b/optional decision, flagged for the plan-stage Codex review and human input, not
+  silently dropped.
+- Access token == refresh token in S1, so a leaked token remains refreshable until an epoch bump.
+  S1b (distinct `typ`-scoped tokens, longer refresh expiry, `jti` rotation + reuse detection, and
+  the frontend two-token handling + moving `/refresh` to a POST body per the auth-body-only rule)
+  addresses token theft. It is intentionally a separate, human-reviewed PR.
+
+### S1 tests
+- Refresh after **demotion** (`change_role` bumps epoch) → refresh **rejected** (epoch mismatch);
+  and a *new* login yields a token with the new role. (If we instead keep the token valid across a
+  role *promotion*, assert the minted role equals the DB role.)
+- Refresh after **deactivation** (`approved → 0` + epoch bump) → rejected.
+- Refresh after **password change** (epoch bump) → old sessions rejected.
+- **Normal refresh** for an unchanged active user → succeeds and the minted token's role/fields come
+  from the DB row.
+- **DB-load path:** `auth_refresh` reads the pool (regression against the current "explicitly does
+  not use the DB pool" behavior). Guard that a token for a now-deleted user is rejected.
+- Migration guard tests updated; `session_epoch` present after migrate.
 
 ### Migration & compatibility
-- The migration is additive (new table); `EXPECTED_LATEST_MIGRATION` and the manifest count update
-  per the migrations skill. No change to existing tables.
-- Existing access tokens keep working until they expire (they still decode). Only the refresh
-  contract changes. Frontend and API ship together (S1 is one PR spanning both), so the response
-  shape change is coordinated.
+- Additive column only; existing tokens keep decoding. Pre-migration tokens have no `sepoch` claim —
+  `auth_refresh` treats a missing `sepoch` as epoch `0` (matching the column default), so existing
+  sessions refresh normally the first time and pick up the claim thereafter. A user whose epoch has
+  already been bumped (>0) correctly rejects a legacy no-`sepoch` token.
+
+### S1b (deferred, separate human-reviewed PR)
+Distinct access/refresh tokens (`typ` claim, longer refresh `exp`), a `refresh_token` revocation
+table with rotation + reuse detection, frontend two-token storage, and `/api/auth/refresh` moved to
+a POST JSON body. Tracked as the defense-in-depth follow-up to S1.
 
 ## 6. Architecture & isolation
 

--- a/.planning/superpowers/specs/2026-07-11-security-hardening-535-design.md
+++ b/.planning/superpowers/specs/2026-07-11-security-hardening-535-design.md
@@ -258,9 +258,37 @@ production secrets or deployment topology that must not be changed autonomously 
 - **S4 Docker-socket proxy + removing writable prod mounts** — production Compose topology; the
   build-side items (source maps, `stats.html`, nginx denies) are safe and can be pulled forward.
 
-## 9. Non-goals
+## 9. Plan-stage Codex corrections folded (2026-07-11)
+
+The plan-stage Codex adversarial review found real, plan-breaking issues, all folded into the plans:
+- **S0:** obsolete *signature* assertions (`expect_match(sig_line, "^function\\(review_id_requested\\)")`
+  at `test-endpoint-review.R:612,652,695,735`; `status:183`) and per-route `expect_false(require_role)`
+  permission blocks must all be inverted; behavioral denial tests must cover **all seven** gated routes
+  with a deny-before-query sentinel + Reviewer positive control; the approval-queue consumers are
+  **Curator+** (not Reviewer/Curator/Admin) but still send the Bearer token, so Reviewer+ gating is safe.
+- **S1:** the epoch increment must be **atomic in the mutation SQL statement** (not a separate post-commit
+  bump) to close a refresh/revocation race; the real bulk SQL lives in `user-service.R` (not the
+  delegating `user-bulk-endpoint-service.R`); `user_create()` is **broken** (inserts `user_email`, column
+  is `email`) so test fixtures must use parameterized SQL; namespace all dplyr verbs in `auth_refresh`
+  and validate the decoded user id; bump **all four** migration-guard assertions (name + count 40→41 +
+  `res$latest`). Design choice made explicit: a privilege change bumps the epoch → refresh is **rejected**
+  (force re-login), not silently downgraded.
+
+## 10. Scope narrowing (Codex HIGH-5)
+
+The anonymous, **approval-gated** `/api/entity/<id>/review` and `.../status` routes return the *approved*
+primary review/status `comment` (`entity-read-endpoint-service.R:333,354`). These do **not** leak drafts
+or curator identities, but whether an approved `comment` is public editorial content or private workflow
+metadata is a distinct product decision. It is recorded as program follow-up **S8-c: "classify approved
+review/status comment visibility"** and is **out of S0 scope**. The earlier "entity family wholly untouched
+/ safe" wording is narrowed to: *the entity family's draft/identity exposure is already closed; approved
+comment visibility is a separate, tracked question.*
+
+## 11. Non-goals
 
 - No refactor beyond what each fix requires (YAGNI). Performance cleanups adjacent to the P0 code
   (whole-table collects in review detail) are deferred to S7.
-- No change to the public entity/gene data surface, which the audit confirms is already
-  approved-gated.
+- No change to the public entity/gene *draft* surface (already approval-gated). The approved-comment
+  visibility question is deferred to S8-c (§10), not resolved here.
+- The pre-existing bulk-approval `account_status`/`approving_user_id` schema mismatch is noted but **not**
+  fixed in this P0 PR (tracked separately).

--- a/.planning/superpowers/specs/2026-07-11-security-hardening-535-design.md
+++ b/.planning/superpowers/specs/2026-07-11-security-hardening-535-design.md
@@ -1,0 +1,228 @@
+# Security & Reliability Hardening (#535) — Program + P0 Slice Design
+
+Date: 2026-07-11
+Issue: [#535](https://github.com/berntpopp/sysndd/issues/535) — umbrella remediation of the 2026-07-11 deep repository audit (independently validated by Claude Opus 4.8 at `xhigh`).
+Status: **Design — awaiting review**
+
+## 1. What this is
+
+Issue #535 is an umbrella issue collecting ~25 distinct findings across authorization, secrets,
+restore safety, deployment hardening, resource use, frontend correctness, and maintainability.
+It is far too large for a single spec/plan/PR. The issue itself says *"Security-critical work must
+land first; lower-priority work may be split into linked child issues."*
+
+This document does two things:
+
+1. **Decomposes** the umbrella into sequenced, independently-shippable child slices (§3).
+2. **Fully specs the P0 security slice** — the two authorization findings the audit ranks as
+   *"fix immediately"* — which is what we implement first (§4–§7).
+
+The remaining slices are scoped here at roadmap granularity and each gets its own spec → plan → PR
+cycle. Several of them (restore redesign, production credential rotation, Docker-socket topology
+change) touch production secrets and deployment topology that cannot be safely validated from the
+dev checkout; those are explicitly **human-gated** and are *not* auto-executed (§8).
+
+## 2. Verified findings (deep review)
+
+Both P0 findings were re-verified against current `master` (HEAD `8cc39642`) during this review:
+
+- **P0-1 confirmed.** `api/core/middleware.R:93-97` forwards *every* unauthenticated `GET`. The
+  review list handler defaults `filter_review_approved = FALSE`, filters *for* unapproved rows
+  (`review_endpoints.R:34-36,100-103`), and returns `synopsis`, reviewer/approver `user_name` +
+  `user_role`, and `comment` to anonymous callers (`:104-124`). The status list is identical
+  (`status_endpoints.R:27-28,87-113`). The enumerable detail/subresource routes
+  (`review_endpoints.R:385,439,481,523`; `status_endpoints.R:168`) query raw tables with no
+  approval gate. Two tests **actively assert the absence of a role gate**
+  (`test-endpoint-review.R:200-214`, `test-endpoint-status.R:156-166`).
+
+- **P0-2 confirmed.** `auth_refresh()` decodes the presented token and reissues claims verbatim with
+  **no DB lookup** (`auth-service.R:140-164`). `auth_generate_token()` returns the **same JWT** as
+  both `access_token` and `refresh_token` (`:194-198`), and `/api/auth/refresh` is allowlisted
+  (`middleware.R:32`). A demoted or deactivated user refreshes stale privileges indefinitely until
+  the (short) `exp`, and can keep doing so forever because the refresh token never expires
+  differently from the access token and carries no revocation state.
+
+**Prior work does not cover P0.** A previous security effort (#520/#521, v0.29.2/v0.29.3, spec
+`2026-07-06-security-bug-scan-fixes-design.md`) fixed a related "#3 exposure class": it gated the
+phenotype/variant **connect views** on `review_approved = 1` (migration
+`042_gate_connect_views_review_approved.sql`) and hardened the entity endpoints + SEO service.
+That work did **not** touch the `/api/review` or `/api/status` **endpoint handlers**, nor the
+refresh flow. This audit (post-#521) and a fresh re-read of current `master` confirm both P0
+findings remain open. There are currently **no open PRs or branches** targeting #535.
+
+**Frontend consumption (load-bearing for the P0-1 design):** the `/api/review` and `/api/status`
+**list** endpoints have *no* current frontend consumer (`listReviews`/`listStatus` are unused
+outside `api/review.ts`/`api/status.ts`). The detail/subresource routes are consumed only by
+**authenticated curation/review** composables — `useReviewForm.ts`, `useReviewData.ts`,
+`useStatusForm.ts`. Public approved curation data reaches the browser through the already
+approved-gated `/api/entity/*` family (e.g. `GET /api/entity/<id>/review`, a *different* endpoint).
+This means these two endpoint families are **curation surfaces**, and gating them behind Reviewer+
+does not break any known public page.
+
+## 3. Program decomposition (sequenced slices)
+
+Ordering follows the audit's own "Recommended remediation order". Dependencies noted.
+
+| Slice | Findings | Surface | Risk | Autonomy |
+|-------|----------|---------|------|----------|
+| **S0 — Endpoint authorization** (this spec) | P0-1 | `api/endpoints`, tests | Low, api-only, in-repo testable | **Implement now** |
+| **S1 — Revocable role-current refresh** (this spec) | P0-2 | `api/services`, migration, `middleware`, frontend auth store | Medium — auth flow + DB + FE | **Implement now** |
+| S2 — Secrets out of jobs/argv | P1-1 | backup service, async-job service, `backup-functions` | Medium — touches prod cred handling | Spec + plan; **human-gated execution** (credential rotation is operator work) |
+| S3 — Restore fencing redesign | P1-2 | restore plane, Compose, ops runbook | High — production topology | Spec only; **human-gated** |
+| S4 — Deployment hardening | P1-3/4/5/6 | Compose, Vite, nginx, Dockerfile, Makefile | Medium — infra/build | Spec + plan; deploy-topology items **human-gated** |
+| S5 — Frontend request ownership | P1-7, P2-3 | `tableRequestCoordinator`, 4 composables | Low-Med — FE only, unit-testable | Spec + plan; implementable after S0/S1 |
+| S6 — Clustering admission controls | P2-1 | job submission services | Medium | Spec + plan |
+| S7 — Perf & retention | P2-2/4/5/6 | composables barrel, external-proxy cache, backup I/O, job retention | Medium | Spec + plan |
+| S8 — Defense-in-depth & maintainability | P2-7/8, P3, misc | MCP DB principal, throttling, CSPRNG, HTML-escape, dead code, CI gating | Low-Med, several independent | Spec + plan; several are quick wins |
+
+Cheap, low-risk, clearly-correct wins that can be pulled forward opportunistically (each < ~1 PR):
+dead backup `executor_fn` removal, HTML-escape signup fields, CSPRNG temp passwords, Makefile
+`pipefail` on restore targets, source-map/`stats.html` suppression. These are noted in S4/S8 but
+carry no infra decision, so they are safe to batch when convenient.
+
+**This session implements S0 and S1** (the P0 slice) as two separate PRs, opened for human sign-off
+(no auto-merge of security-critical auth changes). Everything else is left as sequenced roadmap.
+
+## 4. S0 — Endpoint authorization (P0-1)
+
+### Goal
+No anonymous caller can read draft/unapproved curation rows, curator identities, roles, comments,
+or workflow state through `/api/review` or `/api/status`. Approved-public data continues to reach
+the public through its existing approved-gated paths.
+
+### Strategy: gate the curation families behind Reviewer+
+Because these two families are curation surfaces with no public consumer, the correct and safest
+fix is to require **Reviewer+** on every route that can expose draft rows or curator metadata,
+using the established `require_role(req, res, "Reviewer")` pattern already used across
+`api/endpoints/*`. This is strictly safer than building parallel "public approved-only" routes and
+introduces no new column-stripping logic that could regress.
+
+Routes to gate at **Reviewer+**:
+- `GET /api/review/` (list), `GET /api/review/<id>`, `.../phenotypes`, `.../variation`, `.../publications`
+- `GET /api/status/` (list), `GET /api/status/<id>`
+- Write/approve routes (`/create`, `/update`, `/approve/<id>`) — verify they already gate at
+  Curator/Reviewer; add the guard if any is missing (the audit did not flag them, but the plan must
+  confirm rather than assume).
+
+Routes that may stay public (verify in plan):
+- `GET /api/status/_list` returns only the status *category* vocabulary
+  (`ndd_entity_status_categories_list`), no curation rows or identities. Keep public **only if**
+  the plan confirms it exposes no draft/identity data; it is consumed by public entity-create option
+  loaders.
+
+### Escalation gate (plan must execute, not assume)
+Before finalizing, the plan **must** verify no public/OpenAPI-documented/MCP consumer depends on an
+anonymous approved-only list from these two families (grep frontend, check `openapi.json` tags, check
+the MCP repository queries, check the sitemap/prerender). If such a consumer exists, that specific
+route is instead handled by the **split strategy**: hard-code the approved predicate
+(`review_approved == TRUE` / `status_approved == TRUE`) **and** drop the curator-identity/comment/
+workflow columns for anonymous callers, keeping full behavior for Reviewer+. Default remains
+"gate at Reviewer+"; split is the fallback only where a real public consumer is found.
+
+### Tests
+- **Invert** `test-endpoint-review.R:200-214` and `test-endpoint-status.R:156-166`: assert the list
+  handlers now contain `require_role(`.
+- **Add anonymous-access denial tests**: anonymous `GET /api/review/`, `/api/review/<id>`,
+  subresources, `/api/status/`, `/api/status/<id>` return 401/403 and **no** draft row / curator
+  identity in the body. A Reviewer token gets the data (positive control).
+- Keep the existing write-path/approval tests green.
+
+### Out of scope for S0
+The audit's secondary note that review detail routes "collect whole tables before filtering"
+(`review_endpoints.R:446-455,488-497,530-539`) is a **performance** cleanup, not part of the
+authorization fix. It is folded into S7, not S0, to keep the security PR minimal and reviewable.
+
+## 5. S1 — Revocable, role-current token refresh (P0-2)
+
+### Goal
+A refresh operation reflects the **current** account state: a deactivated or demoted user cannot
+mint fresh privileges, refresh tokens are distinct from access tokens, rotate on use, and can be
+revoked.
+
+### Design
+1. **Distinct tokens.** `auth_generate_token()` mints two different JWTs:
+   - *access token*: short `exp` (`config$token_expiry`, default 3600s), `typ="access"`, carries the
+     role claims as today.
+   - *refresh token*: longer `exp` (new `config$refresh_token_expiry`, default e.g. 30 days),
+     `typ="refresh"`, carries `user_id` + a server-generated **`jti`** and **nothing role-bearing**
+     that a stale copy could trust.
+2. **Server-side revocation store.** New migration `db/migrations/043_add_refresh_tokens.sql` (next
+   after the current latest `042_gate_connect_views_review_approved.sql`; bump
+   `EXPECTED_LATEST_MIGRATION` + the two manifest guard tests) adds a
+   `refresh_token` table: `jti` (PK, indexed), `user_id`, `issued_at`, `expires_at`, `revoked_at`
+   (nullable), `rotated_to_jti` (nullable, for reuse detection), `user_agent`/`ip` optional. On
+   sign-in, insert the issued `jti`.
+3. **Refresh flow (`auth_refresh`)** now:
+   - Decode + signature-verify the refresh JWT; require `typ="refresh"`.
+   - Look up its `jti` in `refresh_token`. Reject if missing, `revoked_at` set, or expired.
+   - **Reuse detection:** if the `jti` was already rotated (`rotated_to_jti` set), treat as replay —
+     revoke the whole chain for that user and reject.
+   - **Load current user by `user_id` from the DB.** Require `approved == 1` (active). Mint the new
+     access token's role **from the DB row**, not the token.
+   - **Rotate:** mark the old `jti` `revoked_at`/`rotated_to_jti`, issue a new refresh `jti`, return
+     new access + new refresh token.
+4. **Revoke on account change.** When a user is demoted, deactivated, or deleted (admin user
+   endpoints), revoke all their outstanding refresh `jti`s. Deactivation/demotion then prevents any
+   further refresh immediately.
+5. **Frontend coordination.** The auth store must store and send the refresh token to
+   `/api/auth/refresh`, accept the rotated refresh token in the response, and replace it. Today the
+   endpoint returns only a string access token; the response shape becomes
+   `{ access_token, refresh_token, token_type, expires_in }`. Keep a transitional path so an
+   in-flight legacy session degrades gracefully (forces re-login rather than 500).
+
+### Tests
+- Refresh after **demotion** → new access token carries the *new* (lower) role.
+- Refresh after **deactivation** → rejected.
+- **Replay:** using a rotated (old) refresh token → rejected and chain revoked.
+- **Rotation:** each refresh returns a new refresh `jti`; old one no longer works.
+- **Expiry:** expired refresh token rejected; expired access token still refreshable within refresh
+  window.
+- **Distinctness:** access token ≠ refresh token; access token cannot be used at `/refresh` (`typ`
+  mismatch) and refresh token cannot authenticate a normal protected route.
+
+### Migration & compatibility
+- The migration is additive (new table); `EXPECTED_LATEST_MIGRATION` and the manifest count update
+  per the migrations skill. No change to existing tables.
+- Existing access tokens keep working until they expire (they still decode). Only the refresh
+  contract changes. Frontend and API ship together (S1 is one PR spanning both), so the response
+  shape change is coordinated.
+
+## 6. Architecture & isolation
+
+- S0 and S1 are **independent code areas** (endpoint authz vs auth token service + migration + FE)
+  with minimal overlap (both could touch `middleware.R`, but S0 does not need to). They are
+  implemented in **separate git worktrees / branches** by parallel agents and become **two PRs**.
+- Each unit stays testable in isolation: S0 via the R endpoint test suite; S1 via auth-service unit
+  tests + a migration + frontend auth-store unit tests.
+- Neither PR is auto-merged: both are security-critical and get Codex adversarial review of the diff
+  plus human sign-off.
+
+## 7. Verification (both slices)
+
+- `make code-quality-audit` (file-size ratchet) — both PRs must keep touched files < 600 lines.
+- Targeted R tests in the running API container (tests dir is not bind-mounted): the inverted +
+  new endpoint tests (S0), the auth-service refresh tests (S1).
+- `cd app && npm run test:unit` for the S1 frontend auth-store changes.
+- `make test-api-fast` as the PR gate; `make ci-local` before handoff where scope warrants.
+- Live end-to-end sanity where feasible (mint a Reviewer JWT, hit the gated routes; exercise the
+  refresh flow) — the audit repeatedly notes that masking effects only surface in the fully-loaded
+  API env, so prefer a live check over unit tests alone.
+
+## 8. Explicitly deferred / human-gated (not auto-executed this session)
+
+These are specced at roadmap level (§3) and left for their own cycles because they involve
+production secrets or deployment topology that must not be changed autonomously from a dev checkout:
+
+- **S2 credential rotation** — the code change (resolve secrets from mounted config, mode-0600
+  defaults file, scrub payload rows) is implementable, but *rotating the live DB credential* is
+  operator work and must be human-driven.
+- **S3 restore fencing redesign** — changes production maintenance topology; design only.
+- **S4 Docker-socket proxy + removing writable prod mounts** — production Compose topology; the
+  build-side items (source maps, `stats.html`, nginx denies) are safe and can be pulled forward.
+
+## 9. Non-goals
+
+- No refactor beyond what each fix requires (YAGNI). Performance cleanups adjacent to the P0 code
+  (whole-table collects in review detail) are deferred to S7.
+- No change to the public entity/gene data surface, which the audit confirms is already
+  approved-gated.


### PR DESCRIPTION
Planning artifacts for the #535 P0 security remediation (the umbrella audit's two 'fix immediately' findings). Provides context for the two code PRs.

Contents:
- `.planning/superpowers/specs/2026-07-11-security-hardening-535-design.md` — program decomposition of the umbrella into sequenced slices (S0–S8) + full spec of the P0 slice.
- `.planning/superpowers/plans/2026-07-11-security-535-s0-endpoint-authz-plan.md` and `…-s1-session-epoch-refresh-plan.md` — test-first implementation plans.
- `.planning/reviews/2026-07-11-security-535-p0-plan-codex-review.md` — Codex adversarial plan review (its findings are folded into the plans).

The remaining audit slices (P1 secrets/restore, P1 deployment hardening, P2 resource/frontend, P3 maintainability) are scoped at roadmap level in the spec for their own cycles. Several (restore fencing, prod credential rotation, Docker-socket topology) are explicitly human-gated.

https://claude.ai/code/session_01GMkyFzt2kPytWzp8QBqaqc