### PR TITLE
chore(release): v0.29.9 — #535 security hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.29.9] — 2026-07-12
+
+Security hardening (#535) — remediation of an adversarial repository audit. This release closes credential-exposure, authorization, and token-revocation gaps and hardens the production build and database restore. Verified end-to-end against the running stack (endpoint authorization, live token-refresh revocation, durable-job payload credential-safety, and job-type single-flight) plus an independent adversarial security review.
+
+### Security
+
+- Gate the draft-exposing `/api/review` routes (list, detail, phenotypes, variation, publications) and the `/api/status/<id>` detail route at Reviewer+; anonymous requests now receive `403` with no draft rows or curator identities in the body. The public `/api/status/_list` status-category vocabulary stays open by design (#537, #535 P0-1).
+- Revocable, role-current token refresh via a per-user `session_epoch` (migration `043`). Every issued JWT carries the epoch; privilege and state mutations increment it atomically in the same SQL statement; and `auth_refresh` reads current account state under a row lock and mints claims from the database row. Demotion, deactivation, password change, deletion, or a pre-deploy (epoch-less) token therefore lose refresh capability immediately (#538, #535 P0-2).
+- Keep database credentials out of durable backup jobs — no credentials in process arguments, shell, or the persisted job payload — and scrub credentials from terminal job payloads (#539, #535 P1-1).
+- Resolve database credentials at run time for all durable job families instead of persisting them in job payloads, and add job-type single-flight for destructive maintenance jobs (HGNC, comparisons, OMIM, force-apply) (#542, #535 S2b).
+- Never emit production source maps or the bundle-analyzer report, and make the database restore path fail-closed (#540, #535 S4).
+
+### Fixed
+
+- Generation-based request ownership for faceted tables and search suggestions, preventing stale or out-of-order responses from overwriting current results during rapid filter, sort, and pagination changes (#541, #535 S5).
+
+### Added
+
+- Security-hardening specification, implementation plans, and adversarial code-review records under `.planning/` (#536).
+
 ## [0.29.8] — 2026-07-11
 
 Bugfix — a pre-existing, app-wide cursor-pagination bug that silently dropped one row on the first→second page transition of every cursor-paginated table. This is an intentional behavior change (it flips the buggy cursor value), verified live against the running dev stack across multiple tables, not only in unit tests.

--- a/api/version_spec.json
+++ b/api/version_spec.json
@@ -1,7 +1,7 @@
 {
   "title": "SysNDD API",
   "description": "This is the API powering the SysNDD website, allowing programmatic access to the database contents.",
-  "version": "0.29.8",
+  "version": "0.29.9",
   "contact": {
     "name": "API Support",
     "url": "https://berntpopp.github.io/sysndd/api.html",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysndd",
-  "version": "0.29.8",
+  "version": "0.29.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysndd",
-      "version": "0.29.8",
+      "version": "0.29.9",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@unhead/vue": "^3.1.7",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.29.8",
+  "version": "0.29.9",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Release **v0.29.9** — ships the #535 security-hardening program (slices S0/S2/S4/S5/S2b).

Version bumped across all four surfaces (`app/package.json`, both root fields in `app/package-lock.json`, `api/version_spec.json`) plus a dated `## [0.29.9]` CHANGELOG section.

## Included (already merged to master)
- #537 — P0-1: gate draft-exposing `/api/review*` + `/api/status/<id>` at Reviewer+
- #538 — P0-2: revocable, role-current token refresh via `session_epoch` (migration `043`)
- #539 — P1-1: DB credentials out of durable backup jobs + terminal-payload scrub
- #540 — S4: no prod source maps / bundle-analyzer report; fail-closed DB restore
- #541 — S5: generation-based request ownership (table coordinator + search suggestions)
- #542 — S2b: run-time DB credentials for all durable job families + job-type single-flight
- #536 — planning docs + adversarial Codex reviews

## Verification (final merged master)
- `make code-quality-audit` clean; `lint-api` (171 files, 0 issues); `lint-app` (0 errors); `verify-seo-app` pass
- Frontend: `type-check` + `type-check:strict` clean; **1972** unit tests pass
- R security tests in-container against a real DB: **401 pass, 0 fail**; **7 static guard tests** pass
- Live monkey checks against the running stack: endpoint authz (anon 403 / Reviewer 200), session-epoch refresh revocation (legacy + epoch-bump → 401; valid → DB-derived claims), durable-job payload has no credentials + single-flight `409`, prod build has no source maps / stats.html
- Independent adversarial security review: **SHIP, 0 blocking findings**

Note: umbrella issue #535 stays open — remaining slices (S3/S5b/S6/S7/S8) are not in this release.

https://claude.ai/code/session_01GMkyFzt2kPytWzp8QBqaqc