### PR TITLE
fix(security): gate /api/review + /api/status draft routes at Reviewer+ (#535 P0-1)

### DIFF
--- a/api/endpoints/review_endpoints.R
+++ b/api/endpoints/review_endpoints.R
@@ -32,6 +32,8 @@
 #*
 #* @get /
 function(req, res, filter_review_approved = FALSE) {
+  require_role(req, res, "Reviewer")
+
   # Ensure logical
   filter_review_approved <- as.logical(filter_review_approved)
 
@@ -383,7 +385,9 @@ function(req, res, re_review = FALSE, direct_approval = FALSE) {
 #* @response 200 OK. Returns the review data.
 #*
 #* @get /<review_id_requested>
-function(review_id_requested) {
+function(req, res, review_id_requested) {
+  require_role(req, res, "Reviewer")
+
   review_id_requested <- URLdecode(review_id_requested) %>%
     str_split(pattern = ",", simplify = TRUE) %>%
     str_replace_all(" ", "") %>%
@@ -437,7 +441,9 @@ function(review_id_requested) {
 #* @response 200 OK. Returns a list of phenotypes.
 #*
 #* @get /<review_id_requested>/phenotypes
-function(review_id_requested) {
+function(req, res, review_id_requested) {
+  require_role(req, res, "Reviewer")
+
   review_id_requested <- URLdecode(review_id_requested) %>%
     str_split(pattern = ",", simplify = TRUE) %>%
     str_replace_all(" ", "") %>%
@@ -479,7 +485,9 @@ function(review_id_requested) {
 #* @response 200 OK. Returns the list of variant ontology terms.
 #*
 #* @get /<review_id_requested>/variation
-function(review_id_requested) {
+function(req, res, review_id_requested) {
+  require_role(req, res, "Reviewer")
+
   review_id_requested <- URLdecode(review_id_requested) %>%
     str_split(pattern = ",", simplify = TRUE) %>%
     str_replace_all(" ", "") %>%
@@ -521,7 +529,9 @@ function(review_id_requested) {
 #* @response 200 OK. Returns the publications.
 #*
 #* @get /<review_id_requested>/publications
-function(review_id_requested) {
+function(req, res, review_id_requested) {
+  require_role(req, res, "Reviewer")
+
   review_id_requested <- URLdecode(review_id_requested) %>%
     str_split(pattern = ",", simplify = TRUE) %>%
     str_replace_all(" ", "") %>%

--- a/api/endpoints/status_endpoints.R
+++ b/api/endpoints/status_endpoints.R
@@ -25,6 +25,8 @@
 #*
 #* @get /
 function(req, res, filter_status_approved = FALSE) {
+  require_role(req, res, "Reviewer")
+
   filter_status_approved <- as.logical(filter_status_approved)
 
   entity_status_categories_coll <- pool %>%
@@ -166,7 +168,9 @@ function(req, res, filter_status_approved = FALSE) {
 #* @response 200 OK. Returns the status data.
 #*
 #* @get /<status_id_requested>
-function(status_id_requested) {
+function(req, res, status_id_requested) {
+  require_role(req, res, "Reviewer")
+
   status_id_requested <- URLdecode(status_id_requested) %>%
     str_split(pattern = ",", simplify = TRUE) %>%
     str_replace_all(" ", "") %>%
@@ -225,6 +229,8 @@ function(status_id_requested) {
 #*
 #* @response 200 OK. Returns paginated status categories.
 #*
+#* Public: returns only the status-category vocabulary (ndd_entity_status_categories_list);
+#* no draft rows, curator identities, or approval state. Consumed by public entity-create option loaders.
 #* @get _list
 function(page_after = 0, page_size = "all") {
   status_list_collected <- pool %>%

--- a/api/endpoints/status_endpoints.R
+++ b/api/endpoints/status_endpoints.R
@@ -153,6 +153,54 @@ function(req, res, filter_status_approved = FALSE) {
 }
 
 
+#* Get List of All Status
+#*
+#* Retrieves all status categories from ndd_entity_status_categories_list.
+#*
+#* # `Return`
+#* Returns a paginated list of categories with links (navigation URLs),
+#* meta (perPage, currentPage, totalPages), and data (actual status category records).
+#*
+#* NOTE: This static `_list` route MUST be declared BEFORE the dynamic
+#* `/<status_id_requested>` route below. Plumber matches routes in declaration
+#* order, so if the dynamic route came first it would capture `/status/_list`
+#* (with status_id_requested = "_list") and — now that the dynamic route is
+#* gated at Reviewer+ (#535 P0-1) — return 403 for this public vocabulary
+#* endpoint. Declaring `_list` first keeps it publicly reachable.
+#*
+#* @tag status
+#* @serializer json list(na="string")
+#*
+#* @param page_after Cursor after which entries are shown (default: 0).
+#* @param page_size Page size in cursor pagination (default: "all").
+#*
+#* @response 200 OK. Returns paginated status categories.
+#*
+#* Public: returns only the status-category vocabulary (ndd_entity_status_categories_list);
+#* no draft rows, curator identities, or approval state. Consumed by public entity-create option loaders.
+#* @get _list
+function(page_after = 0, page_size = "all") {
+  status_list_collected <- pool %>%
+    tbl("ndd_entity_status_categories_list") %>%
+    arrange(category_id) %>%
+    collect()
+
+  # Apply pagination
+  pagination_info <- generate_cursor_pag_inf_safe(
+    status_list_collected,
+    page_size,
+    page_after,
+    "category_id"
+  )
+
+  list(
+    links = pagination_info$links,
+    meta = pagination_info$meta,
+    data = pagination_info$data
+  )
+}
+
+
 #* Get Single Status by Status ID
 #*
 #* Retrieves detailed info for a specific status ID.
@@ -210,47 +258,6 @@ function(req, res, status_id_requested) {
     arrange(status_date)
 
   status_table_collected
-}
-
-
-#* Get List of All Status
-#*
-#* Retrieves all status categories from ndd_entity_status_categories_list.
-#*
-#* # `Return`
-#* Returns a paginated list of categories with links (navigation URLs),
-#* meta (perPage, currentPage, totalPages), and data (actual status category records).
-#*
-#* @tag status
-#* @serializer json list(na="string")
-#*
-#* @param page_after Cursor after which entries are shown (default: 0).
-#* @param page_size Page size in cursor pagination (default: "all").
-#*
-#* @response 200 OK. Returns paginated status categories.
-#*
-#* Public: returns only the status-category vocabulary (ndd_entity_status_categories_list);
-#* no draft rows, curator identities, or approval state. Consumed by public entity-create option loaders.
-#* @get _list
-function(page_after = 0, page_size = "all") {
-  status_list_collected <- pool %>%
-    tbl("ndd_entity_status_categories_list") %>%
-    arrange(category_id) %>%
-    collect()
-
-  # Apply pagination
-  pagination_info <- generate_cursor_pag_inf_safe(
-    status_list_collected,
-    page_size,
-    page_after,
-    "category_id"
-  )
-
-  list(
-    links = pagination_info$links,
-    meta = pagination_info$meta,
-    data = pagination_info$data
-  )
 }
 
 

--- a/api/scripts/verify-endpoints.R
+++ b/api/scripts/verify-endpoints.R
@@ -104,7 +104,6 @@ verify_endpoint <- function(path, expected_status = 200, description = "") {
 public_endpoints <- list(
   list(path = "/api/entity/", desc = "Entity root"),
   list(path = "/api/gene/", desc = "Gene root"),
-  list(path = "/api/status/", desc = "Status list"),
   list(path = "/api/status/_list", desc = "Status categories"),
   list(path = "/api/ontology/variant", desc = "Variant ontology"),
   list(path = "/api/phenotype/count", desc = "Phenotype count"),
@@ -117,7 +116,6 @@ public_endpoints <- list(
   list(path = "/api/analysis/functional_clustering", desc = "Functional clustering"),
   list(path = "/api/variant/count", desc = "Variant count"),
   list(path = "/api/publication/", desc = "Publication root"),
-  list(path = "/api/review/", desc = "Review root"),
   list(path = "/api/admin/api_version", desc = "Admin API version")
 )
 
@@ -126,6 +124,9 @@ protected_endpoints <- list(
   list(path = "/api/user/list", desc = "User list"),
   list(path = "/api/user/table", desc = "User table"),
   list(path = "/api/re_review/table", desc = "Re-review table"),
+  # #535 P0-1: review/status draft-exposing list routes are now Reviewer+ (were public).
+  list(path = "/api/status/", desc = "Status list (Reviewer+; drafts/identities)"),
+  list(path = "/api/review/", desc = "Review root (Reviewer+; drafts/identities)"),
   list(path = "/api/logs/", desc = "Logs root")
 )
 

--- a/api/tests/testthat/test-endpoint-review.R
+++ b/api/tests/testthat/test-endpoint-review.R
@@ -197,19 +197,19 @@ test_that("GET / review list: validation — filter_review_approved coerced via 
   })
 })
 
-test_that("GET / review list: permission — public read (no require_role)", {
+test_that("GET / review list: permission — requires Reviewer+", {
   with_test_db_transaction({
     src <- review_source()
     dec_idx <- grep("^#\\*\\s+@get\\s+/\\s*$", src)[[1L]]
     # The list handler body runs from dec_idx+1 to the next decorator block.
     # Grab enough lines to cover the whole function, then assert the body
-    # does NOT contain require_role() — GET / is the public list endpoint.
+    # gates at Reviewer+ — GET / exposes draft rows and curator identities.
     next_decorator <- grep("^#\\*\\s+@(get|post|put|delete)\\b", src)
     next_after <- next_decorator[next_decorator > dec_idx][[1L]]
     body_blob <- paste(src[dec_idx:(next_after - 1L)], collapse = "\n")
-    expect_false(
-      grepl("require_role\\(", body_blob),
-      info = "GET /review is a public list endpoint; no require_role() guard expected."
+    expect_true(
+      grepl("require_role\\(\\s*req\\s*,\\s*res\\s*,\\s*\"Reviewer\"", body_blob),
+      info = "This GET route must gate at Reviewer+ (draft/curator-identity exposure)."
     )
   })
 })
@@ -609,7 +609,7 @@ test_that("GET /<review_id_requested>: happy path — decorator + parameterised 
     )
     dec_idx <- grep("^#\\*\\s+@get\\s+/<review_id_requested>\\s*$", src)[[1L]]
     sig_line <- src[dec_idx + 1L]
-    expect_match(sig_line, "^function\\(review_id_requested\\)")
+    expect_match(sig_line, "^function\\(req, res, review_id_requested\\)")
   })
 })
 
@@ -623,7 +623,7 @@ test_that("GET /<review_id_requested>: validation — handler URLdecodes + split
   })
 })
 
-test_that("GET /<review_id_requested>: permission — public read (no require_role)", {
+test_that("GET /<review_id_requested>: permission — requires Reviewer+", {
   with_test_db_transaction({
     src <- review_source()
     dec_idx <- grep("^#\\*\\s+@get\\s+/<review_id_requested>\\s*$", src)[[1L]]
@@ -631,7 +631,10 @@ test_that("GET /<review_id_requested>: permission — public read (no require_ro
     next_dec <- grep("^#\\*\\s+@(get|post|put|delete)\\b", src)
     after <- next_dec[next_dec > dec_idx][[1L]]
     body_blob <- paste(src[dec_idx:(after - 1L)], collapse = "\n")
-    expect_false(grepl("require_role\\(", body_blob))
+    expect_true(
+      grepl("require_role\\(\\s*req\\s*,\\s*res\\s*,\\s*\"Reviewer\"", body_blob),
+      info = "This GET route must gate at Reviewer+ (draft/curator-identity exposure)."
+    )
   })
 })
 
@@ -649,7 +652,7 @@ test_that("GET /<review_id>/phenotypes: happy path — decorator surface present
     )
     dec_idx <- grep("^#\\*\\s+@get\\s+/<review_id_requested>/phenotypes\\s*$", src)[[1L]]
     sig_line <- src[dec_idx + 1L]
-    expect_match(sig_line, "^function\\(review_id_requested\\)")
+    expect_match(sig_line, "^function\\(req, res, review_id_requested\\)")
   })
 })
 
@@ -668,14 +671,17 @@ test_that("GET /<review_id>/phenotypes: validation — body filters by review_id
   })
 })
 
-test_that("GET /<review_id>/phenotypes: permission — public read (no require_role)", {
+test_that("GET /<review_id>/phenotypes: permission — requires Reviewer+", {
   with_test_db_transaction({
     src <- review_source()
     dec_idx <- grep("^#\\*\\s+@get\\s+/<review_id_requested>/phenotypes\\s*$", src)[[1L]]
     next_dec <- grep("^#\\*\\s+@(get|post|put|delete)\\b", src)
     after <- next_dec[next_dec > dec_idx][[1L]]
     body_blob <- paste(src[dec_idx:(after - 1L)], collapse = "\n")
-    expect_false(grepl("require_role\\(", body_blob))
+    expect_true(
+      grepl("require_role\\(\\s*req\\s*,\\s*res\\s*,\\s*\"Reviewer\"", body_blob),
+      info = "This GET route must gate at Reviewer+ (draft/curator-identity exposure)."
+    )
   })
 })
 
@@ -692,7 +698,7 @@ test_that("GET /<review_id>/variation: happy path — decorator surface present"
     )
     dec_idx <- grep("^#\\*\\s+@get\\s+/<review_id_requested>/variation\\s*$", src)[[1L]]
     sig_line <- src[dec_idx + 1L]
-    expect_match(sig_line, "^function\\(review_id_requested\\)")
+    expect_match(sig_line, "^function\\(req, res, review_id_requested\\)")
   })
 })
 
@@ -708,14 +714,17 @@ test_that("GET /<review_id>/variation: validation — joins variation_ontology_l
   })
 })
 
-test_that("GET /<review_id>/variation: permission — public read (no require_role)", {
+test_that("GET /<review_id>/variation: permission — requires Reviewer+", {
   with_test_db_transaction({
     src <- review_source()
     dec_idx <- grep("^#\\*\\s+@get\\s+/<review_id_requested>/variation\\s*$", src)[[1L]]
     next_dec <- grep("^#\\*\\s+@(get|post|put|delete)\\b", src)
     after <- next_dec[next_dec > dec_idx][[1L]]
     body_blob <- paste(src[dec_idx:(after - 1L)], collapse = "\n")
-    expect_false(grepl("require_role\\(", body_blob))
+    expect_true(
+      grepl("require_role\\(\\s*req\\s*,\\s*res\\s*,\\s*\"Reviewer\"", body_blob),
+      info = "This GET route must gate at Reviewer+ (draft/curator-identity exposure)."
+    )
   })
 })
 
@@ -732,7 +741,7 @@ test_that("GET /<review_id>/publications: happy path — decorator surface prese
     )
     dec_idx <- grep("^#\\*\\s+@get\\s+/<review_id_requested>/publications\\s*$", src)[[1L]]
     sig_line <- src[dec_idx + 1L]
-    expect_match(sig_line, "^function\\(review_id_requested\\)")
+    expect_match(sig_line, "^function\\(req, res, review_id_requested\\)")
   })
 })
 
@@ -747,14 +756,17 @@ test_that("GET /<review_id>/publications: validation — pulls ndd_review_public
   })
 })
 
-test_that("GET /<review_id>/publications: permission — public read (no require_role)", {
+test_that("GET /<review_id>/publications: permission — requires Reviewer+", {
   with_test_db_transaction({
     src <- review_source()
     dec_idx <- grep("^#\\*\\s+@get\\s+/<review_id_requested>/publications\\s*$", src)[[1L]]
     next_dec <- grep("^#\\*\\s+@(get|post|put|delete)\\b", src)
     after <- next_dec[next_dec > dec_idx][[1L]]
     body_blob <- paste(src[dec_idx:(after - 1L)], collapse = "\n")
-    expect_false(grepl("require_role\\(", body_blob))
+    expect_true(
+      grepl("require_role\\(\\s*req\\s*,\\s*res\\s*,\\s*\"Reviewer\"", body_blob),
+      info = "This GET route must gate at Reviewer+ (draft/curator-identity exposure)."
+    )
   })
 })
 

--- a/api/tests/testthat/test-endpoint-review.R
+++ b/api/tests/testthat/test-endpoint-review.R
@@ -848,3 +848,40 @@ test_that("PUT /approve/<review_id>: permission — non-Curator role blocked wit
     expect_false(svc_called)
   })
 })
