### PR TITLE
docs: S1b token-hardening design+plan+review (NOT implementation-ready) — DO NOT AUTO-MERGE (#535)

### DIFF
--- a/.planning/reviews/2026-07-12-security-535-s1b-plan-codex-review.md
+++ b/.planning/reviews/2026-07-12-security-535-s1b-plan-codex-review.md
@@ -1,0 +1,53 @@
+# S1b plan — Codex adversarial review (gpt-5.6-sol, xhigh) — Verdict: FIX-FIRST (NOT implementation-ready)
+
+This deep plan review found **4 BLOCKERs + 7 HIGHs** — precisely the subtle auth landmines that make
+S1b unsafe to implement autonomously. S1b therefore ships as a **design + plan + this review** (a
+docs/design PR); the plan must be revised to resolve these before ANY code lands.
+
+## BLOCKER
+1. **Reuse response is rolled back.** Prod `auth_refresh` runs in `dbWithTransaction`; raising 401
+   inside it rolls back the `revoked_at`/`session_epoch` writes. Return a `reuse_detected` outcome,
+   COMMIT it, then raise 401 outside the transaction. Test that the 401 leaves revocation committed.
+2. **SPA never receives the initial refresh token.** `/authenticate` returns only `access_token` (a
+   string); `authenticate()`/`LoginView` expect a scalar. Define the login wire contract and make
+   user-read + refresh-row insert atomic before implementing. The pair helper needs a `conn`/txn that
+   `auth_signin` does not currently have.
+3. **Token-type isolation is one-way.** Refresh rejects access tokens, but middleware/`auth_verify`
+   don't require `typ="access"`, so a refresh token is a valid Bearer on ungated endpoints. Add
+   fail-closed expected-typ validation to EVERY consumer. Password-reset JWTs share the key and have
+   no `typ` — give them `typ="password_reset"`, validate only on that route.
+4. **Rollout claim is false.** "Land together" can't update already-loaded JS; a hard POST cut / GET
+   410 logs out in-flight SPAs, and an object-returning `/authenticate` breaks their re-login. Use a
+   phased/versioned contract (backend supports legacy scalar+GET AND new pair+POST; deploy SPA;
+   retain compatibility for the access-token window; then remove legacy).
+
+## HIGH (summary)
+- Concurrent legitimate refresh (multi-tab/double-click/retry/lost-response) trips reuse → logs out
+  all sessions; need single-flight + a documented grace/retry policy vs strict logout.
+- Lock ordering (token-then-user, bulk-lock all tokens) can deadlock; classify epoch BEFORE reuse;
+  treat stale-epoch tokens as already-revoked unless account-wide IR is intended.
+- "Revoke chain" = revoke EVERY session (no family id); add `family_id`/parent linkage OR make
+  account-wide-compromise explicit.
+- The shipped S1 regression fixture mints `auth_generate_token(...)$access_token` and presents it to
+  refresh — the new typ gate rejects it and it has no refresh row; update the FIXTURE only, keep the
+  legacy/epoch/DB-role assertions; add commit-after-reuse + concurrency tests.
+- Logout does no server revocation — add a credential-body POST logout that revokes the family.
+
+## MEDIUM/LOW
+- 044 underspecified (reassert columns/indexes; `expires_at` index; `(user_id, revoked_at)` or
+  `(family_id, revoked_at)`; UUID `BINARY(16)`/`ascii_bin`). Migration count is 42 — update
+  `test-unit-analysis-snapshot-migration.R:8` + `test-unit-core-views-manifest.R:12,21`.
+- Epoch bump does NOT kill existing access tokens (stateless, ~1h) — correct the threat-model wording.
+- refresh_token table growth needs expiry cleanup (tie to S7) + `expires_at` index + user-delete
+  cleanup.
+- Frontend: specify access/refresh/user all-or-none, Plumber scalar-array normalization, atomic
+  replacement, refresh single-flight, LoginView/MSW/OpenAPI-drift/interceptor updates.
+- refresh token in `localStorage` is XSS-readable — prefer HttpOnly/SameSite cookie or record the
+  accepted residual.
+
+## Confirmed correct
+`FOR UPDATE` prevents double-rotation; preserving approval/epoch/DB-claims under the user lock keeps
+S1's invariant once the txn defects are fixed; POST-body refresh honors auth-body-only + stays
+allowlisted; minimal-claims refresh + server `jti` + stateless short access is the right split;
+checking both JWT + row expiry is right; password/role/approval/deactivation epoch bumps already
+invalidate refresh.

--- a/.planning/superpowers/plans/2026-07-12-security-535-s1b-token-hardening-plan.md
+++ b/.planning/superpowers/plans/2026-07-12-security-535-s1b-token-hardening-plan.md
@@ -1,3 +1,5 @@
+> **STATUS: NOT IMPLEMENTATION-READY.** The Codex plan review (`.planning/reviews/2026-07-12-security-535-s1b-plan-codex-review.md`) found 4 BLOCKERs + 7 HIGHs (txn-rollback of the reuse response, SPA never gets the refresh token, one-way typ isolation, false rollout claim, concurrent-refresh false reuse, lock-order deadlock, "revoke chain"=revoke-all, regression-fixture must change, no server-side logout revocation). Resolve these in a plan v2 before writing code. This PR ships the design + plan + review for human decision, NOT an implementation.
+
 # S1b — Distinct/Revocable/Rotating Tokens — Plan (implementation-ready; human-gated)
 
 > REQUIRED SUB-SKILL: superpowers:test-driven-development. Design:

--- a/.planning/superpowers/plans/2026-07-12-security-535-s1b-token-hardening-plan.md
+++ b/.planning/superpowers/plans/2026-07-12-security-535-s1b-token-hardening-plan.md
@@ -1,0 +1,73 @@
+# S1b — Distinct/Revocable/Rotating Tokens — Plan (implementation-ready; human-gated)
+
+> REQUIRED SUB-SKILL: superpowers:test-driven-development. Design:
+> `.../specs/2026-07-12-security-535-s1b-token-hardening-design.md`.
+> **Risk: HIGH — auth flow + migration + SPA token model. The live regression gate (Task 6) is
+> mandatory before merge; do not ship without it. All-or-nothing: the backend POST change and the
+> frontend two-token change land together (or behind a transitional shim) so an in-flight SPA never
+> breaks.**
+
+## Non-regression gate (run at start AND end — must stay green)
+The shipped S1 behavior (PR #538) is the invariant: legacy no-`sepoch` token → 401; epoch-bump →
+401; valid → 200 with DB-derived (role-current) claims, minted under `SELECT … FOR UPDATE`. Reuse
+`test-unit-auth-refresh-epoch.R` as the regression suite; every S1b change keeps it green.
+
+## Task 1 — Migration 044 + manifest (RED: guard tests)
+- [ ] `db/migrations/044_add_refresh_tokens.sql`: `refresh_token(jti CHAR(36) PK, user_id INT NOT
+  NULL, issued_at DATETIME, expires_at DATETIME, used_at DATETIME NULL, replaced_by CHAR(36) NULL,
+  revoked_at DATETIME NULL, session_epoch INT NOT NULL, KEY(user_id))`. Idempotent (information_schema
+  guard, `CREATE TABLE IF NOT EXISTS`), restore-drift safe (match 043's style).
+- [ ] Bump `EXPECTED_LATEST_MIGRATION` (`migration-manifest.R:5`) → `044_add_refresh_tokens.sql`; bump
+  the min-count; update guard tests `test-unit-analysis-snapshot-migration.R:8` and
+  `test-unit-core-views-manifest.R` (count). RED → GREEN.
+
+## Task 2 — Distinct token minting (auth-service.R)
+- [ ] `auth_generate_token()` gains `typ = "access"` and keeps the full claims + `sepoch` + access
+  `exp` (`config$token_expiry`). Add `config$refresh_expiry` (default 30d).
+- [ ] New `auth_issue_token_pair(user, config, conn)`: mints the access token AND a refresh token
+  (`typ="refresh"`, minimal claims `user_id`+`sepoch`+`jti`, `exp = refresh_expiry`) and INSERTs the
+  refresh row (`jti`, `user_id`, `issued_at`, `expires_at`, `session_epoch`) via `conn`. `auth_signin`
+  returns the pair (its shape already has both fields) inside its existing flow.
+- Tests: access & refresh are distinct, carry `typ`, have different `exp`; a refresh row is inserted.
+
+## Task 3 — Rotation + reuse detection (auth_refresh)
+- [ ] Inside the existing `FOR UPDATE` transaction: require `typ=="refresh"` (reject an access token);
+  keep the legacy `sepoch`-missing reject and the `user_id` validation. `SELECT … FROM refresh_token
+  WHERE jti=? FOR UPDATE`:
+  - not found / expired / `revoked_at` set → reject;
+  - `used_at` set (already rotated) → **REUSE**: `UPDATE refresh_token SET revoked_at=NOW() WHERE
+    user_id=? AND revoked_at IS NULL` **and** bump `user.session_epoch` (kill outstanding access) →
+    reject with re-login error;
+  - else read `user FOR UPDATE` (S1 checks: `approved=1`, `token.sepoch==user.session_epoch`), then
+    **rotate**: mint a new pair from the DB row, `UPDATE refresh_token SET used_at=NOW(),
+    replaced_by=<new jti> WHERE jti=<old>`, INSERT the new row. Return **both** new tokens.
+- Tests: valid rotation (old used_at set, new jti, both tokens, role from DB); reuse → chain revoked +
+  epoch bumped + reject; unknown/expired/revoked jti → reject; access-token-as-refresh → reject.
+- **Regression:** the Task-0 epoch/legacy tests stay green.
+
+## Task 4 — POST /api/auth/refresh (endpoint + middleware)
+- [ ] Change the route to `@post` reading JSON body `{ refresh_token }` (auth-body-only rule);
+  response `{ access_token, refresh_token, token_type, expires_in }`. Keep it in `AUTH_ALLOWLIST`.
+  (Decision: keep a transitional GET returning 410, or hard-cut — human call, default hard-cut with
+  the frontend updated in the same PR.)
+
+## Task 5 — Frontend two-token + POST (auth.ts + store)
+- [ ] `app/src/api/auth.ts:108`: `refresh()` → `apiClient.post('/api/auth/refresh', { refresh_token })`
+  reading the stored refresh token; return the new pair. Typed client only.
+- [ ] Auth store stores BOTH tokens (no raw `localStorage` writes in views); interceptor sends the
+  **access** token; `refresh()` replaces both on success; any refresh failure → logout.
+- Tests: `auth.ts` posts the body + stores both; store round-trips two tokens.
+
+## Task 6 — VERIFY (mandatory live regression, per umbrella §7)
+- [ ] In-container R (test DB): auth-service rotation/reuse/typ tests + migration guards +
+  `test-unit-auth-refresh-epoch.R` (regression). `cd app && npm run type-check && test:unit`.
+- [ ] **Live monkey (auth — masking only surfaces loaded):** restart `api`+`worker`+`worker-maintenance`;
+  mint tokens with the dev-block secret; drive (a) POST refresh → new PAIR; (b) replay OLD refresh →
+  chain revoked + epoch bumped + 401; (c) **S0-2 regression:** legacy token → 401, epoch-bump → 401,
+  valid → 200 DB-derived. Browser login→refresh→still-authed.
+- [ ] `make code-quality-audit`, `make lint-api`, `make lint-app`. Codex plan review AND diff review
+  (xhigh). Fold → PR (do-not-auto-merge, security-critical).
+
+## Human decisions (flag on the PR)
+`refresh_expiry` default; keep-GET-shim vs hard-cut; whether reuse-detection's epoch bump (logs out
+all sessions) is the desired UX; device/IP binding (out of scope).

--- a/.planning/superpowers/specs/2026-07-12-security-535-s1b-token-hardening-design.md
+++ b/.planning/superpowers/specs/2026-07-12-security-535-s1b-token-hardening-design.md
@@ -1,0 +1,128 @@
+# S1b — Distinct, Revocable, Rotating Access/Refresh Tokens — Design
+
+Date: 2026-07-12
+Issue: [#535](https://github.com/berntpopp/sysndd/issues/535) — umbrella hardening, slice **S1b**
+(the deferred defense-in-depth follow-up to the shipped S1 session-epoch refresh, PR #538).
+Parent design: `.planning/superpowers/specs/2026-07-11-security-hardening-535-design.md` §5 S1b.
+Risk: **HIGH** — touches the auth flow, a DB migration, and the SPA token model. Human-gated.
+
+## 1. What this is and the invariant it must preserve
+
+Shipped S1 (v0.29.9) made refresh **role-current and revocable via a session epoch**: every JWT
+carries a `sepoch` claim; `auth_refresh()` re-reads the DB row under `SELECT … FOR UPDATE`, requires
+`approved=1` and `token.sepoch == user.session_epoch`, mints the new token from the **DB row** (not
+the token), and **rejects a legacy no-`sepoch` token** (`auth-service.R:140-220`, `auth_generate_token`
+`:231-258`). Privilege/state mutations increment `session_epoch` atomically.
+
+S1b adds the audit's remaining P0-2 defense-in-depth that S1 deliberately deferred: **access and
+refresh are the same JWT today** (`auth_generate_token` returns one token as both), so a leaked
+access token is refreshable until an epoch bump. S1b makes them **distinct** (typ-scoped, different
+lifetimes), stores refresh tokens in a **revocation table with single-use rotation and reuse
+detection**, and moves `/api/auth/refresh` to a **POST JSON body** (auth-body-only rule).
+
+**Hard non-regression invariant (a live gate, §7):** S1b must NOT weaken S1. After S1b:
+- a legacy no-`sepoch` (and now no-`typ`) token is still rejected;
+- an epoch bump (demotion/deactivation/password change) still immediately blocks refresh;
+- refresh still mints role/claims from the DB row under the row lock, never from the token.
+
+## 2. Design
+
+### 2.1 Migration `044_add_refresh_tokens.sql`
+New table `refresh_token`:
+- `jti CHAR(36) PRIMARY KEY` (UUID v4, the refresh token's unique id),
+- `user_id INT NOT NULL` (indexed; FK-free to match repo convention, app-enforced),
+- `issued_at DATETIME NOT NULL`, `expires_at DATETIME NOT NULL`,
+- `used_at DATETIME NULL` (set when this token is rotated/consumed — single-use),
+- `replaced_by CHAR(36) NULL` (the jti this rotated into — the rotation chain),
+- `revoked_at DATETIME NULL` (set when the chain is force-revoked on reuse detection),
+- `session_epoch INT NOT NULL` (the epoch the token was minted under — audit/debug).
+Idempotent (`CREATE TABLE IF NOT EXISTS` + information_schema guards, restore-drift safe, matching
+043's style). Bump `EXPECTED_LATEST_MIGRATION` (`migration-manifest.R:5`) to `044_add_refresh_tokens.sql`,
+the min-count, and the two guard tests (`test-unit-analysis-snapshot-migration.R:8`,
+`test-unit-core-views-manifest.R` count).
+
+### 2.2 Token minting — distinct access + refresh (`auth_generate_token`)
+- **Access token:** `typ="access"`, exp = `config$token_expiry` (3600s), carries the full user
+  claims + `sepoch` (unchanged from S1, plus `typ`). No DB row.
+- **Refresh token:** `typ="refresh"`, exp = `config$refresh_expiry` (new; default e.g. 30 days),
+  carries `user_id`, `sepoch`, and a fresh `jti`; a row is INSERTed into `refresh_token`
+  (`issued_at`, `expires_at`, `session_epoch`). The refresh token carries **minimal** claims (id +
+  epoch + jti + typ) — it is only a rotation credential, not an authorization token.
+- `auth_signin` returns BOTH tokens (already its shape). A new internal helper
+  `auth_issue_token_pair(user, config, conn)` mints the pair + inserts the refresh row in the caller's
+  transaction. `auth_generate_token` keeps minting the **access** token (used by refresh's
+  role-current mint) so the existing single-token call sites stay valid.
+
+### 2.3 Refresh — rotation + reuse detection (`auth_refresh`)
+`auth_refresh(refresh_token, pool, config)` now, inside the SAME `FOR UPDATE` transaction as S1:
+1. decode + verify signature + `exp`; require `typ == "refresh"` (reject an access token presented
+   as refresh); require `sepoch` present (legacy reject preserved) and a valid `user_id`.
+2. `SELECT … FROM refresh_token WHERE jti = ? FOR UPDATE`.
+   - **not found** → reject (unknown/forged jti).
+   - `revoked_at` set → reject (chain already force-revoked).
+   - `used_at` set (already rotated) → **REUSE DETECTED**: this is a replayed single-use token →
+     force-revoke the whole chain for this user (`UPDATE refresh_token SET revoked_at=NOW() WHERE
+     user_id=? AND revoked_at IS NULL`) AND **bump `user.session_epoch`** (so any outstanding access
+     tokens are also killed at their next refresh) → reject with a re-login error.
+   - expired row → reject.
+3. read the `user` row `FOR UPDATE` (S1 logic): `approved=1`, `token.sepoch == user.session_epoch`.
+4. **rotate:** mint a NEW pair from the DB row; `UPDATE refresh_token SET used_at=NOW(),
+   replaced_by=<new jti> WHERE jti=<old>`; INSERT the new refresh row. Return **both** the new access
+   and new refresh token.
+Any failure → `stop_for_unauthorized` (frontend logs out). Reuse detection is the key new property.
+
+### 2.4 Endpoint — POST JSON body
+`/api/auth/refresh` becomes a **POST** with JSON body `{ refresh_token }` (auth-body-only rule;
+matches the signup/authenticate transport hardening). Response: JSON
+`{ access_token, refresh_token, token_type:"Bearer", expires_in }`. It stays in `AUTH_ALLOWLIST`
+(the refresh token is the credential). Keep a **transitional GET** that returns 410/deprecation only
+if needed; default is to move cleanly to POST and update the one frontend caller in the same PR.
+
+### 2.5 Frontend — two-token storage + POST refresh
+- `app/src/api/auth.ts:108`: `refresh()` becomes `apiClient.post('/api/auth/refresh', { refresh_token })`
+  reading the stored refresh token, and returns the new pair. Typed client only.
+- The auth store (`app/src/stores/*` / `useAuth`) stores BOTH tokens (never raw `localStorage.token`
+  writes in views). The request interceptor keeps sending the **access** token as the Bearer; the
+  refresh token is used only by `refresh()`. On refresh success, both are replaced (rotation). On any
+  refresh failure, log out (existing proactive-logout behavior).
+- Access-token expiry shortens nothing that S1 didn't already set; the refresh token's longer life is
+  what enables a longer session, with rotation limiting theft value.
+
+## 3. Tests (TDD)
+- **Unit (auth-service):** access/refresh are DISTINCT tokens with different `typ` and `exp`; an
+  access token presented to refresh is rejected (`typ` gate); a valid refresh rotates (old `used_at`
+  set, new jti issued, both tokens returned, role from DB); **reuse of an already-rotated refresh
+  token force-revokes the chain and bumps the epoch**; an unknown/expired/revoked jti is rejected.
+- **Regression (S1 invariant, MUST stay green):** legacy no-`sepoch`/no-`typ` token rejected; epoch
+  mismatch (post-demotion) rejected; role minted from DB row. Reuse the shipped
+  `test-unit-auth-refresh-epoch.R` assertions.
+- **Migration guards** updated (name + count + `res$latest`).
+- **Frontend:** `auth.ts` refresh POSTs the body and stores both tokens (its `.spec.ts`); the store
+  round-trips two tokens.
+
+## 4. Verification (live, per the umbrella spec §7 — masking only surfaces in the loaded env)
+- In-container R tests (auth-service + migration guards) against the test DB.
+- **Live monkey (mandatory for auth):** restart `api` + `worker` + `worker-maintenance`; mint tokens
+  via the dev-block secret; drive: (a) POST refresh returns a new PAIR; (b) replay the OLD refresh
+  token → chain revoked + epoch bumped + 401; (c) **S0-2 regression**: legacy token → 401, epoch-bump
+  → 401, valid → 200 with DB-derived claims. Verify the SPA login→refresh→still-authed cycle in the
+  browser.
+- `make code-quality-audit`, `make lint-api`, `cd app && npm run type-check && npm run test:unit`.
+- Codex adversarial plan review AND diff review at xhigh.
+
+## 5. Risk & rollout (human-gated)
+- **Frontend two-token migration** is the riskiest part: an in-flight SPA with only the old
+  single-token model must still work. The access token is unchanged in shape (still a valid Bearer),
+  so already-signed-in users keep working; they get a refresh token on their next `signin`/`refresh`.
+  A user who refreshes with a pre-S1b token (no `typ=refresh`, no jti row) is rejected → forced
+  re-login (acceptable, one-time, same as the S1 legacy-reject).
+- **Reuse-detection + epoch bump** deliberately logs out ALL of a user's sessions on a detected replay
+  — correct for theft, but note the UX (a benign double-submit of a refresh could trip it; mitigated
+  because rotation is only triggered by the SPA's single refresh path, not concurrently).
+- Config: `refresh_expiry` (default 30d) and whether to keep the GET transitional shim are the human
+  decisions flagged for sign-off.
+
+## 6. Out of scope
+- No change to access-token validation on normal requests (still stateless JWT + `sepoch`-at-refresh;
+  per-request epoch check remains the separate optional decision from S1's residual-risk note).
+- No refresh-token binding to device/IP (a further hardening; noted).


### PR DESCRIPTION
**Design + plan + adversarial review — slice S1b of #535. DO NOT AUTO-MERGE. This is NOT an implementation — it is a design/plan PR for human decision. Umbrella #535 stays open.**

## What
The deferred defense-in-depth follow-up to the shipped S1 session-epoch refresh (PR #538): distinct access/refresh tokens (typ-scoped, different lifetimes), a `refresh_token` revocation table with single-use rotation + reuse detection, and POST `/api/auth/refresh` with a two-token SPA. This PR ships the **spec + TDD plan + a deep Codex plan review** — not code.

## Why design-only (NOT implementation-ready)
A deep Codex adversarial **plan** review (gpt-5.6-sol, xhigh) found **4 BLOCKERs + 7 HIGHs** — exactly the subtle auth landmines that make this unsafe to implement autonomously without live-stack verification and a human topology/UX decision:
- **BLOCKER:** the reuse-detection response is rolled back by prod's `dbWithTransaction` (must commit the revocation, then 401 outside the txn);
- **BLOCKER:** the SPA never receives the initial refresh token (`/authenticate` returns only a scalar; login wire contract must be redefined atomically);
- **BLOCKER:** token-`typ` isolation is one-way (a refresh token is a valid Bearer on ungated endpoints; password-reset JWTs share the key with no typ);
- **BLOCKER:** the "land together" rollout can't update already-loaded SPA JS — needs a phased/versioned contract, not a hard cut;
- **HIGHs:** concurrent legitimate refresh trips reuse (multi-tab/retry) → logs out all sessions; lock-order deadlock + epoch-before-reuse ordering; "revoke chain" actually revokes every session (no family id); the S1 regression fixture must change (mints an access token for refresh); logout does no server-side revocation.

Full review: `.planning/reviews/2026-07-12-security-535-s1b-plan-codex-review.md`. The plan carries a **NOT IMPLEMENTATION-READY** banner and the regression gate (must not regress the shipped S1 epoch/legacy-reject invariant). A plan v2 resolving the blockers + the human decisions (`refresh_expiry`, phased rollout vs hard-cut, family-scoped vs account-wide revocation, HttpOnly cookie vs localStorage) is required before any code.

Refs #535
