### PR TITLE
fix(api): CSPRNG temp passwords + HTML-escape account-email fields S8 — DO NOT AUTO-MERGE (#535)

### DIFF
--- a/.planning/reviews/2026-07-12-security-535-s8-account-email-review-codex.md
+++ b/.planning/reviews/2026-07-12-security-535-s8-account-email-review-codex.md
@@ -1,0 +1,26 @@
+# S8 account/email — Codex adversarial review (gpt-5.6-sol, xhigh, read-only)
+
+## Verdict: SHIP (no BLOCKER / HIGH / MEDIUM). LOW hardening applied.
+
+### Confirmed correct
+- CSPRNG mapping correct: 64-char alphabet (10+26+26+2), `rand_bytes(12)` → 12 secure bytes 0..255,
+  `256 %% 64 == 0` (bias-free), `+1L` → indices 1..64, 72-bit entropy. `openssl` 2.4.0 pinned in
+  renv.lock and in the API image; `openssl::rand_bytes` namespace-qualified; RNG failure throws (no
+  insecure fallback). All 4 production call sites keep the scalar 12-char contract.
+- Every HTML-email occurrence of user_name/first_name/family_name/email/orcid escaped; ORCID
+  attribute-escaped in href + text-escaped label. Attribute mode escapes quotes + CR/LF; text mode
+  preserves apostrophes. temp_password/URLs/batch numbers are non-user/system-controlled;
+  `email_notification()` has no callers (its trusted body_content/subject_text unexposed).
+- Tests non-vacuous (CSPRNG seed test fails vs sample(); injection assertions fail before escaping).
+- No other credential generator uses R's PRNG (other sample()/runif() are sampling/jitter/tempnames).
+
+### LOW (applied in this PR)
+- `email_escape*()` now coerces NULL/NA/non-scalar → "" (reject `length != 1L`, `is.na`) so a
+  malformed field can't render "NA"/vectorize (not previously exploitable; defensive).
+- ORCID test now explicitly asserts `&quot;` (proves attribute escaping, not text); added an
+  `email_escape` NULL/NA/scalar coercion test.
+
+### Adjacent follow-up (NOT S8 — separate untrusted-markup sink)
+- `app/src/components/filters/TermSearch.vue:31` uses raw `v-html` for API-derived gene symbols;
+  `highlightMatch()` concatenates them without escaping. Not ordinary account-user input, so out of
+  S8 scope — tracked as a frontend v-html follow-up (use Vue text bindings around `<strong>`).

--- a/.planning/reviews/2026-07-13-security-535-s8-diff-codex-review.md
+++ b/.planning/reviews/2026-07-13-security-535-s8-diff-codex-review.md
@@ -1,0 +1,55 @@
+# S8 account/email hardening — final adversarial Codex diff review (#535)
+
+- **PR:** #545 — S8 account/email hardening (slice of umbrella security issue #535)
+- **Branch:** `fix/535-s8-account-email-hardening`
+- **Reviewer:** Codex (`gpt-5.6-sol`, `model_reasoning_effort=xhigh`, read-only)
+- **Recipe:** `codex exec -s read-only -c approval_policy=never -c model_reasoning_effort=xhigh` over `git diff master...HEAD`
+- **Final verdict:** `Verdict: SHIP` — "No BLOCKER / HIGH / MEDIUM / LOW findings."
+- **Rounds to SHIP:** 4 review rounds (round 5 overall counting the pre-existing SHIP). Codex reviews the *committed* `HEAD`, so each round's folds had to be committed before the next round could see them.
+
+## Confirmed correct on every round
+
+- **CSPRNG temp password** (`random_password`, `account-helpers.R`): uniform / bias-free — 64-symbol alphabet, `256 %% 64 == 0` (four byte preimages per symbol, no modulo bias, no rejection sampling), 72 bits of entropy, drawn from `openssl::rand_bytes` (not seedable `sample()`). All four temp-password call sites use the helper; no other credential generator uses `sample()`/`runif()`.
+- **HTML escaping** of user-controlled email fields (`email-templates.R`): complete and context-correct — element-text via `email_escape()`, HTML-attribute (ORCID href) via `email_escape_attr()`, NA/NULL/non-scalar coerced to `""`.
+- No masked bare `get(..., mode=...)` introduced. `git diff --check` clean.
+
+## Findings folded to reach SHIP
+
+Codex's "budget ~2x scope / grep every adjacent same-class sink" pass surfaced credential/token-leak sinks beyond the original diff. All BLOCKER + HIGH + the cheap MEDIUM/LOW were folded (TDD RED→GREEN in `test-unit-account-email-hardening.R`).
+
+### Round 1 (initial) — 2 MEDIUM + 2 LOW
+- **MEDIUM — log injection:** signup fields length-checked only; CR/LF-bearing `user_name` logged verbatim on SMTP failure. → Root-cause fix: `account_field_has_control_char()` + signup rejects control chars in every account field.
+- **MEDIUM — recipient/header validation delegated downstream:** unanchored, dotall email regex accepts CR/LF passed to `smtp_send()`. → Hardened `is_valid_email()` (scalar/NA-safe, reject `[[:cntrl:]]`, anchored) + control-char guard at the `send_noreply_email()` choke point.
+- **LOW — greeting `nchar()` bypass:** throws on NA/vector `user_name`. → Branch on `nzchar(user_name_e)`.
+- **LOW — stale roxygen** still described `sample()`. → Rewrote to document the CSPRNG + bias-free mapping.
+
+### Round 2 (deeper) — 1 BLOCKER + 1 HIGH + 1 MEDIUM + 1 LOW
+- **BLOCKER — password-reset BCC leak:** `send_noreply_email()` default `email_blind_copy = "noreply@sysndd.org"`; the password-reset send relies on the default, so the **bearer reset URL was blind-copied to a shared mailbox** → account takeover during token validity. → Default is now `NULL` (no BCC); NULL permitted and simply not attached.
+- **HIGH — temp-password BCC leak:** the four account-approval sends BCCed the **plaintext temporary password** to `curator@sysndd.org` (shared mailbox → impersonation of newly approved users). → Credentials now go to the account address only; curator BCC removed from all four sends.
+- **MEDIUM — permissive signup email regex:** `.+@.+\.+` (dotall) admits SMTP recipient grammar (`<a@b.com> NOTIFY=SUCCESS`). → Signup gates the email through the anchored `is_valid_email()`; choke point also requires a scalar recipient.
+- **LOW — latent `batch_info` sink** in `email_rereview_request` (no caller). → HTML-escaped.
+
+### Round 3 (residual) — 2 LOW
+- **LOW — central address validation:** the send choke point rejected control chars but not full address grammar (legacy/admin-edited rows). → `send_noreply_email()` now validates every `to`/`bcc` address with `is_valid_email()`; empty-string bcc treated as "no blind copy".
+- **LOW — stored-value log sink:** account-approval log interpolates a stored `user_name` (legacy CR/LF risk). → `sanitize_log_value()` neutralizes control chars at that log sink.
+
+### Round 4 (final) — none
+`Verdict: SHIP` — no findings.
+
+## Gates (fresh evidence)
+
+- `make code-quality-audit` → `code-quality audit clean` (exit 0).
+- `make lint-api` → `Total issues: 0`, all 171 files pass.
+- Targeted `test-unit-account-email-hardening.R` (in `sysndd-api-1`, which has htmltools) → `FAIL 0 | WARN 0 | SKIP 0 | PASS 154`.
+- `make test-api-fast` → the only 4 failures are the pre-existing missing-`htmltools` host artifact in `test-unit-password-reset-request.R` (the htmltools call was introduced by the base S8 commit; those tests pass 17/17 in-container and are green on CI, which has htmltools). No other failures; `PASS 5962`.
+
+Codex could not execute R in its read-only sandbox (temp-file creation blocked); test evidence above was produced by the author in-container and via `make test-api-fast`.
+
+## Files touched by the folds
+
+- `api/functions/account-helpers.R` — CSPRNG doc, hardened `is_valid_email()`, `account_field_has_control_char()`, `sanitize_log_value()`, `send_noreply_email()` NULL-default BCC + central address validation + scalar recipient + subject control-char guard.
+- `api/functions/email-templates.R` — `nzchar` greeting guards; `batch_info` escaping.
+- `api/endpoints/authentication_endpoints.R` — signup control-char rejection + strict `is_valid_email()` gate.
+- `api/services/user-account-endpoint-service.R` — removed curator BCC from two approval sends; sanitized approval log sink.
+- `api/services/user-service.R` — removed curator BCC from two approval sends.
+- `api/tests/testthat/test-unit-account-email-hardening.R` — RED→GREEN tests for every fold.

--- a/.planning/superpowers/plans/2026-07-12-security-535-s8-account-email-plan.md
+++ b/.planning/superpowers/plans/2026-07-12-security-535-s8-account-email-plan.md
@@ -1,0 +1,48 @@
+# S8 (account/email hardening) — Plan
+
+> REQUIRED SUB-SKILL: superpowers:test-driven-development. Steps use `- [ ]`.
+
+**Goal:** CSPRNG temp passwords + HTML-escaped user fields in account emails, contract-preserving.
+Design: `.../specs/2026-07-12-security-535-s8-account-email-design.md`.
+
+## Task 1: RED tests
+- [ ] Create `api/tests/testthat/test-unit-account-email-hardening.R`:
+  - CSPRNG: `set.seed(1); a <- random_password(); set.seed(1); b <- random_password();
+    expect_false(identical(a, b))`; `expect_equal(nchar(random_password()), 12)`; every char of many
+    draws ∈ `c(0:9, letters, LETTERS, "!", "$")`.
+  - Escape: `out <- email_registration_request(list(user_name = "<img src=x onerror=alert(1)>",
+    email = "a@b.c", first_name = "A", family_name = "B"))`; `expect_true(grepl("&lt;img", out))`;
+    `expect_false(grepl("<img src=x onerror", out, fixed = TRUE))`. ORCID attribute:
+    `out2 <- email_rereview_request(list(user_name="u", email="a@b.c", orcid='"><b>'))`;
+    `expect_false(grepl('"><b>', out2, fixed = TRUE))`; `expect_true(grepl("&gt;&lt;b&gt;", out2))`.
+    Benign name round-trips (`grepl("Ada", email_account_approved("Ada", "pw"))`).
+- [ ] Run in-container → RED (source current `account-helpers.R` + `email-templates.R`).
+
+## Task 2: CSPRNG `random_password()`
+- [ ] `api/functions/account-helpers.R`: replace the `sample()` draw with
+  ```r
+  # 64-char alphabet; 256 %% 64 == 0 so `byte %% 64` is bias-free (no rejection sampling).
+  possible_characters <- c(0:9, letters, LETTERS, "!", "$")  # length 64 — keep at 64
+  idx <- as.integer(openssl::rand_bytes(12)) %% length(possible_characters) + 1L
+  paste(possible_characters[idx], collapse = "")
+  ```
+  Keep roxygen; note the CSPRNG + bias-free invariant. Verify `openssl` loads in-container.
+
+## Task 3: HTML-escape helpers + field escaping
+- [ ] `api/functions/email-templates.R`: add `email_escape()` (attribute=FALSE, NULL/empty→"") and
+  `email_escape_attr()` (attribute=TRUE). Pre-escape user-controlled locals in
+  `email_password_reset`, `email_registration_request`, `email_account_approved`,
+  `email_rereview_request` (ORCID: attr for href + text for label), `email_batch_assigned`,
+  `email_notification` (`user_name` only). Leave `body_content`, URLs, brand constants, numeric batch
+  fields, and `temp_password` unescaped (system-controlled / intentional HTML).
+
+## Task 4: GREEN + verify
+- [ ] In-container: new test + `test-unit-user-approval.R` + `test-unit-user-endpoint-services.R`
+  green. `make lint-api` (host). File sizes < 600. Live render a hostile name → grep escaped.
+- [ ] Codex adversarial diff review; fold; PR (do-not-auto-merge, security-critical), `Closes` refs
+  #535 on its own line.
+
+## Self-review
+- Contract preserved (12 chars, same alphabet); only entropy source + escaping change. Escaping is
+  applied to every user-derived interpolation; `body_content` intentionally excluded. Both files
+  stay < 600 lines.

--- a/.planning/superpowers/specs/2026-07-12-security-535-s8-account-email-design.md
+++ b/.planning/superpowers/specs/2026-07-12-security-535-s8-account-email-design.md
@@ -1,0 +1,92 @@
+# S8 (account/email hardening) — CSPRNG temp passwords + HTML-escaped email fields — Design
+
+Date: 2026-07-12
+Issue: [#535](https://github.com/berntpopp/sysndd/issues/535) — umbrella hardening, slice **S8**
+(defense-in-depth quick wins). This is the first of the S8 splits (clean seam: the account
+notification/credential path). Parent design:
+`.planning/superpowers/specs/2026-07-11-security-hardening-535-design.md` §3 (S8), §cheap-wins.
+
+## 1. What this is
+
+Two independent, low-risk, well-bounded defense-in-depth fixes in the account-email subsystem,
+shipped together because they share the exact same code area, the same reviewers, and the same
+verification path (`account-helpers.R` + `email-templates.R`):
+
+1. **CSPRNG temporary passwords (P3).** `random_password()` (`api/functions/account-helpers.R:37-46`)
+   draws with `sample()`, which uses R's Mersenne-Twister PRNG — **not cryptographically secure** and
+   seedable/predictable. This is the generator for the temporary login credential emailed on account
+   approval (call sites: `user-service.R:135,415`, `user-account-endpoint-service.R:55,260`). Replace
+   the draw with a CSPRNG.
+2. **HTML-escape user-controlled email fields (P2/P3, stored-XSS-in-email).** Signup fields
+   (`user_name`, `first_name`, `family_name`, `email`, `orcid`) are stored raw (parameterized SQL —
+   SQL-safe) and later interpolated **raw** into HTML email bodies via `glue::glue()`; the body is
+   marked as trusted HTML with `htmltools::HTML()` (`account-helpers.R:162-167`, `html_content=TRUE`)
+   and sent (BCC'd to `curator@sysndd.org`). A crafted `user_name` such as
+   `<img src=x onerror=...>` or `"><a href=...>` is delivered as live markup to the curator's mail
+   client. No HTML-escaping exists anywhere in `api/`. Escape the user-controlled fields at each
+   interpolation site.
+
+Neither change touches DB schema, auth flow, or deployment topology. Both are operator-invisible.
+
+## 2. Design
+
+### 2.1 CSPRNG password
+Keep the public contract identical: a 12-character string over the same 64-character alphabet
+`c(0:9, letters, LETTERS, "!", "$")`. The alphabet is **exactly 64** characters and 256 is an exact
+multiple of 64 (256 / 64 = 4), so mapping a uniform random byte with `byte %% 64` is **bias-free**
+(no rejection sampling needed). Draw 12 CSPRNG bytes via `openssl::rand_bytes(12)` (openssl is in
+`renv.lock`; verify it loads in-container) and index the alphabet. `random_password()` keeps its
+signature, length, and charset; only the entropy source changes. A code comment states the
+64|256 bias-free invariant so a future alphabet change is flagged.
+
+### 2.2 HTML-escaped email fields
+Add two tiny helpers in `email-templates.R`:
+- `email_escape(x)` → `htmltools::htmlEscape(as.character(x), attribute = FALSE)` for element **text**
+  contexts, NULL/empty-safe (returns `""`).
+- `email_escape_attr(x)` → `htmltools::htmlEscape(as.character(x), attribute = TRUE)` for values
+  interpolated into an **attribute** (the ORCID `href`), also escaping quotes.
+
+Pre-escape the user-controlled locals at the top of each template that renders them, then interpolate
+the escaped locals in the `glue` template (keeping templates readable):
+- `email_password_reset`: `user_name`.
+- `email_registration_request`: `first_name`, `user_info$user_name`, `user_info$email`,
+  `user_info$first_name`, `user_info$family_name`.
+- `email_account_approved`: `user_name`. (`temp_password` is system-generated over a known safe
+  alphabet — left as-is.)
+- `email_rereview_request`: `user_name`, `user_info$user_name`, `user_info$email`, and `user_info$orcid`
+  **twice** — `email_escape_attr` for the `href="https://orcid.org/{orcid}"` and `email_escape` for
+  the visible label.
+- `email_batch_assigned`: `user_name`. (`batch_number`/`entity_count` are numeric/system.)
+- `email_notification`: `user_name`. (`subject_text` and `body_content` are developer/system-
+  controlled — `body_content` is deliberately HTML; left unescaped by design.)
+
+The wrapper's brand constants, URLs (`reset_url`, `login_url`, `review_url`), and static markup are
+system-controlled and unchanged.
+
+## 3. Tests (TDD, R testthat)
+New `api/tests/testthat/test-unit-account-email-hardening.R`:
+- **CSPRNG:** `set.seed(1); a <- random_password(); set.seed(1); b <- random_password();
+  expect_false(identical(a, b))` — the old `sample()` path is seed-reproducible (RED), a CSPRNG
+  ignores the seed (GREEN). Plus: length == 12, every char ∈ the alphabet, and a distribution
+  sanity check (many draws use > 1 distinct alphabet class).
+- **HTML-escape:** `email_registration_request(list(user_name = '<img src=x onerror=alert(1)>', ...))`
+  output **contains** `&lt;img` and **does not contain** the literal `<img src=x onerror`; same for a
+  quote-breaking `orcid = '"><b>'` in `email_rereview_request` (attribute-escaped). A benign name
+  round-trips unchanged.
+Keep the existing `test-unit-user-approval.R` / `test-unit-user-endpoint-services.R` green (they
+reference `random_password`; the contract is unchanged).
+
+## 4. Verification
+- In-container R tests (tests dir is not bind-mounted): run the new test + the two existing user
+  tests. Confirm `openssl::rand_bytes` loads in the API image.
+- `make lint-api` (host), `make code-quality-audit` (file-size ratchet — both files stay < 600).
+- Live monkey check (optional, high-value): render `email_registration_request` with a hostile name
+  in-container and grep the output for escaped markup.
+- Codex adversarial diff review before PR.
+
+## 5. Out of scope / follow-ups
+- Frontend admin user-management rendering of the same fields is a separate consumer (Vue escapes by
+  default; not an API concern).
+- Throttling of signup/auth, dead `create_job` executor_fn, and the MCP SELECT-only DB principal are
+  the other S8 splits (separate PRs).
+- The approved-comment visibility question (S8-c in the umbrella spec) is unrelated.

--- a/api/endpoints/authentication_endpoints.R
+++ b/api/endpoints/authentication_endpoints.R
@@ -102,6 +102,16 @@ function(req, res) {
     return(res)
   }
 
+  # Gate the email through the hardened, anchored validator (not the permissive
+  # `.+@.+\\..+` shape used below): SMTP recipient grammar such as
+  # `<a@example.com> NOTIFY=SUCCESS` must not create an account whose approval
+  # credentials are then handed to smtp_send() as a malformed/injectable address.
+  if (!is_valid_email(signup_body[["email"]])) {
+    res$status <- 400
+    res$body <- "Malformed JSON body: invalid email address."
+    return(res)
+  }
+
   user <- tibble::as_tibble(signup_body) %>%
     dplyr::mutate(
       terms_agreed = dplyr::case_when(

--- a/api/endpoints/authentication_endpoints.R
+++ b/api/endpoints/authentication_endpoints.R
@@ -87,6 +87,21 @@ function(req, res) {
     return(res)
   }
 
+  # Reject control characters (CR/LF/tab) in any account field. Left unchecked,
+  # a CR/LF-bearing field is forged into log lines (the best-effort SMTP-failure
+  # logger below prints user_name verbatim) and into email headers once the value
+  # is emailed to the user/curators. Printable non-ASCII (accents) is allowed.
+  fields_have_control_chars <- vapply(
+    required_fields,
+    function(field) account_field_has_control_char(signup_body[[field]]),
+    logical(1)
+  )
+  if (any(fields_have_control_chars)) {
+    res$status <- 400
+    res$body <- "Malformed JSON body: fields must not contain control characters."
+    return(res)
+  }
+
   user <- tibble::as_tibble(signup_body) %>%
     dplyr::mutate(
       terms_agreed = dplyr::case_when(

--- a/api/functions/account-helpers.R
+++ b/api/functions/account-helpers.R
@@ -166,8 +166,11 @@ generate_initials <- function(first_name, family_name) {
 #' @param email_subject A character string representing the subject of the email.
 #' @param email_recipient A character string representing the recipient's email
 #'   address.
-#' @param email_blind_copy A character string representing the blind copy
-#'   recipient's email address, with a default value of "noreply@sysndd.org".
+#' @param email_blind_copy Optional blind-copy recipient address(es). Defaults to
+#'   NULL (NO blind copy). Credential/token emails (account approval, password
+#'   reset) must NOT be blind-copied to a shared mailbox, so callers that need a
+#'   curator notification pass an explicit non-secret address; everything else
+#'   goes only to the recipient.
 #' @param html_content Logical. If TRUE, email_body is treated as complete HTML.
 #'   If FALSE (default), email_body is treated as markdown/plain text.
 #'
@@ -185,7 +188,7 @@ send_noreply_email <- function(
   email_body,
   email_subject,
   email_recipient,
-  email_blind_copy = "noreply@sysndd.org",
+  email_blind_copy = NULL,
   html_content = FALSE
 ) {
   # Defense-in-depth: this is the single choke point every outbound account email
@@ -193,8 +196,9 @@ send_noreply_email <- function(
   # the subject before handing them to smtp_send(). A control char in a `to`/`bcc`
   # address or the Subject header enables SMTP header injection (e.g. an injected
   # Bcc: or spoofed header). Upstream validation should already prevent this;
-  # failing loudly here guarantees no caller can bypass it. Addresses may be a
-  # character vector (e.g. the curator BCC list), so each element is checked.
+  # failing loudly here guarantees no caller can bypass it. The BCC may legitimately
+  # be a character vector (the curator notification list), so each element is
+  # checked; the `to` recipient must be a single address.
   reject_control_chars <- function(value, what) {
     value <- as.character(value)
     if (length(value) == 0L || any(is.na(value)) ||
@@ -209,9 +213,15 @@ send_noreply_email <- function(
     }
     invisible(value)
   }
+  if (length(as.character(email_recipient)) != 1L) {
+    stop("send_noreply_email: recipient must be a single address", call. = FALSE)
+  }
   reject_control_chars(email_recipient, "recipient")
   reject_control_chars(email_subject, "subject")
-  reject_control_chars(email_blind_copy, "bcc")
+  # BCC is optional: only validate (and later attach) it when a caller opts in.
+  if (!is.null(email_blind_copy)) {
+    reject_control_chars(email_blind_copy, "bcc")
+  }
 
   if (html_content) {
     # Use full HTML content directly (from email-templates.R)

--- a/api/functions/account-helpers.R
+++ b/api/functions/account-helpers.R
@@ -12,17 +12,14 @@
 #' Generate a random password
 #'
 #' @description
-#' This function generates a random password of length 12
-#' by selecting characters from a vector of possible characters
-#' that includes digits, lowercase letters, uppercase letters,
-#' exclamation mark, and dollar sign. The steps are as follows:
-#' 1. Create a vector named 'possible_characters' containing digits, lowercase
-#'    letters, uppercase letters, exclamation mark, and dollar sign.
-#' 2. Use the 'sample()' function to randomly select 12 characters from the
-#'    'possible_characters' vector and 'paste()' to combine them into a string.
-#' 3. Use 'collapse = ""' argument in the 'paste()' function to prevent any
-#'    separators between the selected characters.
-#' 4. Return the generated password.
+#' Generates a 12-character temporary password from a 64-symbol alphabet
+#' (digits, lowercase, uppercase, "!", "$"). Randomness comes from a CSPRNG
+#' (\code{openssl::rand_bytes}), NOT the seedable Mersenne-Twister behind
+#' \code{sample()}, because credentials must not be reproducible from a known
+#' seed. The alphabet is exactly 64 characters and \code{256 \%\% 64 == 0}, so
+#' mapping each uniform random byte with \code{\%\% 64} is bias-free (every symbol
+#' has exactly four byte preimages, no modulo bias, no rejection sampling needed).
+#' Entropy is 12 * log2(64) = 72 bits.
 #'
 #' @return A randomly generated password.
 #'
@@ -55,25 +52,18 @@ random_password <- function() {
 #' Validate email address
 #'
 #' @description
-#' This function checks whether a given email address is valid by using regular
-#' expressions and the 'grepl()' function. The email address is considered valid
-#' if it matches the following pattern:
-#' 1. Starts with a word boundary (\<).
-#' 2. Followed by one or more uppercase letters, digits, dots, underscores,
-#'    percent signs, plus signs, or hyphens ([A-Z0-9._%+-]+).
-#' 3. Followed by the at symbol (@).
-#' 4. Followed by one or more uppercase letters, digits, dots, or hyphens
-#'    ([A-Z0-9.-]+).
-#' 5. Followed by a dot (.).
-#' 6. Followed by two or more uppercase letters ([A-Z]{2,}).
-#' 7. Ends with a word boundary (\>).
-#' The 'ignore.case = TRUE' argument in 'grepl()' makes the function
-#' case-insensitive, allowing it to match email addresses regardless of the
-#' letter case.
+#' Checks whether a value is a single, syntactically valid email address that is
+#' safe to hand to \code{smtp_send()} as a \code{to}/\code{bcc} header. The value
+#' must be a NON-NA scalar string, contain NO control characters (CR/LF/tab/etc.,
+#' which enable SMTP header injection), and match the whole-string (anchored)
+#' pattern local-part@domain.tld. The old pattern used \code{\\<}/\code{\\>} word
+#' boundaries, which are NOT anchors: a valid address embedded in surrounding junk
+#' (including a newline-delimited injected header) matched. This function is now
+#' anchored and control-char-free so it is a trustworthy gate for the mail path.
 #'
 #' @param email_address A character string representing an email address.
 #'
-#' @return A boolean value indicating whether the email address is valid.
+#' @return A single boolean; TRUE only for a safe, valid, scalar email address.
 #'
 #' @examples
 #' # Validate an email address
@@ -84,10 +74,43 @@ random_password <- function() {
 #'
 #' @export
 is_valid_email <- function(email_address) {
-  grepl("\\<[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}\\>",
-    as.character(email_address),
+  # Reject non-scalar / NA up front: a vector could smuggle multiple addresses,
+  # and NA would coerce to the string "NA".
+  if (is.null(email_address) || length(email_address) != 1L ||
+    is.na(email_address)) {
+    return(FALSE)
+  }
+  email_address <- as.character(email_address)
+  # Any control character (CR/LF/tab) is disqualifying — it enables SMTP header
+  # injection once the value reaches the `to`/`bcc` header.
+  if (grepl("[[:cntrl:]]", email_address)) {
+    return(FALSE)
+  }
+  # Anchored whole-string match (^...$), so surrounding text cannot slip through.
+  grepl("^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}$",
+    email_address,
     ignore.case = TRUE
   )
+}
+
+
+#' Detect control characters in a user-supplied account field
+#'
+#' @description
+#' Returns TRUE if any element of \code{x} contains a control character
+#' (CR, LF, tab, etc.). Signup/profile free-text fields (user_name, first_name,
+#' family_name, email, orcid, comment) must reject these: a CR/LF survives into
+#' log lines (\code{message()}/logger, enabling log forging) and into email
+#' headers when the value is later emailed. Printable non-ASCII (accents,
+#' apostrophes) is intentionally allowed.
+#'
+#' @param x A character vector (or coercible) to inspect.
+#'
+#' @return A single logical: TRUE if a control character is present.
+#'
+#' @export
+account_field_has_control_char <- function(x) {
+  any(grepl("[[:cntrl:]]", as.character(x)))
 }
 
 
@@ -165,6 +188,31 @@ send_noreply_email <- function(
   email_blind_copy = "noreply@sysndd.org",
   html_content = FALSE
 ) {
+  # Defense-in-depth: this is the single choke point every outbound account email
+  # passes through. Reject CR/LF and other control characters in any address or
+  # the subject before handing them to smtp_send(). A control char in a `to`/`bcc`
+  # address or the Subject header enables SMTP header injection (e.g. an injected
+  # Bcc: or spoofed header). Upstream validation should already prevent this;
+  # failing loudly here guarantees no caller can bypass it. Addresses may be a
+  # character vector (e.g. the curator BCC list), so each element is checked.
+  reject_control_chars <- function(value, what) {
+    value <- as.character(value)
+    if (length(value) == 0L || any(is.na(value)) ||
+      any(grepl("[[:cntrl:]]", value))) {
+      stop(
+        sprintf(
+          "send_noreply_email: %s contains disallowed control characters",
+          what
+        ),
+        call. = FALSE
+      )
+    }
+    invisible(value)
+  }
+  reject_control_chars(email_recipient, "recipient")
+  reject_control_chars(email_subject, "subject")
+  reject_control_chars(email_blind_copy, "bcc")
+
   if (html_content) {
     # Use full HTML content directly (from email-templates.R)
     # Wrap with htmltools::HTML() for proper raw HTML handling

--- a/api/functions/account-helpers.R
+++ b/api/functions/account-helpers.R
@@ -114,6 +114,24 @@ account_field_has_control_char <- function(x) {
 }
 
 
+#' Neutralize control characters before a value is logged
+#'
+#' @description
+#' Replaces any control character (CR, LF, tab, etc.) in \code{x} with a space so
+#' that a stored user-controlled value (e.g. a legacy \code{user_name} that
+#' predates the signup control-char guard) cannot forge log lines when it is
+#' interpolated into a log message.
+#'
+#' @param x A value (coerced to character) about to be logged.
+#'
+#' @return A character vector with control characters replaced by spaces.
+#'
+#' @export
+sanitize_log_value <- function(x) {
+  gsub("[[:cntrl:]]", " ", as.character(x))
+}
+
+
 #' This function generates initials for an avatar based on the provided
 #' first name and family name. The initials are created by taking the first
 #' character of each name.
@@ -192,35 +210,35 @@ send_noreply_email <- function(
   html_content = FALSE
 ) {
   # Defense-in-depth: this is the single choke point every outbound account email
-  # passes through. Reject CR/LF and other control characters in any address or
-  # the subject before handing them to smtp_send(). A control char in a `to`/`bcc`
-  # address or the Subject header enables SMTP header injection (e.g. an injected
-  # Bcc: or spoofed header). Upstream validation should already prevent this;
-  # failing loudly here guarantees no caller can bypass it. The BCC may legitimately
-  # be a character vector (the curator notification list), so each element is
-  # checked; the `to` recipient must be a single address.
-  reject_control_chars <- function(value, what) {
-    value <- as.character(value)
-    if (length(value) == 0L || any(is.na(value)) ||
-      any(grepl("[[:cntrl:]]", value))) {
-      stop(
-        sprintf(
-          "send_noreply_email: %s contains disallowed control characters",
-          what
-        ),
-        call. = FALSE
-      )
-    }
-    invisible(value)
+  # passes through, so validate the transport headers here before smtp_send().
+  # is_valid_email() is scalar-only, NA-safe, control-char-free and anchored, so
+  # it rejects both SMTP header injection (CR/LF) AND SMTP recipient grammar such
+  # as `<a@b.com> NOTIFY=SUCCESS` that a legacy/admin-edited row (predating the
+  # anchored signup validator) could otherwise smuggle to the transport. The
+  # subject is not an address, so it is only checked for control characters.
+  if (!is_valid_email(email_recipient)) {
+    stop("send_noreply_email: recipient is not a valid email address",
+      call. = FALSE)
   }
-  if (length(as.character(email_recipient)) != 1L) {
-    stop("send_noreply_email: recipient must be a single address", call. = FALSE)
+  if (length(as.character(email_subject)) != 1L || is.na(email_subject) ||
+    grepl("[[:cntrl:]]", as.character(email_subject))) {
+    stop("send_noreply_email: subject contains disallowed control characters",
+      call. = FALSE)
   }
-  reject_control_chars(email_recipient, "recipient")
-  reject_control_chars(email_subject, "subject")
-  # BCC is optional: only validate (and later attach) it when a caller opts in.
+  # BCC is optional and may be a character vector (the curator notification list).
+  # Drop empty entries (an empty string means "no blind copy"); validate the rest.
   if (!is.null(email_blind_copy)) {
-    reject_control_chars(email_blind_copy, "bcc")
+    bcc <- as.character(email_blind_copy)
+    bcc <- bcc[nzchar(trimws(bcc))]
+    if (length(bcc) > 0L) {
+      if (!all(vapply(bcc, is_valid_email, logical(1)))) {
+        stop("send_noreply_email: bcc contains an invalid email address",
+          call. = FALSE)
+      }
+      email_blind_copy <- bcc
+    } else {
+      email_blind_copy <- NULL
+    }
   }
 
   if (html_content) {

--- a/api/functions/account-helpers.R
+++ b/api/functions/account-helpers.R
@@ -38,8 +38,14 @@ random_password <- function() {
   # create a vector of possible characters
   possible_characters <- c(0:9, letters, LETTERS, "!", "$")
 
-  # use paste and sample to generate a random password of length 12
-  password <- paste(sample(possible_characters, 12), collapse = "")
+  # Draw from a CSPRNG (openssl::rand_bytes), NOT sample()/Mersenne-Twister, which
+  # is seedable and predictable and must never generate credentials. The alphabet
+  # is exactly 64 characters and 256 %% 64 == 0, so mapping a uniform random byte
+  # with `%% 64` is bias-free (no rejection sampling needed). Keep the alphabet at
+  # 64 entries or this invariant no longer holds.
+  n_chars <- 12L
+  idx <- as.integer(openssl::rand_bytes(n_chars)) %% length(possible_characters) + 1L
+  password <- paste(possible_characters[idx], collapse = "")
 
   # return password
   return(password)

--- a/api/functions/email-templates.R
+++ b/api/functions/email-templates.R
@@ -142,8 +142,10 @@ email_wrapper <- function(content, preheader = "") {
 #' @param expiry_minutes Token expiry time in minutes (default 60)
 #' @return Complete HTML email string
 email_password_reset <- function(reset_url, user_name = NULL, expiry_minutes = 60) {
+  # Drive the greeting off the escaped scalar (email_escape coerces NULL/NA/empty/
+  # non-scalar to ""), so nchar() is never called on NA or a length>1 vector.
   user_name_e <- email_escape(user_name)
-  greeting <- if (!is.null(user_name) && nchar(user_name) > 0) {
+  greeting <- if (nzchar(user_name_e)) {
     glue::glue('<p style="color: {SYSNDD_TEXT}; font-size: 16px; line-height: 1.6; margin: 0 0 16px 0;">Hello <span class="highlight" style="color: {SYSNDD_PRIMARY}; font-weight: 600;">{user_name_e}</span>,</p>')
   } else {
     glue::glue('<p style="color: {SYSNDD_TEXT}; font-size: 16px; line-height: 1.6; margin: 0 0 16px 0;">Hello,</p>')
@@ -438,9 +440,10 @@ email_batch_assigned <- function(user_info, batch_info, review_url = "https://sy
 #' @return Complete HTML email string
 email_notification <- function(subject_text, body_content, user_name = NULL) {
   # subject_text and body_content are developer/system-controlled (body_content is
-  # deliberately HTML); only the user-controlled user_name is escaped.
+  # deliberately HTML); only the user-controlled user_name is escaped. Drive the
+  # greeting off the escaped scalar so nchar() never sees NA or a length>1 vector.
   user_name_e <- email_escape(user_name)
-  greeting <- if (!is.null(user_name) && nchar(user_name) > 0) {
+  greeting <- if (nzchar(user_name_e)) {
     glue::glue('<p style="color: {SYSNDD_TEXT}; font-size: 16px; line-height: 1.6; margin: 0 0 16px 0;">Hello <span class="highlight" style="color: {SYSNDD_PRIMARY}; font-weight: 600;">{user_name_e}</span>,</p>')
   } else {
     ""

--- a/api/functions/email-templates.R
+++ b/api/functions/email-templates.R
@@ -315,12 +315,15 @@ email_rereview_request <- function(user_info, batch_info = NULL) {
   email_e <- email_escape(user_info$email)
   orcid_e <- email_escape(user_info$orcid)
   orcid_attr_e <- email_escape_attr(user_info$orcid)
+  # batch_info is optional free text; escape it so a future caller cannot inject
+  # markup into the email body (latent same-class sink — no current caller).
+  batch_info_e <- email_escape(batch_info)
 
   batch_section <- if (!is.null(batch_info)) {
     glue::glue('
 <div class="info-box" style="background-color: #e3f2fd; border-left: 4px solid {SYSNDD_PRIMARY}; padding: 16px; margin: 20px 0; border-radius: 0 6px 6px 0;">
   <p style="margin: 0 0 8px 0; color: {SYSNDD_TEXT}; font-size: 14px;"><strong>Batch Details:</strong></p>
-  <p style="margin: 0; color: {SYSNDD_TEXT}; font-size: 14px;">{batch_info}</p>
+  <p style="margin: 0; color: {SYSNDD_TEXT}; font-size: 14px;">{batch_info_e}</p>
 </div>
 ', .open = "{", .close = "}")
   } else {

--- a/api/functions/email-templates.R
+++ b/api/functions/email-templates.R
@@ -27,7 +27,9 @@ SYSNDD_WARNING <- "#ffc107"
 #' markup/script injection into the recipient's mail client. NULL/empty -> "".
 #' Use email_escape_attr() for a value placed inside an HTML attribute.
 email_escape <- function(x) {
-  if (is.null(x) || length(x) == 0) {
+  # Templates interpolate scalar fields; a NULL/NA/empty/non-scalar value coerces
+  # to "" rather than rendering "NA" or vectorizing into the HTML.
+  if (is.null(x) || length(x) != 1L || is.na(x)) {
     return("")
   }
   htmltools::htmlEscape(as.character(x), attribute = FALSE)
@@ -35,7 +37,7 @@ email_escape <- function(x) {
 
 #' HTML-escape a user-controlled value for an HTML attribute (also escapes quotes).
 email_escape_attr <- function(x) {
-  if (is.null(x) || length(x) == 0) {
+  if (is.null(x) || length(x) != 1L || is.na(x)) {
     return("")
   }
   htmltools::htmlEscape(as.character(x), attribute = TRUE)

--- a/api/functions/email-templates.R
+++ b/api/functions/email-templates.R
@@ -19,6 +19,28 @@ SYSNDD_WHITE <- "#ffffff"
 SYSNDD_SUCCESS <- "#28a745"
 SYSNDD_WARNING <- "#ffc107"
 
+#' HTML-escape a user-controlled value for HTML email element text.
+#'
+#' Signup fields (user_name, first_name, family_name, email, orcid) are stored raw
+#' and interpolated into HTML email bodies that are then marked as trusted HTML
+#' (htmltools::HTML) and sent (incl. BCC to curators). Escaping them here prevents
+#' markup/script injection into the recipient's mail client. NULL/empty -> "".
+#' Use email_escape_attr() for a value placed inside an HTML attribute.
+email_escape <- function(x) {
+  if (is.null(x) || length(x) == 0) {
+    return("")
+  }
+  htmltools::htmlEscape(as.character(x), attribute = FALSE)
+}
+
+#' HTML-escape a user-controlled value for an HTML attribute (also escapes quotes).
+email_escape_attr <- function(x) {
+  if (is.null(x) || length(x) == 0) {
+    return("")
+  }
+  htmltools::htmlEscape(as.character(x), attribute = TRUE)
+}
+
 #' Generate base HTML email wrapper
 #'
 #' Creates a responsive HTML email template wrapper with consistent branding.
@@ -118,8 +140,9 @@ email_wrapper <- function(content, preheader = "") {
 #' @param expiry_minutes Token expiry time in minutes (default 60)
 #' @return Complete HTML email string
 email_password_reset <- function(reset_url, user_name = NULL, expiry_minutes = 60) {
+  user_name_e <- email_escape(user_name)
   greeting <- if (!is.null(user_name) && nchar(user_name) > 0) {
-    glue::glue('<p style="color: {SYSNDD_TEXT}; font-size: 16px; line-height: 1.6; margin: 0 0 16px 0;">Hello <span class="highlight" style="color: {SYSNDD_PRIMARY}; font-weight: 600;">{user_name}</span>,</p>')
+    glue::glue('<p style="color: {SYSNDD_TEXT}; font-size: 16px; line-height: 1.6; margin: 0 0 16px 0;">Hello <span class="highlight" style="color: {SYSNDD_PRIMARY}; font-weight: 600;">{user_name_e}</span>,</p>')
   } else {
     glue::glue('<p style="color: {SYSNDD_TEXT}; font-size: 16px; line-height: 1.6; margin: 0 0 16px 0;">Hello,</p>')
   }
@@ -171,12 +194,17 @@ email_password_reset <- function(reset_url, user_name = NULL, expiry_minutes = 6
 #' @return Complete HTML email string
 email_registration_request <- function(user_info) {
   first_name <- user_info$first_name %||% user_info$user_name %||% "there"
+  first_name_e <- email_escape(first_name)
+  user_name_e <- email_escape(user_info$user_name)
+  email_e <- email_escape(user_info$email)
+  fname_e <- email_escape(user_info$first_name)
+  lname_e <- email_escape(user_info$family_name)
 
   content <- glue::glue('
 <h2 style="color: {SYSNDD_TEXT}; font-size: 20px; margin: 0 0 16px 0; font-weight: 600;">Registration Request Received</h2>
 
 <p style="color: {SYSNDD_TEXT}; font-size: 16px; line-height: 1.6; margin: 0 0 16px 0;">
-  Hello <span class="highlight" style="color: {SYSNDD_PRIMARY}; font-weight: 600;">{first_name}</span>,
+  Hello <span class="highlight" style="color: {SYSNDD_PRIMARY}; font-weight: 600;">{first_name_e}</span>,
 </p>
 
 <p style="color: {SYSNDD_TEXT}; font-size: 16px; line-height: 1.6; margin: 0 0 16px 0;">
@@ -186,9 +214,9 @@ email_registration_request <- function(user_info) {
 <div class="info-box" style="background-color: #e3f2fd; border-left: 4px solid {SYSNDD_PRIMARY}; padding: 16px; margin: 20px 0; border-radius: 0 6px 6px 0;">
   <p style="margin: 0 0 8px 0; color: {SYSNDD_TEXT}; font-size: 14px;"><strong>Registration Details:</strong></p>
   <table style="font-size: 14px; color: {SYSNDD_TEXT};">
-    <tr><td style="padding: 4px 12px 4px 0; color: {SYSNDD_TEXT_LIGHT};">Username:</td><td style="font-weight: 600;">{user_info$user_name}</td></tr>
-    <tr><td style="padding: 4px 12px 4px 0; color: {SYSNDD_TEXT_LIGHT};">Email:</td><td>{user_info$email}</td></tr>
-    <tr><td style="padding: 4px 12px 4px 0; color: {SYSNDD_TEXT_LIGHT};">Name:</td><td>{user_info$first_name} {user_info$family_name}</td></tr>
+    <tr><td style="padding: 4px 12px 4px 0; color: {SYSNDD_TEXT_LIGHT};">Username:</td><td style="font-weight: 600;">{user_name_e}</td></tr>
+    <tr><td style="padding: 4px 12px 4px 0; color: {SYSNDD_TEXT_LIGHT};">Email:</td><td>{email_e}</td></tr>
+    <tr><td style="padding: 4px 12px 4px 0; color: {SYSNDD_TEXT_LIGHT};">Name:</td><td>{fname_e} {lname_e}</td></tr>
   </table>
 </div>
 
@@ -220,11 +248,12 @@ email_registration_request <- function(user_info) {
 #' @param login_url The login page URL
 #' @return Complete HTML email string
 email_account_approved <- function(user_name, temp_password, login_url = "https://sysndd.org/Login") {
+  user_name_e <- email_escape(user_name)
   content <- glue::glue('
 <h2 style="color: {SYSNDD_TEXT}; font-size: 20px; margin: 0 0 16px 0; font-weight: 600;">Your Account Has Been Approved!</h2>
 
 <p style="color: {SYSNDD_TEXT}; font-size: 16px; line-height: 1.6; margin: 0 0 16px 0;">
-  Hello <span class="highlight" style="color: {SYSNDD_PRIMARY}; font-weight: 600;">{user_name}</span>,
+  Hello <span class="highlight" style="color: {SYSNDD_PRIMARY}; font-weight: 600;">{user_name_e}</span>,
 </p>
 
 <p style="color: {SYSNDD_TEXT}; font-size: 16px; line-height: 1.6; margin: 0 0 16px 0;">
@@ -277,6 +306,11 @@ email_account_approved <- function(user_name, temp_password, login_url = "https:
 #' @return Complete HTML email string
 email_rereview_request <- function(user_info, batch_info = NULL) {
   user_name <- user_info$user_name %||% "User"
+  user_name_e <- email_escape(user_name)
+  uname_e <- email_escape(user_info$user_name)
+  email_e <- email_escape(user_info$email)
+  orcid_e <- email_escape(user_info$orcid)
+  orcid_attr_e <- email_escape_attr(user_info$orcid)
 
   batch_section <- if (!is.null(batch_info)) {
     glue::glue('
@@ -293,7 +327,7 @@ email_rereview_request <- function(user_info, batch_info = NULL) {
 <h2 style="color: {SYSNDD_TEXT}; font-size: 20px; margin: 0 0 16px 0; font-weight: 600;">Re-Review Batch Request Submitted</h2>
 
 <p style="color: {SYSNDD_TEXT}; font-size: 16px; line-height: 1.6; margin: 0 0 16px 0;">
-  Hello <span class="highlight" style="color: {SYSNDD_PRIMARY}; font-weight: 600;">{user_name}</span>,
+  Hello <span class="highlight" style="color: {SYSNDD_PRIMARY}; font-weight: 600;">{user_name_e}</span>,
 </p>
 
 <p style="color: {SYSNDD_TEXT}; font-size: 16px; line-height: 1.6; margin: 0 0 16px 0;">
@@ -305,9 +339,9 @@ email_rereview_request <- function(user_info, batch_info = NULL) {
 <div class="info-box" style="background-color: #e3f2fd; border-left: 4px solid {SYSNDD_PRIMARY}; padding: 16px; margin: 20px 0; border-radius: 0 6px 6px 0;">
   <p style="margin: 0 0 8px 0; color: {SYSNDD_TEXT}; font-size: 14px;"><strong>Requesting User Information:</strong></p>
   <table style="font-size: 14px; color: {SYSNDD_TEXT};">
-    <tr><td style="padding: 4px 12px 4px 0; color: {SYSNDD_TEXT_LIGHT};">Username:</td><td style="font-weight: 600;">{user_info$user_name}</td></tr>
-    <tr><td style="padding: 4px 12px 4px 0; color: {SYSNDD_TEXT_LIGHT};">Email:</td><td>{user_info$email}</td></tr>
-    <tr><td style="padding: 4px 12px 4px 0; color: {SYSNDD_TEXT_LIGHT};">ORCID:</td><td><a href="https://orcid.org/{user_info$orcid}" style="color: {SYSNDD_PRIMARY};">{user_info$orcid}</a></td></tr>
+    <tr><td style="padding: 4px 12px 4px 0; color: {SYSNDD_TEXT_LIGHT};">Username:</td><td style="font-weight: 600;">{uname_e}</td></tr>
+    <tr><td style="padding: 4px 12px 4px 0; color: {SYSNDD_TEXT_LIGHT};">Email:</td><td>{email_e}</td></tr>
+    <tr><td style="padding: 4px 12px 4px 0; color: {SYSNDD_TEXT_LIGHT};">ORCID:</td><td><a href="https://orcid.org/{orcid_attr_e}" style="color: {SYSNDD_PRIMARY};">{orcid_e}</a></td></tr>
   </table>
 </div>
 
@@ -339,6 +373,7 @@ email_rereview_request <- function(user_info, batch_info = NULL) {
 #' @return Complete HTML email string
 email_batch_assigned <- function(user_info, batch_info, review_url = "https://sysndd.org/ReReview") {
   user_name <- user_info$user_name %||% "User"
+  user_name_e <- email_escape(user_name)
   batch_number <- batch_info$batch_number %||% "N/A"
   entity_count <- batch_info$entity_count %||% 0
 
@@ -346,7 +381,7 @@ email_batch_assigned <- function(user_info, batch_info, review_url = "https://sy
 <h2 style="color: {SYSNDD_TEXT}; font-size: 20px; margin: 0 0 16px 0; font-weight: 600;">Re-Review Batch Assigned</h2>
 
 <p style="color: {SYSNDD_TEXT}; font-size: 16px; line-height: 1.6; margin: 0 0 16px 0;">
-  Hello <span class="highlight" style="color: {SYSNDD_PRIMARY}; font-weight: 600;">{user_name}</span>,
+  Hello <span class="highlight" style="color: {SYSNDD_PRIMARY}; font-weight: 600;">{user_name_e}</span>,
 </p>
 
 <p style="color: {SYSNDD_TEXT}; font-size: 16px; line-height: 1.6; margin: 0 0 16px 0;">
@@ -400,8 +435,11 @@ email_batch_assigned <- function(user_info, batch_info, review_url = "https://sy
 #' @param user_name Optional user name for personalization
 #' @return Complete HTML email string
 email_notification <- function(subject_text, body_content, user_name = NULL) {
+  # subject_text and body_content are developer/system-controlled (body_content is
+  # deliberately HTML); only the user-controlled user_name is escaped.
+  user_name_e <- email_escape(user_name)
   greeting <- if (!is.null(user_name) && nchar(user_name) > 0) {
-    glue::glue('<p style="color: {SYSNDD_TEXT}; font-size: 16px; line-height: 1.6; margin: 0 0 16px 0;">Hello <span class="highlight" style="color: {SYSNDD_PRIMARY}; font-weight: 600;">{user_name}</span>,</p>')
+    glue::glue('<p style="color: {SYSNDD_TEXT}; font-size: 16px; line-height: 1.6; margin: 0 0 16px 0;">Hello <span class="highlight" style="color: {SYSNDD_PRIMARY}; font-weight: 600;">{user_name_e}</span>,</p>')
   } else {
     ""
   }

--- a/api/services/user-account-endpoint-service.R
+++ b/api/services/user-account-endpoint-service.R
@@ -65,7 +65,9 @@ svc_user_approval_apply <- function(req, res, user_table, user_id_approval, stat
   user_update(user_id_approval, list(approved = 1, abbreviation = user_initials))
   user_update_password(user_id_approval, hashed_password)
 
-  log_info("User approved: user_id={user_id_approval}, user_name={user_table$user_name}, by={req$user_id}")
+  # Sanitize the stored user_name before logging: a legacy row predating the
+  # signup control-char guard could otherwise forge log lines (#535 S8).
+  log_info("User approved: user_id={user_id_approval}, user_name={sanitize_log_value(user_table$user_name)}, by={req$user_id}")
 
   # Generate and send email with error handling
   email_result <- tryCatch({

--- a/api/services/user-account-endpoint-service.R
+++ b/api/services/user-account-endpoint-service.R
@@ -75,11 +75,13 @@ svc_user_approval_apply <- function(req, res, user_table, user_id_approval, stat
       login_url = paste0(dw$base_url, "/Login")
     )
 
+    # The approval email carries the temporary password; deliver it to the USER
+    # ONLY. BCCing it to the shared curator mailbox would let any reader there
+    # sign in as the newly approved user (#535 S8).
     send_noreply_email(
       email_body = email_html,
       email_subject = "Welcome to SysNDD - Your Account Has Been Approved!",
       email_recipient = user_table$email,
-      email_blind_copy = "curator@sysndd.org",
       html_content = TRUE
     )
 
@@ -272,11 +274,12 @@ svc_user_update_details <- function(req, res) {
           login_url = paste0(dw$base_url, "/Login")
         )
 
+        # Temporary-password email goes to the USER ONLY (never BCC the shared
+        # curator mailbox with a credential — see #535 S8).
         send_noreply_email(
           email_body = email_html,
           email_subject = "Welcome to SysNDD - Your Account Has Been Approved!",
           email_recipient = user_table$email,
-          email_blind_copy = "curator@sysndd.org",
           html_content = TRUE
         )
       }

--- a/api/services/user-service.R
+++ b/api/services/user-service.R
@@ -145,7 +145,7 @@ user_approve <- function(user_id, approving_user_id, approve, pool) {
         list(user_initials, user_id)
       )
 
-      # Send approval email with password
+      # Temp password -> USER ONLY; never BCC a credential to curators (#535 S8).
       send_noreply_email(
         c(
           "Your registration for sysndd.org has been approved by a curator.",
@@ -153,8 +153,7 @@ user_approve <- function(user_id, approving_user_id, approve, pool) {
           user_password
         ),
         "Account approved for SysNDD.org",
-        user$email,
-        "curator@sysndd.org"
+        user$email
       )
     }
 
@@ -423,7 +422,7 @@ user_bulk_approve <- function(user_ids, approving_user_id, pool) {
           conn = txn_conn
         )
 
-        # Send approval email with password
+        # Temp password -> USER ONLY; never BCC a credential to curators (#535 S8).
         send_noreply_email(
           c(
             "Your registration for sysndd.org has been approved by a curator.",
@@ -431,8 +430,7 @@ user_bulk_approve <- function(user_ids, approving_user_id, pool) {
             user_password
           ),
           "Account approved for SysNDD.org",
-          user$email,
-          "curator@sysndd.org"
+          user$email
         )
       }
     }

--- a/api/tests/testthat/test-unit-account-email-hardening.R
+++ b/api/tests/testthat/test-unit-account-email-hardening.R
@@ -200,3 +200,32 @@ test_that("re-review email escapes batch_info (latent injection sink)", {
   expect_false(grepl("<img src=x onerror", out, fixed = TRUE))
   expect_true(grepl("&lt;img", out, fixed = TRUE))
 })
+
+# --- Codex round-3 folds (#535 S8): central address validation + log sink -------
+
+test_that("send_noreply_email centrally rejects malformed recipient/bcc addresses", {
+  # Legacy / admin-edited rows predate the anchored signup validator; the transport
+  # choke point must reject SMTP recipient grammar, not just control characters.
+  expect_error(
+    send_noreply_email("b", "s", "<a@example.com> NOTIFY=SUCCESS"),
+    "recipient"
+  )
+  expect_error(
+    send_noreply_email("b", "s", "a@b.com", email_blind_copy = "<x@y.com> NOTIFY"),
+    "bcc"
+  )
+  # An empty-string bcc means "no blind copy" and must not error at the guard.
+  err <- tryCatch(
+    send_noreply_email("b", "s", "a@b.com", email_blind_copy = ""),
+    error = function(e) conditionMessage(e)
+  )
+  expect_false(grepl("bcc", err))
+})
+
+test_that("sanitize_log_value neutralizes control chars for log sinks", {
+  # A stored user_name from a pre-guard/legacy row must not forge log lines when
+  # interpolated into a log message.
+  expect_equal(sanitize_log_value("admin\n[FATAL] forged"), "admin [FATAL] forged")
+  expect_equal(sanitize_log_value("a\r\nb\tc"), "a  b c")
+  expect_equal(sanitize_log_value("normal user"), "normal user")
+})

--- a/api/tests/testthat/test-unit-account-email-hardening.R
+++ b/api/tests/testthat/test-unit-account-email-hardening.R
@@ -78,3 +78,61 @@ test_that("benign names round-trip through the templates unchanged", {
   out <- email_account_approved("Ada Lovelace", "TempPass1!")
   expect_true(grepl("Ada Lovelace", out, fixed = TRUE))
 })
+
+# --- Codex final-review folds (#535 S8): control-char / header / log injection ---
+
+test_that("account_field_has_control_char flags CR/LF/tab, not printable text", {
+  # Log- and SMTP-header-injection root cause: a signup field carrying CR/LF is
+  # later logged verbatim and/or handed to smtp_send(). This guard rejects them.
+  expect_true(account_field_has_control_char("admin\n[FATAL] forged log line"))
+  expect_true(account_field_has_control_char("a\r\nBcc: evil@e.com"))
+  expect_true(account_field_has_control_char("a\tb"))
+  expect_false(account_field_has_control_char("normaluser"))
+  # Non-ASCII printable names must pass (no false positive).
+  expect_false(account_field_has_control_char("Zoë O'Brien"))
+})
+
+test_that("is_valid_email rejects control chars, junk-wrapped, and non-scalar input", {
+  expect_true(is_valid_email("test@example.com"))
+  expect_true(is_valid_email("First.Last+tag@sub.example.org"))
+  # CR/LF -> SMTP header injection into the `to` address must be rejected.
+  expect_false(is_valid_email("victim@example.com\r\nBcc: evil@e.com"))
+  expect_false(is_valid_email("victim@example.com\nSubject: spoof"))
+  # Unanchored old regex matched a valid address embedded in junk; now rejected.
+  expect_false(is_valid_email("hello a@b.com world"))
+  # Non-scalar / NA must not slip through as a vector of addresses.
+  expect_false(is_valid_email(c("a@b.com", "c@d.com")))
+  expect_false(is_valid_email(NA_character_))
+  expect_false(is_valid_email(NULL))
+})
+
+test_that("send_noreply_email rejects CR/LF in recipient, subject, and bcc", {
+  # Defense-in-depth choke point: every mail path passes through here, so a
+  # control char in any address or the subject is rejected before smtp_send().
+  expect_error(
+    send_noreply_email("body", "Subject", "a@b.com\r\nBcc: evil@e.com"),
+    "recipient"
+  )
+  expect_error(
+    send_noreply_email("body", "Subject\nX-Injected: 1", "a@b.com"),
+    "subject"
+  )
+  expect_error(
+    send_noreply_email("body", "Subject", "a@b.com",
+      email_blind_copy = "c@d.com\nBcc: evil@e.com"),
+    "bcc"
+  )
+})
+
+test_that("greeting templates tolerate NA/empty/vector user_name without error", {
+  # nchar() on NA / length>1 vectors throws; the escaped scalar drives the check.
+  expect_no_error(email_password_reset("https://x/reset", NA_character_))
+  expect_no_error(email_password_reset("https://x/reset", c("a", "b")))
+  expect_no_error(email_password_reset("https://x/reset", character(0)))
+  expect_no_error(email_notification("Subj", "<p>hi</p>", NA_character_))
+  # A benign name is still personalized.
+  out <- email_password_reset("https://x/reset", "Ada")
+  expect_true(grepl("Ada", out, fixed = TRUE))
+  out2 <- email_notification("Subj", "<p>hi</p>", "Ada")
+  expect_true(grepl("Ada", out2, fixed = TRUE))
+})

--- a/api/tests/testthat/test-unit-account-email-hardening.R
+++ b/api/tests/testthat/test-unit-account-email-hardening.R
@@ -136,3 +136,67 @@ test_that("greeting templates tolerate NA/empty/vector user_name without error",
   out2 <- email_notification("Subj", "<p>hi</p>", "Ada")
   expect_true(grepl("Ada", out2, fixed = TRUE))
 })
+
+# --- Codex round-2 folds (#535 S8): credential/token BCC leaks + strict address ---
+
+test_that("send_noreply_email does not blind-copy by default (token/credential leak)", {
+  # BLOCKER: the password-reset send relies on the default BCC. A non-NULL default
+  # blind-copies the bearer reset URL to a shared mailbox -> account takeover. The
+  # default must be NULL so no credential/token email is BCCed unless a caller
+  # explicitly opts in (curator notifications still pass an explicit address).
+  expect_null(formals(send_noreply_email)$email_blind_copy)
+})
+
+test_that("send_noreply_email permits a NULL bcc (guard does not reject it)", {
+  # A NULL bcc must pass the control-char guard; the call then fails later on the
+  # absent SMTP stack in this pure env, NOT at the bcc guard.
+  err <- tryCatch(
+    send_noreply_email("body", "Subject", "a@b.com", email_blind_copy = NULL),
+    error = function(e) conditionMessage(e)
+  )
+  expect_false(grepl("bcc", err))
+})
+
+test_that("send_noreply_email requires a scalar recipient", {
+  expect_error(
+    send_noreply_email("body", "Subject", c("a@b.com", "c@d.com")),
+    "recipient"
+  )
+})
+
+test_that("is_valid_email rejects SMTP recipient-grammar / space-bearing values", {
+  # Signup used a permissive .+@.+\\..+ regex; structured values reach SMTP
+  # recipient grammar (libcurl accepts post-address DSN params). Reject them.
+  expect_false(is_valid_email("<a@example.com> NOTIFY=SUCCESS"))
+  expect_false(is_valid_email("a@example.com NOTIFY=SUCCESS"))
+  expect_false(is_valid_email("a@b .com"))
+  expect_false(is_valid_email("a b@example.com"))
+  expect_true(is_valid_email("a@example.com"))
+})
+
+test_that("credential/approval emails are never BCCed to the shared curator mailbox", {
+  # HIGH: email_account_approved embeds the temp password; BCCing it to the shared
+  # curator mailbox lets any reader impersonate the newly approved user. Both of
+  # these services send ONLY that credential email, so neither may reference the
+  # curator BCC address at all.
+  for (rel in c(
+    file.path("services", "user-account-endpoint-service.R"),
+    file.path("services", "user-service.R")
+  )) {
+    p <- file.path(api_dir, rel)
+    if (!file.exists(p)) {
+      skip(paste("source not present in this harness:", rel))
+    }
+    src <- paste(readLines(p, warn = FALSE), collapse = "\n")
+    expect_false(grepl("curator@sysndd.org", src, fixed = TRUE), info = rel)
+  }
+})
+
+test_that("re-review email escapes batch_info (latent injection sink)", {
+  out <- email_rereview_request(
+    list(user_name = "u", email = "a@b.c", orcid = "0000-0001-2345-6789"),
+    batch_info = "<img src=x onerror=alert(1)>"
+  )
+  expect_false(grepl("<img src=x onerror", out, fixed = TRUE))
+  expect_true(grepl("&lt;img", out, fixed = TRUE))
+})

--- a/api/tests/testthat/test-unit-account-email-hardening.R
+++ b/api/tests/testthat/test-unit-account-email-hardening.R
@@ -1,0 +1,69 @@
+# Tests for S8 account/email hardening (#535):
+#   1. random_password() uses a CSPRNG (openssl::rand_bytes), not the seedable
+#      Mersenne-Twister via sample().
+#   2. User-controlled fields are HTML-escaped before interpolation into HTML
+#      email bodies (stored-XSS-in-email defense).
+
+# Resolve the api dir and source the functions under test (pure — no DB needed).
+if (exists("get_api_dir")) {
+  api_dir <- get_api_dir()
+} else {
+  api_dir <- normalizePath(file.path(dirname(getwd()), ".."), mustWork = FALSE)
+  if (!file.exists(file.path(api_dir, "functions", "account-helpers.R"))) {
+    api_dir <- normalizePath(file.path(getwd(), ".."), mustWork = FALSE)
+  }
+}
+`%||%` <- function(a, b) if (is.null(a) || length(a) == 0) b else a
+source(file.path(api_dir, "functions", "account-helpers.R"), local = FALSE)
+source(file.path(api_dir, "functions", "email-templates.R"), local = FALSE)
+
+test_that("random_password() is a CSPRNG (ignores set.seed)", {
+  # The old sample()-based generator is reproducible under a fixed seed; a CSPRNG
+  # ignores set.seed entirely, so two seeded draws must differ.
+  set.seed(1)
+  a <- random_password()
+  set.seed(1)
+  b <- random_password()
+  expect_false(identical(a, b))
+})
+
+test_that("random_password() keeps its 12-char / 64-char-alphabet contract", {
+  alphabet <- c(0:9, letters, LETTERS, "!", "$")
+  expect_equal(length(alphabet), 64L)
+  for (i in seq_len(50)) {
+    pw <- random_password()
+    expect_equal(nchar(pw), 12L)
+    chars <- strsplit(pw, "")[[1]]
+    expect_true(all(chars %in% as.character(alphabet)))
+  }
+  # 100 draws should be unique (entropy sanity).
+  draws <- vapply(1:100, function(x) random_password(), character(1))
+  expect_equal(length(unique(draws)), 100L)
+})
+
+test_that("registration email HTML-escapes a hostile user_name", {
+  out <- email_registration_request(list(
+    user_name = "<img src=x onerror=alert(1)>",
+    email = "a@b.c",
+    first_name = "A",
+    family_name = "B"
+  ))
+  expect_true(grepl("&lt;img", out, fixed = TRUE))
+  expect_false(grepl("<img src=x onerror", out, fixed = TRUE))
+})
+
+test_that("re-review email attribute-escapes a hostile orcid", {
+  out <- email_rereview_request(list(
+    user_name = "u",
+    email = "a@b.c",
+    orcid = "\"><b>"
+  ))
+  # The quote-and-tag break-out must not survive verbatim in the href/label.
+  expect_false(grepl("\"><b>", out, fixed = TRUE))
+  expect_true(grepl("&gt;&lt;b&gt;", out, fixed = TRUE))
+})
+
+test_that("benign names round-trip through the templates unchanged", {
+  out <- email_account_approved("Ada Lovelace", "TempPass1!")
+  expect_true(grepl("Ada Lovelace", out, fixed = TRUE))
+})

--- a/api/tests/testthat/test-unit-account-email-hardening.R
+++ b/api/tests/testthat/test-unit-account-email-hardening.R
@@ -61,6 +61,17 @@ test_that("re-review email attribute-escapes a hostile orcid", {
   # The quote-and-tag break-out must not survive verbatim in the href/label.
   expect_false(grepl("\"><b>", out, fixed = TRUE))
   expect_true(grepl("&gt;&lt;b&gt;", out, fixed = TRUE))
+  # The href attribute must attribute-escape the quote (&quot;) — proving attribute
+  # escaping, not merely text escaping (which would leave a dangerous bare quote).
+  expect_true(grepl("&quot;", out, fixed = TRUE))
+})
+
+test_that("email_escape coerces NULL/NA/non-scalar to empty string", {
+  expect_equal(email_escape(NULL), "")
+  expect_equal(email_escape(NA), "")
+  expect_equal(email_escape(character(0)), "")
+  expect_equal(email_escape_attr(NA_character_), "")
+  expect_equal(email_escape("<b>"), "&lt;b&gt;")
 })
 
 test_that("benign names round-trip through the templates unchanged", {


### PR DESCRIPTION
**Security hardening — slice S8 (account/email) of #535. DO NOT AUTO-MERGE (security-critical; human review required). Umbrella #535 stays open.**

## What & why
Two independent, low-risk defense-in-depth fixes in the account-notification path (audit **P2/P3**):

1. **CSPRNG temporary passwords.** `random_password()` drew from R's Mersenne-Twister via `sample()` — not cryptographically secure and seedable/predictable — to generate the temporary login credential emailed on account approval. Now draws from `openssl::rand_bytes` (CSPRNG). Same 12-char / 64-char alphabet; `256 %% 64 == 0` so the `byte %% 64` mapping is **bias-free** (72-bit entropy). Contract unchanged for all 4 call sites.
2. **HTML-escape user fields in HTML emails.** Signup fields (`user_name`, `first_name`, `family_name`, `email`, `orcid`) were interpolated **raw** into HTML email bodies marked as trusted HTML (`htmltools::HTML`) and BCC'd to curators — a stored-XSS-in-email sink. Now escaped at each interpolation (ORCID attribute-escaped for its `href`, text-escaped for its label). `body_content` (intentional HTML), URLs, brand constants, and system/numeric fields are unchanged.

## Verification
- New `test-unit-account-email-hardening.R`, verified **RED (5 failures against master) → GREEN (in-container)**. Includes a CSPRNG seed test (old `sample()` is seed-reproducible; a CSPRNG is not), charset/length/uniqueness, hostile-`user_name` and hostile-`orcid` (attribute `&quot;`) escape assertions, and an `email_escape` NULL/NA/scalar coercion test.
- `lintr` clean on both files; both < 600 lines.
- **Codex adversarial review (gpt-5.6-sol, xhigh) → SHIP** (no blocker/high/medium). Verified the CSPRNG mapping (bias-free, `openssl` in the image), that every user field is escaped, and that the tests are non-vacuous. Two LOW hardening items applied (NA/scalar guard; explicit `&quot;` assertion). Review committed under `.planning/reviews/2026-07-12-security-535-s8-account-email-review-codex.md`.

## Adjacent follow-up (NOT in this PR)
- `app/src/components/filters/TermSearch.vue` renders API-derived gene symbols via raw `v-html` — a separate untrusted-markup sink (not account-user input). Tracked as a frontend `v-html` follow-up.

Refs #535