+
+
+# =============================================================================
+# Behavioral deny-before-query: every gated GET route must reject an
+# anonymous / insufficient-role caller BEFORE touching the database, so no
+# draft rows or curator identities can leak. A sentinel `pool` (whose use as a
+# dbplyr source would error) proves the handler stops at `require_role`.
+# =============================================================================
+
+test_that("review GET routes: anonymous/insufficient role is denied BEFORE any DB access (403)", {
+  with_test_db_transaction({
+    deny <- function(req, res, min_role) {
+      res$status <- 403L
+      stop("forbidden")
+    }
+    # decorator -> (id-arg?) for each gated GET route
+    routes <- list(
+      list(dec = "^#\\*\\s+@get\\s+/\\s*$",                                   args = list()),
+      list(dec = "^#\\*\\s+@get\\s+/<review_id_requested>\\s*$",              args = list(review_id_requested = "1")),
+      list(dec = "^#\\*\\s+@get\\s+/<review_id_requested>/phenotypes\\s*$",   args = list(review_id_requested = "1")),
+      list(dec = "^#\\*\\s+@get\\s+/<review_id_requested>/variation\\s*$",    args = list(review_id_requested = "1")),
+      list(dec = "^#\\*\\s+@get\\s+/<review_id_requested>/publications\\s*$", args = list(review_id_requested = "1"))
+    )
+    for (r in routes) {
+      env <- new.env(parent = globalenv())
+      env$require_role <- deny
+      # sentinel: any dbplyr use errors, so a green test proves deny-before-query
+      env$pool <- structure(list(), class = "SENTINEL_DB")
+      handler <- extract_review_handler(r$dec, env)
+      res <- new.env()
+      res$status <- 200L
+      call_args <- c(list(req = list(), res = res), r$args)
+      expect_error(do.call(handler, call_args), "forbidden", info = r$dec)
+      expect_equal(res$status, 403L)
+    }
+  })
+})

--- a/api/tests/testthat/test-endpoint-status.R
+++ b/api/tests/testthat/test-endpoint-status.R
@@ -153,16 +153,16 @@ test_that("GET / status list: validation — filter_status_approved coerced via 
   })
 })
 
-test_that("GET / status list: permission — public read (no require_role)", {
+test_that("GET / status list: permission — requires Reviewer+", {
   with_test_db_transaction({
     src <- status_source()
     dec_idx <- grep("^#\\*\\s+@get\\s+/\\s*$", src)[[1L]]
     next_dec <- grep("^#\\*\\s+@(get|post|put|delete)\\b", src)
     after <- next_dec[next_dec > dec_idx][[1L]]
     body_blob <- paste(src[dec_idx:(after - 1L)], collapse = "\n")
-    expect_false(
-      grepl("require_role\\(", body_blob),
-      info = "GET /status is a public list endpoint; no require_role() guard expected."
+    expect_true(
+      grepl("require_role\\(\\s*req\\s*,\\s*res\\s*,\\s*\"Reviewer\"", body_blob),
+      info = "This GET route must gate at Reviewer+ (draft/curator-identity exposure)."
     )
   })
 })
@@ -180,7 +180,7 @@ test_that("GET /<status_id_requested>: happy path — parameterised signature", 
     )
     dec_idx <- grep("^#\\*\\s+@get\\s+/<status_id_requested>\\s*$", src)[[1L]]
     sig_line <- src[dec_idx + 1L]
-    expect_match(sig_line, "^function\\(status_id_requested\\)")
+    expect_match(sig_line, "^function\\(req, res, status_id_requested\\)")
   })
 })
 
@@ -194,14 +194,17 @@ test_that("GET /<status_id_requested>: validation — URLdecodes + splits on com
   })
 })
 
-test_that("GET /<status_id_requested>: permission — public read (no require_role)", {
+test_that("GET /<status_id_requested>: permission — requires Reviewer+", {
   with_test_db_transaction({
     src <- status_source()
     dec_idx <- grep("^#\\*\\s+@get\\s+/<status_id_requested>\\s*$", src)[[1L]]
     next_dec <- grep("^#\\*\\s+@(get|post|put|delete)\\b", src)
     after <- next_dec[next_dec > dec_idx][[1L]]
     body_blob <- paste(src[dec_idx:(after - 1L)], collapse = "\n")
-    expect_false(grepl("require_role\\(", body_blob))
+    expect_true(
+      grepl("require_role\\(\\s*req\\s*,\\s*res\\s*,\\s*\"Reviewer\"", body_blob),
+      info = "This GET route must gate at Reviewer+ (draft/curator-identity exposure)."
+    )
   })
 })
 

--- a/api/tests/testthat/test-endpoint-status.R
+++ b/api/tests/testthat/test-endpoint-status.R
@@ -607,3 +607,38 @@ test_that("PUT /approve/<status_id>: permission — non-Curator role blocked wit
     expect_false(svc_called)
   })
 })
+
+
+# =============================================================================
+# Behavioral deny-before-query: the gated status GET routes (list + detail,
+# NOT `_list`, which is public vocabulary by design) must reject an anonymous /
+# insufficient-role caller BEFORE touching the database, so no draft rows or
+# curator identities can leak. A sentinel `pool` (whose use as a dbplyr source
+# would error) proves the handler stops at `require_role`.
+# =============================================================================
+
+test_that("status GET routes: anonymous/insufficient role is denied BEFORE any DB access (403)", {
+  with_test_db_transaction({
+    deny <- function(req, res, min_role) {
+      res$status <- 403L
+      stop("forbidden")
+    }
+    # decorator -> (id-arg?) for each gated GET route (NOT `_list`, which is public)
+    routes <- list(
+      list(dec = "^#\\*\\s+@get\\s+/\\s*$",                        args = list()),
+      list(dec = "^#\\*\\s+@get\\s+/<status_id_requested>\\s*$",   args = list(status_id_requested = "1"))
+    )
+    for (r in routes) {
+      env <- new.env(parent = globalenv())
+      env$require_role <- deny
+      # sentinel: any dbplyr use errors, so a green test proves deny-before-query
+      env$pool <- structure(list(), class = "SENTINEL_DB")
+      handler <- extract_status_handler(r$dec, env)
+      res <- new.env()
+      res$status <- 200L
+      call_args <- c(list(req = list(), res = res), r$args)
+      expect_error(do.call(handler, call_args), "forbidden", info = r$dec)
+      expect_equal(res$status, 403L)
+    }
+  })
+})

--- a/api/tests/testthat/test-endpoint-status.R
+++ b/api/tests/testthat/test-endpoint-status.R
@@ -261,6 +261,21 @@ test_that("GET _list status: permission — public read (no require_role)", {
   })
 })
 
+test_that("GET _list status: route precedence — declared BEFORE dynamic /<status_id_requested>", {
+  # #535 P0-1 regression guard: plumber matches routes in declaration order.
+  # The static `_list` route MUST be declared before the dynamic detail route,
+  # otherwise `/status/_list` is captured by the (now Reviewer+-gated) detail
+  # handler and the public vocabulary endpoint 403s. This locks the ordering
+  # that keeps `_list` publicly reachable.
+  src <- status_source()
+  list_idx <- grep("^#\\*\\s+@get\\s+_list\\s*$", src)[[1L]]
+  detail_idx <- grep("^#\\*\\s+@get\\s+/<status_id_requested>\\s*$", src)[[1L]]
+  expect_lt(
+    list_idx, detail_idx,
+    label = "The `_list` route decorator must appear before `/<status_id_requested>`"
+  )
+})
+
 
 # =============================================================================
 # POST /create -- create status (shared handler with PUT /update)


### PR DESCRIPTION
## Summary

Closes the **P0-1** authorization finding from the #535 deep-audit umbrella: anonymous `GET`
requests reach `/api/review` and `/api/status`, whose defaults select **unapproved draft** rows and
return curator identities, roles, comments, and workflow state. This gates every draft-exposing GET
route at **Reviewer+**.

Part of #535. Security-critical — please review before merge; **do not auto-merge**.

## What changed

- `require_role(req, res, "Reviewer")` is the first statement in all seven draft-exposing GET
  handlers: review list + `/<id>` + `/phenotypes` + `/variation` + `/publications`; status list +
  `/<id>`. The five review detail/subresource handlers and the status detail handler were widened
  from `function(<id>)` to `function(req, res, <id>)` (Plumber binds `req`/`res` and path params by
  name).
- `GET /api/status/_list` stays **public** (category vocabulary only — no drafts/identities). Fixed
  a latent route-precedence bug: the static `_list` route was declared *after* the dynamic
  `/<status_id_requested>` route, so once the detail route is gated, `/status/_list` was shadowed
  and 403'd (and on `master` it silently returned the detail handler's empty output). `_list` is now
  declared first; a regression test locks the ordering.
- Write/approve routes were already `require_role`-gated (create/update → Reviewer, approve →
  Curator); unchanged.
- Tests: inverted every `public read (no require_role)` permission block and the obsolete
  `function(<id>)` signature assertions; added deny-before-query behavioral tests (a sentinel `pool`
  that errors if touched proves the gate fires before any DB access) for all seven routes.
- `api/scripts/verify-endpoints.R`: moved `/api/review/` and `/api/status/` from public to
  protected (kept `/api/status/_list` public).

## Not in scope (tracked follow-ups)

- Approved review/status `comment` text served via the already approval-gated `/api/entity/<id>/*`
  routes is not a draft/identity leak; whether an *approved* comment is public editorial content vs
  private workflow metadata is a separate product decision (audit follow-up S8-c).

## Verification

- `test-endpoint-review.R` PASS 81, `test-endpoint-status.R` PASS 58 (FAIL 0, SKIP 0) against the
  test DB.
- `make code-quality-audit`: clean.
- Live (anonymous): all 7 gated routes → **403** `application/problem+json` (no draft rows /
  identities in the body); `/api/status/_list` → **200**; a Reviewer JWT → **200** with data.
- Independently reviewed read-only by Codex (`gpt-5`): **SAFE TO MERGE** from an
  authorization/data-exposure perspective (no BLOCKER/HIGH/MEDIUM); the two LOW findings
  (stale verifier script, route-precedence guard) are folded above.

Spec/plan: `.planning/superpowers/specs/2026-07-11-security-hardening-535-design.md`,
`.planning/superpowers/plans/2026-07-11-security-535-s0-endpoint-authz-plan.md`.

https://claude.ai/code/session_01GMkyFzt2kPytWzp8QBqaqc
