### PR TITLE
fix: harden frontend request ownership (#553)

### DIFF
--- a/.planning/reviews/2026-07-13-security-535-s5c-request-ownership-diff-codex-review.md
+++ b/.planning/reviews/2026-07-13-security-535-s5c-request-ownership-diff-codex-review.md
@@ -1,0 +1,20 @@
+# #553 S5c request ownership — final Codex diff review
+
+Scope: the complete `fix/535-s5c-request-ownership` diff against `master`.
+
+## Rounds to merge bar
+
+1. Initial deep review found per-table unmount/deferred callback gaps, shared network-consumer cleanup gaps, stale PubTator feedback, and reset/state ownership gaps.
+2. Review found a typed `NetworkMetadata` fixture compile blocker, modal A→B ownership gap, and remaining mount-time deferred callbacks. These were covered with deterministic tests and fixed.
+3. Review found the remaining HIGH: a modal generation guard could not prevent an already-started `useReviewForm.loadReviewData()` or `useStatusForm.loadStatusData()` from mutating shared form state after B had won. Direct form A→B tests failed RED (A overwrote B), then passed after loader-level generation/abort ownership and reset invalidation were added. The same pass added a deterministic queued-idle-hydration-after-unmount regression test.
+4. Final xhigh review found no BLOCKER/HIGH defects. It verified typed-client signals, form loader generation/reset/finally behavior, child-loader A→B sequencing, table ownership, and network idle-callback cleanup.
+
+Final reviewer verdict:
+
+> No BLOCKER/HIGH defect found; focused Vitest execution is environment-blocked.
+
+`BLOCKER/HIGH remaining: no`
+
+The reviewer was correctly unable to start Vitest in its read-only sandbox because Vite could not create `.vite-temp`; the identical focused tests and full unit suite were run successfully in the writable worktree.
+
+Raw prompts and outputs are retained alongside this summary as `*-diff-codex-*.md` and `*-diff-codex-*.txt`.

--- a/.planning/reviews/2026-07-13-security-535-s5c-request-ownership-plan-codex-out.txt
+++ b/.planning/reviews/2026-07-13-security-535-s5c-request-ownership-plan-codex-out.txt
@@ -1,0 +1,10205 @@
+Reading prompt from stdin...
+OpenAI Codex v0.144.1
+--------
+workdir: /home/bernt-popp/development/sysndd/.claude/worktrees/535-s5c-request-ownership
+model: gpt-5.6-terra
+provider: openai
+approval: never
+sandbox: read-only
+reasoning effort: xhigh
+reasoning summaries: none
+session id: 019f5795-09bc-7b03-9e60-90bb23f8d463
+--------
+user
+# #553 S5c request-ownership plan review
+
+Perform a deep xhigh adversarial **plan** review only. Do not edit files. The approved scope is
+exactly the #553 S5c plan at
+`.planning/superpowers/plans/2026-07-13-security-535-s5c-request-ownership-plan.md`.
+
+Read that plan, current target code/tests, and the shipped S5/S5b records:
+
+- `.planning/superpowers/plans/2026-07-12-security-535-s5b-resource-ownership-plan.md`
+- `.planning/reviews/2026-07-13-security-535-s5b-diff-codex-review.md`
+
+Targets:
+
+- `useUserData`: params-keyed shared in-flight transport map with independent subscribing
+  instances.
+- `tableRequestCoordinator`: cross-instance consumer ownership separate from its shared transport.
+- `useEntityInfo`, `useReviewData`, `usePubtatorGenePublications`, `useAdminTrendData`,
+  `useNetworkData`, `usePubtatorAdmin`: generation/slot ownership plus abort protection.
+- `useOntologyAdminTable`: deferred `currentPage` ownership.
+
+The solution must use existing typed `@/api/*` clients only (no raw axios/localStorage), preserve
+public composable APIs, keep source/test files under 600 lines, and add deterministic deferred
+A-B-A/out-of-order tests for stale success, catch, finally, abort cleanup, cross-instance shared
+subscribers, and page reset. Abort is optimization; ownership checks establish correctness.
+
+Attack the plan for stale overwrites, cross-instance suppression, same-param A-B-A slot corruption,
+controller deletion/abort races, unmount/reset and `nextTick` writes, shared preloads, cache poisoning,
+unhandled stale errors, URL/busy regressions, test vacuity, and implementation-size risks. Expand to
+adjacent same-class races in these exact files only. Classify every finding BLOCKER/HIGH/MEDIUM/LOW.
+End exactly with `Verdict: <SHIP|FIX-FIRST>` and state whether any BLOCKER or HIGH remains.
+
+codex
+I’m reviewing the approved plan against the current composables and the shipped S5/S5b work, with emphasis on ownership and cancellation races. I’ll use the repository’s security and code-quality review guidance to structure the adversarial pass; this is read-only.
+exec
+/bin/bash -lc "sed -n '1,240p' /home/bernt-popp/.codex/superpowers/skills/using-superpowers/SKILL.md && sed -n '1,260p' .agents/skills/sysndd-security-bug-scan/SKILL.md && sed -n '1,260p' .agents/skills/sysndd-code-quality/SKILL.md" in /home/bernt-popp/development/sysndd/.claude/worktrees/535-s5c-request-ownership
+ succeeded in 0ms:
+---
+name: using-superpowers
+description: Use when starting any conversation - establishes how to find and use skills, requiring Skill tool invocation before ANY response including clarifying questions
+---
+
+<SUBAGENT-STOP>
+If you were dispatched as a subagent to execute a specific task, skip this skill.
+</SUBAGENT-STOP>
+
+<EXTREMELY-IMPORTANT>
+If you think there is even a 1% chance a skill might apply to what you are doing, you ABSOLUTELY MUST invoke the skill.
+
+IF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.
+
+This is not negotiable. This is not optional. You cannot rationalize your way out of this.
+</EXTREMELY-IMPORTANT>
+
+## Instruction Priority
+
+Superpowers skills override default system prompt behavior, but **user instructions always take precedence**:
+
+1. **User's explicit instructions** (CLAUDE.md, GEMINI.md, AGENTS.md, direct requests) — highest priority
+2. **Superpowers skills** — override default system behavior where they conflict
+3. **Default system prompt** — lowest priority
+
+If CLAUDE.md, GEMINI.md, or AGENTS.md says "don't use TDD" and a skill says "always use TDD," follow the user's instructions. The user is in control.
+
+## How to Access Skills
+
+**In Claude Code:** Use the `Skill` tool. When you invoke a skill, its content is loaded and presented to you—follow it directly. Never use the Read tool on skill files.
+
+**In Copilot CLI:** Use the `skill` tool. Skills are auto-discovered from installed plugins. The `skill` tool works the same as Claude Code's `Skill` tool.
+
+**In Gemini CLI:** Skills activate via the `activate_skill` tool. Gemini loads skill metadata at session start and activates the full content on demand.
+
+**In other environments:** Check your platform's documentation for how skills are loaded.
+
+## Platform Adaptation
+
+Skills use Claude Code tool names. Non-CC platforms: see `references/copilot-tools.md` (Copilot CLI), `references/codex-tools.md` (Codex) for tool equivalents. Gemini CLI users get the tool mapping loaded automatically via GEMINI.md.
+
+# Using Skills
+
+## The Rule
+
+**Invoke relevant or requested skills BEFORE any response or action.** Even a 1% chance a skill might apply means that you should invoke the skill to check. If an invoked skill turns out to be wrong for the situation, you don't need to use it.
+
+```dot
+digraph skill_flow {
+    "User message received" [shape=doublecircle];
+    "About to EnterPlanMode?" [shape=doublecircle];
+    "Already brainstormed?" [shape=diamond];
+    "Invoke brainstorming skill" [shape=box];
+    "Might any skill apply?" [shape=diamond];
+    "Invoke Skill tool" [shape=box];
+    "Announce: 'Using [skill] to [purpose]'" [shape=box];
+    "Has checklist?" [shape=diamond];
+    "Create TodoWrite todo per item" [shape=box];
+    "Follow skill exactly" [shape=box];
+    "Respond (including clarifications)" [shape=doublecircle];
+
+    "About to EnterPlanMode?" -> "Already brainstormed?";
+    "Already brainstormed?" -> "Invoke brainstorming skill" [label="no"];
+    "Already brainstormed?" -> "Might any skill apply?" [label="yes"];
+    "Invoke brainstorming skill" -> "Might any skill apply?";
+
+    "User message received" -> "Might any skill apply?";
+    "Might any skill apply?" -> "Invoke Skill tool" [label="yes, even 1%"];
+    "Might any skill apply?" -> "Respond (including clarifications)" [label="definitely not"];
+    "Invoke Skill tool" -> "Announce: 'Using [skill] to [purpose]'";
+    "Announce: 'Using [skill] to [purpose]'" -> "Has checklist?";
+    "Has checklist?" -> "Create TodoWrite todo per item" [label="yes"];
+    "Has checklist?" -> "Follow skill exactly" [label="no"];
+    "Create TodoWrite todo per item" -> "Follow skill exactly";
+}
+```
+
+## Red Flags
+
+These thoughts mean STOP—you're rationalizing:
+
+| Thought | Reality |
+|---------|---------|
+| "This is just a simple question" | Questions are tasks. Check for skills. |
+| "I need more context first" | Skill check comes BEFORE clarifying questions. |
+| "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
+| "I can check git/files quickly" | Files lack conversation context. Check for skills. |
+| "Let me gather information first" | Skills tell you HOW to gather information. |
+| "This doesn't need a formal skill" | If a skill exists, use it. |
+| "I remember this skill" | Skills evolve. Read current version. |
+| "This doesn't count as a task" | Action = task. Check for skills. |
+| "The skill is overkill" | Simple things become complex. Use it. |
+| "I'll just do this one thing first" | Check BEFORE doing anything. |
+| "This feels productive" | Undisciplined action wastes time. Skills prevent this. |
+| "I know what that means" | Knowing the concept ≠ using the skill. Invoke it. |
+
+## Skill Priority
+
+When multiple skills could apply, use this order:
+
+1. **Process skills first** (brainstorming, debugging) - these determine HOW to approach the task
+2. **Implementation skills second** (frontend-design, mcp-builder) - these guide execution
+
+"Let's build X" → brainstorming first, then implementation skills.
+"Fix this bug" → debugging first, then domain-specific skills.
+
+## Skill Types
+
+**Rigid** (TDD, debugging): Follow exactly. Don't adapt away discipline.
+
+**Flexible** (patterns): Adapt principles to context.
+
+The skill itself tells you which.
+
+## User Instructions
+
+Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.
+---
+name: sysndd-security-bug-scan
+description: Use when reviewing or writing SysNDD code for security vulnerabilities or correctness bugs — authorization/role gates, SQL/expression injection, credential and secret handling, data exposure through public or MCP surfaces, resource-exhaustion/DoS from external calls, error/info leakage, and the repo's known R/Plumber footguns — especially before merging a diff or PR
+---
+
+# SysNDD Security & Bug Scan
+
+A focused **defect + vulnerability** review pass over a diff or PR. Distinct from `sysndd-code-quality` (maintainability) — this hunts for exploitable and correctness-breaking defects. It complements the generic `/security-review` and `/code-review` by encoding SysNDD's specific gates, helpers, and footguns.
+
+Core insight: almost every SysNDD vulnerability is **"bypassed a safe helper that already exists."** For each finding, prefer the in-repo helper over a hand-rolled fix.
+
+## Workflow
+
+1. Scope the diff. For each new/changed **endpoint, DB query, external call, or auth path**, run the relevant checks below.
+2. Flag any hand-rolled code that a listed helper already covers.
+3. Run the guard tests for the touched areas (see Verify) — a failing guard test usually means the change is wrong, not the guard.
+4. Report findings by severity with `file:line` and the concrete in-repo fix; separate must-fix from optional.
+
+## Security Checks
+
+### Authorization & privilege escalation
+- Every write / admin / curation endpoint must call `require_role(req, res, "<Role>")`. Auth is **per-endpoint** (no global deny filter) — a handler with no gate is reachable **unauthenticated**.
+- `direct_approval` escalates the gate to **Curator** server-side; never trust the client flag (re-checked in `svc_status_apply_direct_approval` / `review_apply_direct_approval`). The frontend `hasMinRole` is UX, not a control.
+- Attribution is server-set: `status_user_id <- req$user_id`. Never accept `*_user_id` from the request body.
+
+### Injection (SQL / expression / RCE)
+- User `filter` / `sort` tokens must pass through `validate_query_column()` via `generate_filter_expressions()` / `generate_sort_expressions()` with `allowed_columns_for_view()`. **Never `paste0()` or raw input into `rlang::parse_exprs()`** — over a dbplyr `tbl` that is SQL injection **and** R-side RCE (local partial-eval runs `system(...)` etc.).
+- Parameterize SQL with `?` placeholders + `DBI::dbBind(stmt, unname(params))`. No string-interpolated values.
+- URL-encode external path/query segments: `utils::URLencode(x, reserved = TRUE)`.
+
+### Data exposure (public / MCP)
+- MCP and public reads are **approved-public only**: reviews gated `is_primary = 1 AND review_approved = 1`; records from `ndd_entity_view` (active only). A query dropping these leaks **draft/unapproved** curation. See `sysndd-mcp-readonly`.
+- MCP must not write, generate LLM summaries, or call live external providers.
+
+### Secrets & credentials
+- Auth-sensitive inputs (`/auth/signup`, `/auth/authenticate`, password change) are **JSON body only** — never query string (leaks into access/Traefik logs, browser history).
+- Log through `sanitize_request()` / `sanitize_object()` (`SENSITIVE_FIELDS` redaction in `core/logging_sanitizer.R`); never log tokens, passwords, or secrets.
+- Do not bake `config.yml` / secrets into image layers (no `COPY config.yml` in `api/Dockerfile`; use the runtime mount).
+- Passwords use Argon2id/sodium (`hash_password` / `verify_password` in `core/security.R`); never plaintext comparison.
+
+### Resource exhaustion / DoS
+- Every external HTTP call derives its timeout/retry from `external_proxy_budget()` or `make_external_request()` — **no hardcoded `req_timeout(<n>)`** (enforced by `test-unit-external-budget-guard.R`). Wrap fetchers in `memoise_external_success_only(source = "<provider>")`.
+- Cheap routes (`/health`, `/auth`, `/statistics`) must never call an external fetcher (`test-unit-cheap-route-isolation.R`).
+- Public expensive operations are throttled or cache-only (async submit cap; LLM generation is Curator+ only).
+
+### Error / info leakage
+- Mount every endpoint sub-router via `mount_endpoint()` (attaches the RFC 9457 `errorHandler` + `notFoundHandler`). A bare `plumber::pr_mount(...)` leaks opaque `500`s with internal detail and drops correct status codes. Throw classed errors (`stop_for_bad_request` / `stop_for_unauthorized` / …), not bare `stop()`.
+
+## Correctness Footguns (SysNDD-specific)
+
+- `DBI::dbBind()` with `?` placeholders needs `unname(params)`; named lists fail silently.
+- `dplyr::select` / `filter` are masked (biomaRt/AnnotationDbi) — namespace them explicitly.
+- `config::get` masks `base::get` in the loaded API/worker env — bare `get(x, mode = "function")` errors "unused argument (mode)"; use `base::get` or direct dispatch (`test-unit-base-exists-get-guard.R`).
+- Plumber returns JSON scalars as arrays — unwrap before feeding back into params.
+- Use `inherits(x, "Date")`, not `is.Date()`.
+- Worker-executed code is sourced at worker start — a change is not live until the worker restarts.
+
+## Verify
+
+Run the guard tests for the touched areas, then `make lint-api` and the appropriate test lane:
+
+`test-unit-security.R`, `test-unit-filter-column-allowlist.R`, `test-unit-endpoint-error-handler.R`, `test-endpoint-auth.R` / `test-integration-auth.R`, `test-unit-*-endpoint-guard.R`, `test-unit-external-budget-guard.R`, `test-unit-cheap-route-isolation.R`.
+
+Lead with findings ordered by severity, each with `file:line` and the in-repo fix. If nothing is found, say so and list the checks run plus residual risk.
+---
+name: sysndd-code-quality
+description: Use when reviewing or changing SysNDD code for maintainability, modularity, file size, duplication, simplicity, typed boundaries, tests, or architecture quality before handoff
+---
+
+# SysNDD Code Quality
+
+Use this skill as a focused review pass before handoff, during refactors, or when touching large or shared SysNDD files.
+
+## Review Workflow
+
+1. Inspect the diff and the nearby implementation patterns before judging the change.
+2. Run deterministic checks first when they are relevant: `make code-quality-audit`, `git diff --check`, targeted tests, `make lint-api`, `make lint-app`, `cd app && npm run type-check`, `cd app && npm run type-check:strict`, or the smallest useful single-test command from `AGENTS.md`.
+3. Review the changed files for the quality risks below.
+4. Report concrete findings with file and line references. Distinguish must-fix issues from optional cleanup.
+
+## Quality Checks
+
+- **Modularity:** each file/module should have one clear responsibility and a readable public surface. Prefer cohesive helpers, composables, services, or repository functions over adding another mode to an already broad file.
+- **600-line soft ceiling:** flag handwritten source files that exceed or approach 600 lines when the change makes them larger. `make code-quality-audit` enforces the deterministic ratchet: new oversized files fail, and baseline oversized files may not grow. Tests, migrations, fixtures, generated files, and tightly coupled implementations may exceed the ceiling when splitting would reduce clarity.
+- **KISS:** prefer direct, local solutions that match existing patterns. Push back on speculative abstractions, new dependencies, clever generic utilities, and cross-layer shortcuts.
+- **DRY:** remove meaningful duplicated business logic, API normalization, query construction, or UI state handling. Do not extract tiny one-off code if it makes call flow harder to follow.
+- **SOLID, pragmatically:** apply dependency direction and single-responsibility thinking, but do not introduce class-heavy architecture just to satisfy a slogan.
+- **Frontend boundaries:** views and components should use typed clients from `app/src/api/*`; do not add raw axios calls or direct `localStorage.token` / `localStorage.user` access.
+- **API boundaries:** endpoint files should stay thin and delegate reusable logic to services/repositories/helpers without dropping required `svc_` or `service_` prefixes.
+- **Tests:** behavior changes need targeted tests or a documented deterministic check. API integration tests that write DB state should use `with_test_db_transaction()` or document why rollback is not possible.
+- **Docs:** update durable docs when behavior, commands, runtime assumptions, or contributor expectations change.
+
+## Output
+
+Lead with findings ordered by severity. If there are no findings, say that and list any checks run plus residual risk.
+
+exec
+/bin/bash -lc "rg --files -g 'AGENTS.md' -g '*useUserData*' -g '*tableRequestCoordinator*' -g '*EntityInfo*' -g '*ReviewData*' -g '*Pubtator*' -g '*TrendData*' -g '*NetworkData*' -g '*OntologyAdminTable*' -g '*request*ownership*' .planning app/src | sort" in /home/bernt-popp/development/sysndd/.claude/worktrees/535-s5c-request-ownership
+ succeeded in 0ms:
+.planning/reviews/2026-07-13-security-535-s5c-request-ownership-plan-codex-out.txt
+.planning/reviews/2026-07-13-security-535-s5c-request-ownership-plan-codex-prompt.md
+.planning/superpowers/plans/2026-07-11-security-535-s5-request-ownership-plan.md
+.planning/superpowers/plans/2026-07-13-security-535-s5c-request-ownership-plan.md
+app/src/components/analyses/PubtatorAnnotatedText.spec.ts
+app/src/components/analyses/PubtatorAnnotatedText.vue
+app/src/components/analyses/PubtatorNDDGenes.spec.ts
+app/src/components/analyses/PubtatorNDDGenes.vue
+app/src/components/analyses/PubtatorNDDStats.vue
+app/src/components/analyses/PubtatorNDDTable.spec.ts
+app/src/components/analyses/PubtatorNDDTable.vue
+app/src/components/analyses/PubtatorPublicationDetail.vue
+app/src/components/analyses/usePubtatorGenesTable.spec.ts
+app/src/components/analyses/usePubtatorGenesTable.ts
+app/src/components/analyses/usePubtatorPublicationTable.spec.ts
+app/src/components/analyses/usePubtatorPublicationTable.ts
+app/src/components/annotations/PubtatorStatsCard.vue
+app/src/composables/useNetworkData.spec.ts
+app/src/composables/useNetworkData.ts
+app/src/composables/usePubtatorAdmin.ts
+app/src/composables/usePubtatorAdminPanel.ts
+app/src/composables/usePubtatorGenePublications.spec.ts
+app/src/composables/usePubtatorGenePublications.ts
+app/src/composables/usePubtatorParser.spec.ts
+app/src/composables/usePubtatorParser.ts
+app/src/utils/tableRequestCoordinator.spec.ts
+app/src/utils/tableRequestCoordinator.ts
+app/src/views/admin/ManagePubtator.spec.ts
+app/src/views/admin/ManagePubtator.vue
+app/src/views/admin/composables/__tests__/useUserData.spec.ts
+app/src/views/admin/composables/useAdminTrendData.ts
+app/src/views/admin/composables/useOntologyAdminTable.ts
+app/src/views/admin/composables/useUserData.ts
+app/src/views/analyses/PubtatorNDD.vue
+app/src/views/curate/components/EntityInfoHeader.spec.ts
+app/src/views/curate/components/EntityInfoHeader.vue
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts
+app/src/views/curate/composables/useEntityInfo.ts
+app/src/views/review/composables/__tests__/useReviewData.spec.ts
+app/src/views/review/composables/useReviewData.ts
+
+exec
+/bin/bash -lc 'wc -l .planning/superpowers/plans/2026-07-13-security-535-s5c-request-ownership-plan.md .planning/superpowers/plans/2026-07-12-security-535-s5b-resource-ownership-plan.md .planning/reviews/2026-07-13-security-535-s5b-diff-codex-review.md app/src/views/admin/composables/useUserData.ts app/src/utils/tableRequestCoordinator.ts app/src/views/curate/composables/useEntityInfo.ts app/src/views/review/composables/useReviewData.ts app/src/composables/usePubtatorGenePublications.ts app/src/views/admin/composables/useAdminTrendData.ts app/src/composables/useNetworkData.ts app/src/composables/usePubtatorAdmin.ts app/src/views/admin/composables/useOntologyAdminTable.ts; find .. -name AGENTS.md -print' in /home/bernt-popp/development/sysndd/.claude/worktrees/535-s5c-request-ownership
+ succeeded in 0ms:
+   104 .planning/superpowers/plans/2026-07-13-security-535-s5c-request-ownership-plan.md
+   317 .planning/superpowers/plans/2026-07-12-security-535-s5b-resource-ownership-plan.md
+   101 .planning/reviews/2026-07-13-security-535-s5b-diff-codex-review.md
+   440 app/src/views/admin/composables/useUserData.ts
+   109 app/src/utils/tableRequestCoordinator.ts
+   208 app/src/views/curate/composables/useEntityInfo.ts
+   336 app/src/views/review/composables/useReviewData.ts
+   127 app/src/composables/usePubtatorGenePublications.ts
+   148 app/src/views/admin/composables/useAdminTrendData.ts
+   317 app/src/composables/useNetworkData.ts
+   206 app/src/composables/usePubtatorAdmin.ts
+   465 app/src/views/admin/composables/useOntologyAdminTable.ts
+  2878 total
+../535-composables-bundle-budget/AGENTS.md
+../535-composables-bundle-budget/app/node_modules/cytoscape/AGENTS.md
+../535-dead-create-job-executor/AGENTS.md
+../535-s5c-request-ownership/AGENTS.md
+../535-stream-backups/AGENTS.md
+../535-auth-endpoint-rate-limit/AGENTS.md
+../535-mcp-select-principal/AGENTS.md
+
+exec
+/bin/bash -lc "sed -n '1,180p' .planning/superpowers/plans/2026-07-13-security-535-s5c-request-ownership-plan.md && sed -n '1,360p' .planning/superpowers/plans/2026-07-12-security-535-s5b-resource-ownership-plan.md && sed -n '1,160p' .planning/reviews/2026-07-13-security-535-s5b-diff-codex-review.md" in /home/bernt-popp/development/sysndd/.claude/worktrees/535-s5c-request-ownership
+ succeeded in 0ms:
+# #553 S5c Frontend Request Ownership Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:test-driven-development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure only a read request that still owns a consumer's latest intent may update reactive data, error, busy/loading flags, browser state, or deferred callbacks.
+
+**Architecture:** Follow S5/S5b's two-level model. Each composable owns a monotonic instance generation plus its own `AbortController`; starting a newer logical read aborts and invalidates the old one, and every success/catch/finally/deferred callback checks ownership. Shared transports retain their own slot identity: `useUserData` stores pending promises by parameter key and every subscribing instance applies only when its local generation/params are current; `tableRequestCoordinator` gives each caller a consumer generation rather than using its global transport generation as consumer identity.
+
+**Tech Stack:** Vue 3 composables, typed `@/api/*` clients, AbortController, Vitest/MSW.
+
+---
+
+## Invariants
+
+- No raw axios or direct `localStorage.token` / `localStorage.user` access.
+- Capture identity before every await; stale success, catch, finally, `nextTick`, and abort cleanup are no-ops for consumer state.
+- Abort is best-effort only; generation/slot checks remain the correctness boundary.
+- A shared in-flight transport may serve multiple current consumers, but a transport completion may not clear/replace a newer transport slot.
+- Tests use deferred promises and resolve obsolete work after the newer intent; no sleep-based race tests.
+- Keep every touched source and test below 600 lines. Extract a cohesive test fixture/helper only if a target approaches the ceiling.
+
+## Task 1: Plan review before production edits
+
+**Files:**
+- Create: `.planning/reviews/2026-07-13-security-535-s5c-request-ownership-plan-codex-review.md`
+
+- [ ] Run a background, xhigh, read-only Codex plan review against this plan, the S5/S5b plans/reviews, and the nine target files.
+- [ ] Fold any BLOCKER/HIGH and inexpensive MEDIUM/LOW into this plan before tests or production code.
+
+## Task 2: `useUserData` params-keyed shared transport
+
+**Files:**
+- Modify: `app/src/views/admin/composables/useUserData.ts`
+- Test: `app/src/views/admin/composables/__tests__/useUserData.spec.ts`
+
+- [ ] Add RED tests for two mounted/live instances requesting the same params: exactly one typed-client request, both current subscribers receive the result, and neither instance remains busy.
+- [ ] Add RED tests for A-B-A and stale rejection/finally while the newer request remains pending; prove a stale request cannot clear the new slot, cache, busy flag, or URL.
+- [ ] Replace `moduleApiCallInProgress`/single-param bookkeeping with a module `Map<string, Promise<UserTableResponse>>` and per-param latest-start sequence/cache metadata. A new transport records itself only if it still owns its keyed slot; stale completion cannot delete or cache over a newer same-param transport.
+- [ ] Each `useUserData()` instance retains its own intent generation and params predicate. A shared promise is subscribed to rather than silently returning; success/catch/finally, `nextTick(currentPage)`, and cache apply require that local predicate.
+- [ ] Run the targeted spec GREEN.
+
+## Task 3: Cross-instance table transport ownership
+
+**Files:**
+- Modify: `app/src/utils/tableRequestCoordinator.ts`
+- Test: `app/src/utils/tableRequestCoordinator.spec.ts`
+
+- [ ] Add RED tests with two distinct consumers sharing params: a later request from consumer B must not suppress still-current A; both apply the shared response exactly once.
+- [ ] Add RED tests for one consumer changing params while another stays current, and for stale shared rejection; only the stale consumer is suppressed and the new slot is not cleared.
+- [ ] Separate transport-slot generation (network/cache mutation) from caller-owned request generation. The coordinator keeps one shared in-flight slot but creates a per-caller token, and checks that token plus `isCurrent(params)` around apply/onError.
+- [ ] Run the coordinator spec GREEN.
+
+## Task 4: Entity and review workflow reads
+
+**Files:**
+- Modify: `app/src/views/curate/composables/useEntityInfo.ts`
+- Test: `app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts`
+- Modify: `app/src/views/review/composables/useReviewData.ts`
+- Test: `app/src/views/review/composables/__tests__/useReviewData.spec.ts`
+
+- [ ] Add deferred A-B-A tests for entity, review, and status loads. Resolve the original request last and assert no mixed entity/review/status model, no stale clear/reset, and no stale error toast.
+- [ ] Add per-read generation + AbortController state. Start a new logical read by aborting and superseding the previous controller; pass `signal` through the existing typed clients. Guard every multi-call `useEntityInfo.loadReview()` mutation as one atomic snapshot.
+- [ ] In `useReviewData`, independently own table, option-list, entity, review-info, and status-info request families. Guard `isBusy`, `loading`, `loading_status_modal`, reactive-object assignment, option clears, and errors. `resetEntityContext()` invalidates its entity/review generations.
+- [ ] If `useReviewData.ts` approaches 600 lines, move only the request-owner helper/types to an explicitly imported sibling file; preserve its public composable API.
+- [ ] Run both targeted specs GREEN.
+
+## Task 5: Per-gene, trend, network, and PubTator admin reads
+
+**Files:**
+- Modify: `app/src/composables/usePubtatorGenePublications.ts`
+- Test: `app/src/composables/usePubtatorGenePublications.spec.ts`
+- Modify: `app/src/views/admin/composables/useAdminTrendData.ts`
+- Create: `app/src/views/admin/composables/useAdminTrendData.spec.ts`
+- Modify: `app/src/composables/useNetworkData.ts`
+- Test: `app/src/composables/useNetworkData.spec.ts`
+- Modify: `app/src/composables/usePubtatorAdmin.ts`
+- Create: `app/src/composables/usePubtatorAdmin.spec.ts`
+
+- [ ] Add RED tests that supersede a gene/publication read via `resetCache()`/same-gene refetch; stale success, catch, and finally cannot repopulate cache, clear a newer controller, or stop its spinner.
+- [ ] Add RED trend/network/admin-status tests with deferred typed-client promises: B wins over A; A's success/catch/finally cannot clear B's data/loading/error/controller. Test actual abort cleanup where a controller exists.
+- [ ] Give each logical key/request family its own generation and controller. `useNetworkData` preserves the global preload promise as the transport slot but races a local abort signal and gates consumer refs/loading by its per-instance generation; cancelling one consumer must not abort the shared preload for another.
+- [ ] Run all four targeted specs GREEN.
+
+## Task 6: `useOntologyAdminTable` deferred page ownership
+
+**Files:**
+- Modify: `app/src/views/admin/composables/useOntologyAdminTable.ts`
+- Test: `app/src/views/admin/ManageOntology.spec.ts`
+
+- [ ] Add a RED deferred-response test: request page A, start page B, resolve A last, then flush `nextTick`; A must not assign B's `currentPage`, cursors, rows, busy flag, or URL.
+- [ ] Capture a local table-load generation at intent scheduling, pass its ownership predicate into `applyApiResponse`, and recheck it inside the deferred `nextTick(currentPage)` assignment. `doLoadData` passes the same predicate to coordinator apply/error and clears busy only for its own current intent.
+- [ ] Run the focused ManageOntology spec GREEN.
+
+## Task 7: Final verification, adversarial review, and stacked PR
+
+- [ ] Run all targeted specs, `make code-quality-audit`, `make lint-app`, `cd app && npm run type-check:strict`, `cd app && npm run test:unit`, and `git diff --check` with fresh output.
+- [ ] Run a background deep xhigh Codex diff review. Fold all BLOCKER/HIGH and inexpensive MEDIUM/LOW test-first; repeat until no BLOCKER/HIGH remains. Commit the concise round/verdict record to `.planning/reviews/2026-07-13-security-535-s5c-request-ownership-diff-codex-review.md`.
+- [ ] After a final `git status -sb`, commit on `fix/535-s5c-request-ownership`, push, and create one PR with base `fix/535-composables-bundle-budget`, `Closes #553`, and `Refs #535` on separate lines. Do not merge.
+
+## Self-review
+
+- Scope coverage: `useUserData` map → Task 2; coordinator cross-instance semantics → Task 3; entity/review ownership → Task 4; remaining four read composables → Task 5; ontology deferred page write → Task 6.
+- No new public APIs or raw transport boundary are proposed; implementation is restricted to typed existing clients and S5/S5b identity patterns.
+- Every async mutation class named by the issue—success, error, finally, abort cleanup, shared subscriber, and deferred callback—has a deterministic test task.
+# S5b — Frontend Request Ownership (useResource / useAsyncJob / useUserData) — Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:test-driven-development. Steps use `- [ ]`.
+
+**Goal:** Only the latest request for a consumer may mutate state. Close the three request-ownership
+races S5 deferred: `useResource` (per-fetch + transport-slot ownership), `useAsyncJob` (poll
+generation, guarding success AND catch AND `stopPolling`), `useUserData` (module generation +
+response-param-safe cache). Design: `.../specs/2026-07-12-security-535-s5b-resource-ownership-design.md`.
+
+## Global constraints
+- Deterministic tests: manually-resolved deferred promises, resolve the **stale** request last.
+- No public composable signature changes; internal generation state only.
+- Keep touched files < 600 lines. Namespaced/typed as the surrounding code.
+
+---
+
+### Task 1: `useResource` — per-fetch + transport-slot ownership
+
+**Files:** modify `app/src/composables/useResource.ts`; extend `app/src/composables/__tests__/useResource.spec.ts`.
+
+- [ ] **Step 1 — RED tests** (append a `describe('useResource — S5b request ownership', …)`), using
+  per-call deferred resolvers so each fetch is resolved independently:
+
+```ts
+// concurrent same-key refresh: older resolves last, must not win, cache holds newer
+it('two concurrent refresh() for the same key: the stale (older) resolution does not win', async () => {
+  const resolvers: Array<(v: string) => void> = [];
+  const fetcher = vi.fn(() => new Promise<string>((res) => { resolvers.push(res); }));
+  const Comp = defineComponent({ setup() { return { r: useResource('k-race', fetcher, { ttlMs: 60_000 }) }; }, render: () => h('div') });
+  const w = mount(Comp); await nextTick(); await Promise.resolve(); // fetch #0 in flight (initial)
+  resolvers[0]('v0'); await Promise.resolve(); await nextTick();    // settle initial
+  const p1 = (w.vm as any).r.refresh();   // fetch #1
+  const p2 = (w.vm as any).r.refresh();   // fetch #2 (newer)
+  resolvers[2]('fresh'); await p2; await Promise.resolve();
+  resolvers[1]('stale'); await p1; await Promise.resolve();         // stale resolves LAST
+  expect((w.vm as any).r.data.value).toBe('fresh');
+  const cache = useCacheStore();
+  expect(cache.peek('k-race')?.value).toBe('fresh');               // stale did NOT overwrite cache
+  w.unmount();
+});
+
+// stale rejection must not clear a newer fetch's pending slot / newer error/data
+it('a stale rejection does not corrupt the newer fetch cache slot or refs', async () => {
+  const rs: Array<(v: string) => void> = []; const rj: Array<(e: unknown) => void> = [];
+  const fetcher = vi.fn(() => new Promise<string>((res, rej) => { rs.push(res); rj.push(rej); }));
+  const Comp = defineComponent({ setup() { return { r: useResource('k-rej', fetcher, { ttlMs: 60_000 }) }; }, render: () => h('div') });
+  const w = mount(Comp); await nextTick(); await Promise.resolve();
+  rs[0]('v0'); await Promise.resolve(); await nextTick();
+  const p1 = (w.vm as any).r.refresh(); const p2 = (w.vm as any).r.refresh();
+  rs[2]('fresh2'); await p2; await Promise.resolve();
+  rj[1](new Error('stale-boom')); await p1.catch(() => {}); await Promise.resolve();
+  expect((w.vm as any).r.data.value).toBe('fresh2');
+  expect((w.vm as any).r.error.value).toBeNull();                  // stale rejection ignored
+  const cache = useCacheStore();
+  expect(cache.peek('k-rej')?.value).toBe('fresh2');
+  w.unmount();
+});
+```
+
+- [ ] **Step 2 — run RED** — `cd app && npx vitest run src/composables/__tests__/useResource.spec.ts`.
+  The first test fails (stale overwrites data/cache); guards do not yet exist.
+
+- [ ] **Step 3 — implement.** Add per-instance fetch generation and transport-slot ownership.
+
+  Near `activeToken` (line ~48) add: `let fetchGeneration = 0;`
+
+  Rewrite `doFetch` so BOTH branches capture identity at start and guard on it:
+```ts
+  async function doFetch(key: ResourceKey, force: boolean, background = false): Promise<void> {
+    const myToken = activeToken;
+    const myGen = ++fetchGeneration;
+    const isLatest = (): boolean => myToken === activeToken && myGen === fetchGeneration;
+
+    const existing = cache.peek<T>(key);
+    if (existing?.pending && !force) {
+      try {
+        if (!background) loading.value = true;
+        const value = (await existing.pending) as T;
+        if (!isLatest()) return;
+        data.value = value; error.value = null; isStale.value = false;
+      } catch (e) {
+        if (!isLatest()) return;
+        error.value = e instanceof Error ? e : new Error(String(e));
+      } finally {
+        if (isLatest() && !background) loading.value = false;
+      }
+      return;
+    }
+
+    const ac = new AbortController();
+    const promise = (async () => await fetcher(ac.signal))();
+    cache.beginFetch<T>(key, promise, ac);
+    // Transport-slot ownership: only the fetch whose promise is still the slot's
+    // `pending` may write/clear the shared cache entry. A newer beginFetch()
+    // replaces `pending`, so a stale fetch declines to touch the slot.
+    const ownsSlot = (): boolean => cache.peek<T>(key)?.pending === promise;
+    if (!background) loading.value = true;
+    try {
+      const value = await promise;
+      if (ownsSlot()) cache.set<T>(key, value, ttlMs);
+      if (!isLatest()) return;
+      data.value = value; error.value = null; isStale.value = false;
+    } catch (e) {
+      if (ownsSlot()) cache.endFetch(key);
+      if (!isLatest()) return;
+      error.value = e instanceof Error ? e : new Error(String(e));
+    } finally {
+      if (ownsSlot()) cache.endFetch(key);
+      if (isLatest() && !background) loading.value = false;
+    }
+  }
+```
+  (Note: `cache.set()` already nulls `pending`, so the `finally` `ownsSlot()` is false after a
+  successful owned write — no double-clear. `activate`/`abort`/`refresh` are unchanged.)
+
+- [ ] **Step 4 — run GREEN** — the two new tests pass and the whole existing `useResource.spec.ts`
+  suite stays green (dedupe, abort, SWR, cached-null, refresh-preserves-refcount).
+
+- [ ] **Step 5 — commit** `fix(app): per-fetch + transport-slot ownership in useResource (#535 S5b)`.
+
+---
+
+### Task 2: `useAsyncJob` — poll generation guards success + catch + stopPolling
+
+**Files:** modify `app/src/composables/useAsyncJob.ts`; extend `app/src/composables/useAsyncJob.spec.ts`.
+
+- [ ] **Step 1 — RED tests.** Use the existing fake-interval harness. Drive a poll whose HTTP
+  resolution is deferred via a manual `server.use` handler that holds a promise, then `startJob(j2)`
+  before releasing j1's response.
+
+  Simplest deterministic construction: mock the status endpoint to return per-job payloads and
+  assert cross-job non-interference:
+```ts
+it('a stale poll from a superseded job does not overwrite the new job or stop its polling', async () => {
+  // j1 poll resolves AFTER startJob('j2'); j1 must not touch j2 state or polling.
+  let release!: () => void;
+  const gate = new Promise<void>((r) => { release = r; });
+  let seen: string[] = [];
+  server.use(http.get('/api/jobs/:job_id/status', async ({ params }) => {
+    const id = String(params.job_id); seen.push(id);
+    if (id === 'j1') { await gate; return HttpResponse.json({ job_id:['j1'], status:['failed'], error:['j1 crashed'] }); }
+    return HttpResponse.json({ job_id:['j2'], status:['running'], step:['go'], progress:{current:[1],total:[2]} });
+  }));
+  const [job, app] = withSetup(() => useAsyncJob(statusEndpoint, { pollingInterval: TEST_POLL_MS, timerInterval: TEST_TIMER_MS }));
+  job.startJob('j1');
+  await vi.advanceTimersByTimeAsync(TEST_POLL_MS);   // j1 poll starts, awaits gate
+  job.startJob('j2');                                // supersede while j1 in flight
+  release(); await flushPromises();                  // j1 resolves LAST (failed)
+  expect(job.status.value).not.toBe('failed');       // stale j1 did not fail j2
+  expect(job.jobId.value).toBe('j2');
+  expect(job.isPolling.value).toBe(true);            // stale j1 did not stopPolling
+  job.stopPolling(); app.unmount();
+});
+
+it('a stale poll REJECTION does not fail or stop the new job', async () => {
+  let release!: () => void; const gate = new Promise<void>((r)=>{ release = r; });
+  server.use(http.get('/api/jobs/:job_id/status', async ({ params }) => {
+    const id = String(params.job_id);
+    if (id === 'j1') { await gate; return HttpResponse.json({ error:'boom' }, { status: 500 }); }
+    return HttpResponse.json({ job_id:['j2'], status:['running'], step:['go'], progress:{current:[0],total:[0]} });
+  }));
+  const [job, app] = withSetup(() => useAsyncJob(statusEndpoint, { pollingInterval: TEST_POLL_MS, timerInterval: TEST_TIMER_MS }));
+  job.startJob('j1'); await vi.advanceTimersByTimeAsync(TEST_POLL_MS);
+  job.startJob('j2'); release(); await flushPromises();
+  expect(job.status.value).not.toBe('failed');
+  expect(job.isPolling.value).toBe(true);
+  job.stopPolling(); app.unmount();
+});
+```
+
+- [ ] **Step 2 — run RED** — `npx vitest run src/composables/useAsyncJob.spec.ts` (stale j1 currently
+  fails/stops j2).
+
+- [ ] **Step 3 — implement.** Add `let pollGeneration = 0;` (near the refs). At the top of
+  `checkJobStatus`, after the `if (!jobId.value) return;`, capture `const myGen = pollGeneration;`.
+  Immediately after the `await apiClient.get(...)` resolves — before the `JOB_NOT_FOUND`/status
+  handling — insert `if (myGen !== pollGeneration) return;`. In the `catch`, as the **first**
+  statement, insert `if (myGen !== pollGeneration) return;` (before `stopPolling()`/mutations). In
+  `startJob()` and `reset()` add `pollGeneration += 1;` (in `reset`, after `stopPolling()`; in
+  `startJob`, before `resumePolling()`).
+
+- [ ] **Step 4 — run GREEN** — new tests pass; all existing useAsyncJob lifecycle tests stay green
+  (complete/blocked/500/404/200-JOB_NOT_FOUND, reset).
+
+- [ ] **Step 5 — commit** `fix(app): poll-generation ownership in useAsyncJob (#535 S5b)`.
+
+---
+
+### Task 3: `useUserData` — module generation + response-param-safe cache
+
+**Files:** modify `app/src/views/admin/composables/useUserData.ts`; extend
+`app/src/views/admin/composables/__tests__/useUserData.spec.ts`.
+
+- [ ] **Step 1 — RED tests.** Use deferred `axios.get` resolvers (the spec mocks axios at module
+  level). Fire P1, change params, fire P2, resolve P1 LAST:
+```ts
+it('an out-of-order stale response does not apply or clear busy over the newer request', async () => {
+  const axios = await getAxiosMock();
+  const resolvers: Array<(v: unknown) => void> = [];
+  axios.get.mockImplementation(() => new Promise((res) => { resolvers.push(res); }));
+  const data = useUserData();
+  const p1 = data.loadDataNow();                 // P1 params (default)
+  data.perPage.value = 50;                        // change → P2 params differ
+  const p2 = data.loadDataNow();                  // P2
+  resolvers[1]({ status: 200, data: { ...userTablePayload, meta: [{ ...userTablePayload.meta[0], totalItems: 99 }] } });
+  await p2; await flushPromises();
+  resolvers[0]({ status: 200, data: userTablePayload }); // stale P1 resolves LAST
+  await p1; await flushPromises();
+  expect(data.totalRows.value).toBe(99);          // P2 data retained, P1 ignored
+});
+
+it('the 500ms cache does not serve a prior params response for new params', async () => {
+  const axios = await getAxiosMock();
+  axios.get.mockResolvedValueOnce({ status: 200, data: userTablePayload });        // P1
+  const data = useUserData();
+  await data.loadDataNow(); await flushPromises();
+  data.perPage.value = 50;                          // params change (P2)
+  axios.get.mockResolvedValueOnce({ status: 200, data: { ...userTablePayload, meta:[{...userTablePayload.meta[0], totalItems: 7}] } });
+  await data.loadDataNow(); await flushPromises();  // must fetch P2, not serve P1 cache
+  expect(data.totalRows.value).toBe(7);
+  expect(axios.get).toHaveBeenCalledTimes(2);
+});
+```
+
+- [ ] **Step 2 — run RED** — `npx vitest run src/views/admin/composables/__tests__/useUserData.spec.ts`.
+
+- [ ] **Step 3 — implement.** Add module state `let moduleLastApiResponseParams: string | null =
+  null;` and `let moduleRequestGeneration = 0;`, reset both in `__resetUserDataCache()`.
+  In `doLoadData`:
+  - recent-cache branch: only apply when `moduleLastApiResponse && moduleLastApiResponseParams ===
+    urlParam`.
+  - after passing the dedup guards, `const myGen = ++moduleRequestGeneration;` and clear
+    `moduleLastApiResponse = null; moduleLastApiResponseParams = null;` at request start.
+  - success: `if (myGen !== moduleRequestGeneration) return;` before clearing
+    `moduleApiCallInProgress`, recording `moduleLastApiResponse = data` /
+    `moduleLastApiResponseParams = urlParam`, `applyApiResponse`, `updateBrowserUrl`.
+  - catch: `if (myGen !== moduleRequestGeneration) return;` before clearing
+    `moduleApiCallInProgress` / toasting.
+  - finally: `if (myGen === moduleRequestGeneration) tableData.isBusy.value = false;`.
+
+- [ ] **Step 4 — run GREEN** — new tests pass; existing useUserData tests stay green (loadData
+  populate, error path clears isBusy, roleList, handlePageChange 2 calls, removeFilters).
+
+- [ ] **Step 5 — commit** `fix(app): module-generation + param-safe cache in useUserData (#535 S5b)`.
+
+---
+
+### Task 4: Verify, Codex diff review, PR
+
+- [ ] **Step 1 — full verify** — `cd app && npm run test:unit`; `npm run type-check`;
+  `npm run type-check:strict`; `make lint-app`; `make code-quality-audit` (file-size ratchet).
+- [ ] **Step 2 — Codex adversarial diff review** at GPT-5.5 xhigh; commit to
+  `.planning/reviews/2026-07-12-security-535-s5b-diff-codex-review.md`; fix → re-review until SHIP.
+- [ ] **Step 3 — open PR** against master (do-not-auto-merge, security-critical), `Closes` line refs
+  #535 on its own line. Do NOT auto-merge.
+
+## Codex plan-review corrections folded — Plan v2 (2026-07-12)
+
+Full review: `.planning/reviews/2026-07-12-security-535-s5b-plan-codex-review.md` (Verdict FIX-FIRST).
+These **override** Tasks 1-4 above.
+
+- **Task 1 (useResource) — use a shared cache-slot epoch, not a per-instance fetch generation.**
+  `pending === promise` guards cache **writes** only; consumer refs need a cross-consumer signal.
+  Add `epoch: number` to `cacheStore` `CacheEntry`, incremented in `beginFetch`, preserved by
+  `set`/`endFetch`/`subscribe`. In `doFetch`, capture `myEpoch` (network branch: after `beginFetch`;
+  subscribe branch: the pending's epoch). Consumer-ref writes (`data`/`error`/`isStale`) and the
+  foreground `loading` clear are gated on `myToken === activeToken && peek(key)?.epoch === myEpoch`
+  in BOTH branches. Cache writes stay gated on `ownsSlot()` (`pending === promise`). This subsumes
+  the earlier per-instance generation. **Also (HIGH #4):** `activate()` (cache-hit + null-key
+  branches) and `abort()` synchronously set `loading.value = false` so a superseded foreground fetch
+  cannot leave `loading` stuck. Tests: concurrent refresh (stale loses), stale rejection **while the
+  newer fetch is still pending** (assert `cache.pending`/`loading` stay owned by the newer fetch,
+  then resolve it), A→cached-B / A→SWR-B / explicit-abort clear `loading`.
+- **Task 2 (useAsyncJob) — add generation-scoped single-flight + make cancellation bump generation.**
+  Keep `pollGeneration` (bumped in `startJob`). Add `inFlightGeneration: number | null`: at the top
+  of `checkJobStatus`, `if (inFlightGeneration === myGen) return;` (single-flight for this job
+  generation) else set it; clear in `finally` only if still `=== myGen`. **`stopPolling()` bumps
+  `pollGeneration`** (so public cancel / terminal / `reset` / unmount invalidate an in-flight poll).
+  Guard success (incl. 200 `JOB_NOT_FOUND`/terminal) and catch with `if (myGen !== pollGeneration)
+  return;` immediately after `await` / first in catch. Tests: stale success, stale rejection
+  (deferred gate via a "handler entered" signal — start timer advance WITHOUT awaiting, await the
+  entered signal, supersede, release, then await), overlapping same-job single-flight, j1→j2→j1.
+- **Task 3 (useUserData) — instance-local consumer ownership + module transport, unmount cleanup.**
+  Keep transport dedup + 500 ms response cache **module-level** (`moduleApiCallInProgress`,
+  `moduleLastApiParams`, `moduleLastApiResponse`, `moduleLastApiResponseParams`). Make **consumer
+  ownership instance-local**: `let instanceGeneration = 0; let disposed = false;`. Extract
+  `buildUrlParam()`. Bump `instanceGeneration` in `loadData()` (at debounce SCHEDULE time — closes
+  the 50 ms window) and `loadDataNow()`; `doLoadData()` captures `myGen`. `stillOwner()` =
+  `!disposed && myGen === instanceGeneration`. The completing fetch always clears
+  `moduleApiCallInProgress` and records the param-keyed response (transport); apply/URL run only when
+  `stillOwner()` **and** `buildUrlParam() === urlParam` (checked BEFORE `applyApiResponse` mutates
+  refs); `isBusy` clear + recent-cache serve gate on `stillOwner()` (generation only — our own apply
+  legitimately changes params). Recent-cache branch requires a **non-null** response whose
+  `moduleLastApiResponseParams === urlParam`; a fresh request nulls the cached response. Pass
+  `stillOwner` into `applyApiResponse` and guard its `nextTick(currentPage)` write. `onBeforeUnmount`
+  sets `disposed = true` and clears the debounce timer. Tests: out-of-order apply, cache-param
+  sentinel test (cache P1, defer P2, set a sentinel, second identical P2 while pending, assert P1
+  not reapplied, then resolve P2), stuck-isBusy on supersede.
+- **Task 3b (NEW — adjacent, folded per review HIGH #9): `useMetadataAdmin` wrong-vocabulary race.**
+  `app/src/views/admin/composables/useMetadataAdmin.ts`. `loadRows()` captures
+  `const mySlug = activeSlug.value; const myGen = ++rowsGeneration;`, fetches `mySlug`, and applies
+  `rows`/`listMeta` only if `myGen === rowsGeneration && mySlug === activeSlug.value` (guard success,
+  catch, and the `loadingRows` finally). Prevents late vocabulary-A rows from populating the B table
+  (which would let an edit mutate the wrong vocabulary with an A row id). Extend/create its spec.
+- **Deferred to S5c follow-up (review 10, 16, 17):** whole-workflow load ownership
+  (`useEntityInfo`, `useReviewData`) and read-composable ownership (`useAdminTrendData`,
+  `usePubtatorGenePublications`, `useNetworkData`, `usePubtatorAdmin`). Larger, multi-call; tracked in
+  the final report, not built in S5b.
+
+## Self-review
+- Spec coverage: §2.1→Task1, §2.2→Task2, §2.3→Task3; adjacent §review-9→Task3b; deterministic
+  deferred-promise races in each.
+- Consistency: uniform "capture identity at start; mutate only if still owner/latest". useResource =
+  cache-slot epoch (cross-consumer) + activeToken (key) for refs, `pending === promise` for cache.
+  useAsyncJob = pollGeneration + single-flight. useUserData = instance generation (consumer) + module
+  transport. useMetadataAdmin = rowsGeneration + slug.
+- No public signature changes; no placeholders.
+# S5b diff — Codex adversarial review (final, gpt-5.x, xhigh, read-only)
+
+Final pre-merge adversarial diff review of PR #544 (S5b frontend request-ownership,
+slice of #535). Reviews run with `codex exec -s read-only -c model_reasoning_effort=xhigh`
+against `git diff master...HEAD`. This record covers the final passes (rounds 2–4);
+the round-1 record is `2026-07-12-security-535-s5b-diff-codex-review.md`.
+
+## Round 2 (commit 5d6e2849) — Verdict: FIX-FIRST (no BLOCKERs, 2 HIGH)
+
+- **HIGH (useResource — subscriber path):** the shared-pending subscriber applied the
+  awaited value even after ANOTHER consumer superseded the slot, stranding the
+  subscriber on same-key stale data. The r1 fix (per-instance generation) avoided
+  *stuck loading* but the correct behavior is to *follow the current slot*.
+  → **Fixed:** capture the subscribed slot `epoch`; on supersession call a new
+  `followCurrentSlot(key, background)` that hydrates from the resolved cache entry if
+  the superseding fetch already completed, else re-enters `doFetch` to follow/restart
+  it. Never applies the stale value, never leaves loading stuck, no redundant 3rd fetch
+  (no await between the two peeks), recursion bounded by monotonic epochs.
+- **HIGH (useUserData — module cache poisoning):** the module recent-response cache was
+  written unconditionally on every completion, so a superseded SAME-param fetch
+  (A1→B→A2, A2 first) completing last overwrote the fresher cached A2. Param-keying only
+  protects cross-param, not same-param out-of-order.
+  → **Fixed:** module-wide monotonic per-fetch-START sequence `moduleFetchSeq` +
+  `moduleLastResponseSeq`; the cache write happens only when `mySeq >= moduleLastResponseSeq`.
+  Preserves the existing A→B→cached-A isBusy behavior (unlike gating by current intent).
+- **MEDIUM (touched files):** `loadRoleList`/`loadUserList` disposal guards;
+  `useMetadataAdmin.loadCatalog` generation guard.
+
+## Round 3 (worktree, pre-commit) — Verdict: FIX-FIRST (no BLOCKERs, 1 genuine MEDIUM)
+
+- **HIGH (useResource — owner/starter path):** SYMMETRIC gap — a consumer that OWNS an
+  in-flight fetch still wrote its stale value into its own refs when another consumer
+  advanced the slot (`consumerCurrent()` stayed true while `slotCurrent()` went false).
+  → **Fixed:** the owner success AND catch paths now `if (!slotCurrent()) return
+  followCurrentSlot(...)` after the `consumerCurrent()` check, symmetric with the
+  subscriber path.
+- **HIGH (useMetadataAdmin — catalog auto-select ownership):** a newer catalog could
+  keep a stale `activeSlug` with rows loading under it (catalog/selection desync).
+  → **Fixed:** after accepting a catalog under the generation guard, reconcile
+  `activeSlug` — reselect the first entry (or clear on empty) when the active slug is
+  absent from the accepted catalog, routing through `selectVocabulary` so
+  `rowsGeneration` bumps and an older catalog-initiated row load is superseded.
+- **MEDIUM (useMetadataAdmin — empty-catalog branch, introduced by the r3 fix):** the
+  empty-catalog reconcile branch cleared `activeSlug`/`rows` but did not bump
+  `rowsGeneration` or clear `loadingRows`, so an in-flight row load left the spinner
+  stuck. → **Fixed:** bump `rowsGeneration` and set `loadingRows = false` in that branch.
+- **MEDIUM (useUserData — single in-flight boolean):** the coarse module dedup boolean
+  cannot represent two concurrent same-param transports; a second same-param instance
+  returns from the dedup branch without subscribing to the first's promise. This is
+  **pre-existing** (not S5b-introduced — displayed-data correctness is fully guarded by
+  the ownership checks) and was scoped to **S5c** (params-keyed in-flight promise map)
+  in the r1 plan review. **Deferred to S5c.**
+- **LOW (useMetadataAdmin — mutation busy flags):** `saving`/`deleting` are unordered
+  across overlapping mutations. Mutations are UI-serialized (buttons disabled while
+  saving), a different concern from read/poll response-ownership. **Deferred.**
+- The two "HIGH" items about the r2/r3 folds being "unstaged" were an artifact of
+  reviewing `master...HEAD` before the folds were committed; Codex confirmed the
+  worktree folds are correct ("hands loading ownership correctly, avoids cache
+  poisoning, no synchronous recursion hazard"). Resolved by committing (5d8836e5).
+
+## Round 4 (commit 5d8836e5) — Verdict: FIX-FIRST (no BLOCKER/HIGH, 1 MEDIUM)
+
+All r2/r3 folds committed and verified in `master...HEAD`; no BLOCKER/HIGH remained.
+One residual MEDIUM:
+
+- **MEDIUM (useUserData — cache write guard):** the guard compared the completing
+  fetch's start sequence with the last cache *writer*, not the latest start. In
+  A1→B→A2, if stale A1 resolved BEFORE A2, A1 passed the guard (no later writer yet)
+  and transiently repopulated the A cache; a cache-serve in that window returned A1
+  until A2 corrected it. → **Fixed (commit 123314dd):** replace `moduleLastResponseSeq`
+  with a per-parameter-key latest-start map (`moduleLatestStartSeqByParam`); a
+  completing fetch may record the cache only if it is still the latest-STARTED fetch
+  for its own params. Closes the same-param window in ANY completion order; preserves
+  A→B→cached-A (different params). Regression test added.
+
+## Round 5 (commit 123314dd) — Verdict: SHIP
+
+No BLOCKER/HIGH/MEDIUM/LOW findings. All committed folds verified in `master...HEAD`;
+no new hazard. Typed `@/api/*` clients only; `axios` used only for `isAxiosError` plus
+a JSDoc example; no direct `localStorage.token`/`localStorage.user`. `useAsyncJob`
+poll-generation + single-flight and the `cacheStore` global monotonic epoch counter
+re-confirmed sound. Codex ran `vue-tsc --noEmit`, targeted ESLint, and `git diff --check`
+itself — all passed.
+
+## Deferred to S5c (documented, not built in S5b)
+
+- `useUserData` params-keyed in-flight promise transport map (replaces the single
+  boolean dedup; fixes the cross-instance two-same-param-instances dedup miss).
+- Read-composable request-ownership in other files: `usePubtatorGenePublications`,
+  `useAdminTrendData` (catch/finally versioning), `tableRequestCoordinator`
+  (cross-instance single generation), `useOntologyAdminTable` (deferred `currentPage`),
+  `useNetworkData`, `usePubtatorAdmin`.
+- `useMetadataAdmin` mutation busy-flag ordering (`saving`/`deleting`).
+
+## Gates (final)
+
+- `make code-quality-audit` → OK (exit 0)
+- `make lint-app` → 0 errors (warnings pre-existing `no-explicit-any`)
+- `cd app && npm run type-check:strict` → 0 errors (all scopes OK)
+- `cd app && npm run type-check` (full `vue-tsc --noEmit`) → 0 errors
+- `cd app && npm run test:unit` → 1995 passed | 2 todo, 0 failures (264 files)
+
+exec
+/bin/bash -lc "sed -n '1,520p' app/src/views/admin/composables/useUserData.ts && wc -l app/src/views/admin/composables/__tests__/useUserData.spec.ts && sed -n '1,720p' app/src/views/admin/composables/__tests__/useUserData.spec.ts" in /home/bernt-popp/development/sysndd/.claude/worktrees/535-s5c-request-ownership
+ succeeded in 0ms:
+import { getCurrentInstance, nextTick, onBeforeUnmount, ref } from 'vue';
+
+import { getUserTable, getRoleList, listUsersByRole } from '@/api/user';
+import type { UserTableResponse } from '@/api/user';
+import useTableData from '@/composables/useTableData';
+import { useExcelExport } from '@/composables/useExcelExport';
+import { useFilterPresets } from '@/composables/useFilterPresets';
+import useUrlParsing from '@/composables/useUrlParsing';
+
+// Module-level TRANSPORT dedup + 500ms response cache (preserves the existing
+// cross-instance semantics from ManageUser.vue line 760). The cached response is
+// keyed by its own params (`moduleLastApiResponseParams`) so it is never served
+// for a request whose params differ (#535 S5b). Consumer-state ownership is
+// instance-local (see `instanceGeneration`), so one instance cannot suppress
+// another's response or leave its `isBusy` stuck.
+let moduleLastApiParams: string | null = null;
+let moduleLastApiCallTime = 0;
+let moduleApiCallInProgress = false;
+let moduleLastApiResponse: unknown = null;
+let moduleLastApiResponseParams: string | null = null;
+// Module-wide monotonic per-fetch-START sequence + the latest start sequence PER
+// PARAMETER KEY (#535 S5b). Param-keying alone does NOT make late-completion order
+// irrelevant: two SAME-param fetches (A1, A2) both write under params A, so a
+// superseded A1 completing in EITHER order could poison the fresher A2. A completing
+// fetch may write the recent-response cache only when it is still the latest-STARTED
+// fetch for its own params (`moduleLatestStartSeqByParam.get(params) === mySeq`), so
+// no out-of-order stale same-param response can poison the cache, while a still-latest
+// fetch for DIFFERENT params (A vs B) is unaffected. The map is module-level so it
+// stays monotonic across instances that share the module cache.
+let moduleFetchSeq = 0;
+const moduleLatestStartSeqByParam = new Map<string, number>();
+
+/** Reset the module-level cache — for use in tests only. */
+export function __resetUserDataCache(): void {
+  moduleLastApiParams = null;
+  moduleLastApiCallTime = 0;
+  moduleApiCallInProgress = false;
+  moduleLastApiResponse = null;
+  moduleLastApiResponseParams = null;
+  moduleFetchSeq = 0;
+  moduleLatestStartSeqByParam.clear();
+}
+
+export interface FilterEntry {
+  content: string | null;
+  join_char: string | null;
+  operator: string;
+}
+
+export type ManageUserFilter = Record<string, FilterEntry>;
+
+export interface RoleOption {
+  value: string;
+  text: string;
+}
+
+export interface UserOption {
+  value: number;
+  text: string;
+  role: string;
+}
+
+export interface UseUserDataOptions {
+  onToast?: (...args: unknown[]) => void;
+  onScrollbarUpdate?: () => void;
+}
+
+export function useUserData(options: UseUserDataOptions = {}) {
+  const { onToast, onScrollbarUpdate } = options;
+
+  const tableData = useTableData({
+    pageSizeInput: 25,
+    sortInput: '+user_name',
+    pageAfterInput: '0',
+  });
+  const { filterObjToStr, filterStrToObj, sortStringToVariables } = useUrlParsing();
+  const filterPresets = useFilterPresets('sysndd-manage-user-presets');
+  const { isExporting, exportToExcel } = useExcelExport();
+
+  const users = ref<Array<Record<string, unknown>>>([]);
+  const role_options = ref<RoleOption[]>([]);
+  const user_options = ref<UserOption[]>([]);
+  const totalPages = ref(0);
+  const isInitializing = ref(true);
+  let loadDataDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Instance-local request ownership (#535 S5b). Two orthogonal signals:
+  //  - `latestIntent` is the params string of the most recent load intent, set the
+  //    moment a load is requested (loadData schedule / loadDataNow). An in-flight
+  //    response applies only if its params still equal `latestIntent`, which closes
+  //    the 50ms debounce window (refs already describe P2 while P1 is in flight)
+  //    WITHOUT orphaning a deduped identical request (same params → same intent).
+  //  - `startGeneration` is bumped only when a fetch actually starts, so among
+  //    same-params requests only the latest-started may apply (true A-B-A: A#1, B,
+  //    A2 all in flight → only A2 wins). `disposed` stops any late continuation
+  //    from mutating a torn-down instance.
+  let startGeneration = 0;
+  let latestIntent: string | null = null;
+  let disposed = false;
+  // Independent per-loader generations for the static option lists (#535 S5b MEDIUM):
+  // an older loadRoleList()/loadUserList() completing last must not overwrite the
+  // newer snapshot.
+  let roleListGeneration = 0;
+  let userListGeneration = 0;
+
+  const filter = ref<ManageUserFilter>({
+    any: { content: null, join_char: null, operator: 'contains' },
+    user_name: { content: null, join_char: null, operator: 'contains' },
+    email: { content: null, join_char: null, operator: 'contains' },
+    user_role: { content: null, join_char: ',', operator: 'any' },
+    approved: { content: null, join_char: null, operator: 'equals' },
+    abbreviation: { content: null, join_char: null, operator: 'contains' },
+    first_name: { content: null, join_char: null, operator: 'contains' },
+    family_name: { content: null, join_char: null, operator: 'contains' },
+    orcid: { content: null, join_char: null, operator: 'contains' },
+    comment: { content: null, join_char: null, operator: 'contains' },
+  });
+
+  function buildUrlParam(): string {
+    return `sort=${tableData.sort.value}&filter=${tableData.filter_string.value}&page_after=${tableData.currentItemID.value}&page_size=${tableData.perPage.value}`;
+  }
+
+  function applyApiResponse(data: UserTableResponse, stillOwner: () => boolean): void {
+    // meta is typed `unknown` on the envelope; it's a 1-element array of paging
+    // scalars (Plumber may serialize numbers as strings, hence Number()).
+    const meta = ((data.meta as Array<Record<string, unknown>>) ?? [])[0] ?? {};
+    users.value = data.data as unknown as Array<Record<string, unknown>>;
+    tableData.totalRows.value = Number(meta.totalItems) || 0;
+    nextTick(() => {
+      // The deferred write must re-check ownership: a newer request or an unmount
+      // may have superseded this response between the sync apply and this tick.
+      if (stillOwner()) tableData.currentPage.value = Number(meta.currentPage) || 0;
+    });
+    totalPages.value = Number(meta.totalPages) || 0;
+    tableData.prevItemID.value = Number(meta.prevItemID) || 0;
+    tableData.currentItemID.value = Number(meta.currentItemID) || 0;
+    tableData.nextItemID.value = Number(meta.nextItemID) || 0;
+    tableData.lastItemID.value = Number(meta.lastItemID) || 0;
+    tableData.executionTime.value = Number(meta.executionTime) || 0;
+    onScrollbarUpdate?.();
+  }
+
+  async function doLoadData(): Promise<void> {
+    const urlParam = buildUrlParam();
+    const now = Date.now();
+
+    // Recent-response cache: serve only a NON-NULL response stored under THESE
+    // params, and only if this instance still wants them.
+    if (
+      moduleLastApiResponseParams === urlParam &&
+      moduleLastApiResponse != null &&
+      now - moduleLastApiCallTime < 500
+    ) {
+      if (!disposed && urlParam === latestIntent) {
+        // A current cache hit is a completed current intent: apply, sync the URL,
+        // and clear busy — otherwise a still-pending superseded request (A→B→cached-A)
+        // could leave isBusy stuck true forever.
+        applyApiResponse(
+          moduleLastApiResponse as UserTableResponse,
+          () => !disposed && urlParam === latestIntent
+        );
+        updateBrowserUrl();
+        tableData.isBusy.value = false;
+      }
+      return;
+    }
+    // Transport dedup: an identical request is already in flight. Do NOT bump the
+    // start generation here — the in-flight request is the same intent.
+    if (moduleApiCallInProgress && moduleLastApiParams === urlParam) return;
+
+    // A real fetch starts now → own the start generation. `stillOwner` combines it
+    // with the params intent so it stays stable across applyApiResponse's own ref
+    // mutations (latestIntent only moves on a new loadData/loadDataNow call).
+    const myGen = ++startGeneration;
+    // Module-wide start order, recorded as the latest start for THIS param key so the
+    // recent-response cache write guard below only lets the latest-started same-param
+    // fetch record the cache.
+    const mySeq = ++moduleFetchSeq;
+    moduleLatestStartSeqByParam.set(urlParam, mySeq);
+    const stillOwner = (): boolean =>
+      !disposed && myGen === startGeneration && urlParam === latestIntent;
+
+    moduleLastApiParams = urlParam;
+    moduleLastApiCallTime = now;
+    moduleApiCallInProgress = true;
+    // A fresh request invalidates any stored response until this one records its own.
+    moduleLastApiResponse = null;
+    moduleLastApiResponseParams = null;
+    if (stillOwner()) tableData.isBusy.value = true;
+
+    try {
+      const data = await getUserTable({
+        sort: tableData.sort.value,
+        filter: tableData.filter_string.value,
+        page_after: tableData.currentItemID.value,
+        page_size: String(tableData.perPage.value),
+      });
+      // Transport bookkeeping: the completing fetch clears the in-flight flag. The
+      // recent-response cache is written only if this fetch is still the latest-STARTED
+      // fetch for its own params, so a superseded same-param response completing in ANY
+      // order cannot overwrite (or transiently repopulate) the fresher cached value.
+      moduleApiCallInProgress = false;
+      if (moduleLatestStartSeqByParam.get(urlParam) === mySeq) {
+        moduleLastApiResponse = data;
+        moduleLastApiResponseParams = urlParam;
+      }
+      // Consumer apply: only the latest-started request for the current intent.
+      if (!stillOwner()) return;
+      applyApiResponse(data, stillOwner);
+      updateBrowserUrl();
+    } catch (e) {
+      moduleApiCallInProgress = false;
+      if (!stillOwner()) return;
+      onToast?.(e, 'Error', 'danger');
+    } finally {
+      if (stillOwner()) tableData.isBusy.value = false;
+    }
+  }
+
+  function loadData(): void {
+    // Record the new intent immediately (before the debounce) so an in-flight
+    // response for the previous intent is superseded even during the 50ms window.
+    latestIntent = buildUrlParam();
+    if (loadDataDebounceTimer) clearTimeout(loadDataDebounceTimer);
+    loadDataDebounceTimer = setTimeout(() => {
+      loadDataDebounceTimer = null;
+      void doLoadData();
+    }, 50);
+  }
+
+  // Bypasses debounce for tests + first-paint
+  async function loadDataNow(): Promise<void> {
+    latestIntent = buildUrlParam();
+    return doLoadData();
+  }
+
+  async function loadRoleList(): Promise<void> {
+    const myGen = ++roleListGeneration;
+    const stillCurrent = (): boolean => !disposed && myGen === roleListGeneration;
+    try {
+      const roles = await getRoleList();
+      if (!stillCurrent()) return; // superseded by a newer load or a torn-down instance
+      role_options.value = roles.map((item) => ({
+        value: item.role,
+        text: item.role,
+      }));
+    } catch (e) {
+      if (!stillCurrent()) return;
+      onToast?.(e, 'Error', 'danger');
+    }
+  }
+
+  async function loadUserList(): Promise<void> {
+    const myGen = ++userListGeneration;
+    const stillCurrent = (): boolean => !disposed && myGen === userListGeneration;
+    try {
+      const list = await listUsersByRole({ roles: 'Curator,Reviewer' });
+      if (!stillCurrent()) return; // superseded by a newer load or a torn-down instance
+      user_options.value = list.map((item) => ({
+        value: item.user_id,
+        text: item.user_name,
+        role: item.user_role,
+      }));
+    } catch (e) {
+      if (!stillCurrent()) return;
+      onToast?.(e, 'Error', 'danger');
+    }
+  }
+
+  function updateBrowserUrl(): void {
+    if (isInitializing.value) return;
+    const searchParams = new URLSearchParams();
+    if (tableData.sort.value) searchParams.set('sort', tableData.sort.value);
+    if (tableData.filter_string.value) searchParams.set('filter', tableData.filter_string.value);
+    const currentItemID = String(tableData.currentItemID.value);
+    if (currentItemID !== '' && currentItemID !== '0') {
+      searchParams.set('page_after', String(tableData.currentItemID.value));
+    }
+    searchParams.set('page_size', String(tableData.perPage.value));
+    const newUrl = `${window.location.pathname}?${searchParams.toString()}`;
+    window.history.replaceState({ ...window.history.state }, '', newUrl);
+  }
+
+  function filtered(): void {
+    const next = filterObjToStr(filter.value);
+    if (next !== tableData.filter_string.value) tableData.filter_string.value = next;
+    loadData();
+  }
+
+  function handlePageChange(value: number): void {
+    if (value === 1) tableData.currentItemID.value = 0;
+    else if (value === totalPages.value)
+      tableData.currentItemID.value = Number(tableData.lastItemID.value) || 0;
+    else if (value > tableData.currentPage.value)
+      tableData.currentItemID.value = Number(tableData.nextItemID.value) || 0;
+    else if (value < tableData.currentPage.value)
+      tableData.currentItemID.value = Number(tableData.prevItemID.value) || 0;
+    filtered();
+  }
+
+  function handlePerPageChange(newPerPage: number | string): void {
+    tableData.perPage.value = parseInt(String(newPerPage), 10);
+    tableData.currentItemID.value = 0;
+    filtered();
+  }
+
+  function handleSortByOrDescChange(): void {
+    tableData.currentItemID.value = 0;
+    const sortColumn = tableData.sortBy.value.length > 0 ? tableData.sortBy.value[0].key : '';
+    const sortOrder = tableData.sortBy.value.length > 0 ? tableData.sortBy.value[0].order : 'asc';
+    tableData.sort.value = (sortOrder === 'desc' ? '-' : '+') + sortColumn;
+    filtered();
+  }
+
+  function handleSortUpdate(newSortBy: Array<{ key: string; order: 'asc' | 'desc' }>): void {
+    tableData.sortBy.value = newSortBy;
+    handleSortByOrDescChange();
+  }
+
+  function removeFilters(): void {
+    Object.keys(filter.value).forEach((key) => {
+      const entry = filter.value[key];
+      if (entry && typeof entry === 'object' && 'content' in entry) entry.content = null;
+    });
+    filtered();
+  }
+
+  function clearFilter(key: string): void {
+    if (filter.value[key]) filter.value[key].content = null;
+    filtered();
+  }
+
+  function handleExport(): void {
+    exportToExcel(users.value, {
+      filename: `users_export_${new Date().toISOString().split('T')[0]}`,
+      sheetName: 'Users',
+      headers: {
+        user_name: 'User Name',
+        email: 'Email',
+        user_role: 'Role',
+        approved: 'Approved',
+        abbreviation: 'Abbreviation',
+        first_name: 'First Name',
+        family_name: 'Family Name',
+        orcid: 'ORCID',
+        comment: 'Comment',
+        created_at: 'Created',
+      },
+    });
+  }
+
+  function loadFilterPreset(name: string): boolean {
+    const preset = filterPresets.loadPreset(name);
+    if (!preset) return false;
+    Object.keys(preset).forEach((key) => {
+      if (filter.value[key]) filter.value[key] = preset[key] as FilterEntry;
+    });
+    filtered();
+    return true;
+  }
+
+  function deleteFilterPreset(name: string): void {
+    filterPresets.deletePreset(name);
+  }
+
+  function saveFilterPreset(name: string): void {
+    filterPresets.savePreset(name, JSON.parse(JSON.stringify(filter.value)));
+  }
+
+  // Filter-preset naming uses the app's modal language (SavePresetModal) rather
+  // than a native window.prompt(); the modal state lives here next to the
+  // preset actions it drives.
+  const savePresetModalOpen = ref(false);
+
+  function confirmSavePreset(name: string): void {
+    saveFilterPreset(name);
+    onToast?.(`Saved preset: ${name}`, 'Filter Preset', 'success', true, 3000);
+  }
+
+  function setInitialized(): void {
+    nextTick(() => {
+      isInitializing.value = false;
+    });
+  }
+
+  // Teardown: cancel a pending debounce and invalidate ownership so a late
+  // response cannot apply rows or call history.replaceState() after the view has
+  // unmounted/navigated away. Guarded so a bare composable call (unit tests) does
+  // not warn about a lifecycle hook registered outside a component setup.
+  function dispose(): void {
+    disposed = true;
+    if (loadDataDebounceTimer) {
+      clearTimeout(loadDataDebounceTimer);
+      loadDataDebounceTimer = null;
+    }
+  }
+  if (getCurrentInstance()) {
+    onBeforeUnmount(dispose);
+  }
+
+  return {
+    // table-data passthrough (so the view doesn't need to re-pull useTableData)
+    ...tableData,
+    isExporting,
+    exportToExcel,
+    filterPresets,
+    filterObjToStr,
+    filterStrToObj,
+    sortStringToVariables,
+    // owned state
+    users,
+    role_options,
+    roleOptions: role_options, // canonical TS name
+    user_options,
+    totalPages,
+    filter,
+    isInitializing,
+    // actions
+    loadData,
+    loadDataNow,
+    loadRoleList,
+    loadUserList,
+    filtered,
+    handlePageChange,
+    handlePerPageChange,
+    handleSortByOrDescChange,
+    handleSortUpdate,
+    removeFilters,
+    clearFilter,
+    handleExport,
+    loadFilterPreset,
+    deleteFilterPreset,
+    saveFilterPreset,
+    savePresetModalOpen,
+    confirmSavePreset,
+    setInitialized,
+    // Teardown hook (auto-invoked on unmount when mounted; exposed for tests).
+    dispose,
+  };
+}
+333 app/src/views/admin/composables/__tests__/useUserData.spec.ts
+// app/src/views/admin/composables/__tests__/useUserData.spec.ts
+/**
+ * Unit tests for `useUserData` — the data-loading composable extracted
+ * from `ManageUser.vue` during W1 of v11.2 monolith-cleanup.
+ *
+ * Mock strategy: stub `axios` at the module level (matching the W6 Review.vue
+ * composable precedent in `src/views/review/composables/__tests__/`).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
+
+vi.mock('axios', () => {
+  const axiosMock = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: {
+      request: {
+        use: vi.fn(),
+        _cb: null,
+      },
+      response: {
+        use: vi.fn(),
+      },
+    },
+    isAxiosError: (err: unknown): boolean =>
+      typeof err === 'object' && err !== null && 'isAxiosError' in err,
+  };
+  return {
+    default: axiosMock,
+    ...axiosMock,
+    AxiosHeaders: class {
+      private store = new Map<string, string>();
+      has(key: string): boolean {
+        return this.store.has(key.toLowerCase());
+      }
+      get(key: string): string | null {
+        return this.store.get(key.toLowerCase()) ?? null;
+      }
+      set(key: string, value: string): this {
+        this.store.set(key.toLowerCase(), value);
+        return this;
+      }
+    },
+    AxiosError: Error,
+  };
+});
+
+vi.mock('@/router', () => ({
+  default: {
+    push: vi.fn(),
+    currentRoute: { value: { fullPath: '/admin/manage-user' } },
+  },
+}));
+
+import { __resetUserDataCache, useUserData } from '../useUserData';
+
+interface AxiosMock {
+  get: ReturnType<typeof vi.fn>;
+}
+async function getAxiosMock(): Promise<AxiosMock> {
+  const axios = await import('axios');
+  return axios.default as unknown as AxiosMock;
+}
+
+const userTablePayload = {
+  data: [
+    {
+      user_id: 1,
+      user_name: 'alice',
+      email: 'alice@example.org',
+      user_role: 'Curator',
+      approved: 1,
+    },
+    { user_id: 2, user_name: 'bob', email: 'bob@example.org', user_role: 'Reviewer', approved: 1 },
+  ],
+  meta: [
+    {
+      totalItems: 2,
+      currentPage: 1,
+      totalPages: 1,
+      prevItemID: 0,
+      currentItemID: 0,
+      nextItemID: 0,
+      lastItemID: 0,
+      executionTime: 5,
+      fspec: [],
+    },
+  ],
+};
+
+describe('useUserData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetUserDataCache();
+  });
+
+  it('loadData populates users and meta', async () => {
+    const axios = await getAxiosMock();
+    axios.get.mockResolvedValueOnce({ status: 200, data: userTablePayload });
+    const data = useUserData();
+    expect(data.users.value).toEqual([]);
+    await data.loadDataNow();
+    await flushPromises();
+    expect(data.users.value).toHaveLength(2);
+    expect(data.totalRows.value).toBe(2);
+    expect(data.totalPages.value).toBe(1);
+  });
+
+  it('loadData error path surfaces via toast hook and clears isBusy', async () => {
+    const axios = await getAxiosMock();
+    const err = new Error('boom');
+    axios.get.mockRejectedValueOnce(err);
+    const toasts: Array<unknown[]> = [];
+    const data = useUserData({ onToast: (...args: unknown[]) => toasts.push(args) });
+    await data.loadDataNow();
+    await flushPromises();
+    expect(data.isBusy.value).toBe(false);
+    expect(toasts).toHaveLength(1);
+  });
+
+  it('loadRoleList populates role_options', async () => {
+    const axios = await getAxiosMock();
+    axios.get.mockResolvedValueOnce({
+      status: 200,
+      data: [{ role: 'Administrator' }, { role: 'Curator' }],
+    });
+    const data = useUserData();
+    await data.loadRoleList();
+    await flushPromises();
+    expect(data.roleOptions.value).toEqual([
+      { value: 'Administrator', text: 'Administrator' },
+      { value: 'Curator', text: 'Curator' },
+    ]);
+  });
+
+  it('handlePageChange triggers a second loadData call', async () => {
+    const axios = await getAxiosMock();
+    axios.get.mockResolvedValue({ status: 200, data: userTablePayload });
+    const data = useUserData();
+    await data.loadDataNow();
+    await flushPromises();
+    expect(axios.get).toHaveBeenCalledTimes(1);
+    // Reset cache so the second call (with same params) isn't deduped
+    __resetUserDataCache();
+    data.handlePageChange(2);
+    await new Promise((r) => setTimeout(r, 80)); // wait past 50ms debounce
+    await flushPromises();
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('removeFilters clears every filter content', async () => {
+    const data = useUserData();
+    data.filter.value.user_name.content = 'alice';
+    data.removeFilters();
+    expect(data.filter.value.user_name.content).toBeNull();
+    // removeFilters() schedules a 50ms debounced load; dispose so its timer cannot
+    // fire inside a later test with a different axios mock / module state.
+    data.dispose();
+  });
+
+  // --- S5b request ownership -------------------------------------------------
+
+  it('an out-of-order stale response does not apply over the newer request', async () => {
+    const axios = await getAxiosMock();
+    const resolvers: Array<(v: unknown) => void> = [];
+    axios.get.mockImplementation(() => new Promise((res) => resolvers.push(res)));
+    const data = useUserData();
+    const p1 = data.loadDataNow(); // P1 (default params)
+    data.perPage.value = 50; // params change → P2 differs
+    const p2 = data.loadDataNow(); // P2 (latest)
+    // resolve the newer P2 first, then the stale P1 LAST
+    resolvers[1]({
+      status: 200,
+      data: { ...userTablePayload, meta: [{ ...userTablePayload.meta[0], totalItems: 99 }] },
+    });
+    await p2;
+    await flushPromises();
+    resolvers[0]({ status: 200, data: userTablePayload }); // stale P1 (totalItems 2)
+    await p1;
+    await flushPromises();
+    expect(data.totalRows.value).toBe(99); // P2 retained; stale P1 ignored
+  });
+
+  it('the 500ms cache never serves a response cached under different params', async () => {
+    const axios = await getAxiosMock();
+    axios.get.mockResolvedValueOnce({ status: 200, data: userTablePayload }); // P1: totalItems 2
+    const data = useUserData();
+    await data.loadDataNow();
+    await flushPromises();
+    expect(data.totalRows.value).toBe(2);
+
+    data.perPage.value = 50; // params → P2
+    let resolveB!: (v: unknown) => void;
+    axios.get.mockImplementationOnce(() => new Promise((res) => (resolveB = res)));
+    const pB = data.loadDataNow(); // P2 in flight
+    data.totalRows.value = 999; // sentinel — a wrong cache-serve would overwrite this
+    await data.loadDataNow(); // 2nd identical P2 while pending
+    await Promise.resolve();
+    expect(data.totalRows.value).toBe(999); // must NOT serve P1's cached response for P2
+
+    resolveB({
+      status: 200,
+      data: { ...userTablePayload, meta: [{ ...userTablePayload.meta[0], totalItems: 7 }] },
+    });
+    await pB;
+    await flushPromises();
+    expect(data.totalRows.value).toBe(7); // the real P2 response applies
+  });
+
+  it('a response arriving after dispose() does not apply', async () => {
+    const axios = await getAxiosMock();
+    let resolve!: (v: unknown) => void;
+    axios.get.mockImplementation(() => new Promise((res) => (resolve = res)));
+    const data = useUserData();
+    const p = data.loadDataNow();
+    data.totalRows.value = 555; // sentinel
+    data.dispose(); // simulate unmount/navigation
+    resolve({
+      status: 200,
+      data: { ...userTablePayload, meta: [{ ...userTablePayload.meta[0], totalItems: 42 }] },
+    });
+    await p;
+    await flushPromises();
+    expect(data.totalRows.value).toBe(555); // disposed → late response ignored
+  });
+
+  it('a superseded same-param response completing last does not poison the recent cache', async () => {
+    // A1→B→A2 all in flight; A1 and A2 share params A. A2 (latest) completes first
+    // and caches fresh A; the stale A1 then completes LAST. A subsequent cache hit
+    // for A must serve A2's data, never the stale A1 (param-keying alone does not
+    // protect same-param out-of-order; the module write-sequence guard does).
+    const axios = await getAxiosMock();
+    const resolvers: Array<(v: unknown) => void> = [];
+    axios.get.mockImplementation(() => new Promise((res) => resolvers.push(res)));
+    const data = useUserData();
+
+    const pA1 = data.loadDataNow(); // A1 (default params) — resolvers[0]
+    data.perPage.value = 50;
+    const pB = data.loadDataNow(); // B (params B) — resolvers[1]
+    data.perPage.value = 25; // back to default params A
+    const pA2 = data.loadDataNow(); // A2 (params A again) — resolvers[2]
+
+    // A2 (latest) completes first → caches fresh A (totalItems 77).
+    resolvers[2]({
+      status: 200,
+      data: { ...userTablePayload, meta: [{ ...userTablePayload.meta[0], totalItems: 77 }] },
+    });
+    await pA2;
+    await flushPromises();
+    // Stale A1 completes LAST (totalItems 2) — must NOT overwrite the cached A2.
+    resolvers[0]({ status: 200, data: userTablePayload });
+    await pA1;
+    await flushPromises();
+
+    // Trigger a cache hit for params A: it must serve A2 (77), not the stale A1 (2).
+    await data.loadDataNow();
+    await flushPromises();
+    expect(data.totalRows.value).toBe(77);
+
+    // let B settle so no timer/promise leaks into the next test
+    resolvers[1]({ status: 200, data: userTablePayload });
+    await pB;
+    await flushPromises();
+    data.dispose();
+  });
+
+  it('a stale same-param response resolving BEFORE the newer one does not populate the cache', async () => {
+    // A1→B→A2 (A1, A2 share params A). Here the STALE A1 resolves FIRST, while A2 is
+    // still pending. A1 is not the latest-started A fetch, so it must not write the
+    // recent-response cache — a cache-serve attempt in that window must not return A1.
+    const axios = await getAxiosMock();
+    const resolvers: Array<(v: unknown) => void> = [];
+    axios.get.mockImplementation(() => new Promise((res) => resolvers.push(res)));
+    const data = useUserData();
+
+    const pA1 = data.loadDataNow(); // A1 (default params) — resolvers[0]
+    data.perPage.value = 50;
+    const pB = data.loadDataNow(); // B (params B) — resolvers[1]
+    data.perPage.value = 25;
+    const pA2 = data.loadDataNow(); // A2 (params A again, latest A start) — resolvers[2]
+
+    // Stale A1 resolves FIRST (totalItems 2), while A2 is still pending.
+    resolvers[0]({ status: 200, data: userTablePayload });
+    await pA1;
+    await flushPromises();
+
+    // Cache-serve attempt for params A must NOT return the stale A1 (cache empty here).
+    data.totalRows.value = 555; // sentinel — a wrong cache-serve would overwrite this
+    const pA3 = data.loadDataNow(); // resolvers[3]
+    await Promise.resolve();
+    await flushPromises();
+    expect(data.totalRows.value).toBe(555); // stale A1 was not served from the cache
+
+    // Settle the remaining requests so nothing leaks into the next test.
+    resolvers[2]({ status: 200, data: userTablePayload });
+    resolvers[1]({ status: 200, data: userTablePayload });
+    resolvers[3]({ status: 200, data: userTablePayload });
+    await pA2;
+    await pB;
+    await pA3;
+    await flushPromises();
+    data.dispose();
+  });
+
+  it('A→B→cached-A does not leave isBusy stuck true', async () => {
+    const axios = await getAxiosMock();
+    const resolvers: Array<(v: unknown) => void> = [];
+    axios.get.mockImplementation(() => new Promise((res) => resolvers.push(res)));
+    const data = useUserData();
+    const pA = data.loadDataNow(); // A (default params) in flight
+    data.perPage.value = 50;
+    const pB = data.loadDataNow(); // B in flight
+    // stale A completes while B is pending → caches A's response
+    resolvers[0]({ status: 200, data: userTablePayload });
+    await pA;
+    await flushPromises();
+    // switch back to A (served from the <500ms cache)
+    data.perPage.value = 25;
+    await data.loadDataNow();
+    await flushPromises();
+    expect(data.isBusy.value).toBe(false); // cache hit cleared busy; not stuck from B
+    // let B settle (superseded — must not resurrect busy)
+    resolvers[1]({ status: 200, data: userTablePayload });
+    await pB;
+    await flushPromises();
+    expect(data.isBusy.value).toBe(false);
+    data.dispose();
+  });
+});
+
+exec
+/bin/bash -lc "sed -n '1,260p' app/src/utils/tableRequestCoordinator.ts && sed -n '1,420p' app/src/utils/tableRequestCoordinator.spec.ts && sed -n '1,280p' app/src/views/curate/composables/useEntityInfo.ts && sed -n '1,460p' app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts && sed -n '1,260p' app/src/api/user.ts" in /home/bernt-popp/development/sysndd/.claude/worktrees/535-s5c-request-ownership
+ succeeded in 0ms:
+export type TableRequestSource = 'cache' | 'network' | 'shared';
+
+export interface TableRequestResult {
+  handled: boolean;
+  source: TableRequestSource;
+}
+
+interface TableRequestOptions<T> {
+  params: string;
+  fetcher: () => Promise<T>;
+  apply: (data: T, source: TableRequestSource) => void;
+  onError: (error: unknown, source: TableRequestSource) => void;
+  isCurrent: (params: string) => boolean;
+  now?: () => number;
+}
+
+export function createTableRequestCoordinator<T>(recentWindowMs = 500) {
+  let lastParams: string | null = null;
+  let lastCallTime = 0;
+  let lastResponse: T | null = null;
+  let lastResponseParams: string | null = null;
+  let inFlightPromise: Promise<T> | null = null;
+  let inFlightParams: string | null = null;
+  // Monotonic request-instance identity. The `params` string alone cannot
+  // distinguish the original request A from a later A2 after an A→B→A sequence
+  // (an A-B-A race), so a generation stamps every network request; only the
+  // latest generation may apply, and only the owning generation may clear the
+  // in-flight slot (#535 P1-7).
+  let inFlightGen = 0;
+  let generation = 0;
+
+  async function request({
+    params,
+    fetcher,
+    apply,
+    onError,
+    isCurrent,
+    now = () => Date.now(),
+  }: TableRequestOptions<T>): Promise<TableRequestResult> {
+    if (inFlightParams === params && inFlightPromise) {
+      const source: TableRequestSource = 'shared';
+      // Borrow the in-flight promise but capture the current generation so a
+      // newer request (even same params) supersedes this borrower.
+      const myGen = generation;
+      const shared = inFlightPromise;
+      try {
+        const data = await shared;
+        if (myGen !== generation || !isCurrent(params)) return { handled: false, source };
+        apply(data, source);
+        return { handled: true, source };
+      } catch (error) {
+        if (myGen !== generation || !isCurrent(params)) return { handled: false, source };
+        onError(error, source);
+        return { handled: true, source };
+      }
+    }
+
+    if (
+      lastParams === params &&
+      now() - lastCallTime < recentWindowMs &&
+      lastResponse !== null &&
+      lastResponseParams === params
+    ) {
+      const source: TableRequestSource = 'cache';
+      if (!isCurrent(params)) return { handled: false, source };
+      apply(lastResponse, source);
+      return { handled: true, source };
+    }
+
+    const source: TableRequestSource = 'network';
+    const myGen = ++generation;
+    lastParams = params;
+    lastCallTime = now();
+    lastResponse = null;
+    lastResponseParams = null;
+
+    const promise = fetcher();
+    inFlightPromise = promise;
+    inFlightParams = params;
+    inFlightGen = myGen;
+
+    try {
+      const data = await promise;
+      // Only the owning generation may clear the in-flight slot / record the
+      // recent-response cache — an older A must not clobber a newer A2's slot.
+      if (inFlightGen === myGen) {
+        inFlightPromise = null;
+        inFlightParams = null;
+        lastResponse = data;
+        lastResponseParams = params;
+      }
+      if (myGen !== generation || !isCurrent(params)) return { handled: false, source };
+      apply(data, source);
+      return { handled: true, source };
+    } catch (error) {
+      if (inFlightGen === myGen) {
+        inFlightPromise = null;
+        inFlightParams = null;
+        lastResponse = null;
+        lastResponseParams = null;
+      }
+      if (myGen !== generation || !isCurrent(params)) return { handled: false, source };
+      onError(error, source);
+      return { handled: true, source };
+    }
+  }
+
+  return { request };
+}
+import { describe, expect, it, vi } from 'vitest';
+import { createTableRequestCoordinator } from './tableRequestCoordinator';
+
+describe('createTableRequestCoordinator', () => {
+  it('awaits an in-flight request before using the recent cache shortcut', async () => {
+    const coordinator = createTableRequestCoordinator<string>();
+    let resolveRequest: (value: string) => void = () => {};
+    const fetcher = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveRequest = resolve;
+        })
+    );
+    const firstApply = vi.fn();
+    const secondApply = vi.fn();
+
+    const first = coordinator.request({
+      params: 'page=1',
+      fetcher,
+      apply: firstApply,
+      onError: vi.fn(),
+      isCurrent: () => true,
+      now: () => 100,
+    });
+    const second = coordinator.request({
+      params: 'page=1',
+      fetcher,
+      apply: secondApply,
+      onError: vi.fn(),
+      isCurrent: () => true,
+      now: () => 101,
+    });
+
+    resolveRequest('response');
+
+    await expect(first).resolves.toEqual({ handled: true, source: 'network' });
+    await expect(second).resolves.toEqual({ handled: true, source: 'shared' });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(firstApply).toHaveBeenCalledWith('response', 'network');
+    expect(secondApply).toHaveBeenCalledWith('response', 'shared');
+  });
+
+  it('does not apply a shared response when the waiting instance changed params', async () => {
+    const coordinator = createTableRequestCoordinator<string>();
+    let currentParams = 'page=1';
+    let resolveRequest: (value: string) => void = () => {};
+    const fetcher = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveRequest = resolve;
+        })
+    );
+    const staleApply = vi.fn();
+
+    const first = coordinator.request({
+      params: 'page=1',
+      fetcher,
+      apply: vi.fn(),
+      onError: vi.fn(),
+      isCurrent: () => true,
+    });
+    const staleWaiter = coordinator.request({
+      params: 'page=1',
+      fetcher,
+      apply: staleApply,
+      onError: vi.fn(),
+      isCurrent: (params) => currentParams === params,
+    });
+
+    currentParams = 'page=2';
+    resolveRequest('response');
+
+    await first;
+    await expect(staleWaiter).resolves.toEqual({ handled: false, source: 'shared' });
+    expect(staleApply).not.toHaveBeenCalled();
+  });
+
+  it('only uses cached responses that match the current params', async () => {
+    const coordinator = createTableRequestCoordinator<string>();
+    const firstApply = vi.fn();
+    const secondApply = vi.fn();
+
+    await coordinator.request({
+      params: 'page=1',
+      fetcher: () => Promise.resolve('first'),
+      apply: firstApply,
+      onError: vi.fn(),
+      isCurrent: () => true,
+      now: () => 100,
+    });
+    const result = await coordinator.request({
+      params: 'page=2',
+      fetcher: () => Promise.resolve('second'),
+      apply: secondApply,
+      onError: vi.fn(),
+      isCurrent: () => true,
+      now: () => 101,
+    });
+
+    expect(result).toEqual({ handled: true, source: 'network' });
+    expect(secondApply).toHaveBeenCalledWith('second', 'network');
+  });
+
+  // #535 P1-7: generation-based request ownership (A-B-A + out-of-order).
+  function deferred<T>() {
+    let resolve!: (v: T) => void;
+    let reject!: (e: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  }
+
+  it('A-B-A: the original A response does not apply after A2 supersedes it', async () => {
+    const coord = createTableRequestCoordinator<string>();
+    const applied: string[] = [];
+    let current = 'A';
+    const dA = deferred<string>();
+    const dB = deferred<string>();
+    const dA2 = deferred<string>();
+
+    const rA = coord.request({ params: 'A', fetcher: () => dA.promise, apply: (d) => applied.push(`A:${d}`), onError: () => {}, isCurrent: (p) => p === current });
+    current = 'B';
+    const rB = coord.request({ params: 'B', fetcher: () => dB.promise, apply: (d) => applied.push(`B:${d}`), onError: () => {}, isCurrent: (p) => p === current });
+    current = 'A';
+    const rA2 = coord.request({ params: 'A', fetcher: () => dA2.promise, apply: (d) => applied.push(`A2:${d}`), onError: () => {}, isCurrent: (p) => p === current });
+
+    dA.resolve('stale');
+    await rA;
+    expect(applied).not.toContain('A:stale');
+
+    dB.resolve('bdata');
+    await rB;
+    expect(applied).not.toContain('B:bdata');
+
+    dA2.resolve('fresh');
+    await rA2;
+    expect(applied).toContain('A2:fresh');
+  });
+
+  it('slot integrity: original A does not corrupt A2 in-flight slot (a 4th A shares A2)', async () => {
+    const coord = createTableRequestCoordinator<string>();
+    const fetchCalls: string[] = [];
+    let current = 'A';
+    const dA = deferred<string>();
+    const dB = deferred<string>();
+    const dA2 = deferred<string>();
+
+    const rA = coord.request({ params: 'A', fetcher: () => { fetchCalls.push('A'); return dA.promise; }, apply: () => {}, onError: () => {}, isCurrent: (p) => p === current });
+    current = 'B';
+    const rB = coord.request({ params: 'B', fetcher: () => { fetchCalls.push('B'); return dB.promise; }, apply: () => {}, onError: () => {}, isCurrent: (p) => p === current });
+    current = 'A';
+    const rA2 = coord.request({ params: 'A', fetcher: () => { fetchCalls.push('A2'); return dA2.promise; }, apply: () => {}, onError: () => {}, isCurrent: (p) => p === current });
+
+    // Original A resolves — must NOT clear A2's in-flight slot.
+    dA.resolve('stale');
+    await rA;
+
+    // A 4th request for A must SHARE A2's in-flight promise (no new fetch). Use a
+    // settled sentinel fetcher so a regression (new fetch) fails fast, not hangs.
+    const applied4: string[] = [];
+    const r4 = coord.request({ params: 'A', fetcher: () => { fetchCalls.push('A4'); return Promise.resolve('A4-unexpected'); }, apply: (d) => applied4.push(d), onError: () => {}, isCurrent: (p) => p === current });
+
+    dB.resolve('bstale'); // superseded B; resolve so its awaited request settles
+    dA2.resolve('fresh');
+    const [r4result] = await Promise.all([r4, rA2, rB]);
+
+    expect(fetchCalls).toEqual(['A', 'B', 'A2']); // no 'A4' — the 4th shared A2's slot
+    expect(r4result.source).toBe('shared');
+    expect(applied4).toEqual(['fresh']);
+
+    // Recent-cache branch returns A2's data after it settled.
+    const r5 = await coord.request({ params: 'A', fetcher: () => Promise.resolve('unused'), apply: () => {}, onError: () => {}, isCurrent: () => true, now: () => 1 });
+    expect(r5.source).toBe('cache');
+  });
+
+  it('error out-of-order: a superseded rejected request does not call onError', async () => {
+    const coord = createTableRequestCoordinator<string>();
+    const errors: string[] = [];
+    let current = 'X';
+    const d1 = deferred<string>();
+    const d2 = deferred<string>();
+
+    const r1 = coord.request({ params: 'X', fetcher: () => d1.promise, apply: () => {}, onError: () => errors.push('X'), isCurrent: (p) => p === current });
+    current = 'Y';
+    const r2 = coord.request({ params: 'Y', fetcher: () => d2.promise, apply: () => {}, onError: () => errors.push('Y'), isCurrent: (p) => p === current });
+
+    d2.resolve('ok');
+    await r2;
+    d1.reject(new Error('stale fail'));
+    await r1;
+    expect(errors).toEqual([]); // superseded X's rejection must not surface
+  });
+});
+// app/src/views/curate/composables/useEntityInfo.ts
+import { computed, ref } from 'vue';
+import {
+  listEntities,
+  getEntityReview,
+  getEntityPhenotypes,
+  getEntityVariation,
+  getEntityPublications,
+  getEntityStatus,
+} from '@/api/entity';
+
+import Review from '@/assets/js/classes/submission/submissionReview';
+import Status from '@/assets/js/classes/submission/submissionStatus';
+import Phenotype from '@/assets/js/classes/submission/submissionPhenotype';
+import Variation from '@/assets/js/classes/submission/submissionVariation';
+import Literature from '@/assets/js/classes/submission/submissionLiterature';
+
+export interface UseEntityInfoOptions {
+  onToast?: (...args: unknown[]) => void;
+}
+
+interface ReviewSnapshot {
+  synopsis: string;
+  comment: string;
+  phenotypes: string[];
+  variationOntology: string[];
+  publications: string[];
+  genereviews: string[];
+}
+
+// Fields loadEntity() asks the entity-LIST endpoint (GET /api/entity/) for.
+// This list MUST be a subset of the columns `ndd_entity_view` exposes
+// (db/migrations/025_create_core_views.sql) + `synopsis` from the review
+// left-join: the API's select_tibble_fields() hard-fails (HTTP 500) when any
+// requested field is absent from the view. `is_active`, `replaced_by` and
+// `details` are NOT in that view, so they must not be requested here:
+//   - `details` is never read by the rename/deactivate handlers.
+//   - `is_active`/`replaced_by` are set explicitly by the deactivate mutation
+//     (useEntityMutations) before submit, so they don't need to be loaded.
+const ENTITY_MUTATION_FIELDS = [
+  'entity_id',
+  'symbol',
+  'hgnc_id',
+  'disease_ontology_name',
+  'disease_ontology_id_version',
+  'hpo_mode_of_inheritance_term',
+  'hpo_mode_of_inheritance_term_name',
+  'category',
+  'ndd_phenotype',
+  'ndd_phenotype_word',
+].join(',');
+
+const arrEqual = (a: string[], b: string[]) => {
+  if (a.length !== b.length) return false;
+  const sa = [...a].sort();
+  const sb = [...b].sort();
+  return sa.every((v, i) => v === sb[i]);
+};
+
+export function useEntityInfo(options: UseEntityInfoOptions = {}) {
+  const { onToast } = options;
+
+  const entity_info = ref<Record<string, any>>({});
+  const review_info = ref<any>(new Review());
+  const status_info = ref<any>(new Status());
+
+  const select_phenotype = ref<string[]>([]);
+  const select_variation = ref<string[]>([]);
+  const select_additional_references = ref<string[]>([]);
+  const select_gene_reviews = ref<string[]>([]);
+
+  const reviewLoadedData = ref<ReviewSnapshot | null>(null);
+
+  const hasReviewChanges = computed(() => {
+    if (!reviewLoadedData.value) return false;
+    const snap = reviewLoadedData.value;
+    return (
+      (review_info.value.synopsis || '') !== snap.synopsis ||
+      (review_info.value.comment || '') !== snap.comment ||
+      !arrEqual(select_phenotype.value, snap.phenotypes) ||
+      !arrEqual(select_variation.value, snap.variationOntology) ||
+      !arrEqual(select_additional_references.value, snap.publications) ||
+      !arrEqual(select_gene_reviews.value, snap.genereviews)
+    );
+  });
+
+  async function loadEntity(entityId: number): Promise<void> {
+    try {
+      const response: any = await listEntities({
+        filter: `equals(entity_id,${entityId})`,
+        fields: ENTITY_MUTATION_FIELDS,
+        page_size: '1',
+        compact: true,
+      });
+      const data = response?.data;
+      if (!Array.isArray(data) || data.length === 0) {
+        onToast?.(`Entity ${entityId} not found`, 'Error', 'danger');
+        entity_info.value = {};
+        return;
+      }
+      entity_info.value = data[0];
+    } catch (e) {
+      onToast?.(e, 'Error', 'danger');
+      entity_info.value = {};
+    }
+  }
+
+  async function loadReview(entityId: number): Promise<void> {
+    try {
+      const review_data: any = await getEntityReview(entityId);
+      const phenotypes_data: any = await getEntityPhenotypes(entityId);
+      const variation_data: any = await getEntityVariation(entityId);
+      const publications_data: any = await getEntityPublications(entityId);
+
+      const new_phenotype = phenotypes_data.map(
+        (item: any) => new Phenotype(item.phenotype_id, item.modifier_id)
+      );
+      select_phenotype.value = phenotypes_data.map(
+        (item: any) => `${item.modifier_id}-${item.phenotype_id}`
+      );
+
+      const new_variation = variation_data.map(
+        (item: any) => new Variation(item.vario_id, item.modifier_id)
+      );
+      select_variation.value = variation_data.map(
+        (item: any) => `${item.modifier_id}-${item.vario_id}`
+      );
+
+      const literature_gene_reviews = publications_data
+        .filter((item: any) => item.publication_type === 'gene_review')
+        .map((item: any) => item.publication_id);
+      const literature_additional_references = publications_data
+        .filter((item: any) => item.publication_type === 'additional_references')
+        .map((item: any) => item.publication_id);
+
+      select_additional_references.value = literature_additional_references;
+      select_gene_reviews.value = literature_gene_reviews;
+
+      const new_literature = new Literature(
+        literature_additional_references,
+        literature_gene_reviews
+      );
+
+      review_info.value = new Review(
+        review_data[0].synopsis,
+        new_literature,
+        new_phenotype,
+        new_variation,
+        review_data[0].comment
+      );
+      review_info.value.review_id = review_data[0].review_id;
+      review_info.value.entity_id = review_data[0].entity_id;
+
+      reviewLoadedData.value = {
+        synopsis: review_info.value.synopsis || '',
+        comment: review_info.value.comment || '',
+        phenotypes: [...select_phenotype.value],
+        variationOntology: [...select_variation.value],
+        publications: [...select_additional_references.value],
+        genereviews: [...select_gene_reviews.value],
+      };
+    } catch (e) {
+      onToast?.(e, 'Error', 'danger');
+    }
+  }
+
+  async function loadStatus(entityId: number): Promise<void> {
+    try {
+      const status_data: any = await getEntityStatus(entityId);
+      status_info.value = new Status(
+        status_data[0].category_id,
+        status_data[0].comment,
+        status_data[0].problematic
+      );
+      status_info.value.status_id = status_data[0].status_id;
+      status_info.value.entity_id = status_data[0].entity_id;
+    } catch (e) {
+      onToast?.(e, 'Error', 'danger');
+    }
+  }
+
+  function reset(): void {
+    entity_info.value = {};
+    review_info.value = new Review();
+    status_info.value = new Status();
+    select_phenotype.value = [];
+    select_variation.value = [];
+    select_additional_references.value = [];
+    select_gene_reviews.value = [];
+    reviewLoadedData.value = null;
+  }
+
+  return {
+    entity_info,
+    review_info,
+    status_info,
+    select_phenotype,
+    select_variation,
+    select_additional_references,
+    select_gene_reviews,
+    reviewLoadedData,
+    hasReviewChanges,
+    loadEntity,
+    loadReview,
+    loadStatus,
+    reset,
+  };
+}
+import { describe, expect, test } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '@/test-utils/mocks/server';
+import { useEntityInfo } from '../useEntityInfo';
+
+// Lifecycle (listen / resetHandlers / close) is provided globally by
+// vitest.setup.ts. This file only adds per-test handler overrides via
+// `server.use(...)`.
+
+describe('useEntityInfo', () => {
+  test('loadEntity populates entity_info from listEntities response', async () => {
+    server.use(
+      http.get('*/api/entity/*', () =>
+        HttpResponse.json({
+          data: [{ entity_id: 7, symbol: 'GRIN2B', disease_ontology_name: 'NDD' }],
+        })
+      )
+    );
+    const e = useEntityInfo();
+    await e.loadEntity(7);
+    expect(e.entity_info.value.entity_id).toBe(7);
+    expect(e.entity_info.value.symbol).toBe('GRIN2B');
+  });
+
+  // Regression guard for the Modify Entity 500 (gene JKAMP / entity 4646).
+  // loadEntity() hits GET /api/entity/ (which queries ndd_entity_view). The API's
+  // select_tibble_fields() returns HTTP 500 when ANY requested field is absent
+  // from that view. Commit a586078a made loadEntity request is_active/replaced_by/
+  // details — columns ndd_entity_view does NOT expose — so every entity selection
+  // 500'd. The requested field set must therefore be a subset of the view's
+  // columns; is_active/replaced_by are set by the deactivate mutation and details
+  // is never read by the rename/deactivate handlers, so none are needed here.
+  test('loadEntity requests only columns ndd_entity_view exposes (no 500)', async () => {
+    // Columns the entity-list endpoint can return: ndd_entity_view
+    // (db/migrations/025_create_core_views.sql) + `synopsis` from the review join.
+    const ENTITY_VIEW_COLUMNS = new Set([
+      'entity_id', 'hgnc_id', 'symbol', 'disease_ontology_id_version',
+      'disease_ontology_name', 'hpo_mode_of_inheritance_term',
+      'hpo_mode_of_inheritance_term_name', 'inheritance_filter', 'ndd_phenotype',
+      'ndd_phenotype_word', 'entry_date', 'category', 'category_id', 'synopsis',
+    ]);
+
+    let requestedFields: string | null = null;
+    server.use(
+      http.get('*/api/entity/*', ({ request }) => {
+        requestedFields = new URL(request.url).searchParams.get('fields');
+        const missing = (requestedFields ?? '')
+          .split(',')
+          .map((f) => f.trim())
+          .filter((f) => f && !ENTITY_VIEW_COLUMNS.has(f));
+        if (missing.length > 0) {
+          // Mirror api select_tibble_fields(): unknown fields are a hard 500.
+          return HttpResponse.json(
+            { error: `Some requested fields are not in the column names: ${missing.join(',')}` },
+            { status: 500 }
+          );
+        }
+        return HttpResponse.json({
+          data: [
+            {
+              entity_id: 3367,
+              symbol: 'FGF13',
+              hgnc_id: 'HGNC:3670',
+              hpo_mode_of_inheritance_term: 'HP:0001417',
+              hpo_mode_of_inheritance_term_name: 'X-linked inheritance',
+              disease_ontology_id_version: 'OMIM:300070',
+              disease_ontology_name: 'developmental and epileptic encephalopathy',
+              ndd_phenotype: 1,
+            },
+          ],
+        });
+      })
+    );
+
+    const toasts: any[] = [];
+    const e = useEntityInfo({ onToast: (...a) => toasts.push(a) });
+    await e.loadEntity(3367);
+
+    // The fields rename/deactivate actually consume (all view-backed) are present.
+    expect(requestedFields).toContain('hgnc_id');
+    expect(requestedFields).toContain('hpo_mode_of_inheritance_term');
+    expect(requestedFields).toContain('disease_ontology_id_version');
+    expect(requestedFields).toContain('ndd_phenotype');
+    // The view-absent columns that caused the 500 must NOT be requested.
+    expect(requestedFields).not.toContain('is_active');
+    expect(requestedFields).not.toContain('replaced_by');
+    expect(requestedFields).not.toContain('details');
+    // No 500 -> no error toast, and the entity loaded.
+    expect(toasts).toHaveLength(0);
+    expect(e.entity_info.value.hgnc_id).toBe('HGNC:3670');
+  });
+
+  test('loadEntity surfaces a not-found toast and clears entity_info', async () => {
+    server.use(http.get('*/api/entity/*', () => HttpResponse.json({ data: [] })));
+    const toasts: any[] = [];
+    const e = useEntityInfo({ onToast: (...a) => toasts.push(a) });
+    await e.loadEntity(99);
+    expect(e.entity_info.value).toEqual({});
+    expect(toasts.length).toBe(1);
+  });
+
+  test('loadReview snapshots reviewLoadedData for change detection', async () => {
+    server.use(
+      http.get('*/api/entity/7/review', () =>
+        HttpResponse.json([{ synopsis: 'syn', comment: 'cm', review_id: 1, entity_id: 7 }])
+      ),
+      http.get('*/api/entity/7/phenotypes', () =>
+        HttpResponse.json([{ phenotype_id: 'HP:1', modifier_id: 'present' }])
+      ),
+      http.get('*/api/entity/7/variation', () =>
+        HttpResponse.json([{ vario_id: 'VARIO:1', modifier_id: 'present' }])
+      ),
+      http.get('*/api/entity/7/publications', () =>
+        HttpResponse.json([
+          { publication_id: 'PMID:1', publication_type: 'gene_review' },
+          { publication_id: 'PMID:2', publication_type: 'additional_references' },
+        ])
+      )
+    );
+    const e = useEntityInfo();
+    await e.loadReview(7);
+    expect(e.reviewLoadedData.value).not.toBeNull();
+    expect(e.select_phenotype.value).toEqual(['present-HP:1']);
+    expect(e.select_gene_reviews.value).toEqual(['PMID:1']);
+    expect(e.hasReviewChanges.value).toBe(false);
+  });
+
+  test('hasReviewChanges flips when a watched field diverges', async () => {
+    server.use(
+      http.get('*/api/entity/7/review', () =>
+        HttpResponse.json([{ synopsis: 'a', comment: 'b', review_id: 1, entity_id: 7 }])
+      ),
+      http.get('*/api/entity/7/phenotypes', () => HttpResponse.json([])),
+      http.get('*/api/entity/7/variation', () => HttpResponse.json([])),
+      http.get('*/api/entity/7/publications', () => HttpResponse.json([]))
+    );
+    const e = useEntityInfo();
+    await e.loadReview(7);
+    expect(e.hasReviewChanges.value).toBe(false);
+    e.review_info.value.synopsis = 'CHANGED';
+    expect(e.hasReviewChanges.value).toBe(true);
+  });
+
+  test('loadStatus populates status_info', async () => {
+    server.use(
+      http.get('*/api/entity/7/status', () =>
+        HttpResponse.json([
+          { category_id: 'definitive', comment: 'c', problematic: 0, status_id: 1, entity_id: 7 },
+        ])
+      )
+    );
+    const e = useEntityInfo();
+    await e.loadStatus(7);
+    expect(e.status_info.value.category_id).toBe('definitive');
+  });
+});
+// app/src/api/user.ts
+//
+// User resource helpers.
+//
+// Mirrors api/endpoints/user_endpoints.R (mounted at /api/user).
+// Phase E.E2: filled during v11.1 Wave 1a (W3).
+//
+// Used by the UserAdmin/UserApproval/UserProfile views and the curate flows
+// that surface contributor stats.
+//
+// NOTE: `PUT /api/user/password/update` is already typed in `auth.ts` as
+// `changePassword(args)` (it cohabits with the auth flow because the
+// reset-via-token endpoints live there). It is NOT re-exported here to
+// avoid drift between the two surfaces.
+
+import type { AxiosRequestConfig } from 'axios';
+import { apiClient } from './client';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ListUserTableParams {
+  filter?: string;
+  sort?: string;
+  page_after?: string | number;
+  page_size?: string;
+  fspec?: string;
+}
+
+/**
+ * One row of the user-table response. Admin sees every user; Curator sees
+ * only the unapproved subset. Mirrors the columns the R handler `select`s.
+ */
+export interface UserTableRow {
+  user_id: number;
+  user_name: string;
+  email: string | null;
+  orcid: string | null;
+  abbreviation: string | null;
+  first_name: string | null;
+  family_name: string | null;
+  comment: string | null;
+  terms_agreed: number | string | null;
+  created_at: string | null;
+  user_role: string;
+  approved: number | string;
+}
+
+/**
+ * Generic cursor-pagination envelope returned by the `table` listing.
+ */
+export interface UserTableResponse {
+  links: unknown;
+  meta: unknown;
+  data: UserTableRow[];
+}
+
+/**
+ * Response from `GET /api/user/<user_id>/contributions`.
+ */
+export interface UserContributions {
+  user_id: number | string;
+  active_status: number;
+  active_reviews: number;
+}
+
+export interface ApproveUserParams {
+  /** R coerces "TRUE"/"FALSE". */
+  status_approval?: boolean;
+}
+
+/**
+ * Response from `PUT /api/user/approval`.
+ *
+ * The R handler returns three different shapes depending on outcome:
+ *   - rejection:                `{ message, user_id }`
+ *   - approve + email success:  `{ message, user_id, user_name, email_sent: true }`
+ *   - approve + email failure:  `{ message, user_id, user_name, email, email_sent: false, email_error }`
+ */
+export interface ApproveUserResponse {
+  message: string;
+  user_id: number;
+  user_name?: string;
+  email?: string;
+  email_sent?: boolean;
+  email_error?: string;
+}
+
+export interface ChangeRoleParams {
+  /** Defaults to "Viewer" server-side when omitted. */
+  role_assigned?: string;
+}
+
+/**
+ * Response from `GET /api/user/role_list`.
+ */
+export interface UserRole {
+  role: string;
+}
+
+export interface ListUsersByRoleParams {
+  /** Comma-separated list of role names; defaults to "Viewer" server-side. */
+  roles?: string;
+}
+
+/**
+ * Compact user row returned by `GET /api/user/list?roles=...`.
+ */
+export interface UserListRow {
+  user_id: number;
+  user_name: string;
+  user_role: string;
+}
+
+/**
+ * Body for `PUT /api/user/profile` (self-service email/orcid update).
+ */
+export interface UpdateProfileRequest {
+  email?: string;
+  orcid?: string;
+}
+
+export interface UpdateProfileResponse {
+  message: string;
+  updated_fields: string[];
+}
+
+/**
+ * Body for `POST /api/user/password/reset/request`. Email-only — the
+ * endpoint returns 200 even when the email is unknown to avoid account
+ * enumeration.
+ */
+export interface PasswordResetRequest {
+  email: string;
+}
+
+/**
+ * Body for `POST /api/user/password/reset/change`. The reset JWT travels
+ * in the `Authorization: Bearer ...` header; passwords MUST be in the body.
+ */
+export interface PasswordResetChangeRequest {
+  password: string;
+  password_confirm: string;
+}
+
+export interface PasswordResetChangeResponse {
+  message: string;
+}
+
+/**
+ * Body for `PUT /api/user/update`. The R handler nests the user fields
+ * under a `user_details` key. `user_id` is mandatory; everything else is
+ * optional patch material.
+ */
+export interface UpdateUserRequest {
+  user_details: {
+    user_id: number;
+    user_name?: string;
+    email?: string;
+    user_role?: string;
+    approved?: boolean | number | string;
+    abbreviation?: string;
+    first_name?: string;
+    family_name?: string;
+    comment?: string;
+    orcid?: string;
+    [key: string]: unknown;
+  };
+}
+
+export interface UpdateUserResponse {
+  message: string;
+}
+
+/**
+ * Common response shape for the bulk endpoints.
+ */
+export interface BulkUserResponse {
+  processed: number;
+  message: string;
+}
+
+export interface BulkApproveRequest {
+  /** Max 20 ids per request (server-enforced). */
+  user_ids: number[];
+}
+
+export interface BulkDeleteRequest {
+  /** Max 20 ids per request. Rejected with 403 if any id is an Administrator. */
+  user_ids: number[];
+}
+
+export interface BulkAssignRoleRequest {
+  /** Max 20 ids per request. */
+  user_ids: number[];
+  /** One of "Administrator", "Curator", "Reviewer", "Viewer". */
+  role: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /api/user/table
+ * Mirrors api/endpoints/user_endpoints.R:28 (handler `@get table`).
+ *
+ * Curator+ only. Admin sees all users, Curator sees only unapproved users.
+ * Supports filter/sort/cursor pagination; returns the `{ links, meta, data }`
+ * envelope. Throws AxiosError on non-2xx (401/403).
+ */
+export async function getUserTable(
+  params: ListUserTableParams = {},
+  config?: AxiosRequestConfig
+): Promise<UserTableResponse> {
+  return apiClient.get<UserTableResponse>('/api/user/table', {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...params },
+  });
+}
+
+/**
+ * GET /api/user/<user_id>/contributions
+ * Mirrors api/endpoints/user_endpoints.R:159 (handler `@get <user_id>/contributions`).
+ *
+ * Users may view their own contributions; Reviewer+ may view any user.
+ * Throws AxiosError on non-2xx (401/403).
+ */
+export async function getUserContributions(
+  user_id: number | string,
+  config?: AxiosRequestConfig
+): Promise<UserContributions> {
+  const path = `/api/user/${encodeURIComponent(String(user_id))}/contributions`;
+  return apiClient.get<UserContributions>(path, config);
+}
+
+/**
+ * PUT /api/user/approval
+ * Mirrors api/endpoints/user_endpoints.R:202 (handler `@put approval`).
+ *
+ * Curator+ only. `status_approval=true` approves and sends a welcome
+ * email; `false` (or omitted) rejects + deletes the user.
+ *
+ * Throws AxiosError on non-2xx (409 if user does not exist or is already
+ * active).
+ */
+export async function approveUser(
+  user_id: number | string,
+  params: ApproveUserParams = {},
+  config?: AxiosRequestConfig
+): Promise<ApproveUserResponse> {
+  return apiClient.put<ApproveUserResponse>('/api/user/approval', undefined, {
+    ...config,
+    params: {
+      ...(config?.params as object | undefined),
+      user_id,
+      ...params,
+    },
+  });
+
+exec
+/bin/bash -lc "rg -n \"createTableRequestCoordinator|\\.request\\(\\{\" app/src --glob '"'!utils/tableRequestCoordinator.spec.ts'"' && sed -n '1,440p' app/src/views/review/composables/useReviewData.ts && sed -n '1,640p' app/src/views/review/composables/__tests__/useReviewData.spec.ts" in /home/bernt-popp/development/sysndd/.claude/worktrees/535-s5c-request-ownership
+ succeeded in 0ms:
+app/src/utils/tableRequestCoordinator.ts:17:export function createTableRequestCoordinator<T>(recentWindowMs = 500) {
+app/src/utils/tableRequestCoordinator.spec.ts:2:import { createTableRequestCoordinator } from './tableRequestCoordinator';
+app/src/utils/tableRequestCoordinator.spec.ts:4:describe('createTableRequestCoordinator', () => {
+app/src/utils/tableRequestCoordinator.spec.ts:6:    const coordinator = createTableRequestCoordinator<string>();
+app/src/utils/tableRequestCoordinator.spec.ts:17:    const first = coordinator.request({
+app/src/utils/tableRequestCoordinator.spec.ts:25:    const second = coordinator.request({
+app/src/utils/tableRequestCoordinator.spec.ts:44:    const coordinator = createTableRequestCoordinator<string>();
+app/src/utils/tableRequestCoordinator.spec.ts:55:    const first = coordinator.request({
+app/src/utils/tableRequestCoordinator.spec.ts:62:    const staleWaiter = coordinator.request({
+app/src/utils/tableRequestCoordinator.spec.ts:79:    const coordinator = createTableRequestCoordinator<string>();
+app/src/utils/tableRequestCoordinator.spec.ts:83:    await coordinator.request({
+app/src/utils/tableRequestCoordinator.spec.ts:91:    const result = await coordinator.request({
+app/src/utils/tableRequestCoordinator.spec.ts:116:    const coord = createTableRequestCoordinator<string>();
+app/src/utils/tableRequestCoordinator.spec.ts:123:    const rA = coord.request({ params: 'A', fetcher: () => dA.promise, apply: (d) => applied.push(`A:${d}`), onError: () => {}, isCurrent: (p) => p === current });
+app/src/utils/tableRequestCoordinator.spec.ts:125:    const rB = coord.request({ params: 'B', fetcher: () => dB.promise, apply: (d) => applied.push(`B:${d}`), onError: () => {}, isCurrent: (p) => p === current });
+app/src/utils/tableRequestCoordinator.spec.ts:127:    const rA2 = coord.request({ params: 'A', fetcher: () => dA2.promise, apply: (d) => applied.push(`A2:${d}`), onError: () => {}, isCurrent: (p) => p === current });
+app/src/utils/tableRequestCoordinator.spec.ts:143:    const coord = createTableRequestCoordinator<string>();
+app/src/utils/tableRequestCoordinator.spec.ts:150:    const rA = coord.request({ params: 'A', fetcher: () => { fetchCalls.push('A'); return dA.promise; }, apply: () => {}, onError: () => {}, isCurrent: (p) => p === current });
+app/src/utils/tableRequestCoordinator.spec.ts:152:    const rB = coord.request({ params: 'B', fetcher: () => { fetchCalls.push('B'); return dB.promise; }, apply: () => {}, onError: () => {}, isCurrent: (p) => p === current });
+app/src/utils/tableRequestCoordinator.spec.ts:154:    const rA2 = coord.request({ params: 'A', fetcher: () => { fetchCalls.push('A2'); return dA2.promise; }, apply: () => {}, onError: () => {}, isCurrent: (p) => p === current });
+app/src/utils/tableRequestCoordinator.spec.ts:163:    const r4 = coord.request({ params: 'A', fetcher: () => { fetchCalls.push('A4'); return Promise.resolve('A4-unexpected'); }, apply: (d) => applied4.push(d), onError: () => {}, isCurrent: (p) => p === current });
+app/src/utils/tableRequestCoordinator.spec.ts:174:    const r5 = await coord.request({ params: 'A', fetcher: () => Promise.resolve('unused'), apply: () => {}, onError: () => {}, isCurrent: () => true, now: () => 1 });
+app/src/utils/tableRequestCoordinator.spec.ts:179:    const coord = createTableRequestCoordinator<string>();
+app/src/utils/tableRequestCoordinator.spec.ts:185:    const r1 = coord.request({ params: 'X', fetcher: () => d1.promise, apply: () => {}, onError: () => errors.push('X'), isCurrent: (p) => p === current });
+app/src/utils/tableRequestCoordinator.spec.ts:187:    const r2 = coord.request({ params: 'Y', fetcher: () => d2.promise, apply: () => {}, onError: () => errors.push('Y'), isCurrent: (p) => p === current });
+app/src/composables/useConfirmGate.spec.ts:16:    gate.request({ title: 'T', message: 'M', confirmLabel: 'Go' }, action);
+app/src/composables/useConfirmGate.spec.ts:27:    gate.request({ title: 'T', message: 'M' }, action);
+app/src/composables/useConfirmGate.spec.ts:41:    gate.request({ title: 'T', message: 'M' }, action);
+app/src/views/admin/composables/useOntologyAdminTable.ts:28:import { createTableRequestCoordinator } from '@/utils/tableRequestCoordinator';
+app/src/views/admin/composables/useOntologyAdminTable.ts:44:const ontologyRequestCoordinator = createTableRequestCoordinator<VariantOntologyListResponse>();
+app/src/views/admin/composables/useOntologyAdminTable.ts:276:    const result = await ontologyRequestCoordinator.request({
+app/src/components/tables/useEntitiesTable.ts:15:import { createTableRequestCoordinator } from '@/utils/tableRequestCoordinator';
+app/src/components/tables/useEntitiesTable.ts:30:const entitiesRequestCoordinator = createTableRequestCoordinator<EntityListResponse>();
+app/src/components/tables/useEntitiesTable.ts:264:    const result = await entitiesRequestCoordinator.request({
+app/src/components/tables/usePhenotypeEntitiesTable.ts:27:import { createTableRequestCoordinator } from '@/utils/tableRequestCoordinator';
+app/src/components/tables/usePhenotypeEntitiesTable.ts:36:  createTableRequestCoordinator<BrowsePhenotypeEntitiesResponse>();
+app/src/components/tables/usePhenotypeEntitiesTable.ts:351:    const result = await phenotypeEntitiesRequestCoordinator.request({
+app/src/components/tables/useGenesTable.ts:35:import { createTableRequestCoordinator } from '@/utils/tableRequestCoordinator';
+app/src/components/tables/useGenesTable.ts:41:const genesRequestCoordinator = createTableRequestCoordinator<PaginatedGeneResponse>();
+app/src/components/tables/useGenesTable.ts:220:    const result = await genesRequestCoordinator.request({
+app/src/components/tables/TablesPhenotypes.spec.ts:46:  createTableRequestCoordinator: () => ({
+app/src/components/analyses/usePublicationsTable.ts:30:import { createTableRequestCoordinator } from '@/utils/tableRequestCoordinator';
+app/src/components/analyses/usePublicationsTable.ts:36:const publicationsRequestCoordinator = createTableRequestCoordinator<PublicationListResponse>();
+app/src/components/analyses/usePublicationsTable.ts:172:    const result = await publicationsRequestCoordinator.request({
+// app/src/views/review/composables/useReviewData.ts
+//
+// W6 of v11.1 finish-hardening — data-loading composable for `Review.vue`.
+//
+// Owns:
+//   - the re-review table fetch (`/api/re_review/table?curate=*`)
+//   - the three lookup-list fetches that feed dropdowns/treeselects in the
+//     modals (phenotype / variation_ontology / status — all `?tree=true`)
+//   - the per-entity context lookup (`/api/entity/?filter=equals(entity_id,...)`)
+//   - the per-review and per-status metadata lookups consumed by modal
+//     footers (`/api/review/<id>` + `/api/status/<id>`)
+//
+// Does NOT own modal state (see `useReviewModals`), filter state (see
+// `useReviewFilters`), or mutations (see `useReviewActions`). Each public
+// method returns `Promise<void>` for the same reason `Review.vue`'s legacy
+// methods did: callers chain `await load(); await refresh()` patterns and
+// don't need the response value back — it's already in the reactive refs.
+
+import { reactive, ref, type Ref } from 'vue';
+import { listEntities } from '@/api/entity';
+import {
+  listPhenotypesTree,
+  listStatusCategoriesTree,
+  listVariationOntologyTree,
+  type TreeNode,
+} from '@/api/list';
+import { getReviewById } from '@/api/review';
+import { getStatusById } from '@/api/status';
+import { getReReviewTable, type ReReviewTableRow } from '@/api/re_review';
+import Review from '@/assets/js/classes/submission/submissionReview';
+import Status from '@/assets/js/classes/submission/submissionStatus';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ReviewEntityInfo {
+  entity_id: number;
+  symbol: string;
+  hgnc_id: string;
+  disease_ontology_id_version: string;
+  disease_ontology_name: string;
+  hpo_mode_of_inheritance_term_name: string;
+  hpo_mode_of_inheritance_term: string;
+}
+
+export interface ReviewInfo {
+  review_id: number | null;
+  entity_id: number | null;
+  review_user_name: string | null;
+  review_user_role: string | null;
+  review_date: string | null;
+  re_review_review_saved: number | null;
+  synopsis?: string;
+  literature?: unknown;
+  phenotypes?: unknown;
+  variation_ontology?: unknown;
+  comment?: unknown;
+}
+
+export interface UseReviewDataOptions {
+  /**
+   * Optional error sink. Called once per rejected fetch with the original
+   * error. Lets `Review.vue` route failures to its toast + aria-live
+   * announcer without `useReviewData` having to know about either.
+   */
+  onError?: (err: unknown) => void;
+}
+
+export interface UseReviewData {
+  // Table state
+  items: Ref<ReReviewTableRow[]>;
+  totalRows: Ref<number>;
+  isBusy: Ref<boolean>;
+  loading: Ref<boolean>;
+
+  // Lookup lists
+  phenotypes_options: Ref<TreeNode[]>;
+  variation_ontology_options: Ref<TreeNode[]>;
+  status_options: Ref<TreeNode[]>;
+
+  // Entity / review / status context (consumed by modal footers)
+  entity_info: ReviewEntityInfo;
+  review_info: ReviewInfo;
+  status_info: Status & {
+    status_id?: number | null;
+    entity_id?: number | null;
+    status_user_name?: string | null;
+    status_user_role?: string | null;
+    status_date?: string | null;
+    re_review_status_saved?: number | null;
+  };
+  loading_status_modal: Ref<boolean>;
+
+  // Loaders
+  loadReReviewData: (curate: boolean) => Promise<void>;
+  loadPhenotypesList: () => Promise<void>;
+  loadVariationOntologyList: () => Promise<void>;
+  loadStatusList: () => Promise<void>;
+  getEntity: (entity_input: number | string) => Promise<void>;
+  loadReviewInfo: (review_id: number | string, re_review_review_saved: number) => Promise<void>;
+  loadStatusInfo: (status_id: number | string, re_review_status_saved: number) => Promise<void>;
+
+  // Reset helpers
+  resetEntityContext: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const EMPTY_ENTITY_INFO: ReviewEntityInfo = {
+  entity_id: 0,
+  symbol: '',
+  hgnc_id: '',
+  disease_ontology_id_version: '',
+  disease_ontology_name: '',
+  hpo_mode_of_inheritance_term_name: '',
+  hpo_mode_of_inheritance_term: '',
+};
+
+interface RawTreeNode {
+  id: string | number;
+  label: string;
+  children?: Array<{ id: string | number; label: string }>;
+}
+
+/**
+ * The phenotype + variation_ontology APIs return a tree where the root
+ * label is `present: <name>` and the children are modifiers. The view
+ * presents them as `<name>` parents with `[present, uncertain, ...]`
+ * children so all modifiers (including "present") are selectable. Pure
+ * function — easier to test in isolation than the embedded method this
+ * replaces in `Review.vue`.
+ */
+export function transformModifierTree(nodes: unknown): TreeNode[] {
+  if (!Array.isArray(nodes)) return [];
+  return nodes.map((node: RawTreeNode) => {
+    const phenotypeName = node.label.replace(/^present:\s*/, '');
+    const ontologyCode = String(node.id).replace(/^\d+-/, '');
+    return {
+      id: `parent-${ontologyCode}`,
+      label: phenotypeName,
+      children: [
+        // Original "present" node becomes the first selectable child.
+        { id: node.id, label: `present: ${phenotypeName}` },
+        ...(node.children ?? []).map((child) => {
+          const modifier = child.label.replace(/:\s*.*$/, '');
+          return { id: child.id, label: `${modifier}: ${phenotypeName}` };
+        }),
+      ],
+    } as TreeNode;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Composable
+// ---------------------------------------------------------------------------
+
+export function useReviewData(options: UseReviewDataOptions = {}): UseReviewData {
+  const { onError } = options;
+
+  // Table state
+  const items = ref<ReReviewTableRow[]>([]);
+  const totalRows = ref(1);
+  const isBusy = ref(false);
+  const loading = ref(true);
+
+  // Lookup lists
+  const phenotypes_options = ref<TreeNode[]>([]);
+  const variation_ontology_options = ref<TreeNode[]>([]);
+  const status_options = ref<TreeNode[]>([]);
+
+  // Entity / review / status context
+  const entity_info = reactive<ReviewEntityInfo>({ ...EMPTY_ENTITY_INFO });
+  const review_info = reactive<ReviewInfo>(new Review() as ReviewInfo);
+  // Initialise the legacy fields the template binds against.
+  Object.assign(review_info, {
+    review_id: null,
+    entity_id: null,
+    review_user_name: null,
+    review_user_role: null,
+    review_date: null,
+    re_review_review_saved: null,
+  });
+  const status_info = reactive(new Status()) as UseReviewData['status_info'];
+  const loading_status_modal = ref(true);
+
+  function reportError(err: unknown): void {
+    if (onError) {
+      onError(err);
+    }
+  }
+
+  async function loadReReviewData(curate: boolean): Promise<void> {
+    isBusy.value = true;
+    try {
+      const payload = await getReReviewTable({ curate });
+      // R serialises the table as `{ data, meta }`; legacy stubs may surface
+      // a bare array — accept either.
+      const rows = Array.isArray(payload)
+        ? payload
+        : ((payload as { data?: ReReviewTableRow[] } | undefined)?.data ?? []);
+      items.value = rows;
+      totalRows.value = rows.length;
+    } catch (err) {
+      reportError(err);
+    }
+    isBusy.value = false;
+    loading.value = false;
+  }
+
+  async function loadPhenotypesList(): Promise<void> {
+    try {
+      const payload = await listPhenotypesTree();
+      phenotypes_options.value = transformModifierTree(payload);
+    } catch (err) {
+      reportError(err);
+      phenotypes_options.value = [];
+    }
+  }
+
+  async function loadVariationOntologyList(): Promise<void> {
+    try {
+      const payload = await listVariationOntologyTree();
+      variation_ontology_options.value = transformModifierTree(payload);
+    } catch (err) {
+      reportError(err);
+      variation_ontology_options.value = [];
+    }
+  }
+
+  async function loadStatusList(): Promise<void> {
+    try {
+      status_options.value = await listStatusCategoriesTree();
+    } catch (err) {
+      reportError(err);
+    }
+  }
+
+  async function getEntity(entity_input: number | string): Promise<void> {
+    try {
+      const payload = await listEntities({
+        filter: `equals(entity_id,${entity_input})`,
+      });
+      const [first] = payload.data as Array<Partial<ReviewEntityInfo>>;
+      if (first) {
+        Object.assign(entity_info, EMPTY_ENTITY_INFO, first);
+      }
+    } catch (err) {
+      reportError(err);
+    }
+  }
+
+  async function loadReviewInfo(
+    review_id: number | string,
+    re_review_review_saved: number
+  ): Promise<void> {
+    try {
+      const rows = await getReviewById(review_id);
+      if (rows && rows.length > 0) {
+        const row = rows[0];
+        review_info.review_id = row.review_id;
+        review_info.entity_id = row.entity_id;
+        review_info.review_user_name = row.review_user_name;
+        review_info.review_user_role = row.review_user_role;
+        review_info.review_date = row.review_date;
+        review_info.re_review_review_saved = re_review_review_saved;
+      }
+    } catch (err) {
+      reportError(err);
+    }
+  }
+
+  async function loadStatusInfo(
+    status_id: number | string,
+    re_review_status_saved: number
+  ): Promise<void> {
+    loading_status_modal.value = true;
+    try {
+      const rows = await getStatusById(status_id);
+      if (rows && rows.length > 0) {
+        const row = rows[0];
+        // Replace the reactive backing object's keys (we cannot reassign
+        // a reactive ref to a brand-new instance without losing the
+        // shared identity callers may have captured).
+        Object.assign(status_info, new Status(row.category_id, row.comment, row.problematic));
+        status_info.status_id = row.status_id;
+        status_info.entity_id = row.entity_id;
+        status_info.status_user_name = row.status_user_name;
+        status_info.status_user_role = row.status_user_role;
+        status_info.status_date = row.status_date;
+        status_info.re_review_status_saved = re_review_status_saved;
+      }
+      loading_status_modal.value = false;
+    } catch (err) {
+      reportError(err);
+    }
+  }
+
+  function resetEntityContext(): void {
+    Object.assign(entity_info, EMPTY_ENTITY_INFO);
+    Object.assign(review_info, new Review() as ReviewInfo, {
+      review_id: null,
+      entity_id: null,
+      review_user_name: null,
+      review_user_role: null,
+      review_date: null,
+      re_review_review_saved: null,
+    });
+  }
+
+  return {
+    items,
+    totalRows,
+    isBusy,
+    loading,
+    phenotypes_options,
+    variation_ontology_options,
+    status_options,
+    entity_info,
+    review_info,
+    status_info,
+    loading_status_modal,
+    loadReReviewData,
+    loadPhenotypesList,
+    loadVariationOntologyList,
+    loadStatusList,
+    getEntity,
+    loadReviewInfo,
+    loadStatusInfo,
+    resetEntityContext,
+  };
+}
+
+export default useReviewData;
+// app/src/views/review/composables/__tests__/useReviewData.spec.ts
+/**
+ * Unit tests for `useReviewData` — the data-loading composable extracted
+ * from `Review.vue` during W6 of v11.1 finish-hardening.
+ *
+ * The composable owns:
+ *   - the re-review table fetch (`/api/re_review/table?curate=*`)
+ *   - the three lookup-list fetches (phenotype / variation_ontology / status,
+ *     all `?tree=true`) that feed dropdowns/treeselects in the modals
+ *   - the entity-context lookup (`/api/entity/?filter=equals(entity_id,...)`)
+ *
+ * It does NOT own modal state, filter state, or mutations — those live in
+ * the sibling composables. The contract here is therefore narrow: load,
+ * expose reactive state, surface errors via the optional `onError` hook.
+ *
+ * Mock strategy: stub `axios` at the module level (the typed clients in
+ * `@/api/*` resolve to `axios.get` under the hood), then assert on the
+ * shape of the URL/params each helper hits and the resulting state.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
+
+vi.mock('axios', () => {
+  const axiosMock = {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    defaults: { baseURL: '', headers: { common: {} } },
+    interceptors: {
+      request: {
+        use: vi.fn(),
+        _cb: null,
+      },
+      response: {
+        use: vi.fn(),
+      },
+    },
+    isAxiosError: (err: unknown): boolean =>
+      typeof err === 'object' && err !== null && 'isAxiosError' in err,
+  };
+  return {
+    default: axiosMock,
+    ...axiosMock,
+    AxiosHeaders: class {
+      private store = new Map<string, string>();
+      has(key: string): boolean {
+        return this.store.has(key.toLowerCase());
+      }
+      get(key: string): string | null {
+        return this.store.get(key.toLowerCase()) ?? null;
+      }
+      set(key: string, value: string): this {
+        this.store.set(key.toLowerCase(), value);
+        return this;
+      }
+    },
+    AxiosError: Error,
+  };
+});
+
+vi.mock('@/router', () => ({
+  default: {
+    push: vi.fn(),
+    currentRoute: { value: { fullPath: '/Review' } },
+  },
+}));
+
+import { useReviewData } from '../useReviewData';
+
+interface AxiosMock {
+  get: ReturnType<typeof vi.fn>;
+}
+
+async function getAxiosMock(): Promise<AxiosMock> {
+  const axios = await import('axios');
+  return axios.default as unknown as AxiosMock;
+}
+
+describe('useReviewData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('loadReReviewData', () => {
+    it('populates items + totalRows on success', async () => {
+      const axios = await getAxiosMock();
+      axios.get.mockResolvedValueOnce({
+        data: {
+          data: [
+            { entity_id: 1, symbol: 'GRIN2B' },
+            { entity_id: 2, symbol: 'GRIN1' },
+          ],
+        },
+      });
+
+      const data = useReviewData();
+      expect(data.isBusy.value).toBe(false);
+      expect(data.loading.value).toBe(true);
+
+      await data.loadReReviewData(false);
+      await flushPromises();
+
+      expect(data.items.value).toHaveLength(2);
+      expect(data.totalRows.value).toBe(2);
+      expect(data.isBusy.value).toBe(false);
+      expect(data.loading.value).toBe(false);
+    });
+
+    it('forwards `curate=true` as the query param', async () => {
+      const axios = await getAxiosMock();
+      axios.get.mockResolvedValueOnce({ data: { data: [] } });
+
+      const data = useReviewData();
+      await data.loadReReviewData(true);
+      await flushPromises();
+
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/re_review/table',
+        expect.objectContaining({
+          params: expect.objectContaining({ curate: true }),
+        })
+      );
+    });
+
+    it('accepts a bare-array payload as a fallback shape', async () => {
+      const axios = await getAxiosMock();
+      axios.get.mockResolvedValueOnce({ data: [{ entity_id: 99 }] });
+
+      const data = useReviewData();
+      await data.loadReReviewData(false);
+      await flushPromises();
+
+      expect(data.items.value).toHaveLength(1);
+      expect(data.totalRows.value).toBe(1);
+    });
+
+    it('invokes onError on rejection and clears the busy/loading flags', async () => {
+      const axios = await getAxiosMock();
+      const err = new Error('boom');
+      axios.get.mockRejectedValueOnce(err);
+
+      const onError = vi.fn();
+      const data = useReviewData({ onError });
+      await data.loadReReviewData(false);
+      await flushPromises();
+
+      expect(onError).toHaveBeenCalledWith(err);
+      expect(data.isBusy.value).toBe(false);
+      expect(data.loading.value).toBe(false);
+      // items should remain at their default (empty array)
+      expect(data.items.value).toEqual([]);
+    });
+  });
+
+  describe('loadPhenotypesList', () => {
+    it('runs the present-prefix transform on the tree response', async () => {
+      const axios = await getAxiosMock();
+      axios.get.mockResolvedValueOnce({
+        data: [
+          {
+            id: '1-HP:0001999',
+            label: 'present: Abnormal facial shape',
+            children: [
+              { id: '2-HP:0001999', label: 'uncertain: Abnormal facial shape' },
+              { id: '3-HP:0001999', label: 'absent: Abnormal facial shape' },
+            ],
+          },
+        ],
+      });
+
+      const data = useReviewData();
+      await data.loadPhenotypesList();
+      await flushPromises();
+
+      expect(data.phenotypes_options.value).toHaveLength(1);
+      const root = data.phenotypes_options.value[0];
+      expect(root.label).toBe('Abnormal facial shape');
+      // Original "present:" node becomes the first child; modifiers follow.
+      expect(root.children).toHaveLength(3);
+      expect(root.children?.[0].label).toBe('present: Abnormal facial shape');
+    });
+
+    it('falls back to [] on a non-array response', async () => {
+      const axios = await getAxiosMock();
+      axios.get.mockResolvedValueOnce({ data: { data: [] } });
+
+      const data = useReviewData();
+      await data.loadPhenotypesList();
+      await flushPromises();
+
+      expect(data.phenotypes_options.value).toEqual([]);
+    });
+
+    it('clears the list and calls onError on rejection', async () => {
+      const axios = await getAxiosMock();
+      const err = new Error('list-down');
+      axios.get.mockRejectedValueOnce(err);
+
+      const onError = vi.fn();
+      const data = useReviewData({ onError });
+      await data.loadPhenotypesList();
+      await flushPromises();
+
+      expect(onError).toHaveBeenCalledWith(err);
+      expect(data.phenotypes_options.value).toEqual([]);
+    });
+  });
+
+  describe('loadVariationOntologyList', () => {
+    it('reuses the present-prefix transform', async () => {
+      const axios = await getAxiosMock();
+      axios.get.mockResolvedValueOnce({
+        data: [
+          {
+            id: '10-VARIO:0001',
+            label: 'present: Missense variant',
+            children: [],
+          },
+        ],
+      });
+
+      const data = useReviewData();
+      await data.loadVariationOntologyList();
+      await flushPromises();
+
+      expect(data.variation_ontology_options.value).toHaveLength(1);
+      expect(data.variation_ontology_options.value[0].label).toBe('Missense variant');
+    });
+  });
+
+  describe('loadStatusList', () => {
+    it('stores the response verbatim (no transform)', async () => {
+      const axios = await getAxiosMock();
+      axios.get.mockResolvedValueOnce({
+        data: [
+          { id: 1, label: 'Definitive' },
+          { id: 2, label: 'Moderate' },
+        ],
+      });
+
+      const data = useReviewData();
+      await data.loadStatusList();
+      await flushPromises();
+
+      expect(data.status_options.value).toHaveLength(2);
+      expect(data.status_options.value[0].label).toBe('Definitive');
+    });
+  });
+
+  describe('getEntity', () => {
+    it('passes the filter as `config.params.filter` and assigns entity_info', async () => {
+      const axios = await getAxiosMock();
+      axios.get.mockResolvedValueOnce({
+        data: { data: [{ entity_id: 501, symbol: 'TEST1' }] },
+      });
+
+      const data = useReviewData();
+      await data.getEntity(501);
+      await flushPromises();
+
+      expect(axios.get).toHaveBeenCalledWith(
+        '/api/entity/',
+        expect.objectContaining({
+          params: expect.objectContaining({ filter: 'equals(entity_id,501)' }),
+        })
+      );
+      expect(data.entity_info.entity_id).toBe(501);
+      expect(data.entity_info.symbol).toBe('TEST1');
+    });
+  });
+
+  describe('loadReviewInfo', () => {
+    it('hydrates review_info from the typed-client response', async () => {
+      const axios = await getAxiosMock();
+      axios.get.mockResolvedValueOnce({
+        data: [
+          {
+            review_id: 42,
+            entity_id: 501,
+            review_user_name: 'alice',
+            review_user_role: 'Reviewer',
+            review_date: '2025-06-01 12:00:00',
+          },
+        ],
+      });
+
+      const data = useReviewData();
+      await data.loadReviewInfo(42, 1);
+      await flushPromises();
+
+      expect(data.review_info.review_id).toBe(42);
+      expect(data.review_info.entity_id).toBe(501);
+      expect(data.review_info.review_user_name).toBe('alice');
+      expect(data.review_info.re_review_review_saved).toBe(1);
+    });
+  });
+
+  describe('resetEntityContext', () => {
+    it('clears entity_info + review_info to a fresh shape', () => {
+      const data = useReviewData();
+      data.entity_info.entity_id = 99;
+      data.entity_info.symbol = 'X';
+      data.review_info.review_id = 5;
+
+      data.resetEntityContext();
+
+      expect(data.entity_info.entity_id).toBe(0);
+      expect(data.entity_info.symbol).toBe('');
+      expect(data.review_info.review_id).toBeNull();
+    });
+  });
+});
+
+codex
+I’ve confirmed the S5b fixes and their deferred scope. The main pressure point so far is the coordinator: it is module-shared by several table composables, so a “per-caller token” needs an explicit ownership contract rather than another coordinator-global counter.
+exec
+/bin/bash -lc "sed -n '1,280p' app/src/composables/usePubtatorGenePublications.ts && sed -n '1,480p' app/src/composables/usePubtatorGenePublications.spec.ts && sed -n '1,300p' app/src/views/admin/composables/useAdminTrendData.ts && sed -n '1,440p' app/src/composables/useNetworkData.ts && sed -n '1,520p' app/src/composables/useNetworkData.spec.ts && sed -n '1,330p' app/src/composables/usePubtatorAdmin.ts" in /home/bernt-popp/development/sysndd/.claude/worktrees/535-s5c-request-ownership
+ succeeded in 0ms:
+// src/composables/usePubtatorGenePublications.ts
+//
+// Per-gene publication-detail cache for the PubtatorNDD gene-prioritization
+// table. Each expandable gene row lazily fetches the full publication rows for
+// its PMIDs from the PubTator table endpoint and caches them by gene_symbol.
+//
+// Extracted from PubtatorNDDGenes.vue (issue: frontend perf & UX sprint) to:
+//   - keep that component under the file-size ceiling,
+//   - scope the cache to the current filter/sort so a filter change cannot show
+//     stale publications in an expanded row (correctness fix), and
+//   - handle aborts and real fetch errors correctly (genuine aborts are
+//     silent; real errors exit the loading state and surface a toast).
+
+import { ref } from 'vue';
+import axios from 'axios';
+import { listPubtatorTable } from '@/api/publication';
+import type useToast from '@/composables/useToast';
+
+export interface PubtatorPublicationData {
+  search_id?: number;
+  pmid: number;
+  doi?: string;
+  title?: string;
+  journal?: string;
+  date?: string;
+  score?: number;
+  gene_symbols?: string;
+  text_hl?: string;
+}
+
+// Derive from the real useToast signature (accepts ToastVariant, not bare
+// string) so consumers can pass useToast().makeToast under strict type-check.
+type MakeToast = ReturnType<typeof useToast>['makeToast'];
+
+export function usePubtatorGenePublications(options: { makeToast: MakeToast }) {
+  const { makeToast } = options;
+
+  // Publication data cache (keyed by gene_symbol).
+  const publicationCache = ref<Record<string, PubtatorPublicationData[]>>({});
+  const loadingPublications = ref<Record<string, boolean>>({});
+
+  // AbortControllers for per-gene fetches (prevents orphaned requests).
+  const abortControllers = new Map<string, AbortController>();
+
+  /**
+   * Reset the entire cache. Call when the gene filter/sort changes so an
+   * expanded row never shows publications fetched under a previous query.
+   * In-flight fetches are aborted so their late responses cannot repopulate
+   * the freshly-cleared cache.
+   */
+  const resetCache = (): void => {
+    abortControllers.forEach((controller) => controller.abort());
+    abortControllers.clear();
+    publicationCache.value = {};
+    loadingPublications.value = {};
+  };
+
+  /** Abort and clear every in-flight fetch (call on component unmount). */
+  const cancelAll = (): void => {
+    abortControllers.forEach((controller) => controller.abort());
+    abortControllers.clear();
+  };
+
+  /**
+   * Fetch publication rows for a gene's PMIDs if not already cached.
+   * Genuine aborts (filter change, unmount) are ignored silently; a real
+   * upstream failure exits the loading state and surfaces a toast.
+   */
+  const fetchPublications = async (geneSymbol: string, pmids: string[]): Promise<void> => {
+    if (pmids.length === 0) return;
+    if (publicationCache.value[geneSymbol]) return; // Already cached
+
+    // Cancel any in-flight request for this gene.
+    abortControllers.get(geneSymbol)?.abort();
+    const controller = new AbortController();
+    abortControllers.set(geneSymbol, controller);
+
+    loadingPublications.value[geneSymbol] = true;
+
+    try {
+      const response = await listPubtatorTable(
+        {
+          filter: `any(pmid,${pmids.join(',')})`,
+          fields: 'search_id,pmid,doi,title,journal,date,score,gene_symbols,text_hl',
+          page_size: String(pmids.length),
+        },
+        { signal: controller.signal }
+      );
+      publicationCache.value[geneSymbol] = (response.data as PubtatorPublicationData[]) || [];
+    } catch (error) {
+      // Genuine aborts (axios CanceledError / DOMException AbortError) are not
+      // errors — the caller intentionally cancelled. Stay silent.
+      if (axios.isCancel(error) || (error as Error)?.name === 'AbortError') {
+        return;
+      }
+      // Real failure: surface it and record an empty result so the row exits
+      // its spinner and shows the PMID fallback rather than spinning forever.
+      makeToast(error, 'Error loading publication details', 'danger');
+      publicationCache.value[geneSymbol] = [];
+    } finally {
+      abortControllers.delete(geneSymbol);
+      loadingPublications.value[geneSymbol] = false;
+    }
+  };
+
+  const getPublications = (geneSymbol: string): PubtatorPublicationData[] =>
+    publicationCache.value[geneSymbol] || [];
+
+  const isLoading = (geneSymbol: string): boolean =>
+    loadingPublications.value[geneSymbol] || false;
+
+  const isCached = (geneSymbol: string): boolean =>
+    publicationCache.value[geneSymbol] !== undefined;
+
+  return {
+    publicationCache,
+    loadingPublications,
+    fetchPublications,
+    getPublications,
+    isLoading,
+    isCached,
+    resetCache,
+    cancelAll,
+  };
+}
+
+export default usePubtatorGenePublications;
+// app/src/composables/usePubtatorGenePublications.spec.ts
+//
+// Covers the per-gene publication-detail cache extracted from
+// PubtatorNDDGenes.vue:
+//   - lazy fetch + caching (no refetch when already cached),
+//   - resetCache() drops stale data on filter/sort change (correctness fix),
+//   - real upstream errors surface a toast and exit the loading state,
+//   - genuine aborts stay silent.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+
+import '@/plugins/axios';
+import '@/api/client';
+import { server } from '@/test-utils/mocks/server';
+import { usePubtatorGenePublications } from './usePubtatorGenePublications';
+
+const makeToast = vi.fn();
+
+beforeEach(() => {
+  makeToast.mockClear();
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+function pubtatorRows() {
+  return HttpResponse.json({
+    data: [
+      {
+        search_id: 1,
+        pmid: 123,
+        title: 'MECP2 paper',
+        journal: 'Journal',
+        date: '2001-01-01',
+        score: 8,
+        gene_symbols: 'MECP2',
+        text_hl: 'MECP2 is linked to NDD.',
+      },
+    ],
+  });
+}
+
+describe('usePubtatorGenePublications', () => {
+  it('fetches and caches publications for a gene, then serves from cache', async () => {
+    let calls = 0;
+    server.use(
+      http.get('*/api/publication/pubtator/table', () => {
+        calls += 1;
+        return pubtatorRows();
+      })
+    );
+
+    const pubs = usePubtatorGenePublications({ makeToast });
+    await pubs.fetchPublications('MECP2', ['123', '456']);
+
+    expect(pubs.isCached('MECP2')).toBe(true);
+    expect(pubs.getPublications('MECP2')).toHaveLength(1);
+    expect(pubs.getPublications('MECP2')[0].title).toBe('MECP2 paper');
+    expect(pubs.isLoading('MECP2')).toBe(false);
+    expect(calls).toBe(1);
+
+    // Second call must hit the cache (no second request).
+    await pubs.fetchPublications('MECP2', ['123', '456']);
+    expect(calls).toBe(1);
+    expect(makeToast).not.toHaveBeenCalled();
+  });
+
+  it('resetCache clears cached publications so a filter/sort change cannot show stale data', async () => {
+    server.use(http.get('*/api/publication/pubtator/table', () => pubtatorRows()));
+
+    const pubs = usePubtatorGenePublications({ makeToast });
+    await pubs.fetchPublications('MECP2', ['123']);
+    expect(pubs.isCached('MECP2')).toBe(true);
+
+    pubs.resetCache();
+    expect(pubs.isCached('MECP2')).toBe(false);
+    expect(pubs.getPublications('MECP2')).toEqual([]);
+  });
+
+  it('surfaces a toast and records an empty result on a real upstream error', async () => {
+    server.use(
+      http.get('*/api/publication/pubtator/table', () => new HttpResponse(null, { status: 500 }))
+    );
+
+    const pubs = usePubtatorGenePublications({ makeToast });
+    await pubs.fetchPublications('SCN2A', ['789']);
+
+    expect(makeToast).toHaveBeenCalledTimes(1);
+    expect(makeToast.mock.calls[0][2]).toBe('danger');
+    // Row exits its spinner and shows the empty/fallback state.
+    expect(pubs.isLoading('SCN2A')).toBe(false);
+    expect(pubs.isCached('SCN2A')).toBe(true);
+    expect(pubs.getPublications('SCN2A')).toEqual([]);
+  });
+
+  it('stays silent and does not cache when the request is aborted', async () => {
+    server.use(
+      http.get('*/api/publication/pubtator/table', async () => {
+        // Delay so the abort lands before the response resolves.
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return pubtatorRows();
+      })
+    );
+
+    const pubs = usePubtatorGenePublications({ makeToast });
+    const pending = pubs.fetchPublications('GRIN2B', ['1', '2']);
+    // resetCache aborts the in-flight controller.
+    pubs.resetCache();
+    await pending;
+
+    expect(makeToast).not.toHaveBeenCalled();
+    expect(pubs.isCached('GRIN2B')).toBe(false);
+    expect(pubs.isLoading('GRIN2B')).toBe(false);
+  });
+
+  it('does nothing for an empty PMID list', async () => {
+    let calls = 0;
+    server.use(
+      http.get('*/api/publication/pubtator/table', () => {
+        calls += 1;
+        return pubtatorRows();
+      })
+    );
+
+    const pubs = usePubtatorGenePublications({ makeToast });
+    await pubs.fetchPublications('EMPTY', []);
+    expect(calls).toBe(0);
+    expect(pubs.isCached('EMPTY')).toBe(false);
+  });
+});
+// views/admin/composables/useAdminTrendData.ts
+import { ref, computed, watch, onUnmounted } from 'vue';
+import { mergeGroupedCumulativeSeries, extractPerGroupSeries } from '@/utils/timeSeriesUtils';
+import type { GroupedTimeSeries } from '@/utils/timeSeriesUtils';
+import { safeArray } from '@/utils/apiUtils';
+import { getEntitiesOverTime } from '@/api/statistics';
+import type { EntitiesOverTimeParams } from '@/api/statistics';
+
+interface TrendDataPoint {
+  date: string;
+  count: number;
+}
+
+export function useAdminTrendData(
+  makeToast: (msg: unknown, title: string, variant: string) => void
+) {
+  const trendData = ref<TrendDataPoint[]>([]);
+  const trendCategoryData = ref<{ dates: string[]; series: Record<string, number[]> }>({
+    dates: [],
+    series: {},
+  });
+
+  const loading = ref(false);
+  const trendYMax = ref<number | undefined>(undefined);
+
+  // Filter controls
+  const granularity = ref<'month' | 'week' | 'day'>('month');
+  const nddFilter = ref<'ndd' | 'non_ndd' | 'all'>('ndd');
+  const categoryDisplay = ref<'combined' | 'by_category'>('combined');
+  const selectedCategories = ref<string[]>(['Definitive', 'Moderate', 'Limited', 'Refuted']);
+
+  // Request versioning and AbortController
+  let abortController: AbortController | null = null;
+  let requestVersion = 0;
+
+  function buildTrendFilter(): string | undefined {
+    const parts: string[] = [];
+
+    if (nddFilter.value === 'ndd') {
+      parts.push('contains(ndd_phenotype_word,Yes)');
+    } else if (nddFilter.value === 'non_ndd') {
+      parts.push('contains(ndd_phenotype_word,No)');
+    }
+
+    if (selectedCategories.value.length > 0 && selectedCategories.value.length < 4) {
+      parts.push(`any(category,${selectedCategories.value.join(',')})`);
+    }
+
+    if (parts.length === 0) return '';
+    if (parts.length === 1 && parts[0] === 'contains(ndd_phenotype_word,Yes)') {
+      return undefined;
+    }
+    return parts.join(',');
+  }
+
+  const trendDescription = computed(() => {
+    const nddLabel =
+      nddFilter.value === 'ndd' ? 'NDD' : nddFilter.value === 'non_ndd' ? 'non-NDD' : 'all';
+
+    if (categoryDisplay.value === 'by_category') {
+      return `Per-category cumulative counts of ${nddLabel} gene-disease associations curated over time.`;
+    }
+    return (
+      `Cumulative count of ${nddLabel} gene-disease associations curated over time.` +
+      ' The dashed trend line represents a 3-period moving average for temporal smoothing.'
+    );
+  });
+
+  // Derived total entities from trend data (final cumulative value)
+  const totalEntities = ref(0);
+
+  async function fetchTrendData(): Promise<void> {
+    abortController?.abort();
+    abortController = new AbortController();
+    const currentVersion = ++requestVersion;
+
+    trendData.value = [];
+    trendCategoryData.value = { dates: [], series: {} };
+    loading.value = true;
+
+    try {
+      const params: EntitiesOverTimeParams = {
+        aggregate: 'entity_id',
+        group: 'category',
+        summarize: granularity.value,
+      };
+      const filterValue = buildTrendFilter();
+      if (filterValue !== undefined) {
+        params.filter = filterValue;
+      }
+
+      const response = await getEntitiesOverTime(params, {
+        signal: abortController.signal,
+      });
+
+      if (currentVersion !== requestVersion) return;
+
+      const allData = safeArray<GroupedTimeSeries>(response?.data);
+      trendData.value = mergeGroupedCumulativeSeries(allData);
+      trendCategoryData.value = extractPerGroupSeries(allData);
+
+      if (trendData.value.length > 0) {
+        const maxVal = trendData.value[trendData.value.length - 1].count;
+        totalEntities.value = maxVal;
+        trendYMax.value = Math.max(trendYMax.value ?? 0, maxVal);
+      }
+
+      abortController = null;
+    } catch (error) {
+      if ((error as Error).name !== 'AbortError') {
+        console.error('Failed to fetch trend data:', error);
+        makeToast('Failed to fetch trend data', 'Error', 'danger');
+        trendData.value = [];
+        trendCategoryData.value = { dates: [], series: {} };
+      }
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  // Auto-refetch on control changes
+  watch(granularity, () => fetchTrendData());
+  watch(nddFilter, () => {
+    trendYMax.value = undefined;
+    fetchTrendData();
+  });
+  watch(selectedCategories, () => fetchTrendData());
+
+  // Cleanup
+  onUnmounted(() => {
+    abortController?.abort();
+    abortController = null;
+  });
+
+  return {
+    trendData,
+    trendCategoryData,
+    trendYMax,
+    totalEntities,
+    loading,
+    granularity,
+    nddFilter,
+    categoryDisplay,
+    selectedCategories,
+    trendDescription,
+    fetchTrendData,
+  };
+}
+// composables/useNetworkData.ts
+
+/**
+ * Composable for network data fetching and transformation
+ *
+ * Provides data fetching from the /api/analysis/network_edges endpoint
+ * and transforms the response into Cytoscape.js ElementDefinition format.
+ *
+ * Follows the established useTableData.ts pattern for data fetching
+ * with loading states and error handling.
+ *
+ * @returns Network data state and fetch function
+ */
+
+import { ref, shallowRef, computed, type Ref, type ComputedRef } from 'vue';
+import type { ElementDefinition } from 'cytoscape';
+import { getNetworkEdges, isSnapshotPreparingError } from '@/api/analysis';
+import type { NetworkNode, NetworkEdge, NetworkResponse, NetworkMetadata } from '@/api/analysis';
+import { isApiError } from '@/api/client';
+import { getClusterColor } from '../utils/clusterColors';
+
+const PUBLIC_NETWORK_PRESET = {
+  cluster_type: 'clusters',
+  min_confidence: '400',
+  max_edges: '10000',
+} as const;
+
+/**
+ * State returned by the useNetworkData composable
+ */
+export interface NetworkDataState {
+  /** Raw network data from API */
+  networkData: Ref<NetworkResponse | null>;
+  /** Loading state */
+  isLoading: Ref<boolean>;
+  /** Error state */
+  error: Ref<Error | null>;
+  /** True when the API returned a snapshot "being prepared" 503 (#420) */
+  isPreparing: Ref<boolean>;
+  /** Network metadata for UI display */
+  metadata: ComputedRef<NetworkMetadata | null>;
+  /** Fetch network data from API */
+  fetchNetworkData: () => Promise<void>;
+  /** Transformed data in Cytoscape.js ElementDefinition format */
+  cytoscapeElements: ComputedRef<ElementDefinition[]>;
+  /** Initial graph render with all nodes and default-visible edges */
+  cytoscapeInitialElements: ComputedRef<ElementDefinition[]>;
+  /** Node-only graph render for the first paint */
+  cytoscapeNodeElements: ComputedRef<ElementDefinition[]>;
+  /** Clear network data and reset state */
+  clearNetworkData: () => void;
+}
+
+const INITIAL_EDGE_CATEGORY = 'Definitive';
+const inflightNetworkRequests = new Map<string, Promise<NetworkResponse>>();
+const NETWORK_REQUEST_KEY = 'public-network-preset';
+
+export function preloadNetworkData(): Promise<NetworkResponse> {
+  const existing = inflightNetworkRequests.get(NETWORK_REQUEST_KEY);
+  if (existing) return existing;
+
+  const request = getNetworkEdges(PUBLIC_NETWORK_PRESET).finally(() => {
+    inflightNetworkRequests.delete(NETWORK_REQUEST_KEY);
+  });
+  inflightNetworkRequests.set(NETWORK_REQUEST_KEY, request);
+  return request;
+}
+
+function getMainClusterId(cluster: NetworkNode['cluster']): number | string {
+  return typeof cluster === 'string' ? parseInt(cluster.split('.')[0], 10) : cluster;
+}
+
+function buildCytoscapeElements(
+  data: NetworkResponse,
+  options: { initialDefaultEdgesOnly?: boolean; omitEdges?: boolean } = {}
+): ElementDefinition[] {
+  const hasDisplayLayout = data.metadata?.display_layout_status === 'available';
+  const clusterIds = new Set<number | string>();
+  const initialEdgeNodeIds = new Set<string>();
+
+  const nodes: ElementDefinition[] = data.nodes.map((node: NetworkNode) => {
+    const mainCluster = getMainClusterId(node.cluster);
+    const category = node.category || INITIAL_EDGE_CATEGORY;
+    const hasPosition = hasDisplayLayout && Number.isFinite(node.x) && Number.isFinite(node.y);
+
+    if (mainCluster !== undefined && mainCluster !== null) {
+      clusterIds.add(mainCluster);
+    }
+    if (category === INITIAL_EDGE_CATEGORY) {
+      initialEdgeNodeIds.add(node.hgnc_id);
+    }
+
+    return {
+      data: {
+        id: node.hgnc_id,
+        parent: mainCluster !== undefined ? `cluster-${mainCluster}` : undefined,
+        symbol: node.symbol,
+        cluster: node.cluster,
+        degree: node.degree,
+        category,
+        size: Math.max(15, Math.sqrt(node.degree || 1) * 6),
+        color: getClusterColor(node.cluster),
+      },
+      ...(hasPosition ? { position: { x: Number(node.x), y: Number(node.y) } } : {}),
+    };
+  });
+
+  const clusterParentNodes: ElementDefinition[] = Array.from(clusterIds).map((clusterId) => ({
+    data: {
+      id: `cluster-${clusterId}`,
+      label: `Cluster ${clusterId}`,
+      isClusterParent: true,
+      color: getClusterColor(clusterId),
+    },
+  }));
+
+  const edges: ElementDefinition[] = options.omitEdges
+    ? []
+    : data.edges.flatMap((edge: NetworkEdge, idx: number) => {
+        if (
+          options.initialDefaultEdgesOnly &&
+          (!initialEdgeNodeIds.has(edge.source) || !initialEdgeNodeIds.has(edge.target))
+        ) {
+          return [];
+        }
+        return [
+          {
+            data: {
+              id: `e${idx}`,
+              source: edge.source,
+              target: edge.target,
+              confidence: edge.confidence,
+              width: Math.max(0.5, edge.confidence * 3),
+            },
+          },
+        ];
+      });
+
+  return [...clusterParentNodes, ...nodes, ...edges];
+}
+
+function networkDataError(err: unknown): Error {
+  if (isApiError<{ code?: string; message?: string }>(err)) {
+    const problem = err.response?.data;
+    if (problem?.code) {
+      return new Error(
+        problem.message ? `${problem.code}: ${problem.message}` : problem.code
+      );
+    }
+  }
+
+  return err instanceof Error ? err : new Error('Failed to fetch network data');
+}
+
+/**
+ * Composable for fetching and transforming network data
+ *
+ * @returns State and functions for managing network data
+ *
+ * @example
+ * ```typescript
+ * const {
+ *   networkData,
+ *   isLoading,
+ *   error,
+ *   fetchNetworkData,
+ *   cytoscapeElements,
+ * } = useNetworkData();
+ *
+ * onMounted(async () => {
+ *   await fetchNetworkData();
+ * });
+ *
+ * // Use cytoscapeElements with useCytoscape composable
+ * watch(cytoscapeElements, (elements) => {
+ *   updateElements(elements);
+ * });
+ * ```
+ */
+export function useNetworkData(): NetworkDataState {
+  // Reactive state
+  const networkData = shallowRef<NetworkResponse | null>(null);
+  const isLoading = ref(false);
+  const error = ref<Error | null>(null);
+  const isPreparing = ref(false);
+
+  /**
+   * Computed metadata for UI display
+   */
+  const metadata = computed<NetworkMetadata | null>(() => {
+    return networkData.value?.metadata || null;
+  });
+
+  /**
+   * Fetch network data from the API
+   *
+   * Fetches the supported public-ready network snapshot preset.
+   */
+  const fetchNetworkData = async (): Promise<void> => {
+    isLoading.value = true;
+    error.value = null;
+    isPreparing.value = false;
+
+    console.log('[useNetworkData] Fetching public network snapshot preset');
+    const startTime = performance.now();
+
+    try {
+      const data = await preloadNetworkData();
+      networkData.value = data;
+
+      const elapsed = performance.now() - startTime;
+      console.log(`[useNetworkData] Fetch complete in ${elapsed.toFixed(0)}ms`);
+      console.log(
+        `[useNetworkData] Received ${data.nodes?.length || 0} nodes, ${data.edges?.length || 0} edges`
+      );
+
+      if (data.metadata?.edges_filtered) {
+        console.log(
+          `[useNetworkData] Edges filtered: showing ${data.metadata.edge_count} of ${data.metadata.total_edges} total`
+        );
+      }
+    } catch (err) {
+      isPreparing.value = isSnapshotPreparingError(err);
+      error.value = networkDataError(err);
+      console.error('Network data fetch error:', err);
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  /**
+   * Transform network data to Cytoscape.js ElementDefinition format
+   *
+   * PERFORMANCE OPTIMIZED:
+   * - Uses backend fCoSE display coordinates when complete, with client fCoSE fallback
+   * - Pre-computes node size and edge width as data properties
+   * - Creates compound parent nodes for clusters to enable visual separation
+   * - Cytoscape uses fcose layout with compound node support
+   *
+   * Computed property that automatically updates when networkData changes.
+   */
+  const cytoscapeElements = computed<ElementDefinition[]>(() => {
+    if (!networkData.value) return [];
+
+    console.log(
+      `[useNetworkData] Transforming ${networkData.value.nodes.length} nodes, ${networkData.value.edges.length} edges`
+    );
+    const startTime = performance.now();
+    const elements = buildCytoscapeElements(networkData.value);
+
+    const elapsed = performance.now() - startTime;
+    console.log(
+      `[useNetworkData] Transform complete in ${elapsed.toFixed(0)}ms (${elements.length} elements)`
+    );
+    return elements;
+  });
+
+  const cytoscapeInitialElements = computed<ElementDefinition[]>(() => {
+    if (!networkData.value) return [];
+
+    console.log(
+      `[useNetworkData] Building initial graph from ${networkData.value.nodes.length} nodes, ${networkData.value.edges.length} edges`
+    );
+    const startTime = performance.now();
+    const elements = buildCytoscapeElements(networkData.value, { initialDefaultEdgesOnly: true });
+
+    const elapsed = performance.now() - startTime;
+    console.log(
+      `[useNetworkData] Initial graph built in ${elapsed.toFixed(0)}ms (${elements.length} elements)`
+    );
+    return elements;
+  });
+
+  const cytoscapeNodeElements = computed<ElementDefinition[]>(() => {
+    if (!networkData.value) return [];
+
+    console.log(
+      `[useNetworkData] Building node graph from ${networkData.value.nodes.length} nodes`
+    );
+    const startTime = performance.now();
+    const elements = buildCytoscapeElements(networkData.value, { omitEdges: true });
+
+    const elapsed = performance.now() - startTime;
+    console.log(
+      `[useNetworkData] Node graph built in ${elapsed.toFixed(0)}ms (${elements.length} elements)`
+    );
+    return elements;
+  });
+
+  /**
+   * Clear network data and reset state
+   */
+  const clearNetworkData = (): void => {
+    networkData.value = null;
+    error.value = null;
+    isPreparing.value = false;
+    isLoading.value = false;
+  };
+
+  return {
+    networkData,
+    isLoading,
+    error,
+    isPreparing,
+    metadata,
+    fetchNetworkData,
+    cytoscapeElements,
+    cytoscapeInitialElements,
+    cytoscapeNodeElements,
+    clearNetworkData,
+  };
+}
+
+export default useNetworkData;
+
+// Re-export types for convenience
+export type { NetworkNode, NetworkEdge, NetworkResponse, NetworkMetadata } from '@/api/analysis';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { nextTick } from 'vue';
+
+import { getNetworkEdges } from '@/api/analysis';
+import { useNetworkData } from './useNetworkData';
+
+vi.mock('@/api/analysis', () => ({
+  getNetworkEdges: vi.fn(),
+  // #420: the composable classifies fetch errors via this helper; default to
+  // "not a snapshot-preparing 503" so the existing error-path assertions hold.
+  isSnapshotPreparingError: vi.fn(() => false),
+}));
+
+const getNetworkEdgesMock = vi.mocked(getNetworkEdges);
+
+describe('useNetworkData', () => {
+  beforeEach(() => {
+    getNetworkEdgesMock.mockReset();
+  });
+
+  it('fetches through the typed analysis client', async () => {
+    getNetworkEdgesMock.mockResolvedValue({
+      nodes: [],
+      edges: [],
+      metadata: {
+        node_count: 0,
+        edge_count: 0,
+        cluster_count: 0,
+        total_edges: 0,
+        edges_filtered: false,
+        elapsed_seconds: 0.1,
+        snapshot: {
+          analysis_type: 'gene_network_edges',
+        },
+      },
+    });
+
+    const state = useNetworkData();
+
+    await state.fetchNetworkData();
+
+    expect(getNetworkEdgesMock).toHaveBeenCalledWith({
+      cluster_type: 'clusters',
+      min_confidence: '400',
+      max_edges: '10000',
+    });
+    expect(state.error.value).toBeNull();
+    expect(state.metadata.value?.snapshot?.analysis_type).toBe('gene_network_edges');
+  });
+
+  it('keeps network data null and exposes snapshot problem codes on rejection', async () => {
+    getNetworkEdgesMock.mockRejectedValue({
+      isAxiosError: true,
+      response: {
+        status: 503,
+        data: {
+          code: 'snapshot_missing',
+          message: 'No public analysis snapshot is currently available.',
+        },
+      },
+    });
+
+    const state = useNetworkData();
+
+    await state.fetchNetworkData();
+
+    expect(state.networkData.value).toBeNull();
+    expect(state.error.value?.message).toContain('snapshot_missing');
+  });
+
+  it('reuses an in-flight preload when fetching the same network payload', async () => {
+    getNetworkEdgesMock.mockResolvedValue({
+      nodes: [],
+      edges: [],
+      metadata: {
+        node_count: 0,
+        edge_count: 0,
+        cluster_count: 0,
+        total_edges: 0,
+        edges_filtered: false,
+        elapsed_seconds: 0.1,
+      },
+    });
+
+    const { preloadNetworkData } = await import('./useNetworkData');
+    const preload = preloadNetworkData();
+    const state = useNetworkData();
+    await state.fetchNetworkData();
+    await preload;
+
+    expect(getNetworkEdgesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('converts finite API coordinates into Cytoscape positions', async () => {
+    getNetworkEdgesMock.mockResolvedValue({
+      nodes: [
+        {
+          hgnc_id: 'HGNC:1',
+          symbol: 'AAA',
+          cluster: 1,
+          degree: 4,
+          category: 'Definitive',
+          x: 10,
+          y: 20,
+        },
+        {
+          hgnc_id: 'HGNC:2',
+          symbol: 'BBB',
+          cluster: 1,
+          degree: 1,
+          category: 'Moderate',
+          x: 30,
+          y: 40,
+        },
+      ],
+      edges: [{ source: 'HGNC:1', target: 'HGNC:2', confidence: 0.8 }],
+      metadata: {
+        node_count: 2,
+        edge_count: 1,
+        cluster_count: 1,
+        total_edges: 1,
+        edges_filtered: false,
+        elapsed_seconds: 0.1,
+        display_layout_status: 'available',
+      },
+    });
+
+    const state = useNetworkData();
+
+    await state.fetchNetworkData();
+    await nextTick();
+
+    const gene = state.cytoscapeElements.value.find((element) => element.data?.id === 'HGNC:1');
+    expect(gene?.position).toEqual({ x: 10, y: 20 });
+  });
+
+  it('builds an initial render payload with all nodes but only default-visible edges', async () => {
+    getNetworkEdgesMock.mockResolvedValue({
+      nodes: [
+        { hgnc_id: 'HGNC:1', symbol: 'AAA', cluster: 1, degree: 4, category: 'Definitive' },
+        { hgnc_id: 'HGNC:2', symbol: 'BBB', cluster: 1, degree: 1, category: 'Moderate' },
+        { hgnc_id: 'HGNC:3', symbol: 'CCC', cluster: 1, degree: 1, category: 'Definitive' },
+      ],
+      edges: [
+        { source: 'HGNC:1', target: 'HGNC:3', confidence: 0.9 },
+        { source: 'HGNC:1', target: 'HGNC:2', confidence: 0.8 },
+      ],
+      metadata: {
+        node_count: 3,
+        edge_count: 2,
+        cluster_count: 1,
+        total_edges: 2,
+        edges_filtered: false,
+        elapsed_seconds: 0.1,
+      },
+    });
+
+    const state = useNetworkData();
+
+    await state.fetchNetworkData();
+    await nextTick();
+
+    const initialIds = state.cytoscapeInitialElements.value.map((element) => element.data?.id);
+    expect(initialIds).toContain('HGNC:2');
+    expect(initialIds).toContain('e0');
+    expect(initialIds).not.toContain('e1');
+    expect(state.cytoscapeElements.value.map((element) => element.data?.id)).toContain('e1');
+  });
+
+  it('builds a node-only payload for the fastest first paint', async () => {
+    getNetworkEdgesMock.mockResolvedValue({
+      nodes: [{ hgnc_id: 'HGNC:1', symbol: 'AAA', cluster: 1, degree: 4 }],
+      edges: [{ source: 'HGNC:1', target: 'HGNC:1', confidence: 0.9 }],
+      metadata: {
+        node_count: 1,
+        edge_count: 1,
+        cluster_count: 1,
+        total_edges: 1,
+        edges_filtered: false,
+        elapsed_seconds: 0.1,
+      },
+    });
+
+    const state = useNetworkData();
+
+    await state.fetchNetworkData();
+    await nextTick();
+
+    const nodeOnlyIds = state.cytoscapeNodeElements.value.map((element) => element.data?.id);
+    expect(nodeOnlyIds).toContain('HGNC:1');
+    expect(nodeOnlyIds).toContain('cluster-1');
+    expect(nodeOnlyIds).not.toContain('e0');
+  });
+
+  it('omits Cytoscape positions when the display artifact is unavailable', async () => {
+    getNetworkEdgesMock.mockResolvedValue({
+      nodes: [{ hgnc_id: 'HGNC:1', symbol: 'AAA', cluster: 1, degree: 4, x: 10, y: 20 }],
+      edges: [],
+      metadata: {
+        node_count: 1,
+        edge_count: 0,
+        cluster_count: 1,
+        total_edges: 0,
+        edges_filtered: false,
+        elapsed_seconds: 0.1,
+        display_layout_status: 'missing',
+      },
+    });
+
+    const state = useNetworkData();
+
+    await state.fetchNetworkData();
+    await nextTick();
+
+    const gene = state.cytoscapeElements.value.find((element) => element.data?.id === 'HGNC:1');
+    expect(gene?.position).toBeUndefined();
+  });
+
+  it('omits Cytoscape positions when an available artifact has incomplete coordinates', async () => {
+    getNetworkEdgesMock.mockResolvedValue({
+      nodes: [{ hgnc_id: 'HGNC:1', symbol: 'AAA', cluster: 1, degree: 4, x: 10 }],
+      edges: [],
+      metadata: {
+        node_count: 1,
+        edge_count: 0,
+        cluster_count: 1,
+        total_edges: 0,
+        edges_filtered: false,
+        elapsed_seconds: 0.1,
+        display_layout_status: 'available',
+      },
+    });
+
+    const state = useNetworkData();
+
+    await state.fetchNetworkData();
+    await nextTick();
+
+    const gene = state.cytoscapeElements.value.find((element) => element.data?.id === 'HGNC:1');
+    expect(gene?.position).toBeUndefined();
+  });
+
+  it('treats fetched network payloads as immutable to avoid deep reactivity overhead', async () => {
+    getNetworkEdgesMock.mockResolvedValue({
+      nodes: [{ hgnc_id: 'HGNC:1', symbol: 'AAA', cluster: 1, degree: 4 }],
+      edges: [],
+      metadata: {
+        node_count: 1,
+        edge_count: 0,
+        cluster_count: 1,
+        total_edges: 0,
+        edges_filtered: false,
+        elapsed_seconds: 0.1,
+      },
+    });
+
+    const state = useNetworkData();
+
+    await state.fetchNetworkData();
+    const originalGene = state.cytoscapeElements.value.find(
+      (element) => element.data?.id === 'HGNC:1'
+    );
+    expect(originalGene?.data?.symbol).toBe('AAA');
+
+    state.networkData.value!.nodes[0].symbol = 'MUTATED';
+    await nextTick();
+
+    const cachedGene = state.cytoscapeElements.value.find(
+      (element) => element.data?.id === 'HGNC:1'
+    );
+    expect(cachedGene?.data?.symbol).toBe('AAA');
+  });
+});
+/**
+ * usePubtatorAdmin - Composable for PubTator cache administration
+ *
+ * Provides functions for managing PubTator3 cache:
+ * - Check cache status for a query
+ * - Submit async fetch jobs with progress tracking
+ * - Clear cache (hard reset)
+ * - Backfill gene symbols for existing cache entries
+ *
+ * Network access goes through the typed `@/api/publication` client (which
+ * routes via the `apiClient` axios singleton, inheriting the Authorization
+ * header + 401 interceptor). The hand-rolled response interfaces were removed
+ * in favour of the canonical types exported by that client.
+ */
+
+import { ref, computed } from 'vue';
+import { useAsyncJob } from '@/composables/useAsyncJob';
+import {
+  getPubtatorCacheStatus,
+  submitPubtatorUpdate,
+  clearPubtatorCache,
+  backfillPubtatorGenes,
+  type PubtatorCacheStatus,
+  type PubtatorAsyncSubmitResponse,
+  type PubtatorClearCacheResponse,
+  type PubtatorBackfillResponse,
+} from '@/api/publication';
+import { isApiError } from '@/api/client';
+
+/**
+ * Composable for PubTator admin operations with async job support
+ */
+export function usePubtatorAdmin() {
+  const error = ref<string | null>(null);
+  const lastStatus = ref<PubtatorCacheStatus | null>(null);
+  const isCheckingStatus = ref(false);
+  const isClearing = ref(false);
+  const isBackfilling = ref(false);
+
+  // Use the async job composable for fetch operations
+  const asyncJob = useAsyncJob((jobId: string) => `/api/jobs/${encodeURIComponent(jobId)}/status`, {
+    pollingInterval: 3000,
+  });
+
+  /**
+   * Get cache status for a query
+   */
+  async function getCacheStatus(query: string): Promise<PubtatorCacheStatus> {
+    isCheckingStatus.value = true;
+    error.value = null;
+
+    try {
+      const status = await getPubtatorCacheStatus({ query });
+      lastStatus.value = status;
+      return status;
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to get cache status';
+      throw err;
+    } finally {
+      isCheckingStatus.value = false;
+    }
+  }
+
+  /**
+   * Submit async PubTator fetch job (non-blocking)
+   * Returns immediately with job_id, use asyncJob state to track progress
+   *
+   * @param query - Search query
+   * @param maxPages - Maximum pages to fetch (default 10)
+   * @param clearOld - Whether to clear existing cache first (hard update)
+   */
+  async function submitFetchJob(
+    query: string,
+    maxPages: number = 10,
+    clearOld: boolean = false
+  ): Promise<PubtatorAsyncSubmitResponse> {
+    error.value = null;
+
+    try {
+      const submit = await submitPubtatorUpdate({
+        query,
+        max_pages: maxPages,
+        clear_old: clearOld,
+      });
+
+      // Start tracking the job with useAsyncJob
+      asyncJob.startJob(submit.job_id);
+
+      return submit;
+    } catch (err) {
+      if (isApiError<{ existing_job_id?: string }>(err) && err.response?.status === 409) {
+        // Duplicate job - extract existing job ID and track it
+        const existingJobId = err.response.data.existing_job_id;
+        if (existingJobId) {
+          asyncJob.startJob(existingJobId);
+          return {
+            job_id: existingJobId,
+            status: 'accepted',
+            query,
+            max_pages: maxPages,
+            estimated_seconds: 0,
+            status_url: `/api/jobs/${existingJobId}/status`,
+          };
+        }
+      }
+      error.value = err instanceof Error ? err.message : 'Failed to submit fetch job';
+      throw err;
+    }
+  }
+
+  /**
+   * Clear cache for all queries
+   */
+  async function clearCache(): Promise<PubtatorClearCacheResponse> {
+    isClearing.value = true;
+    error.value = null;
+
+    try {
+      return await clearPubtatorCache();
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to clear cache';
+      throw err;
+    } finally {
+      isClearing.value = false;
+    }
+  }
+
+  /**
+   * Backfill gene symbols for existing cache entries.
+   *
+   * The `queryId` argument is retained for call-site compatibility, but the
+   * server endpoint always backfills every cached row whose `gene_symbols` is
+   * NULL (it does not read a `query_id` parameter), so the argument is not
+   * forwarded — behavior is identical to the previous implementation.
+   *
+   * @param _queryId - Optional query ID (accepted for compatibility; unused)
+   */
+  async function backfillGeneSymbols(
+    _queryId?: string | number | null
+  ): Promise<PubtatorBackfillResponse> {
+    isBackfilling.value = true;
+    error.value = null;
+
+    try {
+      return await backfillPubtatorGenes({
+        timeout: 120000, // 2 minutes for potentially large backfill
+      });
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to backfill gene symbols';
+      throw err;
+    } finally {
+      isBackfilling.value = false;
+    }
+  }
+
+  /**
+   * Progress percentage (cached / total)
+   */
+  const cacheProgress = computed(() => {
+    if (!lastStatus.value) return 0;
+    const cached = lastStatus.value.pages_cached || 0;
+    const total = lastStatus.value.total_pages_available || 1;
+    return Math.round((cached / total) * 100);
+  });
+
+  return {
+    // Local state
+    error,
+    lastStatus,
+    isCheckingStatus,
+    isClearing,
+    isBackfilling,
+
+    // Async job state (from useAsyncJob)
+    jobId: asyncJob.jobId,
+    jobStatus: asyncJob.status,
+    jobStep: asyncJob.step,
+    jobProgress: asyncJob.progress,
+    jobError: asyncJob.error,
+    jobElapsedSeconds: asyncJob.elapsedSeconds,
+
+    // Async job computed
+    hasRealProgress: asyncJob.hasRealProgress,
+    progressPercent: asyncJob.progressPercent,
+    elapsedTimeDisplay: asyncJob.elapsedTimeDisplay,
+    progressVariant: asyncJob.progressVariant,
+    statusBadgeClass: asyncJob.statusBadgeClass,
+    isJobLoading: asyncJob.isLoading,
+    isPolling: asyncJob.isPolling,
+
+    // Local computed
+    cacheProgress,
+
+    // Methods
+    getCacheStatus,
+    submitFetchJob,
+    clearCache,
+    backfillGeneSymbols,
+
+    // Async job controls
+    stopPolling: asyncJob.stopPolling,
+    resetJob: asyncJob.reset,
+  };
+}
+
+export default usePubtatorAdmin;
+
+exec
+/bin/bash -lc "sed -n '1,560p' app/src/views/admin/composables/useOntologyAdminTable.ts && wc -l app/src/views/admin/ManageOntology.spec.ts && sed -n '1,760p' app/src/views/admin/ManageOntology.spec.ts && sed -n '220,330p' app/src/components/tables/useEntitiesTable.ts && sed -n '190,280p' app/src/components/tables/useGenesTable.ts && sed -n '320,410p' app/src/components/tables/usePhenotypeEntitiesTable.ts && sed -n '150,210p' app/src/components/analyses/usePublicationsTable.ts" in /home/bernt-popp/development/sysndd/.claude/worktrees/535-s5c-request-ownership
+ succeeded in 0ms:
+// views/admin/composables/useOntologyAdminTable.ts
+//
+// State, data loading, cursor pagination, URL sync, filtering, edit-modal
+// orchestration and client-side Excel export for the Admin "Manage Ontology"
+// (VariO variant-ontology) table. Extracted from ManageOntology.vue (#346
+// Wave 2) so the SFC stays a thin shell; the static column/filter/select
+// config lives in ontologyTableConfig.ts.
+//
+// This is an admin curation-metadata surface (see AGENTS.md "Admin curation
+// metadata vocabularies"): editability, the update payload shape
+// (`{ ontology_details: {...} }`), and the ontology outlink behaviour are
+// unchanged by this extraction — only the responsibility's *location*
+// moved. Every network call goes through the typed `@/api/ontology` client.
+
+import { computed, nextTick, onMounted, ref, watch, type Ref } from 'vue';
+import useToast from '@/composables/useToast';
+import useUrlParsing from '@/composables/useUrlParsing';
+import useTableData from '@/composables/useTableData';
+import { useExcelExport } from '@/composables/useExcelExport';
+import { useUiStore } from '@/stores/ui';
+import {
+  listVariantOntology,
+  updateVariantOntology,
+  type VariantOntologyRow,
+  type VariantOntologyListResponse,
+  type UpdateVariantOntologyRequest,
+} from '@/api/ontology';
+import { createTableRequestCoordinator } from '@/utils/tableRequestCoordinator';
+import {
+  ONTOLOGY_TABLE_FIELDS,
+  ONTOLOGY_ACTIVE_FILTER_OPTIONS,
+  ONTOLOGY_OBSOLETE_FILTER_OPTIONS,
+  ONTOLOGY_MOBILE_SORT_OPTIONS,
+  ONTOLOGY_EXPORT_HEADERS,
+  createEmptyOntologyFilter,
+  type OntologyTableField,
+  type OntologyFilter,
+} from '../ontologyTableConfig';
+
+// Module-level request coordinator (survives Vue Router remounts on URL
+// change). Dedupes identical concurrent requests, serves a short recent
+// cache, and (via isCurrent) drops stale responses — see
+// useGenesTable.ts/useEntitiesTable.ts for the same pattern.
+const ontologyRequestCoordinator = createTableRequestCoordinator<VariantOntologyListResponse>();
+
+/** Shape of one `meta[0]` row returned by `GET /api/ontology/variant/table`. */
+interface OntologyListMeta {
+  totalItems: number;
+  currentPage: number;
+  totalPages: number;
+  prevItemID: number | string;
+  currentItemID: number | string;
+  nextItemID: number | string;
+  lastItemID: number | string;
+  executionTime: number;
+}
+
+export interface OntologyActiveFilterEntry {
+  key: string;
+  label: string;
+  value: string;
+}
+
+export function useOntologyAdminTable() {
+  const { makeToast } = useToast();
+  const { filterObjToStr, filterStrToObj, sortStringToVariables } = useUrlParsing();
+  const { isExporting, exportToExcel } = useExcelExport();
+
+  const tableData = useTableData({
+    pageSizeInput: 25,
+    sortInput: '+vario_id',
+    pageAfterInput: '0',
+  });
+
+  // Only the state actually read/written by this composable's functions is
+  // destructured here; everything else (pageOptions, downloading, loading,
+  // sortDesc, sortColumn, removeFiltersButtonVariant/Title, filterOn) is
+  // still exposed to the template/spec via the `...tableData` spread below.
+  const {
+    currentPage,
+    currentItemID,
+    executionTime,
+    perPage,
+    sortBy,
+    sort,
+    filter_string,
+    isBusy,
+    totalRows,
+  } = tableData;
+  // VariO cursor IDs are strings (e.g. "VariO:0026"), not numbers —
+  // useTableData's generic prevItemID/nextItemID/lastItemID types are narrower
+  // (`number | null`), so widen locally rather than coerce with Number()
+  // (which would map every VariO cursor to NaN → 0 and pin the table to page 1,
+  // #531). Mirrors usePublicationsTable's PMID-cursor handling.
+  const prevItemID = tableData.prevItemID as unknown as Ref<string | number>;
+  const nextItemID = tableData.nextItemID as unknown as Ref<string | number>;
+  const lastItemID = tableData.lastItemID as unknown as Ref<string | number>;
+
+  // Component-specific filter shape.
+  const filter = ref<OntologyFilter>(createEmptyOntologyFilter());
+
+  // ── Local state (was data()) ─────────────────────────────────────────────
+  const isInitializing = ref(true);
+  const loadDataDebounceTimer = ref<ReturnType<typeof setTimeout> | null>(null);
+  const totalPages = ref(0);
+  const ontologies = ref<VariantOntologyRow[]>([]);
+  const fields = ref<OntologyTableField[]>([...ONTOLOGY_TABLE_FIELDS]);
+  const mobileSortOptions = ONTOLOGY_MOBILE_SORT_OPTIONS;
+  const activeFilterOptions = ONTOLOGY_ACTIVE_FILTER_OPTIONS;
+  const obsoleteFilterOptions = ONTOLOGY_OBSOLETE_FILTER_OPTIONS;
+
+  // Modal visibility state - Bootstrap-Vue-Next uses v-model pattern.
+  const showEditModal = ref(false);
+  const ontologyToEdit = ref<Partial<VariantOntologyRow>>({});
+
+  // ── Computed ───────────────────────────────────────────────────────────
+  const mobileSortValue = computed<string>({
+    get() {
+      return sort.value || '+vario_id';
+    },
+    set(value: string) {
+      const sort_object = sortStringToVariables(value);
+      sortBy.value = sort_object.sortBy;
+      sort.value = value;
+      currentItemID.value = 0;
+      filtered();
+    },
+  });
+
+  const hasActiveFilters = computed<boolean>(() =>
+    Object.values(filter.value).some((f) => f.content !== null && f.content !== '')
+  );
+
+  const activeFilters = computed<OntologyActiveFilterEntry[]>(() => {
+    const filters: OntologyActiveFilterEntry[] = [];
+    if (filter.value.any.content) {
+      filters.push({ key: 'any', label: 'Search', value: String(filter.value.any.content) });
+    }
+    if (filter.value.is_active.content !== null) {
+      filters.push({
+        key: 'is_active',
+        label: 'Status',
+        value: filter.value.is_active.content === '1' ? 'Active' : 'Inactive',
+      });
+    }
+    if (filter.value.obsolete.content !== null) {
+      filters.push({
+        key: 'obsolete',
+        label: 'Terms',
+        value: filter.value.obsolete.content === '1' ? 'Obsolete' : 'Current',
+      });
+    }
+    return filters;
+  });
+
+  // ── Methods ────────────────────────────────────────────────────────────
+
+  // Update browser URL with current table state. Uses history.replaceState
+  // instead of router.replace to prevent component remount.
+  function updateBrowserUrl(): void {
+    // Don't update URL during initialization - preserves URL params from navigation.
+    if (isInitializing.value) return;
+
+    const searchParams = new URLSearchParams();
+
+    if (sort.value) {
+      searchParams.set('sort', sort.value);
+    }
+    if (filter_string.value) {
+      searchParams.set('filter', filter_string.value);
+    }
+    // Emit page_after for any meaningful cursor — string VariO IDs included
+    // (Number(cursor) > 0 would drop them, leaving the URL un-bookmarkable and
+    // failing to reflect the current page, #531). 0 / "0" / null are the
+    // page-1 sentinel and are omitted.
+    const cursor = currentItemID.value;
+    if (cursor != null && cursor !== 0 && cursor !== '0' && cursor !== '') {
+      searchParams.set('page_after', String(cursor));
+    }
+    searchParams.set('page_size', String(perPage.value));
+
+    const newUrl = `${window.location.pathname}?${searchParams.toString()}`;
+    window.history.replaceState({ ...window.history.state }, '', newUrl);
+  }
+
+  // Filter method that triggers data load.
+  function filtered(): void {
+    const filter_string_loc = filterObjToStr(filter.value);
+    if (filter_string_loc !== filter_string.value) {
+      filter_string.value = filter_string_loc;
+    }
+    currentItemID.value = 0; // Reset to first page on filter change
+    loadData();
+  }
+
+  // Handle page change events.
+  function handlePageChange(value: number): void {
+    if (value === 1) {
+      currentItemID.value = 0;
+    } else if (value === totalPages.value) {
+      currentItemID.value = lastItemID.value;
+    } else if (value > currentPage.value) {
+      currentItemID.value = nextItemID.value;
+    } else if (value < currentPage.value) {
+      currentItemID.value = prevItemID.value;
+    }
+    // Load directly with the cursor computed above — do NOT route through
+    // filtered(), whose unconditional `currentItemID = 0` reset (kept for real
+    // filter/sort/per-page changes) would clobber the cursor back to 0 and pin
+    // every next/prev/last request to page_after=0, i.e. always page 1 (#531).
+    // The filter is unchanged on a page change, so filter_string is already in
+    // sync and needs no recompute.
+    loadData();
+  }
+
+  // Handle per-page change events.
+  function handlePerPageChange(newPerPage: number | string): void {
+    perPage.value = parseInt(String(newPerPage), 10);
+    currentItemID.value = 0;
+    filtered();
+  }
+
+  // Handle sort changes.
+  function handleSortByOrDescChange(): void {
+    currentItemID.value = 0;
+    const sortColumnKey = sortBy.value.length > 0 ? sortBy.value[0].key : '';
+    const sortOrder = sortBy.value.length > 0 ? sortBy.value[0].order : 'asc';
+    const isDesc = sortOrder === 'desc';
+    sort.value = (isDesc ? '-' : '+') + sortColumnKey;
+    filtered();
+  }
+
+  // Remove all filters.
+  function removeFilters(): void {
+    Object.keys(filter.value).forEach((key) => {
+      const entry = filter.value[key];
+      if (entry && typeof entry === 'object' && 'content' in entry) {
+        entry.content = null;
+      }
+    });
+    filtered();
+  }
+
+  // Clear a specific filter.
+  function clearFilter(key: string): void {
+    if (filter.value[key]) {
+      filter.value[key].content = null;
+    }
+    filtered();
+  }
+
+  // Handle sort updates from GenericTable.
+  function handleSortUpdate(newSortBy: Array<{ key: string; order: 'asc' | 'desc' }>): void {
+    sortBy.value = newSortBy;
+    handleSortByOrDescChange();
+  }
+
+  // Load data with debouncing.
+  function loadData(): void {
+    if (loadDataDebounceTimer.value) {
+      clearTimeout(loadDataDebounceTimer.value);
+    }
+    loadDataDebounceTimer.value = setTimeout(() => {
+      loadDataDebounceTimer.value = null;
+      void doLoadData();
+    }, 50);
+  }
+
+  // Actual data loading method with module-level request coordination.
+  async function doLoadData(): Promise<void> {
+    const buildParams = () =>
+      `sort=${sort.value}&filter=${filter_string.value}&page_after=${currentItemID.value}&page_size=${perPage.value}`;
+    const urlParam = buildParams();
+    isBusy.value = true;
+
+    const result = await ontologyRequestCoordinator.request({
+      params: urlParam,
+      fetcher: () =>
+        listVariantOntology({
+          sort: sort.value,
+          filter: filter_string.value,
+          page_after: currentItemID.value,
+          page_size: perPage.value,
+        }),
+      apply: (data, source) => {
+        applyApiResponse(data);
+        if (source === 'network') {
+          updateBrowserUrl();
+        }
+      },
+      onError: (e) => makeToast(e, 'Error', 'danger'),
+      isCurrent: (params) => buildParams() === params,
+    });
+
+    if (result.handled) {
+      isBusy.value = false;
+    }
+  }
+
+  /**
+   * Apply API response data to component state. Extracted to allow reuse
+   * when skipping duplicate API calls (see doLoadData's `apply` callback).
+   */
+  function applyApiResponse(data: VariantOntologyListResponse): void {
+    const meta = (data.meta as OntologyListMeta[])[0];
+
+    ontologies.value = data.data;
+    totalRows.value = meta.totalItems;
+    void nextTick(() => {
+      currentPage.value = meta.currentPage;
+    });
+    totalPages.value = meta.totalPages;
+    // VariO cursor IDs are strings like "VariO:0026" — store them as-is so the
+    // cursor survives to the next page request. Only null/undefined/"null"
+    // collapse to the page-1 sentinel 0 (Number() would map every string to
+    // 0, #531). Mirrors usePublicationsTable's cursorOrZero.
+    const cursorOrZero = (v: unknown): string | number =>
+      v === 'null' ? 0 : (v as string | number) || 0;
+    prevItemID.value = cursorOrZero(meta.prevItemID);
+    currentItemID.value = cursorOrZero(meta.currentItemID);
+    nextItemID.value = cursorOrZero(meta.nextItemID);
+    lastItemID.value = cursorOrZero(meta.lastItemID);
+    executionTime.value = meta.executionTime;
+
+    const uiStore = useUiStore();
+    uiStore.requestScrollbarUpdate();
+  }
+
+  /** Handle client-side Excel export of the currently loaded page. */
+  function handleExport(): void {
+    void exportToExcel(ontologies.value, {
+      filename: `ontology_export_${new Date().toISOString().split('T')[0]}`,
+      sheetName: 'Ontology',
+      headers: ONTOLOGY_EXPORT_HEADERS,
+    });
+  }
+
+  /** Opens the edit modal with the selected ontology data (deep copy to prevent direct mutation). */
+  function editOntology(item: VariantOntologyRow): void {
+    ontologyToEdit.value = JSON.parse(JSON.stringify(item)) as VariantOntologyRow;
+    showEditModal.value = true;
+  }
+
+  /** Updates the ontology data via the API. */
+  async function updateOntologyData(): Promise<void> {
+    try {
+      const data = await updateVariantOntology({
+        ontology_details:
+          ontologyToEdit.value as unknown as UpdateVariantOntologyRequest['ontology_details'],
+      });
+      makeToast(data.message, 'Success', 'success');
+      // Update the ontology in the local state.
+      const index = ontologies.value.findIndex((o) => o.vario_id === ontologyToEdit.value.vario_id);
+      if (index !== -1) {
+        ontologies.value.splice(index, 1, { ...ontologyToEdit.value } as VariantOntologyRow);
+      }
+      // Close the modal after successful update.
+      showEditModal.value = false;
+      // Reset the ontologyToEdit object.
+      ontologyToEdit.value = {};
+    } catch (e) {
+      const err = e as { response?: { data?: { error?: string } }; message?: string };
+      makeToast(err.response?.data?.error || err.message, 'Error', 'danger');
+    }
+  }
+
+  // ── Watchers ───────────────────────────────────────────────────────────
+  // Skip during initialization to prevent multiple API calls on mount.
+  watch(
+    filter,
+    () => {
+      if (isInitializing.value) return;
+      filtered();
+    },
+    { deep: true }
+  );
+  watch(
+    sortBy as Ref<Array<{ key: string; order: 'asc' | 'desc' }>>,
+    () => {
+      if (isInitializing.value) return;
+      handleSortByOrDescChange();
+    },
+    { deep: true }
+  );
+
+  // ── Lifecycle (was mounted) ──────────────────────────────────────────────
+  onMounted(() => {
+    // Initialize from URL parameters.
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('sort')) {
+      const sort_object = sortStringToVariables(urlParams.get('sort') as string);
+      sortBy.value = sort_object.sortBy;
+      sort.value = urlParams.get('sort') as string;
+    }
+    if (urlParams.get('filter')) {
+      filter.value = filterStrToObj(urlParams.get('filter'), filter.value) as OntologyFilter;
+      filter_string.value = urlParams.get('filter') as string;
+    }
+    if (urlParams.get('page_after')) {
+      // Keep the raw cursor: VariO IDs are strings, so parseInt() would map a
+      // bookmarked "VariO:0026" to NaN → 0 and reset to page 1 (#531). The API
+      // accepts a numeric page_after ("5") as a string just as well.
+      currentItemID.value = urlParams.get('page_after') as string;
+    }
+    if (urlParams.get('page_size')) {
+      perPage.value = parseInt(urlParams.get('page_size') as string, 10) || 25;
+    }
+
+    void nextTick(() => {
+      loadData();
+      void nextTick(() => {
+        isInitializing.value = false;
+      });
+    });
+  });
+
+  return {
+    // tableData passthrough (spread for template/vm access parity)
+    ...tableData,
+    // Re-export the string-widened cursor refs so the exposed type matches the
+    // runtime value (VariO IDs are strings) — same underlying refs as the
+    // spread above, only the type surface is widened. Mirrors usePublicationsTable.
+    prevItemID,
+    nextItemID,
+    lastItemID,
+    filterObjToStr,
+    filterStrToObj,
+    sortStringToVariables,
+    isExporting,
+    exportToExcel,
+    // local state
+    filter,
+    isInitializing,
+    loadDataDebounceTimer,
+    totalPages,
+    ontologies,
+    fields,
+    mobileSortOptions,
+    showEditModal,
+    ontologyToEdit,
+    // computed
+    mobileSortValue,
+    activeFilterOptions,
+    obsoleteFilterOptions,
+    hasActiveFilters,
+    activeFilters,
+    // methods
+    updateBrowserUrl,
+    filtered,
+    handlePageChange,
+    handlePerPageChange,
+    handleSortByOrDescChange,
+    removeFilters,
+    clearFilter,
+    handleSortUpdate,
+    loadData,
+    doLoadData,
+    applyApiResponse,
+    handleExport,
+    editOntology,
+    updateOntologyData,
+  };
+}
+
+export default useOntologyAdminTable;
+589 app/src/views/admin/ManageOntology.spec.ts
+// ManageOntology.spec.ts
+/**
+ * #346 Wave 2 Task 6 (ontology domain) — spec for the extracted
+ * `useOntologyAdminTable` controller consumed by `views/admin/ManageOntology.vue`.
+ *
+ * Covers the controller's filter/URL-sync/request/response/pagination/
+ * edit/update/export contract:
+ *   - initial URL state (sort/filter/page_after/page_size) is applied
+ *     before the first request fires, and mounting issues exactly one
+ *     initial GET /api/ontology/variant/table request
+ *   - active-filter chips (`hasActiveFilters`/`activeFilters`) reflect the
+ *     current filter state (status/terms/search labels)
+ *   - cursor pagination transitions (first page -> 0, next -> nextItemID,
+ *     prev -> prevItemID, last -> lastItemID) via handlePageChange, carrying
+ *     the RAW string VariO cursor (e.g. "VariO:0026") to the wire — #531 — and
+ *     applyApiResponse preserving those string cursors instead of Number()-
+ *     coercing them to 0
+ *   - a stale (superseded) response never overwrites newer table state
+ *   - editOntology() deep-copies the row (no shared reference) and
+ *     updateOntologyData() PUTs `{ ontology_details }` via the typed
+ *     `updateVariantOntology` client, then refreshes the row in place,
+ *     closes the modal, and resets the edit buffer
+ *   - handleExport() calls the client-side `exportToExcel` with the
+ *     `ontology_export_<date>` filename, `Ontology` sheet name, and the
+ *     shared `ONTOLOGY_EXPORT_HEADERS` column map
+ *
+ * This is an admin curation-metadata surface (see AGENTS.md "Admin
+ * curation metadata vocabularies"): the update payload shape
+ * (`{ ontology_details: {...} }`) and role gate are unchanged by this
+ * extraction, only re-verified here. `useToast`/`useExcelExport` are
+ * spied at their direct composable module paths, while `useTableData` and
+ * `useUrlParsing` stay real — this
+ * matches the useGenesTable/useEntitiesTable Wave 2 spec pattern.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { ref } from 'vue';
+import { createPinia, setActivePinia } from 'pinia';
+import { http, HttpResponse } from 'msw';
+
+import '@/plugins/axios';
+import { server } from '@/test-utils/mocks/server';
+import { primeAuth } from '@/test-utils/primeAuth';
+import { expectBearerHeader } from '@/test-utils/expectBearerHeader';
+import { useAuth } from '@/composables/useAuth';
+import type { VariantOntologyRow } from '@/api/ontology';
+import { ONTOLOGY_EXPORT_HEADERS } from './ontologyTableConfig';
+import ManageOntology from './ManageOntology.vue';
+
+const makeToastSpy = vi.fn();
+const exportToExcelSpy = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/composables/useToast', () => ({
+  default: () => ({ makeToast: makeToastSpy }),
+}));
+
+vi.mock('@/composables/useExcelExport', () => ({
+  useExcelExport: () => ({ isExporting: ref(false), exportToExcel: exportToExcelSpy }),
+}));
+
+interface OntologyFilterFieldVm {
+  content: string | string[] | null;
+  operator: string;
+  join_char: string | null;
+}
+
+interface OntologyVm {
+  doLoadData: () => Promise<void>;
+  updateOntologyData: () => Promise<void>;
+  editOntology: (item: VariantOntologyRow) => void;
+  handlePageChange: (value: number) => void;
+  handleExport: () => void;
+  removeFilters: () => void;
+  clearFilter: (key: string) => void;
+  ontologyToEdit: Partial<VariantOntologyRow>;
+  ontologies: VariantOntologyRow[];
+  filter: Record<string, OntologyFilterFieldVm>;
+  showEditModal: boolean;
+  hasActiveFilters: boolean;
+  activeFilters: Array<{ key: string; label: string; value: string }>;
+  totalRows: number;
+  totalPages: number;
+  currentPage: number;
+  currentItemID: number | string;
+  // VariO cursor IDs are strings (e.g. "VariO:0026"), not numbers.
+  prevItemID: number | string | null;
+  nextItemID: number | string | null;
+  lastItemID: number | string | null;
+  applyApiResponse: (data: unknown) => void;
+  sort: string;
+}
+
+const DEFAULT_ROW: VariantOntologyRow = {
+  vario_id: 'VariO:0001',
+  vario_name: 'Example',
+  definition: 'Example def',
+  obsolete: 0,
+  is_active: 1,
+  sort: 1,
+  update_date: '2025-01-01',
+};
+
+function ontologyListPayload(
+  metaOverrides: Record<string, unknown> = {},
+  rows: VariantOntologyRow[] = [DEFAULT_ROW]
+) {
+  return {
+    data: rows,
+    meta: [
+      {
+        totalItems: rows.length,
+        currentPage: 1,
+        totalPages: 1,
+        prevItemID: 0,
+        currentItemID: 0,
+        nextItemID: 0,
+        lastItemID: 0,
+        executionTime: 10,
+        ...metaOverrides,
+      },
+    ],
+    links: [],
+  };
+}
+
+// useOntologyAdminTable's request coordinator is intentionally MODULE-level
+// (it must survive Vue Router remounts in production — see
+// useOntologyAdminTable.ts). Inside this spec file the same module instance
+// is shared across every test. Unlike TablesGenes/TablesEntities,
+// ManageOntology has no `pageSizeInput` prop, so every mount reads its
+// initial `page_size` from the URL instead — give each mount a unique one
+// (unless the test explicitly supplies its own) so no two tests' request
+// params can ever collide within the coordinator's ~500ms "recent
+// response" cache window.
+let mountCallIndex = 0;
+
+async function mountView(searchParams: URLSearchParams = new URLSearchParams()) {
+  mountCallIndex += 1;
+  if (!searchParams.has('page_size')) {
+    searchParams.set('page_size', String(30 + mountCallIndex));
+  }
+  window.history.pushState({}, '', `/admin/manage-ontology?${searchParams.toString()}`);
+
+  setActivePinia(createPinia());
+  const wrapper = mount(ManageOntology, {
+    global: {
+      directives: { 'b-tooltip': {}, 'b-toggle': {} },
+      stubs: {
+        GenericTable: { template: '<div />' },
+        TablePaginationControls: { template: '<div />' },
+        OntologyMobileRows: { template: '<div />' },
+        BContainer: { template: '<div><slot /></div>' },
+        BRow: { template: '<div><slot /></div>' },
+        BCol: { template: '<div><slot /></div>' },
+        BCard: { template: '<div><slot name="header" /><slot /></div>' },
+        BBadge: { template: '<span><slot /></span>' },
+        BButton: { template: '<button><slot /></button>' },
+        BSpinner: { template: '<div />' },
+        BFormInput: { template: '<input />' },
+        BInputGroup: { template: '<div><slot name="prepend" /><slot /></div>' },
+        BInputGroupText: { template: '<span><slot /></span>' },
+        BFormSelect: { template: '<select><slot /></select>' },
+        BFormSelectOption: { template: '<option><slot /></option>' },
+        BFormGroup: { template: '<div><slot /></div>' },
+        BFormTextarea: { template: '<textarea />' },
+        BForm: { template: '<form><slot /></form>' },
+        BModal: { template: '<div><slot /></div>' },
+      },
+    },
+  });
+  // The initial load is debounced ~50ms (useOntologyAdminTable's
+  // loadData()); wait it out so the mounted-component's first request has
+  // actually fired before assertions run.
+  await new Promise((resolve) => setTimeout(resolve, 75));
+  await flushPromises();
+  return wrapper;
+}
+
+beforeEach(() => {
+  makeToastSpy.mockClear();
+  exportToExcelSpy.mockClear();
+  vi.stubEnv('VITE_API_URL', '');
+});
+
+afterEach(() => {
+  useAuth().logout();
+  vi.unstubAllEnvs();
+});
+
+describe('ManageOntology — #346 Wave 2 useOntologyAdminTable controller', () => {
+  // -------------------------------------------------------------------------
+  // Initial URL state + exactly-one initial request
+  // -------------------------------------------------------------------------
+
+  it('applies sort/filter/page_after/page_size from the URL and issues exactly one initial request', async () => {
+    let requestCount = 0;
+    let observedQuery: URLSearchParams | null = null;
+    server.use(
+      http.get('/api/ontology/variant/table', ({ request }) => {
+        requestCount += 1;
+        observedQuery = new URL(request.url).searchParams;
+        return HttpResponse.json(ontologyListPayload());
+      })
+    );
+
+    const params = new URLSearchParams();
+    params.set('sort', '-vario_name');
+    params.set('filter', 'contains(vario_name,GR)');
+    params.set('page_after', '5');
+    params.set('page_size', '50');
+
+    await mountView(params);
+
+    expect(requestCount).toBe(1);
+    const q = observedQuery as unknown as URLSearchParams;
+    expect(q.get('sort')).toBe('-vario_name');
+    expect(q.get('filter')).toBe('contains(vario_name,GR)');
+    expect(q.get('page_after')).toBe('5');
+    expect(q.get('page_size')).toBe('50');
+  });
+
+  it('does not fire a duplicate request from the filter/sortBy watchers during initialization', async () => {
+    let requestCount = 0;
+    server.use(
+      http.get('/api/ontology/variant/table', () => {
+        requestCount += 1;
+        return HttpResponse.json(ontologyListPayload());
+      })
+    );
+
+    await mountView();
+
+    expect(requestCount).toBe(1);
+  });
+
+  it('doLoadData() fetches the table with the Bearer header injected by apiClient', async () => {
+    primeAuth('ontology-token');
+    server.use(
+      http.get('/api/ontology/variant/table', ({ request }) => {
+        expectBearerHeader(request, 'ontology-token');
+        return HttpResponse.json(ontologyListPayload());
+      })
+    );
+
+    const wrapper = await mountView();
+    const vm = wrapper.vm as unknown as OntologyVm;
+
+    expect(Array.isArray(vm.ontologies)).toBe(true);
+    expect(vm.ontologies).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Active-filter chips
+  // -------------------------------------------------------------------------
+
+  it('hasActiveFilters/activeFilters reflect the current filter state', async () => {
+    server.use(
+      http.get('/api/ontology/variant/table', () => HttpResponse.json(ontologyListPayload()))
+    );
+
+    const wrapper = await mountView();
+    const vm = wrapper.vm as unknown as OntologyVm;
+
+    expect(vm.hasActiveFilters).toBe(false);
+    expect(vm.activeFilters).toEqual([]);
+
+    vm.filter.any.content = 'seizure';
+    vm.filter.is_active.content = '1';
+    vm.filter.obsolete.content = '0';
+    await flushPromises();
+
+    expect(vm.hasActiveFilters).toBe(true);
+    expect(vm.activeFilters).toEqual([
+      { key: 'any', label: 'Search', value: 'seizure' },
+      { key: 'is_active', label: 'Status', value: 'Active' },
+      { key: 'obsolete', label: 'Terms', value: 'Current' },
+    ]);
+
+    // Flipping the enum values flips the chip labels (inactive/obsolete).
+    vm.filter.is_active.content = '0';
+    vm.filter.obsolete.content = '1';
+    await flushPromises();
+
+    expect(vm.activeFilters).toEqual([
+      { key: 'any', label: 'Search', value: 'seizure' },
+      { key: 'is_active', label: 'Status', value: 'Inactive' },
+      { key: 'obsolete', label: 'Terms', value: 'Obsolete' },
+    ]);
+
+    // Settle the debounced reload the mutations above triggered so no timer
+    // is left dangling into the next test.
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    await flushPromises();
+  });
+
+  it('clearFilter() nulls a single field and removeFilters() nulls every field', async () => {
+    let lastFilterParam: string | null = null;
+    server.use(
+      http.get('/api/ontology/variant/table', ({ request }) => {
+        lastFilterParam = new URL(request.url).searchParams.get('filter');
+        return HttpResponse.json(ontologyListPayload());
+      })
+    );
+
+    const wrapper = await mountView();
+    const vm = wrapper.vm as unknown as OntologyVm;
+    vm.filter.any.content = 'seizure';
+    vm.filter.is_active.content = '1';
+
+    vm.clearFilter('is_active');
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    await flushPromises();
+
+    expect(vm.filter.is_active.content).toBeNull();
+    expect(vm.filter.any.content).toBe('seizure');
+
+    vm.removeFilters();
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    await flushPromises();
+
+    expect(vm.filter.any.content).toBeNull();
+    expect(lastFilterParam).toBe('');
+  });
+
+  // -------------------------------------------------------------------------
+  // Cursor-pagination transitions
+  // -------------------------------------------------------------------------
+
+  it('handlePageChange sends the direction-appropriate STRING VariO cursor (first→0, next/prev/last→raw cursor) — #531', async () => {
+    // #531: ManageOntology paginates on string VariO cursors (e.g.
+    // "VariO:0026"), NOT numbers. Two coupled defects previously pinned it to
+    // page 1: (1) handlePageChange() routed through filtered(), whose
+    // unconditional currentItemID=0 reset (retained for real filter/sort/
+    // per-page changes) clobbered the cursor; (2) the cursor was coerced with
+    // Number(), so every VariO string became NaN → 0. Both are fixed:
+    // handlePageChange loads directly with the RAW cursor. Real VariO ID
+    // strings are used here on purpose — numeric fixtures would mask defect (2).
+    let lastPageAfter: string | null = null;
+    server.use(
+      http.get('/api/ontology/variant/table', ({ request }) => {
+        lastPageAfter = new URL(request.url).searchParams.get('page_after');
+        return HttpResponse.json(ontologyListPayload());
+      })
+    );
+
+    const wrapper = await mountView();
+    const vm = wrapper.vm as unknown as OntologyVm;
+
+    // Each scenario exercises a DISTINCT branch of handlePageChange; re-seed
+    // the cursor/page refs immediately before each call so no scenario's
+    // branch selection can leak into the next. The cursor assertion is
+    // synchronous: handlePageChange() runs to completion in one call stack
+    // and loadData() only *schedules* the debounced fetch, so this captures
+    // the computed cursor BEFORE any network response could reset it —
+    // directly proving both the reset-clobber and the Number() coercion are
+    // gone (a coerced VariO string would read back as 0, not the raw id).
+    const scenarios: Array<{
+      label: string;
+      currentPage: number;
+      totalPages: number;
+      targetPage: number;
+      expected: number | string;
+    }> = [
+      {
+        label: 'first page (value === 1)',
+        currentPage: 3,
+        totalPages: 5,
+        targetPage: 1,
+        expected: 0,
+      },
+      {
+        label: 'next page (value > currentPage)',
+        currentPage: 2,
+        totalPages: 5,
+        targetPage: 3,
+        expected: 'VariO:0026',
+      },
+      {
+        label: 'previous page (value < currentPage)',
+        currentPage: 3,
+        totalPages: 5,
+        targetPage: 2,
+        expected: 'VariO:0005',
+      },
+      {
+        label: 'last page (value === totalPages)',
+        currentPage: 2,
+        totalPages: 5,
+        targetPage: 5,
+        expected: 'VariO:0491',
+      },
+    ];
+
+    for (const { label, currentPage, totalPages, targetPage, expected } of scenarios) {
+      vm.currentPage = currentPage;
+      vm.totalPages = totalPages;
+      vm.nextItemID = 'VariO:0026';
+      vm.prevItemID = 'VariO:0005';
+      vm.lastItemID = 'VariO:0491';
+
+      vm.handlePageChange(targetPage);
+      expect(vm.currentItemID, label).toBe(expected);
+    }
+
+    // End-to-end: only the final scenario's debounced load survives the loop
+    // (each handlePageChange resets the debounce timer). Let it fire and
+    // confirm the real "last page" VariO cursor actually went out on the wire
+    // as page_after — not the old always-0.
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    await flushPromises();
+    expect(lastPageAfter).toBe('VariO:0491');
+  });
+
+  it('applyApiResponse preserves string VariO cursors (does not Number()-coerce them to 0) — #531', async () => {
+    // The applyApiResponse() half of the same fix: the API returns keyset
+    // cursors as VariO ID strings. Number("VariO:0026") is NaN → 0, so the old
+    // `Number(meta.x) || 0` collapsed every cursor to 0 and the next page
+    // request went out with page_after=0 (page 1). cursorOrZero keeps the raw
+    // string; only null/"null" collapse to the page-1 sentinel 0.
+    server.use(
+      http.get('/api/ontology/variant/table', () => HttpResponse.json(ontologyListPayload()))
+    );
+    const wrapper = await mountView();
+    const vm = wrapper.vm as unknown as OntologyVm;
+
+    vm.applyApiResponse({
+      data: [DEFAULT_ROW],
+      meta: [
+        {
+          totalItems: 495,
+          currentPage: 2,
+          totalPages: 20,
+          prevItemID: null,
+          currentItemID: 'VariO:0026',
+          nextItemID: 'VariO:0051',
+          lastItemID: 'VariO:0491',
+          executionTime: 10,
+        },
+      ],
+      links: [],
+    });
+
+    expect(vm.currentItemID).toBe('VariO:0026');
+    expect(vm.nextItemID).toBe('VariO:0051');
+    expect(vm.lastItemID).toBe('VariO:0491');
+    // A null cursor (no previous page) collapses to the page-1 sentinel 0.
+    expect(vm.prevItemID).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Stale-response rejection
+  // -------------------------------------------------------------------------
+
+  it('rejects a stale response that resolves after a newer request has superseded it', async () => {
+    let resolveFirst: (() => void) | null = null;
+    const firstReady = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+
+    server.use(
+      http.get('/api/ontology/variant/table', async ({ request }) => {
+        const sortParam = new URL(request.url).searchParams.get('sort');
+        if (sortParam === '+vario_id') {
+          // First (initial-mount) request: block until told to resolve, so
+          // a second request can supersede it before this one completes.
+          await firstReady;
+          return HttpResponse.json(ontologyListPayload({ totalItems: 111 }));
+        }
+        // Second (superseding) request resolves immediately.
+        return HttpResponse.json(ontologyListPayload({ totalItems: 222 }));
+      })
+    );
+
+    const wrapper = await mountView();
+    const vm = wrapper.vm as unknown as OntologyVm & {
+      sort: string;
+      doLoadData: () => Promise<void>;
+      loadDataDebounceTimer: ReturnType<typeof setTimeout> | null;
+    };
+
+    // Supersede it: change sort and reload before the first request resolves.
+    vm.sort = '-vario_id';
+    if (vm.loadDataDebounceTimer) clearTimeout(vm.loadDataDebounceTimer);
+    await vm.doLoadData();
+    await flushPromises();
+
+    // The second (superseding) request already applied its data.
+    expect(vm.totalRows).toBe(222);
+
+    // Now let the first (stale) request resolve. Its data must be discarded
+    // because doLoadData()'s isCurrent() check no longer matches (sort
+    // changed underneath it).
+    resolveFirst!();
+    await flushPromises();
+
+    expect(vm.totalRows).toBe(222);
+  });
+
+  // -------------------------------------------------------------------------
+  // Edit payload + update refresh
+  // -------------------------------------------------------------------------
+
+  it('editOntology deep-copies the row; updateOntologyData PUTs {ontology_details} and refreshes the row in place', async () => {
+    primeAuth('ontology-write-token');
+    server.use(
+      http.get('/api/ontology/variant/table', () => HttpResponse.json(ontologyListPayload()))
+    );
+
+    const wrapper = await mountView();
+    const vm = wrapper.vm as unknown as OntologyVm;
+
+    vm.editOntology(DEFAULT_ROW);
+    expect(vm.showEditModal).toBe(true);
+    expect(vm.ontologyToEdit).toEqual(DEFAULT_ROW);
+    expect(vm.ontologyToEdit).not.toBe(DEFAULT_ROW);
+
+    // Mutating the edit buffer must not mutate the original row (deep copy).
+    vm.ontologyToEdit.vario_name = 'Renamed';
+    expect(DEFAULT_ROW.vario_name).toBe('Example');
+
+    let observedBody: unknown = null;
+    server.use(
+      http.put('/api/ontology/variant/update', async ({ request }) => {
+        expectBearerHeader(request, 'ontology-write-token');
+        observedBody = await request.json();
+        return HttpResponse.json({ message: 'Updated' });
+      })
+    );
+
+    await vm.updateOntologyData();
+    await flushPromises();
+
+    expect(observedBody).toEqual({
+      ontology_details: { ...DEFAULT_ROW, vario_name: 'Renamed' },
+    });
+    expect(makeToastSpy).toHaveBeenCalledWith('Updated', 'Success', 'success');
+    expect(vm.showEditModal).toBe(false);
+    expect(vm.ontologyToEdit).toEqual({});
+    expect(vm.ontologies.find((o) => o.vario_id === 'VariO:0001')).toEqual({
+      ...DEFAULT_ROW,
+      vario_name: 'Renamed',
+    });
+  });
+
+  it('updateOntologyData() surfaces the API error message on failure and keeps the modal open', async () => {
+    server.use(
+      http.get('/api/ontology/variant/table', () => HttpResponse.json(ontologyListPayload()))
+    );
+
+    const wrapper = await mountView();
+    const vm = wrapper.vm as unknown as OntologyVm;
+    vm.editOntology(DEFAULT_ROW);
+
+    server.use(
+      http.put('/api/ontology/variant/update', () =>
+        HttpResponse.json({ error: 'vario_id not found' }, { status: 404 })
+      )
+    );
+
+    await vm.updateOntologyData();
+    await flushPromises();
+
+    expect(makeToastSpy).toHaveBeenCalledWith('vario_id not found', 'Error', 'danger');
+    expect(vm.showEditModal).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Excel export (client-side, currently loaded page only)
+  // -------------------------------------------------------------------------
+
+  it('handleExport() exports the loaded rows with the ontology_export_<date> filename and shared headers', async () => {
+    server.use(
+      http.get('/api/ontology/variant/table', () => HttpResponse.json(ontologyListPayload()))
+    );
+
+    const wrapper = await mountView();
+    const vm = wrapper.vm as unknown as OntologyVm;
+
+    vm.handleExport();
+
+    const expectedFilename = `ontology_export_${new Date().toISOString().split('T')[0]}`;
+    expect(exportToExcelSpy).toHaveBeenCalledWith(vm.ontologies, {
+      filename: expectedFilename,
+      sheetName: 'Ontology',
+      headers: ONTOLOGY_EXPORT_HEADERS,
+    });
+  });
+});
+  }
+
+  function removeSearch(): void {
+    if (filter.value.any) {
+      filter.value.any.content = null;
+    }
+    filtered();
+  }
+
+  /** Debounced wrapper for doLoadData to prevent duplicate calls from multiple triggers. */
+  function loadData(): void {
+    if (loadDataDebounceTimer.value) {
+      clearTimeout(loadDataDebounceTimer.value);
+    }
+    loadDataDebounceTimer.value = setTimeout(() => {
+      loadDataDebounceTimer.value = null;
+      void doLoadData();
+    }, 50);
+  }
+
+  // v11.3 §4.2.3 option (B): initial-load path that bypasses the debounce so
+  // the mount-time fetch starts immediately (within the spec's <=100 ms
+  // after-nav budget). Used only by the onMounted hook below; reactivity
+  // triggers continue to use loadData() with its 50 ms debounce.
+  function loadDataImmediate(): void {
+    if (loadDataDebounceTimer.value) {
+      clearTimeout(loadDataDebounceTimer.value);
+      loadDataDebounceTimer.value = null;
+    }
+    void doLoadData();
+  }
+
+  /** Fetches /api/entity via the coordinator (dedupe + stale-response guard). */
+  async function doLoadData(): Promise<void> {
+    // `compact` changes the server response shape (count == count_filtered,
+    // no global fspec) so it MUST be part of the dedup key — otherwise a
+    // remounted instance with different controls visibility would receive a
+    // stale response with the wrong fspec semantics.
+    const buildParams = () =>
+      `sort=${sort.value}&filter=${filter_string.value}&page_after=${currentItemID.value}` +
+      `&page_size=${perPage.value}&compact=${!props.showFilterControls}`;
+    const urlParam = buildParams();
+    isBusy.value = true;
+
+    const result = await entitiesRequestCoordinator.request({
+      params: urlParam,
+      fetcher: () =>
+        listEntities({
+          sort: sort.value,
+          filter: filter_string.value,
+          page_after: currentItemID.value,
+          page_size: String(perPage.value),
+          // Embedded callers (GeneView/EntityView) hide the filter dropdowns,
+          // so they don't need the global-fspec round-trip. Compact mode
+          // pushes the filter to SQL and skips the wasted fspec compute.
+          compact: !props.showFilterControls,
+        }),
+      apply: (data, source) => {
+        applyApiResponse(data);
+        if (source === 'network') {
+          // Update URL AFTER API success to prevent component remount during API call
+          updateBrowserUrl();
+        }
+      },
+      onError: (e) => {
+        makeToast(e, 'Error', 'danger');
+      },
+      isCurrent: (params) => buildParams() === params,
+    });
+
+    if (result.handled) {
+      isBusy.value = false;
+      loading.value = false;
+    }
+  }
+
+  /** Applies API response data to state; reused by every coordinator apply() path. */
+  function applyApiResponse(data: EntityListResponse): void {
+    items.value = data.data;
+    const metaArr = data.meta as Array<Record<string, unknown>>;
+    const meta = metaArr[0];
+    totalRows.value = (meta.totalItems as number) || 0;
+    // this solves an update issue in b-pagination component
+    // based on https://github.com/bootstrap-vue/bootstrap-vue/issues/3541
+    void nextTick(() => {
+      currentPage.value = meta.currentPage as number;
+    });
+    totalPages.value = meta.totalPages as number;
+    prevItemID.value = Number(meta.prevItemID) || 0;
+    currentItemID.value = Number(meta.currentItemID) || 0;
+    nextItemID.value = Number(meta.nextItemID) || 0;
+    lastItemID.value = Number(meta.lastItemID) || 0;
+    executionTime.value = meta.executionTime as number;
+
+    // Apply short label overrides for mobile-friendly stacked table headers
+    const fspec = meta.fspec;
+    if (Array.isArray(fspec)) {
+      fields.value = (fspec as EntityTableField[]).map((field) =>
+        ENTITY_SHORT_LABELS[field.key]
+          ? { ...field, label: ENTITY_SHORT_LABELS[field.key] }
+          : field
+      );
+    }
+
+    const uiStore = useUiStore();
+    uiStore.requestScrollbarUpdate();
+  }
+
+  /** Normalize select options for BFormSelect. */
+  function normalizeSelectOptions(options: unknown): Array<{ value: unknown; text: unknown }> {
+    return normalizeEntitySelectOptions(options);
+    const sortColumn = sortBy.value.length > 0 ? sortBy.value[0].key : '';
+    const sortOrder = sortBy.value.length > 0 ? sortBy.value[0].order : 'asc';
+    const isDesc = sortOrder === 'desc';
+    sort.value = (isDesc ? '-' : '+') + sortColumn;
+    filtered();
+  }
+
+  function handleSortByUpdate(newSortBy: Array<{ key: string; order: 'asc' | 'desc' }>): void {
+    sortBy.value = newSortBy;
+    // handleSortByOrDescChange is triggered by the sortBy watcher below.
+  }
+
+  // Debounced loadData to prevent duplicate calls from multiple triggers
+  // (e.g. the filter watcher firing alongside a direct filtered() call).
+  function loadData(): void {
+    if (loadDataDebounceTimer.value) {
+      clearTimeout(loadDataDebounceTimer.value);
+    }
+    loadDataDebounceTimer.value = setTimeout(() => {
+      loadDataDebounceTimer.value = null;
+      void doLoadData();
+    }, 50);
+  }
+
+  async function doLoadData(): Promise<void> {
+    const currentUrlParam = () =>
+      `sort=${sort.value}&filter=${filter_string.value}&page_after=${currentItemID.value}&page_size=${perPage.value}`;
+
+    isBusy.value = true;
+
+    const result = await genesRequestCoordinator.request({
+      params: currentUrlParam(),
+      fetcher: () =>
+        listGenes({
+          sort: sort.value,
+          filter: filter_string.value,
+          page_after: String(currentItemID.value ?? ''),
+          page_size: String(perPage.value),
+        }),
+      apply: (data, source) => {
+        applyApiResponse(data);
+        if (source === 'network') {
+          // Update URL AFTER API success to prevent component remount during
+          // the API call.
+          updateBrowserUrl();
+        }
+      },
+      onError: (e) => {
+        makeToast(e, 'Error', 'danger');
+      },
+      isCurrent: (params) => currentUrlParam() === params,
+    });
+
+    if (result.handled) {
+      isBusy.value = false;
+      loading.value = false;
+    }
+  }
+
+  /**
+   * Apply API response data to component state. Extracted to allow reuse
+   * when skipping duplicate API calls (see doLoadData's `apply` callback).
+   */
+  function applyApiResponse(data: PaginatedGeneResponse): void {
+    const meta = data.meta[0] as GeneListMeta;
+
+    items.value = data.data;
+    totalRows.value = meta.totalItems;
+    // this solves an update issue in b-pagination component
+    // based on https://github.com/bootstrap-vue/bootstrap-vue/issues/3541
+    void nextTick(() => {
+      currentPage.value = meta.currentPage;
+    });
+    totalPages.value = meta.totalPages;
+    prevItemID.value = meta.prevItemID as unknown as number | null;
+    currentItemID.value = meta.currentItemID;
+    nextItemID.value = meta.nextItemID as unknown as number | null;
+    lastItemID.value = meta.lastItemID as unknown as number | null;
+    executionTime.value = meta.executionTime;
+    fields.value = meta.fspec as unknown as GeneTableField[];
+
+    const uiStore = useUiStore();
+    uiStore.requestScrollbarUpdate();
+  }
+
+  function copyLinkToClipboard(): void {
+    const urlParam = `sort=${sort.value}&filter=${filter_string.value}&page_after=${currentItemID.value}&page_size=${perPage.value}`;
+    void navigator.clipboard.writeText(
+      `${import.meta.env.VITE_URL + window.location.pathname}?${urlParam}`
+    );
+  }
+  }
+
+  /**
+   * Remove a phenotype from selection.
+   */
+  function removePhenotype(phenotypeId: string): void {
+    const ids = phenotypeIdList();
+    const index = ids.indexOf(phenotypeId);
+    if (index !== -1) {
+      ids.splice(index, 1);
+      filtered();
+    }
+  }
+
+  function loadEntitiesFromPhenotypes(): void {
+    // Debounce to prevent duplicate calls from multiple triggers
+    if (loadDataDebounceTimer.value) {
+      clearTimeout(loadDataDebounceTimer.value);
+    }
+    loadDataDebounceTimer.value = setTimeout(() => {
+      loadDataDebounceTimer.value = null;
+      void doLoadEntitiesFromPhenotypes();
+    }, 50);
+  }
+
+  async function doLoadEntitiesFromPhenotypes(): Promise<void> {
+    const currentUrlParam = () =>
+      `sort=${sort.value}&filter=${filter_string.value}&page_after=${currentItemID.value}&page_size=${perPage.value}`;
+    const urlParam = currentUrlParam();
+    isBusy.value = true;
+
+    const result = await phenotypeEntitiesRequestCoordinator.request({
+      params: urlParam,
+      fetcher: () =>
+        browsePhenotypeEntities({
+          sort: sort.value,
+          filter: filter_string.value,
+          page_after: currentItemID.value,
+          page_size: String(perPage.value),
+        }),
+      apply: (data, source) => {
+        applyApiResponse(data);
+        if (source === 'network') {
+          // Update URL AFTER API success to prevent component remount during the API call
+          updateBrowserUrl();
+        }
+      },
+      onError: (e) => {
+        makeToast(e, 'Error', 'danger');
+      },
+      isCurrent: (params) => currentUrlParam() === params,
+    });
+
+    if (result.handled) {
+      isBusy.value = false;
+      loading.value = false;
+    }
+  }
+
+  /**
+   * Apply API response data to component state. Extracted to allow reuse
+   * when skipping duplicate API calls.
+   */
+  function applyApiResponse(data: BrowsePhenotypeEntitiesResponse): void {
+    const meta = (data.meta as Array<Record<string, unknown>>)[0];
+    fields.value = meta.fspec as Array<Record<string, unknown>>;
+    items.value = data.data;
+    totalRows.value = meta.totalItems as number;
+    // this solves an update issue in b-pagination component
+    // based on https://github.com/bootstrap-vue/bootstrap-vue/issues/3541
+    void nextTick(() => {
+      currentPage.value = meta.currentPage as number;
+    });
+    totalPages.value = meta.totalPages as number;
+    prevItemID.value = Number(meta.prevItemID) || 0;
+    currentItemID.value = Number(meta.currentItemID) || 0;
+    nextItemID.value = Number(meta.nextItemID) || 0;
+    lastItemID.value = Number(meta.lastItemID) || 0;
+    executionTime.value = meta.executionTime as number;
+
+    const uiStore = useUiStore();
+    uiStore.requestScrollbarUpdate();
+  }
+
+  function requestSelected(): void {
+    if (phenotypeIdList().length > 0) {
+      loadEntitiesFromPhenotypes();
+    } else {
+      items.value = [];
+      totalRows.value = 0;
+      isBusy.value = false;
+
+  /** Debounced wrapper for doLoadData to prevent duplicate calls. */
+  function loadData(): void {
+    if (loadDataDebounceTimer.value) {
+      clearTimeout(loadDataDebounceTimer.value);
+    }
+    loadDataDebounceTimer.value = setTimeout(() => {
+      loadDataDebounceTimer.value = null;
+      void doLoadData();
+    }, 50);
+  }
+
+  /** Fetches /api/publication via the coordinator (dedupe + stale-response guard). */
+  async function doLoadData(): Promise<void> {
+    const buildParams = () =>
+      `sort=${sort.value}` +
+      `&filter=${filter_string.value}` +
+      `&page_after=${currentItemID.value}` +
+      `&page_size=${perPage.value}`;
+    const urlParam = buildParams();
+    isBusy.value = true;
+
+    const result = await publicationsRequestCoordinator.request({
+      params: urlParam,
+      fetcher: () =>
+        listPublications({
+          sort: sort.value,
+          filter: filter_string.value,
+          page_after: String(currentItemID.value),
+          page_size: String(perPage.value),
+          fields: props.fspecInput,
+        }),
+      apply: (data, source) => {
+        applyApiResponse(data);
+        if (source === 'network') {
+          // Update URL AFTER API success to prevent component remount mid-call
+          updateBrowserUrl();
+        }
+      },
+      onError: (error) => makeToast(error, 'Error', 'danger'),
+      isCurrent: (params) => buildParams() === params,
+    });
+
+    if (result.handled) {
+      isBusy.value = false;
+    }
+  }
+
+  /** Applies API response data to state; reused by every coordinator apply() path. */
+  function applyApiResponse(data: PublicationListResponse): void {
+    items.value = data.data;
+
+    const metaArr = data.meta as Array<Record<string, unknown>> | undefined;
+    if (metaArr && metaArr.length > 0) {
+      const metaObj = metaArr[0];
+      totalRows.value = (metaObj.totalItems as number) || 0;
+
+      // Fix for b-pagination
+      void nextTick(() => {
+        currentPage.value = metaObj.currentPage as number;
+      });
+
+exec
+/bin/bash -lc "rg -n \"function (getEntityReview|getEntityPhenotypes|getEntityVariation|getEntityPublications|getEntityStatus|listEntities|getReReviewTable|listPhenotypesTree|listVariationOntologyTree|listStatusCategoriesTree|getReviewById|getStatusById|getEntitiesOverTime|getPubtatorCacheStatus|listPubtatorTable|listVariantOntology)\" app/src/api && rg -n \"getPubtatorCacheStatus|listPubtatorTable|listVariantOntology|function getNetworkEdges\" app/src/api -C 3 && nl -ba .planning/superpowers/plans/2026-07-13-security-535-s5c-request-ownership-plan.md && nl -ba app/src/utils/tableRequestCoordinator.ts && nl -ba app/src/views/admin/composables/useOntologyAdminTable.ts | sed -n '250,335p'" in /home/bernt-popp/development/sysndd/.claude/worktrees/535-s5c-request-ownership
+ succeeded in 0ms:
+app/src/api/statistics.ts:189:export async function getEntitiesOverTime(
+app/src/api/review.ts:201:export async function getReviewById(
+app/src/api/ontology.ts:126:export async function listVariantOntology(
+app/src/api/list.ts:114:export async function listStatusCategoriesTree(config?: AxiosRequestConfig): Promise<TreeNode[]> {
+app/src/api/list.ts:142:export async function listPhenotypesTree(config?: AxiosRequestConfig): Promise<TreeNode[]> {
+app/src/api/list.ts:201:export async function listVariationOntologyTree(config?: AxiosRequestConfig): Promise<TreeNode[]> {
+app/src/api/publication.ts:340:export async function listPubtatorTable(
+app/src/api/publication.ts:353:export async function listPubtatorTableXlsx(
+app/src/api/publication.ts:421:export async function getPubtatorCacheStatus(
+app/src/api/re_review.ts:264:export async function getReReviewTable(
+app/src/api/status.ts:141:export async function getStatusById(
+app/src/api/entity.ts:200:export async function listEntities(
+app/src/api/entity.ts:215:export async function listEntitiesXlsx(
+app/src/api/entity.ts:310:export async function getEntityPhenotypes(
+app/src/api/entity.ts:329:export async function getEntityVariation(
+app/src/api/entity.ts:349:export async function getEntityReview(
+app/src/api/entity.ts:363:export async function getEntityStatus(
+app/src/api/entity.ts:377:export async function getEntityPublications(
+app/src/api/ontology.ts-123- * Administrator-only. Cursor-paginated VariO listing with server-side
+app/src/api/ontology.ts-124- * filtering and sorting.
+app/src/api/ontology.ts-125- */
+app/src/api/ontology.ts:126:export async function listVariantOntology(
+app/src/api/ontology.ts-127-  params: ListVariantOntologyParams = {},
+app/src/api/ontology.ts-128-  config?: AxiosRequestConfig
+app/src/api/ontology.ts-129-): Promise<VariantOntologyListResponse> {
+--
+app/src/api/ontology.spec.ts-7-
+app/src/api/ontology.spec.ts-8-import {
+app/src/api/ontology.spec.ts-9-  getOntology,
+app/src/api/ontology.spec.ts:10:  listVariantOntology,
+app/src/api/ontology.spec.ts-11-  updateVariantOntology,
+app/src/api/ontology.spec.ts-12-  type OntologyTerm,
+app/src/api/ontology.spec.ts-13-  type VariantOntologyListResponse,
+--
+app/src/api/ontology.spec.ts-52-  });
+app/src/api/ontology.spec.ts-53-});
+app/src/api/ontology.spec.ts-54-
+app/src/api/ontology.spec.ts:55:describe('api/ontology — listVariantOntology', () => {
+app/src/api/ontology.spec.ts-56-  it('forwards filter/sort/page_size params', async () => {
+app/src/api/ontology.spec.ts-57-    let observedQuery: URLSearchParams | null = null;
+app/src/api/ontology.spec.ts-58-    const ok: VariantOntologyListResponse = { links: {}, meta: {}, data: [] };
+--
+app/src/api/ontology.spec.ts-63-      })
+app/src/api/ontology.spec.ts-64-    );
+app/src/api/ontology.spec.ts-65-
+app/src/api/ontology.spec.ts:66:    await listVariantOntology({ filter: 'is_active:equals:1', sort: '-update_date' });
+app/src/api/ontology.spec.ts-67-    const q = observedQuery as unknown as URLSearchParams;
+app/src/api/ontology.spec.ts-68-    expect(q.get('filter')).toBe('is_active:equals:1');
+app/src/api/ontology.spec.ts-69-    expect(q.get('sort')).toBe('-update_date');
+--
+app/src/api/ontology.spec.ts-78-
+app/src/api/ontology.spec.ts-79-    let caught: unknown;
+app/src/api/ontology.spec.ts-80-    try {
+app/src/api/ontology.spec.ts:81:      await listVariantOntology();
+app/src/api/ontology.spec.ts-82-    } catch (err) {
+app/src/api/ontology.spec.ts-83-      caught = err;
+app/src/api/ontology.spec.ts-84-    }
+--
+app/src/api/analysis.ts-378- * interaction network for the fixed public preset:
+app/src/api/analysis.ts-379- * cluster_type="clusters", min_confidence="400", max_edges="10000".
+app/src/api/analysis.ts-380- */
+app/src/api/analysis.ts:381:export async function getNetworkEdges(
+app/src/api/analysis.ts-382-  params: NetworkEdgesParams = {},
+app/src/api/analysis.ts-383-  config?: AxiosRequestConfig
+app/src/api/analysis.ts-384-): Promise<NetworkEdgesResponse> {
+--
+app/src/api/publication.ts-337- *
+app/src/api/publication.ts-338- * Cursor-paginated PubTator search-cache table.
+app/src/api/publication.ts-339- */
+app/src/api/publication.ts:340:export async function listPubtatorTable(
+app/src/api/publication.ts-341-  params: PubtatorTableParams = {},
+app/src/api/publication.ts-342-  config?: AxiosRequestConfig
+app/src/api/publication.ts-343-): Promise<PubtatorTableResponse> {
+--
+app/src/api/publication.ts-350-/**
+app/src/api/publication.ts-351- * GET /api/publication/pubtator/table?format=xlsx
+app/src/api/publication.ts-352- */
+app/src/api/publication.ts:353:export async function listPubtatorTableXlsx(
+app/src/api/publication.ts-354-  params: Omit<PubtatorTableParams, 'format'> = {},
+app/src/api/publication.ts-355-  config?: AxiosRequestConfig
+app/src/api/publication.ts-356-): Promise<Blob> {
+--
+app/src/api/publication.ts-418- *
+app/src/api/publication.ts-419- * Throws AxiosError on non-2xx (400 missing query).
+app/src/api/publication.ts-420- */
+app/src/api/publication.ts:421:export async function getPubtatorCacheStatus(
+app/src/api/publication.ts-422-  params: PubtatorCacheStatusParams,
+app/src/api/publication.ts-423-  config?: AxiosRequestConfig
+app/src/api/publication.ts-424-): Promise<PubtatorCacheStatus> {
+--
+app/src/api/publication.spec.ts-11-  listPublications,
+app/src/api/publication.spec.ts-12-  listPublicationsXlsx,
+app/src/api/publication.spec.ts-13-  searchPubtator,
+app/src/api/publication.spec.ts:14:  listPubtatorTable,
+app/src/api/publication.spec.ts:15:  listPubtatorTableXlsx,
+app/src/api/publication.spec.ts-16-  listPubtatorGenes,
+app/src/api/publication.spec.ts-17-  listPubtatorGenesXlsx,
+app/src/api/publication.spec.ts-18-  backfillPubtatorGenes,
+app/src/api/publication.spec.ts:19:  getPubtatorCacheStatus,
+app/src/api/publication.spec.ts-20-  updatePubtator,
+app/src/api/publication.spec.ts-21-  submitPubtatorUpdate,
+app/src/api/publication.spec.ts-22-  clearPubtatorCache,
+--
+app/src/api/publication.spec.ts-120-  });
+app/src/api/publication.spec.ts-121-});
+app/src/api/publication.spec.ts-122-
+app/src/api/publication.spec.ts:123:describe('api/publication — listPubtatorTable', () => {
+app/src/api/publication.spec.ts-124-  it('forces format=json and returns the table envelope', async () => {
+app/src/api/publication.spec.ts-125-    let observedQuery: URLSearchParams | null = null;
+app/src/api/publication.spec.ts-126-    const ok: PubtatorTableResponse = { data: [] };
+--
+app/src/api/publication.spec.ts-131-      })
+app/src/api/publication.spec.ts-132-    );
+app/src/api/publication.spec.ts-133-
+app/src/api/publication.spec.ts:134:    await listPubtatorTable();
+app/src/api/publication.spec.ts-135-    expect((observedQuery as unknown as URLSearchParams).get('format')).toBe('json');
+app/src/api/publication.spec.ts-136-  });
+app/src/api/publication.spec.ts-137-
+--
+app/src/api/publication.spec.ts-146-    );
+app/src/api/publication.spec.ts-147-
+app/src/api/publication.spec.ts-148-    const controller = new AbortController();
+app/src/api/publication.spec.ts:149:    const result = await listPubtatorTable(
+app/src/api/publication.spec.ts-150-      {
+app/src/api/publication.spec.ts-151-        filter: 'any(pmid,123,456)',
+app/src/api/publication.spec.ts-152-        fields: 'search_id,pmid,title',
+--
+app/src/api/publication.spec.ts-165-  });
+app/src/api/publication.spec.ts-166-});
+app/src/api/publication.spec.ts-167-
+app/src/api/publication.spec.ts:168:describe('api/publication — listPubtatorTableXlsx', () => {
+app/src/api/publication.spec.ts-169-  it('returns a Blob and forces format=xlsx', async () => {
+app/src/api/publication.spec.ts-170-    server.use(
+app/src/api/publication.spec.ts-171-      http.get(
+--
+app/src/api/publication.spec.ts-179-          })
+app/src/api/publication.spec.ts-180-      )
+app/src/api/publication.spec.ts-181-    );
+app/src/api/publication.spec.ts:182:    const blob = await listPubtatorTableXlsx();
+app/src/api/publication.spec.ts-183-    expect(blob).toBeInstanceOf(Blob);
+app/src/api/publication.spec.ts-184-  });
+app/src/api/publication.spec.ts-185-});
+--
+app/src/api/publication.spec.ts-254-  });
+app/src/api/publication.spec.ts-255-});
+app/src/api/publication.spec.ts-256-
+app/src/api/publication.spec.ts:257:describe('api/publication — getPubtatorCacheStatus', () => {
+app/src/api/publication.spec.ts-258-  it('forwards query and returns the status envelope', async () => {
+app/src/api/publication.spec.ts-259-    let observedQuery: URLSearchParams | null = null;
+app/src/api/publication.spec.ts-260-    const ok: PubtatorCacheStatus = {
+--
+app/src/api/publication.spec.ts-274-      })
+app/src/api/publication.spec.ts-275-    );
+app/src/api/publication.spec.ts-276-
+app/src/api/publication.spec.ts:277:    await getPubtatorCacheStatus({ query: 'epilepsy' });
+app/src/api/publication.spec.ts-278-    expect((observedQuery as unknown as URLSearchParams).get('query')).toBe('epilepsy');
+app/src/api/publication.spec.ts-279-  });
+app/src/api/publication.spec.ts-280-
+--
+app/src/api/publication.spec.ts-287-
+app/src/api/publication.spec.ts-288-    let caught: unknown;
+app/src/api/publication.spec.ts-289-    try {
+app/src/api/publication.spec.ts:290:      await getPubtatorCacheStatus({ query: '' });
+app/src/api/publication.spec.ts-291-    } catch (err) {
+app/src/api/publication.spec.ts-292-      caught = err;
+app/src/api/publication.spec.ts-293-    }
+     1	# #553 S5c Frontend Request Ownership Implementation Plan
+     2	
+     3	> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:test-driven-development. Steps use checkbox (`- [ ]`) syntax for tracking.
+     4	
+     5	**Goal:** Ensure only a read request that still owns a consumer's latest intent may update reactive data, error, busy/loading flags, browser state, or deferred callbacks.
+     6	
+     7	**Architecture:** Follow S5/S5b's two-level model. Each composable owns a monotonic instance generation plus its own `AbortController`; starting a newer logical read aborts and invalidates the old one, and every success/catch/finally/deferred callback checks ownership. Shared transports retain their own slot identity: `useUserData` stores pending promises by parameter key and every subscribing instance applies only when its local generation/params are current; `tableRequestCoordinator` gives each caller a consumer generation rather than using its global transport generation as consumer identity.
+     8	
+     9	**Tech Stack:** Vue 3 composables, typed `@/api/*` clients, AbortController, Vitest/MSW.
+    10	
+    11	---
+    12	
+    13	## Invariants
+    14	
+    15	- No raw axios or direct `localStorage.token` / `localStorage.user` access.
+    16	- Capture identity before every await; stale success, catch, finally, `nextTick`, and abort cleanup are no-ops for consumer state.
+    17	- Abort is best-effort only; generation/slot checks remain the correctness boundary.
+    18	- A shared in-flight transport may serve multiple current consumers, but a transport completion may not clear/replace a newer transport slot.
+    19	- Tests use deferred promises and resolve obsolete work after the newer intent; no sleep-based race tests.
+    20	- Keep every touched source and test below 600 lines. Extract a cohesive test fixture/helper only if a target approaches the ceiling.
+    21	
+    22	## Task 1: Plan review before production edits
+    23	
+    24	**Files:**
+    25	- Create: `.planning/reviews/2026-07-13-security-535-s5c-request-ownership-plan-codex-review.md`
+    26	
+    27	- [ ] Run a background, xhigh, read-only Codex plan review against this plan, the S5/S5b plans/reviews, and the nine target files.
+    28	- [ ] Fold any BLOCKER/HIGH and inexpensive MEDIUM/LOW into this plan before tests or production code.
+    29	
+    30	## Task 2: `useUserData` params-keyed shared transport
+    31	
+    32	**Files:**
+    33	- Modify: `app/src/views/admin/composables/useUserData.ts`
+    34	- Test: `app/src/views/admin/composables/__tests__/useUserData.spec.ts`
+    35	
+    36	- [ ] Add RED tests for two mounted/live instances requesting the same params: exactly one typed-client request, both current subscribers receive the result, and neither instance remains busy.
+    37	- [ ] Add RED tests for A-B-A and stale rejection/finally while the newer request remains pending; prove a stale request cannot clear the new slot, cache, busy flag, or URL.
+    38	- [ ] Replace `moduleApiCallInProgress`/single-param bookkeeping with a module `Map<string, Promise<UserTableResponse>>` and per-param latest-start sequence/cache metadata. A new transport records itself only if it still owns its keyed slot; stale completion cannot delete or cache over a newer same-param transport.
+    39	- [ ] Each `useUserData()` instance retains its own intent generation and params predicate. A shared promise is subscribed to rather than silently returning; success/catch/finally, `nextTick(currentPage)`, and cache apply require that local predicate.
+    40	- [ ] Run the targeted spec GREEN.
+    41	
+    42	## Task 3: Cross-instance table transport ownership
+    43	
+    44	**Files:**
+    45	- Modify: `app/src/utils/tableRequestCoordinator.ts`
+    46	- Test: `app/src/utils/tableRequestCoordinator.spec.ts`
+    47	
+    48	- [ ] Add RED tests with two distinct consumers sharing params: a later request from consumer B must not suppress still-current A; both apply the shared response exactly once.
+    49	- [ ] Add RED tests for one consumer changing params while another stays current, and for stale shared rejection; only the stale consumer is suppressed and the new slot is not cleared.
+    50	- [ ] Separate transport-slot generation (network/cache mutation) from caller-owned request generation. The coordinator keeps one shared in-flight slot but creates a per-caller token, and checks that token plus `isCurrent(params)` around apply/onError.
+    51	- [ ] Run the coordinator spec GREEN.
+    52	
+    53	## Task 4: Entity and review workflow reads
+    54	
+    55	**Files:**
+    56	- Modify: `app/src/views/curate/composables/useEntityInfo.ts`
+    57	- Test: `app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts`
+    58	- Modify: `app/src/views/review/composables/useReviewData.ts`
+    59	- Test: `app/src/views/review/composables/__tests__/useReviewData.spec.ts`
+    60	
+    61	- [ ] Add deferred A-B-A tests for entity, review, and status loads. Resolve the original request last and assert no mixed entity/review/status model, no stale clear/reset, and no stale error toast.
+    62	- [ ] Add per-read generation + AbortController state. Start a new logical read by aborting and superseding the previous controller; pass `signal` through the existing typed clients. Guard every multi-call `useEntityInfo.loadReview()` mutation as one atomic snapshot.
+    63	- [ ] In `useReviewData`, independently own table, option-list, entity, review-info, and status-info request families. Guard `isBusy`, `loading`, `loading_status_modal`, reactive-object assignment, option clears, and errors. `resetEntityContext()` invalidates its entity/review generations.
+    64	- [ ] If `useReviewData.ts` approaches 600 lines, move only the request-owner helper/types to an explicitly imported sibling file; preserve its public composable API.
+    65	- [ ] Run both targeted specs GREEN.
+    66	
+    67	## Task 5: Per-gene, trend, network, and PubTator admin reads
+    68	
+    69	**Files:**
+    70	- Modify: `app/src/composables/usePubtatorGenePublications.ts`
+    71	- Test: `app/src/composables/usePubtatorGenePublications.spec.ts`
+    72	- Modify: `app/src/views/admin/composables/useAdminTrendData.ts`
+    73	- Create: `app/src/views/admin/composables/useAdminTrendData.spec.ts`
+    74	- Modify: `app/src/composables/useNetworkData.ts`
+    75	- Test: `app/src/composables/useNetworkData.spec.ts`
+    76	- Modify: `app/src/composables/usePubtatorAdmin.ts`
+    77	- Create: `app/src/composables/usePubtatorAdmin.spec.ts`
+    78	
+    79	- [ ] Add RED tests that supersede a gene/publication read via `resetCache()`/same-gene refetch; stale success, catch, and finally cannot repopulate cache, clear a newer controller, or stop its spinner.
+    80	- [ ] Add RED trend/network/admin-status tests with deferred typed-client promises: B wins over A; A's success/catch/finally cannot clear B's data/loading/error/controller. Test actual abort cleanup where a controller exists.
+    81	- [ ] Give each logical key/request family its own generation and controller. `useNetworkData` preserves the global preload promise as the transport slot but races a local abort signal and gates consumer refs/loading by its per-instance generation; cancelling one consumer must not abort the shared preload for another.
+    82	- [ ] Run all four targeted specs GREEN.
+    83	
+    84	## Task 6: `useOntologyAdminTable` deferred page ownership
+    85	
+    86	**Files:**
+    87	- Modify: `app/src/views/admin/composables/useOntologyAdminTable.ts`
+    88	- Test: `app/src/views/admin/ManageOntology.spec.ts`
+    89	
+    90	- [ ] Add a RED deferred-response test: request page A, start page B, resolve A last, then flush `nextTick`; A must not assign B's `currentPage`, cursors, rows, busy flag, or URL.
+    91	- [ ] Capture a local table-load generation at intent scheduling, pass its ownership predicate into `applyApiResponse`, and recheck it inside the deferred `nextTick(currentPage)` assignment. `doLoadData` passes the same predicate to coordinator apply/error and clears busy only for its own current intent.
+    92	- [ ] Run the focused ManageOntology spec GREEN.
+    93	
+    94	## Task 7: Final verification, adversarial review, and stacked PR
+    95	
+    96	- [ ] Run all targeted specs, `make code-quality-audit`, `make lint-app`, `cd app && npm run type-check:strict`, `cd app && npm run test:unit`, and `git diff --check` with fresh output.
+    97	- [ ] Run a background deep xhigh Codex diff review. Fold all BLOCKER/HIGH and inexpensive MEDIUM/LOW test-first; repeat until no BLOCKER/HIGH remains. Commit the concise round/verdict record to `.planning/reviews/2026-07-13-security-535-s5c-request-ownership-diff-codex-review.md`.
+    98	- [ ] After a final `git status -sb`, commit on `fix/535-s5c-request-ownership`, push, and create one PR with base `fix/535-composables-bundle-budget`, `Closes #553`, and `Refs #535` on separate lines. Do not merge.
+    99	
+   100	## Self-review
+   101	
+   102	- Scope coverage: `useUserData` map → Task 2; coordinator cross-instance semantics → Task 3; entity/review ownership → Task 4; remaining four read composables → Task 5; ontology deferred page write → Task 6.
+   103	- No new public APIs or raw transport boundary are proposed; implementation is restricted to typed existing clients and S5/S5b identity patterns.
+   104	- Every async mutation class named by the issue—success, error, finally, abort cleanup, shared subscriber, and deferred callback—has a deterministic test task.
+     1	export type TableRequestSource = 'cache' | 'network' | 'shared';
+     2	
+     3	export interface TableRequestResult {
+     4	  handled: boolean;
+     5	  source: TableRequestSource;
+     6	}
+     7	
+     8	interface TableRequestOptions<T> {
+     9	  params: string;
+    10	  fetcher: () => Promise<T>;
+    11	  apply: (data: T, source: TableRequestSource) => void;
+    12	  onError: (error: unknown, source: TableRequestSource) => void;
+    13	  isCurrent: (params: string) => boolean;
+    14	  now?: () => number;
+    15	}
+    16	
+    17	export function createTableRequestCoordinator<T>(recentWindowMs = 500) {
+    18	  let lastParams: string | null = null;
+    19	  let lastCallTime = 0;
+    20	  let lastResponse: T | null = null;
+    21	  let lastResponseParams: string | null = null;
+    22	  let inFlightPromise: Promise<T> | null = null;
+    23	  let inFlightParams: string | null = null;
+    24	  // Monotonic request-instance identity. The `params` string alone cannot
+    25	  // distinguish the original request A from a later A2 after an A→B→A sequence
+    26	  // (an A-B-A race), so a generation stamps every network request; only the
+    27	  // latest generation may apply, and only the owning generation may clear the
+    28	  // in-flight slot (#535 P1-7).
+    29	  let inFlightGen = 0;
+    30	  let generation = 0;
+    31	
+    32	  async function request({
+    33	    params,
+    34	    fetcher,
+    35	    apply,
+    36	    onError,
+    37	    isCurrent,
+    38	    now = () => Date.now(),
+    39	  }: TableRequestOptions<T>): Promise<TableRequestResult> {
+    40	    if (inFlightParams === params && inFlightPromise) {
+    41	      const source: TableRequestSource = 'shared';
+    42	      // Borrow the in-flight promise but capture the current generation so a
+    43	      // newer request (even same params) supersedes this borrower.
+    44	      const myGen = generation;
+    45	      const shared = inFlightPromise;
+    46	      try {
+    47	        const data = await shared;
+    48	        if (myGen !== generation || !isCurrent(params)) return { handled: false, source };
+    49	        apply(data, source);
+    50	        return { handled: true, source };
+    51	      } catch (error) {
+    52	        if (myGen !== generation || !isCurrent(params)) return { handled: false, source };
+    53	        onError(error, source);
+    54	        return { handled: true, source };
+    55	      }
+    56	    }
+    57	
+    58	    if (
+    59	      lastParams === params &&
+    60	      now() - lastCallTime < recentWindowMs &&
+    61	      lastResponse !== null &&
+    62	      lastResponseParams === params
+    63	    ) {
+    64	      const source: TableRequestSource = 'cache';
+    65	      if (!isCurrent(params)) return { handled: false, source };
+    66	      apply(lastResponse, source);
+    67	      return { handled: true, source };
+    68	    }
+    69	
+    70	    const source: TableRequestSource = 'network';
+    71	    const myGen = ++generation;
+    72	    lastParams = params;
+    73	    lastCallTime = now();
+    74	    lastResponse = null;
+    75	    lastResponseParams = null;
+    76	
+    77	    const promise = fetcher();
+    78	    inFlightPromise = promise;
+    79	    inFlightParams = params;
+    80	    inFlightGen = myGen;
+    81	
+    82	    try {
+    83	      const data = await promise;
+    84	      // Only the owning generation may clear the in-flight slot / record the
+    85	      // recent-response cache — an older A must not clobber a newer A2's slot.
+    86	      if (inFlightGen === myGen) {
+    87	        inFlightPromise = null;
+    88	        inFlightParams = null;
+    89	        lastResponse = data;
+    90	        lastResponseParams = params;
+    91	      }
+    92	      if (myGen !== generation || !isCurrent(params)) return { handled: false, source };
+    93	      apply(data, source);
+    94	      return { handled: true, source };
+    95	    } catch (error) {
+    96	      if (inFlightGen === myGen) {
+    97	        inFlightPromise = null;
+    98	        inFlightParams = null;
+    99	        lastResponse = null;
+   100	        lastResponseParams = null;
+   101	      }
+   102	      if (myGen !== generation || !isCurrent(params)) return { handled: false, source };
+   103	      onError(error, source);
+   104	      return { handled: true, source };
+   105	    }
+   106	  }
+   107	
+   108	  return { request };
+   109	}
+   250	  }
+   251	
+   252	  // Handle sort updates from GenericTable.
+   253	  function handleSortUpdate(newSortBy: Array<{ key: string; order: 'asc' | 'desc' }>): void {
+   254	    sortBy.value = newSortBy;
+   255	    handleSortByOrDescChange();
+   256	  }
+   257	
+   258	  // Load data with debouncing.
+   259	  function loadData(): void {
+   260	    if (loadDataDebounceTimer.value) {
+   261	      clearTimeout(loadDataDebounceTimer.value);
+   262	    }
+   263	    loadDataDebounceTimer.value = setTimeout(() => {
+   264	      loadDataDebounceTimer.value = null;
+   265	      void doLoadData();
+   266	    }, 50);
+   267	  }
+   268	
+   269	  // Actual data loading method with module-level request coordination.
+   270	  async function doLoadData(): Promise<void> {
+   271	    const buildParams = () =>
+   272	      `sort=${sort.value}&filter=${filter_string.value}&page_after=${currentItemID.value}&page_size=${perPage.value}`;
+   273	    const urlParam = buildParams();
+   274	    isBusy.value = true;
+   275	
+   276	    const result = await ontologyRequestCoordinator.request({
+   277	      params: urlParam,
+   278	      fetcher: () =>
+   279	        listVariantOntology({
+   280	          sort: sort.value,
+   281	          filter: filter_string.value,
+   282	          page_after: currentItemID.value,
+   283	          page_size: perPage.value,
+   284	        }),
+   285	      apply: (data, source) => {
+   286	        applyApiResponse(data);
+   287	        if (source === 'network') {
+   288	          updateBrowserUrl();
+   289	        }
+   290	      },
+   291	      onError: (e) => makeToast(e, 'Error', 'danger'),
+   292	      isCurrent: (params) => buildParams() === params,
+   293	    });
+   294	
+   295	    if (result.handled) {
+   296	      isBusy.value = false;
+   297	    }
+   298	  }
+   299	
+   300	  /**
+   301	   * Apply API response data to component state. Extracted to allow reuse
+   302	   * when skipping duplicate API calls (see doLoadData's `apply` callback).
+   303	   */
+   304	  function applyApiResponse(data: VariantOntologyListResponse): void {
+   305	    const meta = (data.meta as OntologyListMeta[])[0];
+   306	
+   307	    ontologies.value = data.data;
+   308	    totalRows.value = meta.totalItems;
+   309	    void nextTick(() => {
+   310	      currentPage.value = meta.currentPage;
+   311	    });
+   312	    totalPages.value = meta.totalPages;
+   313	    // VariO cursor IDs are strings like "VariO:0026" — store them as-is so the
+   314	    // cursor survives to the next page request. Only null/undefined/"null"
+   315	    // collapse to the page-1 sentinel 0 (Number() would map every string to
+   316	    // 0, #531). Mirrors usePublicationsTable's cursorOrZero.
+   317	    const cursorOrZero = (v: unknown): string | number =>
+   318	      v === 'null' ? 0 : (v as string | number) || 0;
+   319	    prevItemID.value = cursorOrZero(meta.prevItemID);
+   320	    currentItemID.value = cursorOrZero(meta.currentItemID);
+   321	    nextItemID.value = cursorOrZero(meta.nextItemID);
+   322	    lastItemID.value = cursorOrZero(meta.lastItemID);
+   323	    executionTime.value = meta.executionTime;
+   324	
+   325	    const uiStore = useUiStore();
+   326	    uiStore.requestScrollbarUpdate();
+   327	  }
+   328	
+   329	  /** Handle client-side Excel export of the currently loaded page. */
+   330	  function handleExport(): void {
+   331	    void exportToExcel(ontologies.value, {
+   332	      filename: `ontology_export_${new Date().toISOString().split('T')[0]}`,
+   333	      sheetName: 'Ontology',
+   334	      headers: ONTOLOGY_EXPORT_HEADERS,
+   335	    });
+
+exec
+/bin/bash -lc "sed -n '175,225p' app/src/api/statistics.ts; sed -n '185,220p' app/src/api/review.ts; sed -n '125,155p' app/src/api/status.ts; sed -n '185,215p' app/src/api/entity.ts; sed -n '300,400p' app/src/api/entity.ts; sed -n '250,280p' app/src/api/re_review.ts; sed -n '100,215p' app/src/api/list.ts; sed -n '410,440p' app/src/api/publication.ts; sed -n '370,395p' app/src/api/analysis.ts; nl -ba app/src/composables/usePubtatorGenePublications.ts; nl -ba app/src/views/admin/composables/useAdminTrendData.ts; nl -ba app/src/composables/useNetworkData.ts | sed -n '125,270p'; nl -ba app/src/composables/usePubtatorAdmin.ts | sed -n '30,95p'" in /home/bernt-popp/development/sysndd/.claude/worktrees/535-s5c-request-ownership
+ succeeded in 0ms:
+  config?: AxiosRequestConfig
+): Promise<NewsRow[]> {
+  return apiClient.get<NewsRow[]>('/api/statistics/news', {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...params },
+  });
+}
+
+/**
+ * GET /api/statistics/entities_over_time
+ * Mirrors api/endpoints/statistics_endpoints.R:74 (handler `@get /entities_over_time`).
+ *
+ * Returns cumulative-entity time-series data with grouped meta information.
+ */
+export async function getEntitiesOverTime(
+  params: EntitiesOverTimeParams = {},
+  config?: AxiosRequestConfig
+): Promise<EntitiesOverTimeResponse> {
+  return apiClient.get<EntitiesOverTimeResponse>('/api/statistics/entities_over_time', {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...params },
+  });
+}
+
+/**
+ * GET /api/statistics/updates
+ * Mirrors api/endpoints/statistics_endpoints.R:234 (handler `@get /updates`).
+ *
+ * Administrator-only. Returns new-entity counts within the given date range.
+ */
+export async function getUpdatesStats(
+  params: AdminDateRangeParams,
+  config?: AxiosRequestConfig
+): Promise<UpdatesStats> {
+  return apiClient.get<UpdatesStats>('/api/statistics/updates', {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...params },
+  });
+}
+
+/**
+ * GET /api/statistics/rereview
+ * Mirrors api/endpoints/statistics_endpoints.R:279 (handler `@get /rereview`).
+ *
+ * Administrator-only. Returns submitted re-review counts within range.
+ */
+export async function getRereviewStats(
+  params: AdminDateRangeParams,
+  config?: AxiosRequestConfig
+): Promise<RereviewStats> {
+  return apiClient.get<RereviewStats>('/api/statistics/rereview', {
+  params: ReviewMutationParams = {},
+  config?: AxiosRequestConfig
+): Promise<ReviewMutationResponse> {
+  return apiClient.put<ReviewMutationResponse, ReviewMutationRequest>('/api/review/update', body, {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...params },
+  });
+}
+
+/**
+ * GET /api/review/<review_id_requested>
+ * Mirrors api/endpoints/review_endpoints.R:410 (handler `@get /<review_id_requested>`).
+ *
+ * Returns the review row(s) for the requested ID. The R handler accepts
+ * comma-separated IDs and returns all matching rows.
+ */
+export async function getReviewById(
+  review_id_requested: number | string,
+  config?: AxiosRequestConfig
+): Promise<ReviewByIdRow[]> {
+  const path = `/api/review/${encodeURIComponent(String(review_id_requested))}`;
+  return apiClient.get<ReviewByIdRow[]>(path, config);
+}
+
+/**
+ * GET /api/review/<review_id_requested>/phenotypes
+ * Mirrors api/endpoints/review_endpoints.R:464 (handler `@get /<review_id_requested>/phenotypes`).
+ */
+export async function getReviewPhenotypes(
+  review_id_requested: number | string,
+  config?: AxiosRequestConfig
+): Promise<ReviewPhenotypeRow[]> {
+  const path = `/api/review/${encodeURIComponent(String(review_id_requested))}/phenotypes`;
+  return apiClient.get<ReviewPhenotypeRow[]>(path, config);
+}
+
+  params: ListStatusParams = {},
+  config?: AxiosRequestConfig
+): Promise<StatusListRow[]> {
+  return apiClient.get<StatusListRow[]>('/api/status/', {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...params },
+  });
+}
+
+/**
+ * GET /api/status/<status_id_requested>
+ * Mirrors api/endpoints/status_endpoints.R:169 (handler `@get /<status_id_requested>`).
+ *
+ * Returns the status row(s) for the requested ID. Comma-separated IDs are
+ * accepted server-side.
+ */
+export async function getStatusById(
+  status_id_requested: number | string,
+  config?: AxiosRequestConfig
+): Promise<StatusByIdRow[]> {
+  const path = `/api/status/${encodeURIComponent(String(status_id_requested))}`;
+  return apiClient.get<StatusByIdRow[]>(path, config);
+}
+
+/**
+ * GET /api/status/_list
+ * Mirrors api/endpoints/status_endpoints.R:229 (handler `@get _list`).
+ *
+ * Returns the paginated status-category list (used by category dropdowns).
+ */
+export async function listStatusCategories(
+  is_reviewed: number | string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /api/entity/
+ * Mirrors api/endpoints/entity_endpoints.R:44 (handler `@get /`).
+ *
+ * Cursor-paginated entity listing. `format=json` (default) returns the
+ * envelope below; `format=xlsx` returns a binary attachment — for that path
+ * use `listEntitiesXlsx()`.
+ */
+export async function listEntities(
+  params: ListEntitiesParams = {},
+  config?: AxiosRequestConfig
+): Promise<EntityListResponse> {
+  return apiClient.get<EntityListResponse>('/api/entity/', {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...params, format: 'json' },
+  });
+}
+
+/**
+ * GET /api/entity/?format=xlsx
+ * Same handler as `listEntities`, but surfaces the XLSX byte stream as a
+ * `Blob` for download.
+ */
+export async function listEntitiesXlsx(
+}
+
+/**
+ * GET /api/entity/<sysndd_id>/phenotypes
+ * Mirrors api/endpoints/entity_endpoints.R:695 (handler `@get /<sysndd_id>/phenotypes`).
+ *
+ * Returns phenotypes for the given entity. By default only phenotypes from
+ * the currently-active review (`is_primary = 1`) are returned; pass
+ * `current_review: false` for the legacy "all active" view.
+ */
+export async function getEntityPhenotypes(
+  sysndd_id: number | string,
+  params: NestedQueryParams = {},
+  config?: AxiosRequestConfig
+): Promise<EntityPhenotypeRow[]> {
+  const path = `/api/entity/${encodeURIComponent(String(sysndd_id))}/phenotypes`;
+  const query = nestedQuery(params);
+  return apiClient.get<EntityPhenotypeRow[]>(path, {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...(query ?? {}) },
+  });
+}
+
+/**
+ * GET /api/entity/<sysndd_id>/variation
+ * Mirrors api/endpoints/entity_endpoints.R:764 (handler `@get /<sysndd_id>/variation`).
+ *
+ * Returns variation-ontology terms for the entity (current review by default).
+ */
+export async function getEntityVariation(
+  sysndd_id: number | string,
+  params: NestedQueryParams = {},
+  config?: AxiosRequestConfig
+): Promise<EntityVariationRow[]> {
+  const path = `/api/entity/${encodeURIComponent(String(sysndd_id))}/variation`;
+  const query = nestedQuery(params);
+  return apiClient.get<EntityVariationRow[]>(path, {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...(query ?? {}) },
+  });
+}
+
+/**
+ * GET /api/entity/<sysndd_id>/review
+ * Mirrors api/endpoints/entity_endpoints.R:823 (handler `@get /<sysndd_id>/review`).
+ *
+ * Returns the primary clinical synopsis for the entity. Always returns at
+ * least one row (an empty-keys row when the entity has no primary review).
+ */
+export async function getEntityReview(
+  sysndd_id: number | string,
+  config?: AxiosRequestConfig
+): Promise<EntityReviewRow[]> {
+  const path = `/api/entity/${encodeURIComponent(String(sysndd_id))}/review`;
+  return apiClient.get<EntityReviewRow[]>(path, config);
+}
+
+/**
+ * GET /api/entity/<sysndd_id>/status
+ * Mirrors api/endpoints/entity_endpoints.R:863 (handler `@get /<sysndd_id>/status`).
+ *
+ * Returns the active status rows for the entity ordered by status_date.
+ */
+export async function getEntityStatus(
+  sysndd_id: number | string,
+  config?: AxiosRequestConfig
+): Promise<EntityStatusRow[]> {
+  const path = `/api/entity/${encodeURIComponent(String(sysndd_id))}/status`;
+  return apiClient.get<EntityStatusRow[]>(path, config);
+}
+
+/**
+ * GET /api/entity/<sysndd_id>/publications
+ * Mirrors api/endpoints/entity_endpoints.R:913 (handler `@get /<sysndd_id>/publications`).
+ *
+ * Returns publications attached to the entity (current review by default).
+ */
+export async function getEntityPublications(
+  sysndd_id: number | string,
+  params: NestedQueryParams = {},
+  config?: AxiosRequestConfig
+): Promise<EntityPublicationRow[]> {
+  const path = `/api/entity/${encodeURIComponent(String(sysndd_id))}/publications`;
+  const query = nestedQuery(params);
+  return apiClient.get<EntityPublicationRow[]>(path, {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...(query ?? {}) },
+  });
+}
+  return apiClient.put<ApproveReReviewResponse>(path, undefined, {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...params },
+  });
+}
+
+/**
+ * GET /api/re_review/table
+ * Mirrors api/endpoints/re_review_endpoints.R:148 (handler `@get table`).
+ *
+ * Returns the role-scoped re-review overview table. Curators see all batches
+ * via `curate=true`; reviewers see only their unsubmitted entries (curate
+ * defaults to FALSE).
+ */
+export async function getReReviewTable(
+  params: ReReviewTableParams = {},
+  config?: AxiosRequestConfig
+): Promise<ReReviewTableRow[]> {
+  return apiClient.get<ReReviewTableRow[]>('/api/re_review/table', {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...params },
+  });
+}
+
+/**
+ * GET /api/re_review/batch/apply
+ * Mirrors api/endpoints/re_review_endpoints.R:278 (handler `@get batch/apply`).
+ *
+ * Reviewer+ only. Sends an email asking for a new re-review batch
+ * assignment. Returns the email-send transport result.
+ */
+  params: ListPaginationParams = {},
+  config?: AxiosRequestConfig
+): Promise<PaginatedListResponse<StatusCategoryRow>> {
+  return apiClient.get<PaginatedListResponse<StatusCategoryRow>>('/api/list/status', {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...treeQuery(false), ...params },
+  });
+}
+
+/**
+ * GET /api/list/status?tree=TRUE
+ *
+ * Tree-formatted status categories for treeselect components.
+ */
+export async function listStatusCategoriesTree(config?: AxiosRequestConfig): Promise<TreeNode[]> {
+  return apiClient.get<TreeNode[]>('/api/list/status', {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...treeQuery(true) },
+  });
+}
+
+/**
+ * GET /api/list/phenotype?tree=FALSE
+ * Mirrors api/endpoints/list_endpoints.R:84 (handler `@get phenotype`).
+ *
+ * Paginated raw phenotype list (HPO terms).
+ */
+export async function listPhenotypes(
+  params: ListPaginationParams = {},
+  config?: AxiosRequestConfig
+): Promise<PaginatedListResponse<PhenotypeRow>> {
+  return apiClient.get<PaginatedListResponse<PhenotypeRow>>('/api/list/phenotype', {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...treeQuery(false), ...params },
+  });
+}
+
+/**
+ * GET /api/list/phenotype?tree=TRUE
+ *
+ * Tree-formatted phenotype list with modifier children (treeselect input).
+ */
+export async function listPhenotypesTree(config?: AxiosRequestConfig): Promise<TreeNode[]> {
+  return apiClient.get<TreeNode[]>('/api/list/phenotype', {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...treeQuery(true) },
+  });
+}
+
+/**
+ * GET /api/list/inheritance?tree=FALSE
+ * Mirrors api/endpoints/list_endpoints.R:156 (handler `@get inheritance`).
+ *
+ * Paginated raw mode-of-inheritance list.
+ */
+export async function listInheritance(
+  params: ListPaginationParams = {},
+  config?: AxiosRequestConfig
+): Promise<PaginatedListResponse<InheritanceRow>> {
+  return apiClient.get<PaginatedListResponse<InheritanceRow>>('/api/list/inheritance', {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...treeQuery(false), ...params },
+  });
+}
+
+/**
+ * GET /api/list/inheritance?tree=TRUE
+ *
+ * Tree-formatted inheritance terms (id + label only).
+ */
+export async function listInheritanceTree(config?: AxiosRequestConfig): Promise<TreeNode[]> {
+  return apiClient.get<TreeNode[]>('/api/list/inheritance', {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...treeQuery(true) },
+  });
+}
+
+/**
+ * GET /api/list/variation_ontology?tree=FALSE
+ * Mirrors api/endpoints/list_endpoints.R:221 (handler `@get variation_ontology`).
+ *
+ * Paginated raw variation-ontology list.
+ */
+export async function listVariationOntology(
+  params: ListPaginationParams = {},
+  config?: AxiosRequestConfig
+): Promise<PaginatedListResponse<VariationOntologyRow>> {
+  return apiClient.get<PaginatedListResponse<VariationOntologyRow>>(
+    '/api/list/variation_ontology',
+    {
+      ...config,
+      params: { ...(config?.params as object | undefined), ...treeQuery(false), ...params },
+    }
+  );
+}
+
+/**
+ * GET /api/list/variation_ontology?tree=TRUE
+ *
+ * Tree-formatted VariO terms with modifier children.
+ */
+export async function listVariationOntologyTree(config?: AxiosRequestConfig): Promise<TreeNode[]> {
+  return apiClient.get<TreeNode[]>('/api/list/variation_ontology', {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...treeQuery(true) },
+  });
+}
+  );
+}
+
+/**
+ * GET /api/publication/pubtator/cache-status
+ * Mirrors api/endpoints/publication_endpoints.R:763 (handler `@get /pubtator/cache-status`).
+ *
+ * Inspects the PubTator cache for the given query.
+ *
+ * Throws AxiosError on non-2xx (400 missing query).
+ */
+export async function getPubtatorCacheStatus(
+  params: PubtatorCacheStatusParams,
+  config?: AxiosRequestConfig
+): Promise<PubtatorCacheStatus> {
+  return apiClient.get<PubtatorCacheStatus>('/api/publication/pubtator/cache-status', {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...params },
+  });
+}
+
+/**
+ * POST /api/publication/pubtator/update
+ * Mirrors api/endpoints/publication_endpoints.R:852 (handler `@post /pubtator/update`).
+ *
+ * Synchronous PubTator update (admin). For long queries, prefer the async
+ * variant `submitPubtatorUpdate()` below.
+ *
+ * Throws AxiosError on non-2xx (400 missing query).
+ */
+export async function updatePubtator(
+  );
+}
+
+/**
+ * GET /api/analysis/network_edges
+ * Mirrors api/endpoints/analysis_endpoints.R:612 (handler `@get network_edges`).
+ *
+ * Returns Cytoscape.js-shaped node/edge payload for the protein-protein
+ * interaction network for the fixed public preset:
+ * cluster_type="clusters", min_confidence="400", max_edges="10000".
+ */
+export async function getNetworkEdges(
+  params: NetworkEdgesParams = {},
+  config?: AxiosRequestConfig
+): Promise<NetworkEdgesResponse> {
+  return apiClient.get<NetworkEdgesResponse>('/api/analysis/network_edges', {
+    ...config,
+    params: { ...(config?.params as object | undefined), ...params },
+  });
+}
+
+/**
+ * GET /api/analysis/functional_cluster_summary
+ * Mirrors api/endpoints/analysis_endpoints.R:713 (handler `@get functional_cluster_summary`).
+ *
+ * Retrieves or generates the LLM summary for a functional cluster.
+     1	// src/composables/usePubtatorGenePublications.ts
+     2	//
+     3	// Per-gene publication-detail cache for the PubtatorNDD gene-prioritization
+     4	// table. Each expandable gene row lazily fetches the full publication rows for
+     5	// its PMIDs from the PubTator table endpoint and caches them by gene_symbol.
+     6	//
+     7	// Extracted from PubtatorNDDGenes.vue (issue: frontend perf & UX sprint) to:
+     8	//   - keep that component under the file-size ceiling,
+     9	//   - scope the cache to the current filter/sort so a filter change cannot show
+    10	//     stale publications in an expanded row (correctness fix), and
+    11	//   - handle aborts and real fetch errors correctly (genuine aborts are
+    12	//     silent; real errors exit the loading state and surface a toast).
+    13	
+    14	import { ref } from 'vue';
+    15	import axios from 'axios';
+    16	import { listPubtatorTable } from '@/api/publication';
+    17	import type useToast from '@/composables/useToast';
+    18	
+    19	export interface PubtatorPublicationData {
+    20	  search_id?: number;
+    21	  pmid: number;
+    22	  doi?: string;
+    23	  title?: string;
+    24	  journal?: string;
+    25	  date?: string;
+    26	  score?: number;
+    27	  gene_symbols?: string;
+    28	  text_hl?: string;
+    29	}
+    30	
+    31	// Derive from the real useToast signature (accepts ToastVariant, not bare
+    32	// string) so consumers can pass useToast().makeToast under strict type-check.
+    33	type MakeToast = ReturnType<typeof useToast>['makeToast'];
+    34	
+    35	export function usePubtatorGenePublications(options: { makeToast: MakeToast }) {
+    36	  const { makeToast } = options;
+    37	
+    38	  // Publication data cache (keyed by gene_symbol).
+    39	  const publicationCache = ref<Record<string, PubtatorPublicationData[]>>({});
+    40	  const loadingPublications = ref<Record<string, boolean>>({});
+    41	
+    42	  // AbortControllers for per-gene fetches (prevents orphaned requests).
+    43	  const abortControllers = new Map<string, AbortController>();
+    44	
+    45	  /**
+    46	   * Reset the entire cache. Call when the gene filter/sort changes so an
+    47	   * expanded row never shows publications fetched under a previous query.
+    48	   * In-flight fetches are aborted so their late responses cannot repopulate
+    49	   * the freshly-cleared cache.
+    50	   */
+    51	  const resetCache = (): void => {
+    52	    abortControllers.forEach((controller) => controller.abort());
+    53	    abortControllers.clear();
+    54	    publicationCache.value = {};
+    55	    loadingPublications.value = {};
+    56	  };
+    57	
+    58	  /** Abort and clear every in-flight fetch (call on component unmount). */
+    59	  const cancelAll = (): void => {
+    60	    abortControllers.forEach((controller) => controller.abort());
+    61	    abortControllers.clear();
+    62	  };
+    63	
+    64	  /**
+    65	   * Fetch publication rows for a gene's PMIDs if not already cached.
+    66	   * Genuine aborts (filter change, unmount) are ignored silently; a real
+    67	   * upstream failure exits the loading state and surfaces a toast.
+    68	   */
+    69	  const fetchPublications = async (geneSymbol: string, pmids: string[]): Promise<void> => {
+    70	    if (pmids.length === 0) return;
+    71	    if (publicationCache.value[geneSymbol]) return; // Already cached
+    72	
+    73	    // Cancel any in-flight request for this gene.
+    74	    abortControllers.get(geneSymbol)?.abort();
+    75	    const controller = new AbortController();
+    76	    abortControllers.set(geneSymbol, controller);
+    77	
+    78	    loadingPublications.value[geneSymbol] = true;
+    79	
+    80	    try {
+    81	      const response = await listPubtatorTable(
+    82	        {
+    83	          filter: `any(pmid,${pmids.join(',')})`,
+    84	          fields: 'search_id,pmid,doi,title,journal,date,score,gene_symbols,text_hl',
+    85	          page_size: String(pmids.length),
+    86	        },
+    87	        { signal: controller.signal }
+    88	      );
+    89	      publicationCache.value[geneSymbol] = (response.data as PubtatorPublicationData[]) || [];
+    90	    } catch (error) {
+    91	      // Genuine aborts (axios CanceledError / DOMException AbortError) are not
+    92	      // errors — the caller intentionally cancelled. Stay silent.
+    93	      if (axios.isCancel(error) || (error as Error)?.name === 'AbortError') {
+    94	        return;
+    95	      }
+    96	      // Real failure: surface it and record an empty result so the row exits
+    97	      // its spinner and shows the PMID fallback rather than spinning forever.
+    98	      makeToast(error, 'Error loading publication details', 'danger');
+    99	      publicationCache.value[geneSymbol] = [];
+   100	    } finally {
+   101	      abortControllers.delete(geneSymbol);
+   102	      loadingPublications.value[geneSymbol] = false;
+   103	    }
+   104	  };
+   105	
+   106	  const getPublications = (geneSymbol: string): PubtatorPublicationData[] =>
+   107	    publicationCache.value[geneSymbol] || [];
+   108	
+   109	  const isLoading = (geneSymbol: string): boolean =>
+   110	    loadingPublications.value[geneSymbol] || false;
+   111	
+   112	  const isCached = (geneSymbol: string): boolean =>
+   113	    publicationCache.value[geneSymbol] !== undefined;
+   114	
+   115	  return {
+   116	    publicationCache,
+   117	    loadingPublications,
+   118	    fetchPublications,
+   119	    getPublications,
+   120	    isLoading,
+   121	    isCached,
+   122	    resetCache,
+   123	    cancelAll,
+   124	  };
+   125	}
+   126	
+   127	export default usePubtatorGenePublications;
+     1	// views/admin/composables/useAdminTrendData.ts
+     2	import { ref, computed, watch, onUnmounted } from 'vue';
+     3	import { mergeGroupedCumulativeSeries, extractPerGroupSeries } from '@/utils/timeSeriesUtils';
+     4	import type { GroupedTimeSeries } from '@/utils/timeSeriesUtils';
+     5	import { safeArray } from '@/utils/apiUtils';
+     6	import { getEntitiesOverTime } from '@/api/statistics';
+     7	import type { EntitiesOverTimeParams } from '@/api/statistics';
+     8	
+     9	interface TrendDataPoint {
+    10	  date: string;
+    11	  count: number;
+    12	}
+    13	
+    14	export function useAdminTrendData(
+    15	  makeToast: (msg: unknown, title: string, variant: string) => void
+    16	) {
+    17	  const trendData = ref<TrendDataPoint[]>([]);
+    18	  const trendCategoryData = ref<{ dates: string[]; series: Record<string, number[]> }>({
+    19	    dates: [],
+    20	    series: {},
+    21	  });
+    22	
+    23	  const loading = ref(false);
+    24	  const trendYMax = ref<number | undefined>(undefined);
+    25	
+    26	  // Filter controls
+    27	  const granularity = ref<'month' | 'week' | 'day'>('month');
+    28	  const nddFilter = ref<'ndd' | 'non_ndd' | 'all'>('ndd');
+    29	  const categoryDisplay = ref<'combined' | 'by_category'>('combined');
+    30	  const selectedCategories = ref<string[]>(['Definitive', 'Moderate', 'Limited', 'Refuted']);
+    31	
+    32	  // Request versioning and AbortController
+    33	  let abortController: AbortController | null = null;
+    34	  let requestVersion = 0;
+    35	
+    36	  function buildTrendFilter(): string | undefined {
+    37	    const parts: string[] = [];
+    38	
+    39	    if (nddFilter.value === 'ndd') {
+    40	      parts.push('contains(ndd_phenotype_word,Yes)');
+    41	    } else if (nddFilter.value === 'non_ndd') {
+    42	      parts.push('contains(ndd_phenotype_word,No)');
+    43	    }
+    44	
+    45	    if (selectedCategories.value.length > 0 && selectedCategories.value.length < 4) {
+    46	      parts.push(`any(category,${selectedCategories.value.join(',')})`);
+    47	    }
+    48	
+    49	    if (parts.length === 0) return '';
+    50	    if (parts.length === 1 && parts[0] === 'contains(ndd_phenotype_word,Yes)') {
+    51	      return undefined;
+    52	    }
+    53	    return parts.join(',');
+    54	  }
+    55	
+    56	  const trendDescription = computed(() => {
+    57	    const nddLabel =
+    58	      nddFilter.value === 'ndd' ? 'NDD' : nddFilter.value === 'non_ndd' ? 'non-NDD' : 'all';
+    59	
+    60	    if (categoryDisplay.value === 'by_category') {
+    61	      return `Per-category cumulative counts of ${nddLabel} gene-disease associations curated over time.`;
+    62	    }
+    63	    return (
+    64	      `Cumulative count of ${nddLabel} gene-disease associations curated over time.` +
+    65	      ' The dashed trend line represents a 3-period moving average for temporal smoothing.'
+    66	    );
+    67	  });
+    68	
+    69	  // Derived total entities from trend data (final cumulative value)
+    70	  const totalEntities = ref(0);
+    71	
+    72	  async function fetchTrendData(): Promise<void> {
+    73	    abortController?.abort();
+    74	    abortController = new AbortController();
+    75	    const currentVersion = ++requestVersion;
+    76	
+    77	    trendData.value = [];
+    78	    trendCategoryData.value = { dates: [], series: {} };
+    79	    loading.value = true;
+    80	
+    81	    try {
+    82	      const params: EntitiesOverTimeParams = {
+    83	        aggregate: 'entity_id',
+    84	        group: 'category',
+    85	        summarize: granularity.value,
+    86	      };
+    87	      const filterValue = buildTrendFilter();
+    88	      if (filterValue !== undefined) {
+    89	        params.filter = filterValue;
+    90	      }
+    91	
+    92	      const response = await getEntitiesOverTime(params, {
+    93	        signal: abortController.signal,
+    94	      });
+    95	
+    96	      if (currentVersion !== requestVersion) return;
+    97	
+    98	      const allData = safeArray<GroupedTimeSeries>(response?.data);
+    99	      trendData.value = mergeGroupedCumulativeSeries(allData);
+   100	      trendCategoryData.value = extractPerGroupSeries(allData);
+   101	
+   102	      if (trendData.value.length > 0) {
+   103	        const maxVal = trendData.value[trendData.value.length - 1].count;
+   104	        totalEntities.value = maxVal;
+   105	        trendYMax.value = Math.max(trendYMax.value ?? 0, maxVal);
+   106	      }
+   107	
+   108	      abortController = null;
+   109	    } catch (error) {
+   110	      if ((error as Error).name !== 'AbortError') {
+   111	        console.error('Failed to fetch trend data:', error);
+   112	        makeToast('Failed to fetch trend data', 'Error', 'danger');
+   113	        trendData.value = [];
+   114	        trendCategoryData.value = { dates: [], series: {} };
+   115	      }
+   116	    } finally {
+   117	      loading.value = false;
+   118	    }
+   119	  }
+   120	
+   121	  // Auto-refetch on control changes
+   122	  watch(granularity, () => fetchTrendData());
+   123	  watch(nddFilter, () => {
+   124	    trendYMax.value = undefined;
+   125	    fetchTrendData();
+   126	  });
+   127	  watch(selectedCategories, () => fetchTrendData());
+   128	
+   129	  // Cleanup
+   130	  onUnmounted(() => {
+   131	    abortController?.abort();
+   132	    abortController = null;
+   133	  });
+   134	
+   135	  return {
+   136	    trendData,
+   137	    trendCategoryData,
+   138	    trendYMax,
+   139	    totalEntities,
+   140	    loading,
+   141	    granularity,
+   142	    nddFilter,
+   143	    categoryDisplay,
+   144	    selectedCategories,
+   145	    trendDescription,
+   146	    fetchTrendData,
+   147	  };
+   148	}
+   125	        }
+   126	        return [
+   127	          {
+   128	            data: {
+   129	              id: `e${idx}`,
+   130	              source: edge.source,
+   131	              target: edge.target,
+   132	              confidence: edge.confidence,
+   133	              width: Math.max(0.5, edge.confidence * 3),
+   134	            },
+   135	          },
+   136	        ];
+   137	      });
+   138	
+   139	  return [...clusterParentNodes, ...nodes, ...edges];
+   140	}
+   141	
+   142	function networkDataError(err: unknown): Error {
+   143	  if (isApiError<{ code?: string; message?: string }>(err)) {
+   144	    const problem = err.response?.data;
+   145	    if (problem?.code) {
+   146	      return new Error(
+   147	        problem.message ? `${problem.code}: ${problem.message}` : problem.code
+   148	      );
+   149	    }
+   150	  }
+   151	
+   152	  return err instanceof Error ? err : new Error('Failed to fetch network data');
+   153	}
+   154	
+   155	/**
+   156	 * Composable for fetching and transforming network data
+   157	 *
+   158	 * @returns State and functions for managing network data
+   159	 *
+   160	 * @example
+   161	 * ```typescript
+   162	 * const {
+   163	 *   networkData,
+   164	 *   isLoading,
+   165	 *   error,
+   166	 *   fetchNetworkData,
+   167	 *   cytoscapeElements,
+   168	 * } = useNetworkData();
+   169	 *
+   170	 * onMounted(async () => {
+   171	 *   await fetchNetworkData();
+   172	 * });
+   173	 *
+   174	 * // Use cytoscapeElements with useCytoscape composable
+   175	 * watch(cytoscapeElements, (elements) => {
+   176	 *   updateElements(elements);
+   177	 * });
+   178	 * ```
+   179	 */
+   180	export function useNetworkData(): NetworkDataState {
+   181	  // Reactive state
+   182	  const networkData = shallowRef<NetworkResponse | null>(null);
+   183	  const isLoading = ref(false);
+   184	  const error = ref<Error | null>(null);
+   185	  const isPreparing = ref(false);
+   186	
+   187	  /**
+   188	   * Computed metadata for UI display
+   189	   */
+   190	  const metadata = computed<NetworkMetadata | null>(() => {
+   191	    return networkData.value?.metadata || null;
+   192	  });
+   193	
+   194	  /**
+   195	   * Fetch network data from the API
+   196	   *
+   197	   * Fetches the supported public-ready network snapshot preset.
+   198	   */
+   199	  const fetchNetworkData = async (): Promise<void> => {
+   200	    isLoading.value = true;
+   201	    error.value = null;
+   202	    isPreparing.value = false;
+   203	
+   204	    console.log('[useNetworkData] Fetching public network snapshot preset');
+   205	    const startTime = performance.now();
+   206	
+   207	    try {
+   208	      const data = await preloadNetworkData();
+   209	      networkData.value = data;
+   210	
+   211	      const elapsed = performance.now() - startTime;
+   212	      console.log(`[useNetworkData] Fetch complete in ${elapsed.toFixed(0)}ms`);
+   213	      console.log(
+   214	        `[useNetworkData] Received ${data.nodes?.length || 0} nodes, ${data.edges?.length || 0} edges`
+   215	      );
+   216	
+   217	      if (data.metadata?.edges_filtered) {
+   218	        console.log(
+   219	          `[useNetworkData] Edges filtered: showing ${data.metadata.edge_count} of ${data.metadata.total_edges} total`
+   220	        );
+   221	      }
+   222	    } catch (err) {
+   223	      isPreparing.value = isSnapshotPreparingError(err);
+   224	      error.value = networkDataError(err);
+   225	      console.error('Network data fetch error:', err);
+   226	    } finally {
+   227	      isLoading.value = false;
+   228	    }
+   229	  };
+   230	
+   231	  /**
+   232	   * Transform network data to Cytoscape.js ElementDefinition format
+   233	   *
+   234	   * PERFORMANCE OPTIMIZED:
+   235	   * - Uses backend fCoSE display coordinates when complete, with client fCoSE fallback
+   236	   * - Pre-computes node size and edge width as data properties
+   237	   * - Creates compound parent nodes for clusters to enable visual separation
+   238	   * - Cytoscape uses fcose layout with compound node support
+   239	   *
+   240	   * Computed property that automatically updates when networkData changes.
+   241	   */
+   242	  const cytoscapeElements = computed<ElementDefinition[]>(() => {
+   243	    if (!networkData.value) return [];
+   244	
+   245	    console.log(
+   246	      `[useNetworkData] Transforming ${networkData.value.nodes.length} nodes, ${networkData.value.edges.length} edges`
+   247	    );
+   248	    const startTime = performance.now();
+   249	    const elements = buildCytoscapeElements(networkData.value);
+   250	
+   251	    const elapsed = performance.now() - startTime;
+   252	    console.log(
+   253	      `[useNetworkData] Transform complete in ${elapsed.toFixed(0)}ms (${elements.length} elements)`
+   254	    );
+   255	    return elements;
+   256	  });
+   257	
+   258	  const cytoscapeInitialElements = computed<ElementDefinition[]>(() => {
+   259	    if (!networkData.value) return [];
+   260	
+   261	    console.log(
+   262	      `[useNetworkData] Building initial graph from ${networkData.value.nodes.length} nodes, ${networkData.value.edges.length} edges`
+   263	    );
+   264	    const startTime = performance.now();
+   265	    const elements = buildCytoscapeElements(networkData.value, { initialDefaultEdgesOnly: true });
+   266	
+   267	    const elapsed = performance.now() - startTime;
+   268	    console.log(
+   269	      `[useNetworkData] Initial graph built in ${elapsed.toFixed(0)}ms (${elements.length} elements)`
+   270	    );
+    30	/**
+    31	 * Composable for PubTator admin operations with async job support
+    32	 */
+    33	export function usePubtatorAdmin() {
+    34	  const error = ref<string | null>(null);
+    35	  const lastStatus = ref<PubtatorCacheStatus | null>(null);
+    36	  const isCheckingStatus = ref(false);
+    37	  const isClearing = ref(false);
+    38	  const isBackfilling = ref(false);
+    39	
+    40	  // Use the async job composable for fetch operations
+    41	  const asyncJob = useAsyncJob((jobId: string) => `/api/jobs/${encodeURIComponent(jobId)}/status`, {
+    42	    pollingInterval: 3000,
+    43	  });
+    44	
+    45	  /**
+    46	   * Get cache status for a query
+    47	   */
+    48	  async function getCacheStatus(query: string): Promise<PubtatorCacheStatus> {
+    49	    isCheckingStatus.value = true;
+    50	    error.value = null;
+    51	
+    52	    try {
+    53	      const status = await getPubtatorCacheStatus({ query });
+    54	      lastStatus.value = status;
+    55	      return status;
+    56	    } catch (err) {
+    57	      error.value = err instanceof Error ? err.message : 'Failed to get cache status';
+    58	      throw err;
+    59	    } finally {
+    60	      isCheckingStatus.value = false;
+    61	    }
+    62	  }
+    63	
+    64	  /**
+    65	   * Submit async PubTator fetch job (non-blocking)
+    66	   * Returns immediately with job_id, use asyncJob state to track progress
+    67	   *
+    68	   * @param query - Search query
+    69	   * @param maxPages - Maximum pages to fetch (default 10)
+    70	   * @param clearOld - Whether to clear existing cache first (hard update)
+    71	   */
+    72	  async function submitFetchJob(
+    73	    query: string,
+    74	    maxPages: number = 10,
+    75	    clearOld: boolean = false
+    76	  ): Promise<PubtatorAsyncSubmitResponse> {
+    77	    error.value = null;
+    78	
+    79	    try {
+    80	      const submit = await submitPubtatorUpdate({
+    81	        query,
+    82	        max_pages: maxPages,
+    83	        clear_old: clearOld,
+    84	      });
+    85	
+    86	      // Start tracking the job with useAsyncJob
+    87	      asyncJob.startJob(submit.job_id);
+    88	
+    89	      return submit;
+    90	    } catch (err) {
+    91	      if (isApiError<{ existing_job_id?: string }>(err) && err.response?.status === 409) {
+    92	        // Duplicate job - extract existing job ID and track it
+    93	        const existingJobId = err.response.data.existing_job_id;
+    94	        if (existingJobId) {
+    95	          asyncJob.startJob(existingJobId);
+
+exec
+/bin/bash -lc "rg -n \"useEntityInfo\\(|\\.reset\\(\\)|resetEntityContext|usePubtatorGenePublications|cancelAll\\(|resetCache\\(|useAdminTrendData\\(|useNetworkData\\(|usePubtatorAdmin\\(\" app/src/views app/src/components app/src/composables --glob '"'!**/*.spec.ts'"' && rg -n \"getEntityPhenotypes\\(|getEntityVariation\\(|getEntityPublications\\(\" app/src --glob '"'!api/entity.ts'"' && rg -n \"getCacheStatus\\(\" app/src --glob '"'!api/publication.ts'"' && rg -n \"fetchNetworkData\\(|clearNetworkData\\(\" app/src --glob '"'!composables/useNetworkData.ts'"'" in /home/bernt-popp/development/sysndd/.claude/worktrees/535-s5c-request-ownership
+ succeeded in 0ms:
+app/src/composables/usePubtatorAdmin.ts:33:export function usePubtatorAdmin() {
+app/src/composables/useNetworkData.ts:168: * } = useNetworkData();
+app/src/composables/useNetworkData.ts:180:export function useNetworkData(): NetworkDataState {
+app/src/views/review/composables/useReviewData.ts:105:  resetEntityContext: () => void;
+app/src/views/review/composables/useReviewData.ts:301:  function resetEntityContext(): void {
+app/src/views/review/composables/useReviewData.ts:332:    resetEntityContext,
+app/src/composables/usePubtatorAdminPanel.ts:25:  const admin = usePubtatorAdmin();
+app/src/composables/usePubtatorGenePublications.ts:1:// src/composables/usePubtatorGenePublications.ts
+app/src/composables/usePubtatorGenePublications.ts:35:export function usePubtatorGenePublications(options: { makeToast: MakeToast }) {
+app/src/composables/usePubtatorGenePublications.ts:127:export default usePubtatorGenePublications;
+app/src/views/admin/composables/useAdminTrendData.ts:14:export function useAdminTrendData(
+app/src/views/admin/ManageNDDScore.vue:394:    importJob.reset();
+app/src/views/admin/ManageNDDScore.vue:414:    importJob.reset();
+app/src/views/admin/composables/useBackupJobs.ts:61:    restoreJob.reset();
+app/src/views/admin/composables/useBackupJobs.ts:94:    backupJob.reset();
+app/src/views/admin/useLlmRegenerationJobs.ts:198:        regenerationJobs[type].reset();
+app/src/views/admin/ManageAnnotations.vue:459:  ontologyJob.reset();
+app/src/views/admin/ManageAnnotations.vue:471:  forceApplyJob.reset();
+app/src/views/admin/ManageAnnotations.vue:488:  hgncJob.reset();
+app/src/views/admin/ManageAnnotations.vue:497:  comparisonsJob.reset();
+app/src/views/admin/ManageAnnotations.vue:524:  publicationRefreshJob.reset();
+app/src/views/admin/ManageAnnotations.vue:550:  publicationRefreshJob.reset();
+app/src/views/admin/AdminStatistics.vue:324:} = useAdminTrendData(makeToast);
+app/src/views/admin/ManageOntologyMappings.vue:264:      refreshJob.reset();
+app/src/components/analyses/PubtatorPublicationDetail.vue:80:import type { PubtatorPublicationData } from '@/composables/usePubtatorGenePublications';
+app/src/components/analyses/useNetworkVisualizationController.ts:65:  } = useNetworkData();
+app/src/views/curate/composables/useModifyEntityWorkflows.ts:82:    combined.reset();
+app/src/views/curate/composables/useModifyEntityWorkflows.ts:127:    combined.reset();
+app/src/views/curate/composables/useModifyEntityWorkflows.ts:150:    info.reset();
+app/src/views/curate/composables/useModifyEntityWorkflows.ts:231:      info.reset();
+app/src/components/analyses/usePubtatorGenesTable.ts:9:// stays in usePubtatorGenePublications.ts -- this composable orchestrates
+app/src/components/analyses/usePubtatorGenesTable.ts:20:import { usePubtatorGenePublications } from '@/composables/usePubtatorGenePublications';
+app/src/components/analyses/usePubtatorGenesTable.ts:209:  // current filter/sort: resetCache() runs on every reload so an expanded row
+app/src/components/analyses/usePubtatorGenesTable.ts:218:  } = usePubtatorGenePublications({ makeToast });
+app/src/views/curate/ModifyEntity.vue:293:    const info = useEntityInfo({ onToast: toastFn });
+app/src/views/curate/composables/useEntityInfo.ts:60:export function useEntityInfo(options: UseEntityInfoOptions = {}) {
+app/src/composables/useEntityVariation.ts:18:    async (signal) => (await getEntityVariation(idRef.value!, {}, { signal })) as unknown[],
+app/src/composables/useEntityPublications.ts:20:    async (signal) => (await getEntityPublications(idRef.value!, {}, { signal })) as unknown[],
+app/src/api/entity.spec.ts:238:    await getEntityPhenotypes(7);
+app/src/api/entity.spec.ts:251:    await getEntityPhenotypes(7, { current_review: false });
+app/src/api/entity.spec.ts:267:    const rows = await getEntityVariation(7);
+app/src/api/entity.spec.ts:332:    const rows = await getEntityPublications(7);
+app/src/views/curate/composables/useEntityInfo.ts:111:      const phenotypes_data: any = await getEntityPhenotypes(entityId);
+app/src/views/curate/composables/useEntityInfo.ts:112:      const variation_data: any = await getEntityVariation(entityId);
+app/src/views/curate/composables/useEntityInfo.ts:113:      const publications_data: any = await getEntityPublications(entityId);
+app/src/api/entity.ts:310:export async function getEntityPhenotypes(
+app/src/api/entity.ts:329:export async function getEntityVariation(
+app/src/api/entity.ts:377:export async function getEntityPublications(
+app/src/composables/useEntityPhenotypes.ts:18:    async (signal) => (await getEntityPhenotypes(idRef.value!, {}, { signal })) as unknown[],
+app/src/composables/usePubtatorAdmin.ts:48:  async function getCacheStatus(query: string): Promise<PubtatorCacheStatus> {
+app/src/composables/usePubtatorAdminPanel.ts:76:      await getCacheStatus(query.value);
+app/src/composables/useNetworkData.spec.ts:40:    await state.fetchNetworkData();
+app/src/composables/useNetworkData.spec.ts:65:    await state.fetchNetworkData();
+app/src/composables/useNetworkData.spec.ts:88:    await state.fetchNetworkData();
+app/src/composables/useNetworkData.spec.ts:130:    await state.fetchNetworkData();
+app/src/composables/useNetworkData.spec.ts:160:    await state.fetchNetworkData();
+app/src/composables/useNetworkData.spec.ts:186:    await state.fetchNetworkData();
+app/src/composables/useNetworkData.spec.ts:212:    await state.fetchNetworkData();
+app/src/composables/useNetworkData.spec.ts:236:    await state.fetchNetworkData();
+app/src/composables/useNetworkData.spec.ts:259:    await state.fetchNetworkData();
+app/src/composables/useNetworkData.ts:171: *   await fetchNetworkData();
+app/src/components/analyses/useNetworkVisualizationController.ts:441:    await fetchNetworkData();
+app/src/components/analyses/useNetworkVisualizationController.ts:506:    await fetchNetworkData();
+
+exec
+/bin/bash -lc "sed -n '250,330p' app/src/views/curate/ModifyEntity.vue; sed -n '1,280p' app/src/views/curate/composables/useModifyEntityWorkflows.ts; sed -n '180,245p' app/src/components/analyses/usePubtatorGenesTable.ts; sed -n '1,120p' app/src/composables/usePubtatorAdminPanel.ts; sed -n '300,350p' app/src/views/admin/AdminStatistics.vue; sed -n '420,530p' app/src/components/analyses/useNetworkVisualizationController.ts" in /home/bernt-popp/development/sysndd/.claude/worktrees/535-s5c-request-ownership
+ succeeded in 0ms:
+  </AuthenticatedPageShell>
+</template>
+
+<script lang="ts">
+import AuthenticatedPageShell from '@/components/layout/AuthenticatedPageShell.vue';
+import { computed, defineComponent, ref, watch } from 'vue';
+import { useToast, useColorAndSymbols, useAriaLive } from '@/composables';
+import { useAuth } from '@/composables/useAuth';
+import useStatusForm from './composables/useStatusForm';
+import { useEntityAutocomplete } from './composables/useEntityAutocomplete';
+import { useEntityInfo } from './composables/useEntityInfo';
+import { useEntityMutations } from './composables/useEntityMutations';
+import { useEntityModifyModals } from './composables/useEntityModifyModals';
+import { useModifyEntityLookups } from './composables/useModifyEntityLookups';
+import { useModifyEntityWorkflows } from './composables/useModifyEntityWorkflows';
+
+import EntityInfoHeader from './components/EntityInfoHeader.vue';
+import EntitySearchPanel from './components/EntitySearchPanel.vue';
+import InlineEntityWorkflow from './components/InlineEntityWorkflow.vue';
+import CombinedStatusReviewWorkflow from './components/CombinedStatusReviewWorkflow.vue';
+import AriaLiveRegion from '@/components/accessibility/AriaLiveRegion.vue';
+import ConfirmDiscardDialog from '@/components/ui/ConfirmDiscardDialog.vue';
+
+export default defineComponent({
+  name: 'ModifyEntity',
+  components: {
+    AuthenticatedPageShell,
+    EntityInfoHeader,
+    EntitySearchPanel,
+    InlineEntityWorkflow,
+    CombinedStatusReviewWorkflow,
+    AriaLiveRegion,
+    ConfirmDiscardDialog,
+  },
+  setup() {
+    const { makeToast } = useToast();
+    const colorAndSymbols = useColorAndSymbols();
+    const { message: a11yMessage, politeness: a11yPoliteness, announce } = useAriaLive();
+
+    // Cast makeToast to the composables' broader (...unknown[]) signature.
+    // makeToast's full typed signature differs from the (...args: unknown[]) =&gt; void
+    // expected by the composable interface (TOAST-SHIM cohort).
+    const toastFn = makeToast as unknown as (...args: unknown[]) => void;
+    const info = useEntityInfo({ onToast: toastFn });
+    const search = useEntityAutocomplete({
+      onToast: toastFn,
+      getCurrentEntityId: () => info.entity_info.value.entity_id,
+    });
+    const mutations = useEntityMutations({ onToast: toastFn, onAnnounce: announce });
+    const modals = useEntityModifyModals();
+    const statusForm = useStatusForm();
+    const { hasMinRole } = useAuth();
+
+    // Direct approval is a Curator+ action (mirrors entity-create + the
+    // /approve endpoints). The toggle is hidden for non-permitted roles and
+    // re-checked server-side, so this is visibility only — never trust it.
+    const isCurator = computed(() => hasMinRole('Curator'));
+
+    // Local modal-specific state not owned by composables
+    const deactivate_check = ref(false);
+    const replace_check = ref(false);
+
+    // Workflow orchestration (rename / deactivate / review / status / combined).
+    const workflows = useModifyEntityWorkflows({
+      info,
+      search,
+      mutations,
+      modals,
+      statusForm,
+      deactivate_check,
+      replace_check,
+      onToast: toastFn,
+      announce,
+    });
+
+    // Tree options (app-global lookup data loaded once on mount)
+    const {
+      phenotypes_options,
+      variation_ontology_options,
+      status_options,
+      status_options_loading,
+// app/src/views/curate/composables/useModifyEntityWorkflows.ts
+/**
+ * Orchestrates the ModifyEntity edit workflows (rename, deactivate, review,
+ * status, and the combined Status & Review flow — issues #36 / #37).
+ *
+ * Extracted from ModifyEntity.vue to keep the thin-shell view under the
+ * file-size ceiling. Owns `activeWorkflow`, the per-workflow show/submit
+ * handlers, and the combined-flow orchestration; depends on the entity-info,
+ * autocomplete, mutations, modals, and status-form composables passed in.
+ */
+
+import { computed, ref, type Ref } from 'vue';
+import { useCombinedStatusReview } from './useCombinedStatusReview';
+import type { useEntityInfo } from './useEntityInfo';
+import type { useEntityAutocomplete } from './useEntityAutocomplete';
+import type { useEntityMutations } from './useEntityMutations';
+import type { useEntityModifyModals } from './useEntityModifyModals';
+import type useStatusForm from './useStatusForm';
+
+export type WorkflowKind = 'rename' | 'deactivate' | 'review' | 'status' | 'combined';
+
+export interface UseModifyEntityWorkflowsDeps {
+  info: ReturnType<typeof useEntityInfo>;
+  search: ReturnType<typeof useEntityAutocomplete>;
+  mutations: ReturnType<typeof useEntityMutations>;
+  modals: ReturnType<typeof useEntityModifyModals>;
+  statusForm: ReturnType<typeof useStatusForm>;
+  deactivate_check: Ref<boolean>;
+  replace_check: Ref<boolean>;
+  onToast: (...args: unknown[]) => void;
+  announce: (msg: string, politeness?: 'polite' | 'assertive') => void;
+}
+
+export function useModifyEntityWorkflows(deps: UseModifyEntityWorkflowsDeps) {
+  const { info, search, mutations, modals, statusForm, deactivate_check, replace_check } = deps;
+  const { onToast, announce } = deps;
+
+  const activeWorkflow = ref<WorkflowKind | null>(null);
+  const combinedLoading = ref(false);
+
+  const combined = useCombinedStatusReview(
+    {
+      hasReviewChanges: info.hasReviewChanges,
+      hasStatusChanges: statusForm.hasChanges,
+      getReviewArgs: () => ({
+        review_info: info.review_info.value,
+        select_phenotype: info.select_phenotype.value,
+        select_variation: info.select_variation.value,
+        select_additional_references: info.select_additional_references.value,
+        select_gene_reviews: info.select_gene_reviews.value,
+      }),
+      submitReview: (args) => mutations.submitReview(args as never),
+      submitStatus: (isUpdate, reReview, directApproval) =>
+        statusForm.submitForm(isUpdate, reReview, directApproval),
+    },
+    {
+      onToast,
+      onAnnounce: announce,
+      setSubmittingState: (state) => mutations.setSubmittingState(state),
+    }
+  );
+
+  const activeWorkflowLoading = computed(() => {
+    switch (activeWorkflow.value) {
+      case 'rename':
+        return modals.loadingRename.value;
+      case 'deactivate':
+        return modals.loadingDeactivate.value;
+      case 'review':
+        return modals.loadingReview.value;
+      case 'status':
+        return modals.loadingStatus.value;
+      case 'combined':
+        return combinedLoading.value;
+      default:
+        return false;
+    }
+  });
+
+  function clearActiveWorkflow(): void {
+    activeWorkflow.value = null;
+    combined.reset();
+    modals.close();
+  }
+
+  async function showEntityRename(): Promise<void> {
+    activeWorkflow.value = 'rename';
+    modals.setLoading('rename', true);
+    search.ontology_input.value = null;
+    search.ontology_display.value = '';
+    search.ontology_search_results.value = [];
+    modals.setLoading('rename', false);
+  }
+
+  async function showEntityDeactivate(): Promise<void> {
+    deactivate_check.value = false;
+    replace_check.value = false;
+    search.replace_entity_input.value = null;
+    search.replace_entity_display.value = '';
+    // Clear stale autocomplete results so the dropdown doesn't open with
+    // leftover suggestions from a previous deactivation attempt.
+    search.replace_entity_search_results.value = [];
+    search.replace_entity_search_loading.value = false;
+    activeWorkflow.value = 'deactivate';
+    modals.setLoading('deactivate', false);
+  }
+
+  async function showReviewModify(): Promise<void> {
+    activeWorkflow.value = 'review';
+    modals.setLoading('review', true);
+    await info.loadReview(info.entity_info.value.entity_id);
+    modals.setLoading('review', false);
+  }
+
+  async function showStatusModify(): Promise<void> {
+    statusForm.resetForm();
+    activeWorkflow.value = 'status';
+    modals.setLoading('status', true);
+    await statusForm.loadStatusByEntity(info.entity_info.value.entity_id);
+    modals.setLoading('status', false);
+  }
+
+  // Combined Status & Review workflow (issue #36): load BOTH the review and the
+  // status so the curator can edit them together in one panel.
+  async function showCombinedModify(): Promise<void> {
+    statusForm.resetForm();
+    combined.reset();
+    activeWorkflow.value = 'combined';
+    combinedLoading.value = true;
+    try {
+      const entityId = info.entity_info.value.entity_id;
+      await Promise.all([info.loadReview(entityId), statusForm.loadStatusByEntity(entityId)]);
+    } finally {
+      combinedLoading.value = false;
+    }
+  }
+
+  function reviewArgs() {
+    return {
+      review_info: info.review_info.value,
+      select_phenotype: info.select_phenotype.value,
+      select_variation: info.select_variation.value,
+      select_additional_references: info.select_additional_references.value,
+      select_gene_reviews: info.select_gene_reviews.value,
+    };
+  }
+
+  function clearSelection(): void {
+    clearActiveWorkflow();
+    info.reset();
+    search.clearAll();
+  }
+
+  async function onSubmitRename(): Promise<void> {
+    try {
+      await mutations.rename({
+        entity_info: info.entity_info.value,
+        ontology_input: search.ontology_input.value,
+      });
+      clearSelection();
+    } catch {
+      // error already toasted in composable
+    }
+  }
+
+  async function onSubmitDeactivate(): Promise<void> {
+    try {
+      await mutations.deactivate({
+        entity_info: info.entity_info.value,
+        deactivate_check: deactivate_check.value,
+        replace_entity_input: search.replace_entity_input.value,
+      });
+      clearSelection();
+      deactivate_check.value = false;
+      replace_check.value = false;
+    } catch {
+      // error already toasted in composable
+    }
+  }
+
+  async function onSubmitReview(): Promise<void> {
+    if (!info.hasReviewChanges.value) {
+      clearActiveWorkflow();
+      return;
+    }
+    try {
+      await mutations.submitReview(reviewArgs());
+      clearSelection();
+    } catch {
+      // error already toasted in composable
+    }
+  }
+
+  async function onSubmitStatus(): Promise<void> {
+    if (!statusForm.hasChanges.value) {
+      clearActiveWorkflow();
+      return;
+    }
+    mutations.setSubmittingState('status');
+    try {
+      await statusForm.submitForm(false, false);
+      onToast('Status submitted successfully', 'Success', 'success');
+      announce('Status submitted successfully');
+      statusForm.resetForm();
+      clearSelection();
+    } catch (e) {
+      onToast(e, 'Error', 'danger');
+      announce('Failed to submit status', 'assertive');
+    } finally {
+      mutations.setSubmittingState(null);
+    }
+  }
+
+  async function onSubmitCombined(): Promise<void> {
+    try {
+      // The composable toasts success and threads the (server-re-checked)
+      // direct-approval flag through both write paths. A no-op returns false so
+      // we just close without firing a stray success message.
+      await combined.submit();
+      statusForm.resetForm();
+      clearSelection();
+    } catch {
+      // submitReview / submitForm already toasted the failure; keep the
+      // selection so the curator can fix and retry.
+    }
+  }
+
+  async function onEntitySelected(entityId: number | null): Promise<void> {
+    search.onEntitySelected(entityId);
+    if (!entityId) {
+      info.reset();
+      clearActiveWorkflow();
+      return;
+    }
+    await info.loadEntity(entityId);
+    if (info.entity_info.value?.entity_id) {
+      search.entity_loaded.value = true;
+    }
+  }
+
+  // submitReviewChange bypasses the hasReviewChanges guard (spec compat).
+  async function submitReviewChange(): Promise<void> {
+    try {
+      await mutations.submitReview(reviewArgs());
+      clearSelection();
+    } catch {
+      // error already toasted in composable
+    }
+  }
+
+  return {
+    activeWorkflow,
+    activeWorkflowLoading,
+    combinedDirectApproval: combined.directApproval,
+    clearActiveWorkflow,
+    showEntityRename,
+    showEntityDeactivate,
+    showReviewModify,
+    showStatusModify,
+    showCombinedModify,
+    onSubmitRename,
+    onSubmitDeactivate,
+    onSubmitReview,
+    onSubmitStatus,
+    onSubmitCombined,
+    onEntitySelected,
+    submitReviewChange,
+  };
+}
+
+export default useModifyEntityWorkflows;
+
+  // Table fields (includes issue #175 enrichment columns) and the
+  // component-specific filter object.
+  const fields = ref<FieldDefinition[]>(createPubtatorGeneFields());
+  const filter = ref<PubtatorGeneFilter>(createDefaultPubtatorGeneFilter());
+
+  // Prioritization filter options.
+  const minPublications = ref<string>('all');
+  const pubCountOptions = [
+    { value: 'all', text: 'All' },
+    { value: '2', text: '2+' },
+    { value: '5', text: '5+' },
+    { value: '10', text: '10+' },
+  ];
+
+  const dateRange = ref<string>('all');
+  const dateRangeOptions = [
+    { value: 'all', text: 'All time' },
+    { value: '1', text: 'Last 1 year' },
+    { value: '2', text: 'Last 2 years' },
+    { value: '5', text: 'Last 5 years' },
+  ];
+
+  // Cursor pagination info, and the non-blocking notice shown when the genes
+  // API reports the gene ranking is not yet computed / is stale.
+  const totalPages = ref(0);
+  const enrichmentNotice = ref<string | null>(null);
+
+  // Per-gene publication-detail cache (extracted composable). Scoped to the
+  // current filter/sort: resetCache() runs on every reload so an expanded row
+  // never shows publications fetched under a previous query.
+  const {
+    fetchPublications,
+    getPublications,
+    isLoading: isLoadingPublications,
+    isCached,
+    resetCache: resetPublicationCache,
+    cancelAll: cancelAllPublicationFetches,
+  } = usePubtatorGenePublications({ makeToast });
+
+  // sortBy as a properly typed array for BTable; "any" filter string binding.
+  const sortByArray = computed(() => sortBy.value);
+  const anyFilterContent = computed({
+    get: () => {
+      const content = filter.value.any.content;
+      return typeof content === 'string' ? content : '';
+    },
+    set: (value: string) => {
+      filter.value.any.content = value || null;
+    },
+  });
+
+  // Helpers for filter content binding.
+  const getFilterContent = (key: string): string => {
+    const content = filter.value[key]?.content;
+    return typeof content === 'string' ? content : '';
+  };
+
+  const setFilterContent = (key: string, value: string) => {
+    if (filter.value[key]) {
+      filter.value[key].content = value || null;
+      filtered();
+    }
+  };
+
+  // Novel gene count, emitted to the parent whenever it changes.
+/**
+ * usePubtatorAdminPanel - view-level orchestration for ManagePubtator.vue
+ *
+ * Wraps the lower-level `usePubtatorAdmin` cache/job composable and adds the
+ * page's own form state (query, page count, hard-update flag), the inline
+ * feedback banner, the clear-all modal flag, and the four action handlers
+ * that translate composable calls into feedback messages.
+ *
+ * Extracted from `ManagePubtator.vue` (refactor #346 WP6 / #399) so the view
+ * is a thin template + single composable call. Behavior, network calls, and
+ * the rendered structure are unchanged.
+ */
+
+import { ref, computed } from 'vue';
+import { usePubtatorAdmin } from '@/composables/usePubtatorAdmin';
+import { extractApiErrorMessage } from '@/utils/api-errors';
+
+export type FeedbackVariant = 'success' | 'danger' | 'info' | 'warning';
+
+/** Default PubTator query seeded in the textarea (unchanged from the view). */
+const DEFAULT_QUERY =
+  '("intellectual disability" OR "mental retardation" OR "autism" OR "epilepsy" OR "neurodevelopmental disorder" OR "neurodevelopmental disease" OR "epileptic encephalopathy") AND (gene OR syndrome) AND (variant OR mutation)';
+
+export function usePubtatorAdminPanel() {
+  const admin = usePubtatorAdmin();
+  const {
+    lastStatus,
+    getCacheStatus,
+    submitFetchJob,
+    clearCache,
+    backfillGeneSymbols,
+    resetJob,
+  } = admin;
+
+  // Form state
+  const query = ref(DEFAULT_QUERY);
+  const maxPages = ref(50);
+  const clearOld = ref(false);
+
+  // UI state
+  const showClearAllModal = ref(false);
+
+  // Feedback banner
+  const feedbackMessage = ref('');
+  const feedbackVariant = ref<FeedbackVariant>('info');
+
+  const feedbackIcon = computed(() => {
+    switch (feedbackVariant.value) {
+      case 'success':
+        return 'bi bi-check-circle-fill';
+      case 'danger':
+        return 'bi bi-exclamation-triangle-fill';
+      case 'warning':
+        return 'bi bi-exclamation-circle-fill';
+      default:
+        return 'bi bi-info-circle-fill';
+    }
+  });
+
+  const cacheStateLabel = computed(() => {
+    if (!lastStatus.value) return 'No status';
+    return lastStatus.value.cached ? 'Cached' : 'Not cached';
+  });
+
+  function formatDate(dateStr: string | null): string {
+    if (!dateStr) return 'N/A';
+    const date = new Date(dateStr);
+    return date.toLocaleString();
+  }
+
+  async function checkStatus(): Promise<void> {
+    if (!query.value.trim()) return;
+    feedbackMessage.value = '';
+
+    try {
+      await getCacheStatus(query.value);
+    } catch (err) {
+      feedbackMessage.value = extractApiErrorMessage(err, 'Failed to check cache status');
+      feedbackVariant.value = 'danger';
+    }
+  }
+
+  async function submitFetch(): Promise<void> {
+    if (!query.value.trim()) return;
+    feedbackMessage.value = '';
+    resetJob(); // Clear any previous job state
+
+    try {
+      await submitFetchJob(query.value, maxPages.value, clearOld.value);
+      feedbackMessage.value = `Job submitted! Fetching ${maxPages.value} pages (~${Math.round((maxPages.value * 2.5) / 60)} min)`;
+      feedbackVariant.value = 'info';
+    } catch (err) {
+      feedbackMessage.value = extractApiErrorMessage(err, 'Failed to submit fetch job');
+      feedbackVariant.value = 'danger';
+    }
+  }
+
+  async function backfillGenes(): Promise<void> {
+    if (!lastStatus.value?.query_id) return;
+    feedbackMessage.value = '';
+
+    try {
+      const backfillResult = await backfillGeneSymbols(lastStatus.value.query_id);
+      feedbackMessage.value = backfillResult.message;
+      feedbackVariant.value = 'success';
+    } catch (err) {
+      feedbackMessage.value = extractApiErrorMessage(err, 'Failed to backfill gene symbols');
+      feedbackVariant.value = 'danger';
+    }
+  }
+
+  async function clearAllCache(): Promise<void> {
+    feedbackMessage.value = '';
+
+    try {
+      const clearResult = await clearCache();
+      feedbackMessage.value = clearResult.message ?? 'Cache cleared.';
+      feedbackVariant.value = 'success';
+      lastStatus.value = null;
+    } catch (err) {
+// outbound call, reading `useAuth().token.value` — so no injected axios,
+// base URL, or auth-header plumbing is needed here.
+
+// Date range (default: last 12 months)
+const today = new Date();
+const twelveMonthsAgo = new Date(today.getFullYear() - 1, today.getMonth(), today.getDate());
+const startDate = ref(twelveMonthsAgo.toISOString().split('T')[0]);
+const endDate = ref(today.toISOString().split('T')[0]);
+
+const lastUpdated = ref<Date | null>(null);
+
+// --- Composables ---
+const {
+  trendData,
+  trendCategoryData,
+  trendYMax,
+  totalEntities,
+  loading: trendLoading,
+  granularity,
+  nddFilter,
+  categoryDisplay,
+  selectedCategories,
+  trendDescription,
+  fetchTrendData,
+} = useAdminTrendData(makeToast);
+
+const {
+  leaderboardData,
+  reReviewLeaderboardData,
+  totalContributors,
+  loadingLeaderboard,
+  loadingReReview,
+  leaderboardScope,
+  reReviewLeaderboardScope,
+  fetchLeaderboard,
+  fetchReReviewLeaderboard,
+} = useLeaderboardData(makeToast);
+
+const {
+  loading: kpiLoading,
+  kpiStats,
+  statistics,
+  reReviewStatistics,
+  updatedReviewsStatistics,
+  updatedStatusesStatistics,
+  fetchKPIStats,
+  fetchExistingStatistics,
+} = useKPIStats(makeToast);
+
+// --- Composite loading state for template ---
+const loading = computed(() => ({
+    () => filterState.value.search,
+    (newPattern) => {
+      searchPattern.value = newPattern;
+      if (isInitialized.value) {
+        updateSearchHighlighting();
+      }
+    },
+    { immediate: true }
+  );
+
+  // Emit node hover events for bidirectional table highlighting
+  watch(
+    () => highlightState.value.hoveredNodeId,
+    (nodeId) => {
+      emit('node-hover', nodeId);
+    }
+  );
+
+  // Initialize on mount
+  onMounted(async () => {
+    // Fetch network data
+    await fetchNetworkData();
+
+    // Wait for DOM update
+    await nextTick();
+
+    if (cytoscapeNodeElements.value.length > 0) {
+      initializeCytoscape(cytoscapeNodeElements.value);
+      initialEdgesMounted.value = false;
+      fullGraphMounted.value = false;
+      handleApplyFilters();
+    } else {
+      initializeCytoscape();
+    }
+
+    // Setup tooltip handlers after a brief delay to ensure cy is ready
+    await nextTick();
+    setupTooltipHandlers();
+
+    // Setup network highlight listeners for bidirectional hover
+    setupHighlightListeners();
+
+    // Apply initial filters (defaults to Definitive only)
+    await nextTick();
+    handleApplyFilters();
+
+    // Setup resize observer to refit graph when container is resized
+    if (cytoscapeContainer.value) {
+      resizeObserver = new ResizeObserver(() => {
+        const cyInstance = cy();
+        if (cyInstance && isInitialized.value) {
+          // Use fitToScreen which handles resize, fit, and manual centering
+          fitToScreen();
+        }
+      });
+      resizeObserver.observe(cytoscapeContainer.value);
+    }
+  });
+
+  // Cleanup resize observer on unmount
+  onBeforeUnmount(() => {
+    if (resizeObserver) {
+      resizeObserver.disconnect();
+      resizeObserver = null;
+    }
+  });
+
+  // Watch for element changes and update the graph
+  watch(cytoscapeNodeElements, (newElements) => {
+    if (isInitialized.value && newElements.length > 0) {
+      updateElements(newElements);
+      initialEdgesMounted.value = false;
+      initialEdgeHydrationQueued.value = false;
+      fullGraphMounted.value = false;
+      // Re-setup tooltip handlers and apply filters after elements update
+      nextTick(() => {
+        setupTooltipHandlers();
+        handleApplyFilters();
+      });
+    }
+  });
+
+  /**
+   * Retry loading network data after an error.
+   */
+  const retryLoadNetwork = async () => {
+    await fetchNetworkData();
+    await nextTick();
+    if (!isInitialized.value) {
+      initializeCytoscape(cytoscapeNodeElements.value);
+      initialEdgesMounted.value = false;
+      fullGraphMounted.value = false;
+      setupTooltipHandlers();
+      handleApplyFilters();
+    } else if (cytoscapeNodeElements.value.length > 0) {
+      mountNodeGraphElements();
+      setupTooltipHandlers();
+      handleApplyFilters();
+    }
+  };
+
+  /**
+   * Select a specific cluster programmatically (for parent component sync).
+   * Used when the parent auto-selects the first cluster on initial load. Does not
+   * emit clusters-changed because the parent already knows the state.
+   */
+  function selectCluster(clusterId: number) {
+    const nextSelection = selectSingleNetworkCluster(clusterId);
+    showAllClusters.value = nextSelection.showAllClusters;
+    selectedClusters.value = nextSelection.selectedClusters;
+    handleApplyFilters();
+
+exec
+/bin/bash -lc "rg -n -C 4 \"cancelAllPublicationFetches|resetPublicationCache\" app/src/components/analyses/usePubtatorGenesTable.ts && sed -n '430,470p' app/src/components/analyses/usePubtatorGenesTable.ts && nl -ba app/src/views/review/composables/useReviewData.ts | sed -n '165,320p' && nl -ba app/src/views/curate/composables/useEntityInfo.ts | sed -n '58,207p'" in /home/bernt-popp/development/sysndd/.claude/worktrees/535-s5c-request-ownership
+ succeeded in 0ms:
+212-    fetchPublications,
+213-    getPublications,
+214-    isLoading: isLoadingPublications,
+215-    isCached,
+216:    resetCache: resetPublicationCache,
+217:    cancelAll: cancelAllPublicationFetches,
+218-  } = usePubtatorGenePublications({ makeToast });
+219-
+220-  // sortBy as a properly typed array for BTable; "any" filter string binding.
+221-  const sortByArray = computed(() => sortBy.value);
+--
+291-
+292-    // The gene set is about to change (filter / sort / page). Drop the per-gene
+293-    // publication cache so an expanded row cannot show publications fetched under
+294-    // the previous query (correctness fix).
+295:    resetPublicationCache();
+296-
+297-    const requestId = ++latestRequestId;
+298-
+299-    try {
+--
+451-  };
+452-
+453-  // Abort all in-flight publication requests on unmount.
+454-  onUnmounted(() => {
+455:    cancelAllPublicationFetches();
+456-  });
+457-
+458-  onMounted(() => {
+459-    const sortObject = sortStringToVariables(props.sortInput);
+--
+511-    // publications (per-gene detail cache passthrough)
+512-    handleRowExpand,
+513-    isLoadingPublications,
+514-    getPublications,
+515:    cancelAllPublicationFetches,
+516-    // helpers
+517-    parsePmids,
+518-    truncateText,
+519-    getCompactTooltipText,
+      await exportToExcel(exportData, {
+        filename: `pubtator_genes_${new Date().toISOString().split('T')[0]}`,
+        sheetName: 'Gene Prioritization',
+        headers: {
+          gene_symbol: 'Gene Symbol',
+          gene_name: 'Gene Name',
+          publication_count: 'NDD Publication Count',
+          background_count: 'Background (Total) Publications',
+          enrichment_ratio: 'Enrichment Ratio',
+          npmi: 'NPMI',
+          fisher_p: 'Fisher p-value',
+          fdr_bh: 'FDR (BH q-value)',
+          oldest_pub_date: 'Oldest Publication',
+          source: 'Source',
+          pmids: 'PMIDs',
+        },
+      });
+      makeToast('Excel file downloaded', 'Success', 'success');
+    } catch (_error) {
+      makeToast('Export failed', 'Error', 'danger');
+    }
+  };
+
+  // Abort all in-flight publication requests on unmount.
+  onUnmounted(() => {
+    cancelAllPublicationFetches();
+  });
+
+  onMounted(() => {
+    const sortObject = sortStringToVariables(props.sortInput);
+    sortBy.value = sortObject.sortBy;
+    sort.value = props.sortInput;
+
+    if (props.filterInput && props.filterInput !== 'null' && props.filterInput !== '') {
+      filter.value = filterStrToObj(props.filterInput, filter.value);
+    }
+
+    // Slight delay, then show the table.
+    setTimeout(() => {
+      loading.value = false;
+    }, 300);
+   165	  const totalRows = ref(1);
+   166	  const isBusy = ref(false);
+   167	  const loading = ref(true);
+   168	
+   169	  // Lookup lists
+   170	  const phenotypes_options = ref<TreeNode[]>([]);
+   171	  const variation_ontology_options = ref<TreeNode[]>([]);
+   172	  const status_options = ref<TreeNode[]>([]);
+   173	
+   174	  // Entity / review / status context
+   175	  const entity_info = reactive<ReviewEntityInfo>({ ...EMPTY_ENTITY_INFO });
+   176	  const review_info = reactive<ReviewInfo>(new Review() as ReviewInfo);
+   177	  // Initialise the legacy fields the template binds against.
+   178	  Object.assign(review_info, {
+   179	    review_id: null,
+   180	    entity_id: null,
+   181	    review_user_name: null,
+   182	    review_user_role: null,
+   183	    review_date: null,
+   184	    re_review_review_saved: null,
+   185	  });
+   186	  const status_info = reactive(new Status()) as UseReviewData['status_info'];
+   187	  const loading_status_modal = ref(true);
+   188	
+   189	  function reportError(err: unknown): void {
+   190	    if (onError) {
+   191	      onError(err);
+   192	    }
+   193	  }
+   194	
+   195	  async function loadReReviewData(curate: boolean): Promise<void> {
+   196	    isBusy.value = true;
+   197	    try {
+   198	      const payload = await getReReviewTable({ curate });
+   199	      // R serialises the table as `{ data, meta }`; legacy stubs may surface
+   200	      // a bare array — accept either.
+   201	      const rows = Array.isArray(payload)
+   202	        ? payload
+   203	        : ((payload as { data?: ReReviewTableRow[] } | undefined)?.data ?? []);
+   204	      items.value = rows;
+   205	      totalRows.value = rows.length;
+   206	    } catch (err) {
+   207	      reportError(err);
+   208	    }
+   209	    isBusy.value = false;
+   210	    loading.value = false;
+   211	  }
+   212	
+   213	  async function loadPhenotypesList(): Promise<void> {
+   214	    try {
+   215	      const payload = await listPhenotypesTree();
+   216	      phenotypes_options.value = transformModifierTree(payload);
+   217	    } catch (err) {
+   218	      reportError(err);
+   219	      phenotypes_options.value = [];
+   220	    }
+   221	  }
+   222	
+   223	  async function loadVariationOntologyList(): Promise<void> {
+   224	    try {
+   225	      const payload = await listVariationOntologyTree();
+   226	      variation_ontology_options.value = transformModifierTree(payload);
+   227	    } catch (err) {
+   228	      reportError(err);
+   229	      variation_ontology_options.value = [];
+   230	    }
+   231	  }
+   232	
+   233	  async function loadStatusList(): Promise<void> {
+   234	    try {
+   235	      status_options.value = await listStatusCategoriesTree();
+   236	    } catch (err) {
+   237	      reportError(err);
+   238	    }
+   239	  }
+   240	
+   241	  async function getEntity(entity_input: number | string): Promise<void> {
+   242	    try {
+   243	      const payload = await listEntities({
+   244	        filter: `equals(entity_id,${entity_input})`,
+   245	      });
+   246	      const [first] = payload.data as Array<Partial<ReviewEntityInfo>>;
+   247	      if (first) {
+   248	        Object.assign(entity_info, EMPTY_ENTITY_INFO, first);
+   249	      }
+   250	    } catch (err) {
+   251	      reportError(err);
+   252	    }
+   253	  }
+   254	
+   255	  async function loadReviewInfo(
+   256	    review_id: number | string,
+   257	    re_review_review_saved: number
+   258	  ): Promise<void> {
+   259	    try {
+   260	      const rows = await getReviewById(review_id);
+   261	      if (rows && rows.length > 0) {
+   262	        const row = rows[0];
+   263	        review_info.review_id = row.review_id;
+   264	        review_info.entity_id = row.entity_id;
+   265	        review_info.review_user_name = row.review_user_name;
+   266	        review_info.review_user_role = row.review_user_role;
+   267	        review_info.review_date = row.review_date;
+   268	        review_info.re_review_review_saved = re_review_review_saved;
+   269	      }
+   270	    } catch (err) {
+   271	      reportError(err);
+   272	    }
+   273	  }
+   274	
+   275	  async function loadStatusInfo(
+   276	    status_id: number | string,
+   277	    re_review_status_saved: number
+   278	  ): Promise<void> {
+   279	    loading_status_modal.value = true;
+   280	    try {
+   281	      const rows = await getStatusById(status_id);
+   282	      if (rows && rows.length > 0) {
+   283	        const row = rows[0];
+   284	        // Replace the reactive backing object's keys (we cannot reassign
+   285	        // a reactive ref to a brand-new instance without losing the
+   286	        // shared identity callers may have captured).
+   287	        Object.assign(status_info, new Status(row.category_id, row.comment, row.problematic));
+   288	        status_info.status_id = row.status_id;
+   289	        status_info.entity_id = row.entity_id;
+   290	        status_info.status_user_name = row.status_user_name;
+   291	        status_info.status_user_role = row.status_user_role;
+   292	        status_info.status_date = row.status_date;
+   293	        status_info.re_review_status_saved = re_review_status_saved;
+   294	      }
+   295	      loading_status_modal.value = false;
+   296	    } catch (err) {
+   297	      reportError(err);
+   298	    }
+   299	  }
+   300	
+   301	  function resetEntityContext(): void {
+   302	    Object.assign(entity_info, EMPTY_ENTITY_INFO);
+   303	    Object.assign(review_info, new Review() as ReviewInfo, {
+   304	      review_id: null,
+   305	      entity_id: null,
+   306	      review_user_name: null,
+   307	      review_user_role: null,
+   308	      review_date: null,
+   309	      re_review_review_saved: null,
+   310	    });
+   311	  }
+   312	
+   313	  return {
+   314	    items,
+   315	    totalRows,
+   316	    isBusy,
+   317	    loading,
+   318	    phenotypes_options,
+   319	    variation_ontology_options,
+   320	    status_options,
+    58	};
+    59	
+    60	export function useEntityInfo(options: UseEntityInfoOptions = {}) {
+    61	  const { onToast } = options;
+    62	
+    63	  const entity_info = ref<Record<string, any>>({});
+    64	  const review_info = ref<any>(new Review());
+    65	  const status_info = ref<any>(new Status());
+    66	
+    67	  const select_phenotype = ref<string[]>([]);
+    68	  const select_variation = ref<string[]>([]);
+    69	  const select_additional_references = ref<string[]>([]);
+    70	  const select_gene_reviews = ref<string[]>([]);
+    71	
+    72	  const reviewLoadedData = ref<ReviewSnapshot | null>(null);
+    73	
+    74	  const hasReviewChanges = computed(() => {
+    75	    if (!reviewLoadedData.value) return false;
+    76	    const snap = reviewLoadedData.value;
+    77	    return (
+    78	      (review_info.value.synopsis || '') !== snap.synopsis ||
+    79	      (review_info.value.comment || '') !== snap.comment ||
+    80	      !arrEqual(select_phenotype.value, snap.phenotypes) ||
+    81	      !arrEqual(select_variation.value, snap.variationOntology) ||
+    82	      !arrEqual(select_additional_references.value, snap.publications) ||
+    83	      !arrEqual(select_gene_reviews.value, snap.genereviews)
+    84	    );
+    85	  });
+    86	
+    87	  async function loadEntity(entityId: number): Promise<void> {
+    88	    try {
+    89	      const response: any = await listEntities({
+    90	        filter: `equals(entity_id,${entityId})`,
+    91	        fields: ENTITY_MUTATION_FIELDS,
+    92	        page_size: '1',
+    93	        compact: true,
+    94	      });
+    95	      const data = response?.data;
+    96	      if (!Array.isArray(data) || data.length === 0) {
+    97	        onToast?.(`Entity ${entityId} not found`, 'Error', 'danger');
+    98	        entity_info.value = {};
+    99	        return;
+   100	      }
+   101	      entity_info.value = data[0];
+   102	    } catch (e) {
+   103	      onToast?.(e, 'Error', 'danger');
+   104	      entity_info.value = {};
+   105	    }
+   106	  }
+   107	
+   108	  async function loadReview(entityId: number): Promise<void> {
+   109	    try {
+   110	      const review_data: any = await getEntityReview(entityId);
+   111	      const phenotypes_data: any = await getEntityPhenotypes(entityId);
+   112	      const variation_data: any = await getEntityVariation(entityId);
+   113	      const publications_data: any = await getEntityPublications(entityId);
+   114	
+   115	      const new_phenotype = phenotypes_data.map(
+   116	        (item: any) => new Phenotype(item.phenotype_id, item.modifier_id)
+   117	      );
+   118	      select_phenotype.value = phenotypes_data.map(
+   119	        (item: any) => `${item.modifier_id}-${item.phenotype_id}`
+   120	      );
+   121	
+   122	      const new_variation = variation_data.map(
+   123	        (item: any) => new Variation(item.vario_id, item.modifier_id)
+   124	      );
+   125	      select_variation.value = variation_data.map(
+   126	        (item: any) => `${item.modifier_id}-${item.vario_id}`
+   127	      );
+   128	
+   129	      const literature_gene_reviews = publications_data
+   130	        .filter((item: any) => item.publication_type === 'gene_review')
+   131	        .map((item: any) => item.publication_id);
+   132	      const literature_additional_references = publications_data
+   133	        .filter((item: any) => item.publication_type === 'additional_references')
+   134	        .map((item: any) => item.publication_id);
+   135	
+   136	      select_additional_references.value = literature_additional_references;
+   137	      select_gene_reviews.value = literature_gene_reviews;
+   138	
+   139	      const new_literature = new Literature(
+   140	        literature_additional_references,
+   141	        literature_gene_reviews
+   142	      );
+   143	
+   144	      review_info.value = new Review(
+   145	        review_data[0].synopsis,
+   146	        new_literature,
+   147	        new_phenotype,
+   148	        new_variation,
+   149	        review_data[0].comment
+   150	      );
+   151	      review_info.value.review_id = review_data[0].review_id;
+   152	      review_info.value.entity_id = review_data[0].entity_id;
+   153	
+   154	      reviewLoadedData.value = {
+   155	        synopsis: review_info.value.synopsis || '',
+   156	        comment: review_info.value.comment || '',
+   157	        phenotypes: [...select_phenotype.value],
+   158	        variationOntology: [...select_variation.value],
+   159	        publications: [...select_additional_references.value],
+   160	        genereviews: [...select_gene_reviews.value],
+   161	      };
+   162	    } catch (e) {
+   163	      onToast?.(e, 'Error', 'danger');
+   164	    }
+   165	  }
+   166	
+   167	  async function loadStatus(entityId: number): Promise<void> {
+   168	    try {
+   169	      const status_data: any = await getEntityStatus(entityId);
+   170	      status_info.value = new Status(
+   171	        status_data[0].category_id,
+   172	        status_data[0].comment,
+   173	        status_data[0].problematic
+   174	      );
+   175	      status_info.value.status_id = status_data[0].status_id;
+   176	      status_info.value.entity_id = status_data[0].entity_id;
+   177	    } catch (e) {
+   178	      onToast?.(e, 'Error', 'danger');
+   179	    }
+   180	  }
+   181	
+   182	  function reset(): void {
+   183	    entity_info.value = {};
+   184	    review_info.value = new Review();
+   185	    status_info.value = new Status();
+   186	    select_phenotype.value = [];
+   187	    select_variation.value = [];
+   188	    select_additional_references.value = [];
+   189	    select_gene_reviews.value = [];
+   190	    reviewLoadedData.value = null;
+   191	  }
+   192	
+   193	  return {
+   194	    entity_info,
+   195	    review_info,
+   196	    status_info,
+   197	    select_phenotype,
+   198	    select_variation,
+   199	    select_additional_references,
+   200	    select_gene_reviews,
+   201	    reviewLoadedData,
+   202	    hasReviewChanges,
+   203	    loadEntity,
+   204	    loadReview,
+   205	    loadStatus,
+   206	    reset,
+   207	  };
+
+exec
+/bin/bash -lc "sed -n '60,150p' app/src/composables/usePubtatorAdminPanel.ts; rg -n -C 3 \"checkStatus|isCheckingStatus|Check Status\" app/src/views/admin/ManagePubtator.vue app/src/composables/usePubtatorAdminPanel.ts; nl -ba app/src/composables/usePubtatorAdminPanel.ts | sed -n '55,105p'; nl -ba app/src/composables/useNetworkData.ts | sed -n '286,318p'; nl -ba app/src/views/admin/ManageOntology.spec.ts | tail -n 20; git status -sb && git branch --show-current && git log -5 --oneline" in /home/bernt-popp/development/sysndd/.claude/worktrees/535-s5c-request-ownership
+ succeeded in 0ms:
+  const cacheStateLabel = computed(() => {
+    if (!lastStatus.value) return 'No status';
+    return lastStatus.value.cached ? 'Cached' : 'Not cached';
+  });
+
+  function formatDate(dateStr: string | null): string {
+    if (!dateStr) return 'N/A';
+    const date = new Date(dateStr);
+    return date.toLocaleString();
+  }
+
+  async function checkStatus(): Promise<void> {
+    if (!query.value.trim()) return;
+    feedbackMessage.value = '';
+
+    try {
+      await getCacheStatus(query.value);
+    } catch (err) {
+      feedbackMessage.value = extractApiErrorMessage(err, 'Failed to check cache status');
+      feedbackVariant.value = 'danger';
+    }
+  }
+
+  async function submitFetch(): Promise<void> {
+    if (!query.value.trim()) return;
+    feedbackMessage.value = '';
+    resetJob(); // Clear any previous job state
+
+    try {
+      await submitFetchJob(query.value, maxPages.value, clearOld.value);
+      feedbackMessage.value = `Job submitted! Fetching ${maxPages.value} pages (~${Math.round((maxPages.value * 2.5) / 60)} min)`;
+      feedbackVariant.value = 'info';
+    } catch (err) {
+      feedbackMessage.value = extractApiErrorMessage(err, 'Failed to submit fetch job');
+      feedbackVariant.value = 'danger';
+    }
+  }
+
+  async function backfillGenes(): Promise<void> {
+    if (!lastStatus.value?.query_id) return;
+    feedbackMessage.value = '';
+
+    try {
+      const backfillResult = await backfillGeneSymbols(lastStatus.value.query_id);
+      feedbackMessage.value = backfillResult.message;
+      feedbackVariant.value = 'success';
+    } catch (err) {
+      feedbackMessage.value = extractApiErrorMessage(err, 'Failed to backfill gene symbols');
+      feedbackVariant.value = 'danger';
+    }
+  }
+
+  async function clearAllCache(): Promise<void> {
+    feedbackMessage.value = '';
+
+    try {
+      const clearResult = await clearCache();
+      feedbackMessage.value = clearResult.message ?? 'Cache cleared.';
+      feedbackVariant.value = 'success';
+      lastStatus.value = null;
+    } catch (err) {
+      feedbackMessage.value = extractApiErrorMessage(err, 'Failed to clear cache');
+      feedbackVariant.value = 'danger';
+    } finally {
+      showClearAllModal.value = false;
+    }
+  }
+
+  return {
+    // Lower-level cache/job composable (state, computed, controls)
+    ...admin,
+    // Form state
+    query,
+    maxPages,
+    clearOld,
+    // UI state
+    showClearAllModal,
+    // Feedback
+    feedbackMessage,
+    feedbackVariant,
+    feedbackIcon,
+    // Local computed
+    cacheStateLabel,
+    // Methods
+    formatDate,
+    checkStatus,
+    submitFetch,
+    backfillGenes,
+    clearAllCache,
+  };
+}
+app/src/composables/usePubtatorAdminPanel.ts-68-    return date.toLocaleString();
+app/src/composables/usePubtatorAdminPanel.ts-69-  }
+app/src/composables/usePubtatorAdminPanel.ts-70-
+app/src/composables/usePubtatorAdminPanel.ts:71:  async function checkStatus(): Promise<void> {
+app/src/composables/usePubtatorAdminPanel.ts-72-    if (!query.value.trim()) return;
+app/src/composables/usePubtatorAdminPanel.ts-73-    feedbackMessage.value = '';
+app/src/composables/usePubtatorAdminPanel.ts-74-
+--
+app/src/composables/usePubtatorAdminPanel.ts-142-    cacheStateLabel,
+app/src/composables/usePubtatorAdminPanel.ts-143-    // Methods
+app/src/composables/usePubtatorAdminPanel.ts-144-    formatDate,
+app/src/composables/usePubtatorAdminPanel.ts:145:    checkStatus,
+app/src/composables/usePubtatorAdminPanel.ts-146-    submitFetch,
+app/src/composables/usePubtatorAdminPanel.ts-147-    backfillGenes,
+app/src/composables/usePubtatorAdminPanel.ts-148-    clearAllCache,
+--
+app/src/views/admin/ManagePubtator.vue-20-        :meta="lastStatus ? cacheStateLabel : 'No query checked'"
+app/src/views/admin/ManagePubtator.vue-21-      >
+app/src/views/admin/ManagePubtator.vue-22-        <div data-testid="pubtator-query-workspace">
+app/src/views/admin/ManagePubtator.vue:23:          <form class="pubtator-query-form" @submit.prevent="checkStatus">
+app/src/views/admin/ManagePubtator.vue-24-            <BFormGroup
+app/src/views/admin/ManagePubtator.vue-25-              label="PubTator query"
+app/src/views/admin/ManagePubtator.vue-26-              label-for="query-input"
+--
+app/src/views/admin/ManagePubtator.vue-38-              <BButton
+app/src/views/admin/ManagePubtator.vue-39-                type="submit"
+app/src/views/admin/ManagePubtator.vue-40-                variant="primary"
+app/src/views/admin/ManagePubtator.vue:41:                :disabled="!query.trim() || isCheckingStatus"
+app/src/views/admin/ManagePubtator.vue-42-              >
+app/src/views/admin/ManagePubtator.vue:43:                <BSpinner v-if="isCheckingStatus" small class="me-1" />
+app/src/views/admin/ManagePubtator.vue-44-                <i v-else class="bi bi-search me-1" aria-hidden="true" />
+app/src/views/admin/ManagePubtator.vue-45-                Check status
+app/src/views/admin/ManagePubtator.vue-46-              </BButton>
+--
+app/src/views/admin/ManagePubtator.vue-310-const {
+app/src/views/admin/ManagePubtator.vue-311-  // Cache/job state
+app/src/views/admin/ManagePubtator.vue-312-  lastStatus,
+app/src/views/admin/ManagePubtator.vue:313:  isCheckingStatus,
+app/src/views/admin/ManagePubtator.vue-314-  isClearing,
+app/src/views/admin/ManagePubtator.vue-315-  isBackfilling,
+app/src/views/admin/ManagePubtator.vue-316-  jobId,
+--
+app/src/views/admin/ManagePubtator.vue-345-
+app/src/views/admin/ManagePubtator.vue-346-  // Methods
+app/src/views/admin/ManagePubtator.vue-347-  formatDate,
+app/src/views/admin/ManagePubtator.vue:348:  checkStatus,
+app/src/views/admin/ManagePubtator.vue-349-  submitFetch,
+app/src/views/admin/ManagePubtator.vue-350-  backfillGenes,
+app/src/views/admin/ManagePubtator.vue-351-  clearAllCache,
+    55	      default:
+    56	        return 'bi bi-info-circle-fill';
+    57	    }
+    58	  });
+    59	
+    60	  const cacheStateLabel = computed(() => {
+    61	    if (!lastStatus.value) return 'No status';
+    62	    return lastStatus.value.cached ? 'Cached' : 'Not cached';
+    63	  });
+    64	
+    65	  function formatDate(dateStr: string | null): string {
+    66	    if (!dateStr) return 'N/A';
+    67	    const date = new Date(dateStr);
+    68	    return date.toLocaleString();
+    69	  }
+    70	
+    71	  async function checkStatus(): Promise<void> {
+    72	    if (!query.value.trim()) return;
+    73	    feedbackMessage.value = '';
+    74	
+    75	    try {
+    76	      await getCacheStatus(query.value);
+    77	    } catch (err) {
+    78	      feedbackMessage.value = extractApiErrorMessage(err, 'Failed to check cache status');
+    79	      feedbackVariant.value = 'danger';
+    80	    }
+    81	  }
+    82	
+    83	  async function submitFetch(): Promise<void> {
+    84	    if (!query.value.trim()) return;
+    85	    feedbackMessage.value = '';
+    86	    resetJob(); // Clear any previous job state
+    87	
+    88	    try {
+    89	      await submitFetchJob(query.value, maxPages.value, clearOld.value);
+    90	      feedbackMessage.value = `Job submitted! Fetching ${maxPages.value} pages (~${Math.round((maxPages.value * 2.5) / 60)} min)`;
+    91	      feedbackVariant.value = 'info';
+    92	    } catch (err) {
+    93	      feedbackMessage.value = extractApiErrorMessage(err, 'Failed to submit fetch job');
+    94	      feedbackVariant.value = 'danger';
+    95	    }
+    96	  }
+    97	
+    98	  async function backfillGenes(): Promise<void> {
+    99	    if (!lastStatus.value?.query_id) return;
+   100	    feedbackMessage.value = '';
+   101	
+   102	    try {
+   103	      const backfillResult = await backfillGeneSymbols(lastStatus.value.query_id);
+   104	      feedbackMessage.value = backfillResult.message;
+   105	      feedbackVariant.value = 'success';
+   286	    );
+   287	    return elements;
+   288	  });
+   289	
+   290	  /**
+   291	   * Clear network data and reset state
+   292	   */
+   293	  const clearNetworkData = (): void => {
+   294	    networkData.value = null;
+   295	    error.value = null;
+   296	    isPreparing.value = false;
+   297	    isLoading.value = false;
+   298	  };
+   299	
+   300	  return {
+   301	    networkData,
+   302	    isLoading,
+   303	    error,
+   304	    isPreparing,
+   305	    metadata,
+   306	    fetchNetworkData,
+   307	    cytoscapeElements,
+   308	    cytoscapeInitialElements,
+   309	    cytoscapeNodeElements,
+   310	    clearNetworkData,
+   311	  };
+   312	}
+   313	
+   314	export default useNetworkData;
+   315	
+   316	// Re-export types for convenience
+   317	export type { NetworkNode, NetworkEdge, NetworkResponse, NetworkMetadata } from '@/api/analysis';
+   570	  // -------------------------------------------------------------------------
+   571	
+   572	  it('handleExport() exports the loaded rows with the ontology_export_<date> filename and shared headers', async () => {
+   573	    server.use(
+   574	      http.get('/api/ontology/variant/table', () => HttpResponse.json(ontologyListPayload()))
+   575	    );
+   576	
+   577	    const wrapper = await mountView();
+   578	    const vm = wrapper.vm as unknown as OntologyVm;
+   579	
+   580	    vm.handleExport();
+   581	
+   582	    const expectedFilename = `ontology_export_${new Date().toISOString().split('T')[0]}`;
+   583	    expect(exportToExcelSpy).toHaveBeenCalledWith(vm.ontologies, {
+   584	      filename: expectedFilename,
+   585	      sheetName: 'Ontology',
+   586	      headers: ONTOLOGY_EXPORT_HEADERS,
+   587	    });
+   588	  });
+   589	});
+## fix/535-s5c-request-ownership
+?? .planning/reviews/2026-07-13-security-535-s5c-request-ownership-plan-codex-out.txt
+?? .planning/reviews/2026-07-13-security-535-s5c-request-ownership-plan-codex-prompt.md
+?? .planning/superpowers/plans/2026-07-13-security-535-s5c-request-ownership-plan.md
+fix/535-s5c-request-ownership
+c4cecd32 perf: gate route bundles and slim composable barrel (#555)
+3ede7ac8 Merge pull request #549 from berntpopp/fix/535-s1b-token-hardening
+c9cfbdbb Merge pull request #546 from berntpopp/fix/535-s3-restore-fencing-design
+278cc8dc Merge pull request #557 from berntpopp/release/v0.29.10
+e3e3be8a chore(release): v0.29.10 — S5b/S8/S6/S7 security hardening
+
+exec
+/bin/bash -lc "rg -n -C 3 \"loadPhenotypesList|loadVariationOntologyList|loadStatusList|loadReReviewData|getEntity\\(|loadReviewInfo\\(|loadStatusInfo\\(|resetEntityContext\" app/src/views/review --glob '"'!composables/useReviewData.ts'"' && rg -n -C 2 \"useReviewData\" app/src/views/review/Review.vue && rg -n -C 3 \"loadEntity\\(|loadReview\\(|loadStatus\\(\" app/src/views/curate --glob '"'!composables/useEntityInfo.ts'"'" in /home/bernt-popp/development/sysndd/.claude/worktrees/535-s5c-request-ownership
+ succeeded in 0ms:
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-83-    vi.clearAllMocks();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-84-  });
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-85-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts:86:  describe('loadReReviewData', () => {
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-87-    it('populates items + totalRows on success', async () => {
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-88-      const axios = await getAxiosMock();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-89-      axios.get.mockResolvedValueOnce({
+--
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-99-      expect(data.isBusy.value).toBe(false);
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-100-      expect(data.loading.value).toBe(true);
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-101-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts:102:      await data.loadReReviewData(false);
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-103-      await flushPromises();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-104-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-105-      expect(data.items.value).toHaveLength(2);
+--
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-113-      axios.get.mockResolvedValueOnce({ data: { data: [] } });
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-114-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-115-      const data = useReviewData();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts:116:      await data.loadReReviewData(true);
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-117-      await flushPromises();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-118-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-119-      expect(axios.get).toHaveBeenCalledWith(
+--
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-129-      axios.get.mockResolvedValueOnce({ data: [{ entity_id: 99 }] });
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-130-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-131-      const data = useReviewData();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts:132:      await data.loadReReviewData(false);
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-133-      await flushPromises();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-134-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-135-      expect(data.items.value).toHaveLength(1);
+--
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-143-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-144-      const onError = vi.fn();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-145-      const data = useReviewData({ onError });
+app/src/views/review/composables/__tests__/useReviewData.spec.ts:146:      await data.loadReReviewData(false);
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-147-      await flushPromises();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-148-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-149-      expect(onError).toHaveBeenCalledWith(err);
+--
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-154-    });
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-155-  });
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-156-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts:157:  describe('loadPhenotypesList', () => {
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-158-    it('runs the present-prefix transform on the tree response', async () => {
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-159-      const axios = await getAxiosMock();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-160-      axios.get.mockResolvedValueOnce({
+--
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-171-      });
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-172-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-173-      const data = useReviewData();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts:174:      await data.loadPhenotypesList();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-175-      await flushPromises();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-176-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-177-      expect(data.phenotypes_options.value).toHaveLength(1);
+--
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-187-      axios.get.mockResolvedValueOnce({ data: { data: [] } });
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-188-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-189-      const data = useReviewData();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts:190:      await data.loadPhenotypesList();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-191-      await flushPromises();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-192-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-193-      expect(data.phenotypes_options.value).toEqual([]);
+--
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-200-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-201-      const onError = vi.fn();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-202-      const data = useReviewData({ onError });
+app/src/views/review/composables/__tests__/useReviewData.spec.ts:203:      await data.loadPhenotypesList();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-204-      await flushPromises();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-205-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-206-      expect(onError).toHaveBeenCalledWith(err);
+--
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-208-    });
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-209-  });
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-210-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts:211:  describe('loadVariationOntologyList', () => {
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-212-    it('reuses the present-prefix transform', async () => {
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-213-      const axios = await getAxiosMock();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-214-      axios.get.mockResolvedValueOnce({
+--
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-222-      });
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-223-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-224-      const data = useReviewData();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts:225:      await data.loadVariationOntologyList();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-226-      await flushPromises();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-227-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-228-      expect(data.variation_ontology_options.value).toHaveLength(1);
+--
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-230-    });
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-231-  });
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-232-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts:233:  describe('loadStatusList', () => {
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-234-    it('stores the response verbatim (no transform)', async () => {
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-235-      const axios = await getAxiosMock();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-236-      axios.get.mockResolvedValueOnce({
+--
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-241-      });
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-242-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-243-      const data = useReviewData();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts:244:      await data.loadStatusList();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-245-      await flushPromises();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-246-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-247-      expect(data.status_options.value).toHaveLength(2);
+--
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-257-      });
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-258-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-259-      const data = useReviewData();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts:260:      await data.getEntity(501);
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-261-      await flushPromises();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-262-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-263-      expect(axios.get).toHaveBeenCalledWith(
+--
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-287-      });
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-288-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-289-      const data = useReviewData();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts:290:      await data.loadReviewInfo(42, 1);
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-291-      await flushPromises();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-292-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-293-      expect(data.review_info.review_id).toBe(42);
+--
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-297-    });
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-298-  });
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-299-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts:300:  describe('resetEntityContext', () => {
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-301-    it('clears entity_info + review_info to a fresh shape', () => {
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-302-      const data = useReviewData();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-303-      data.entity_info.entity_id = 99;
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-304-      data.entity_info.symbol = 'X';
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-305-      data.review_info.review_id = 5;
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-306-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts:307:      data.resetEntityContext();
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-308-
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-309-      expect(data.entity_info.entity_id).toBe(0);
+app/src/views/review/composables/__tests__/useReviewData.spec.ts-310-      expect(data.entity_info.symbol).toBe('');
+--
+app/src/views/review/composables/useReviewData.ts-93-  loading_status_modal: Ref<boolean>;
+app/src/views/review/composables/useReviewData.ts-94-
+app/src/views/review/composables/useReviewData.ts-95-  // Loaders
+app/src/views/review/composables/useReviewData.ts:96:  loadReReviewData: (curate: boolean) => Promise<void>;
+app/src/views/review/composables/useReviewData.ts:97:  loadPhenotypesList: () => Promise<void>;
+app/src/views/review/composables/useReviewData.ts:98:  loadVariationOntologyList: () => Promise<void>;
+app/src/views/review/composables/useReviewData.ts:99:  loadStatusList: () => Promise<void>;
+app/src/views/review/composables/useReviewData.ts-100-  getEntity: (entity_input: number | string) => Promise<void>;
+app/src/views/review/composables/useReviewData.ts-101-  loadReviewInfo: (review_id: number | string, re_review_review_saved: number) => Promise<void>;
+app/src/views/review/composables/useReviewData.ts-102-  loadStatusInfo: (status_id: number | string, re_review_status_saved: number) => Promise<void>;
+app/src/views/review/composables/useReviewData.ts-103-
+app/src/views/review/composables/useReviewData.ts-104-  // Reset helpers
+app/src/views/review/composables/useReviewData.ts:105:  resetEntityContext: () => void;
+app/src/views/review/composables/useReviewData.ts-106-}
+app/src/views/review/composables/useReviewData.ts-107-
+app/src/views/review/composables/useReviewData.ts-108-// ---------------------------------------------------------------------------
+--
+app/src/views/review/composables/useReviewData.ts-192-    }
+app/src/views/review/composables/useReviewData.ts-193-  }
+app/src/views/review/composables/useReviewData.ts-194-
+app/src/views/review/composables/useReviewData.ts:195:  async function loadReReviewData(curate: boolean): Promise<void> {
+app/src/views/review/composables/useReviewData.ts-196-    isBusy.value = true;
+app/src/views/review/composables/useReviewData.ts-197-    try {
+app/src/views/review/composables/useReviewData.ts-198-      const payload = await getReReviewTable({ curate });
+--
+app/src/views/review/composables/useReviewData.ts-210-    loading.value = false;
+app/src/views/review/composables/useReviewData.ts-211-  }
+app/src/views/review/composables/useReviewData.ts-212-
+app/src/views/review/composables/useReviewData.ts:213:  async function loadPhenotypesList(): Promise<void> {
+app/src/views/review/composables/useReviewData.ts-214-    try {
+app/src/views/review/composables/useReviewData.ts-215-      const payload = await listPhenotypesTree();
+app/src/views/review/composables/useReviewData.ts-216-      phenotypes_options.value = transformModifierTree(payload);
+--
+app/src/views/review/composables/useReviewData.ts-220-    }
+app/src/views/review/composables/useReviewData.ts-221-  }
+app/src/views/review/composables/useReviewData.ts-222-
+app/src/views/review/composables/useReviewData.ts:223:  async function loadVariationOntologyList(): Promise<void> {
+app/src/views/review/composables/useReviewData.ts-224-    try {
+app/src/views/review/composables/useReviewData.ts-225-      const payload = await listVariationOntologyTree();
+app/src/views/review/composables/useReviewData.ts-226-      variation_ontology_options.value = transformModifierTree(payload);
+--
+app/src/views/review/composables/useReviewData.ts-230-    }
+app/src/views/review/composables/useReviewData.ts-231-  }
+app/src/views/review/composables/useReviewData.ts-232-
+app/src/views/review/composables/useReviewData.ts:233:  async function loadStatusList(): Promise<void> {
+app/src/views/review/composables/useReviewData.ts-234-    try {
+app/src/views/review/composables/useReviewData.ts-235-      status_options.value = await listStatusCategoriesTree();
+app/src/views/review/composables/useReviewData.ts-236-    } catch (err) {
+--
+app/src/views/review/composables/useReviewData.ts-238-    }
+app/src/views/review/composables/useReviewData.ts-239-  }
+app/src/views/review/composables/useReviewData.ts-240-
+app/src/views/review/composables/useReviewData.ts:241:  async function getEntity(entity_input: number | string): Promise<void> {
+app/src/views/review/composables/useReviewData.ts-242-    try {
+app/src/views/review/composables/useReviewData.ts-243-      const payload = await listEntities({
+app/src/views/review/composables/useReviewData.ts-244-        filter: `equals(entity_id,${entity_input})`,
+--
+app/src/views/review/composables/useReviewData.ts-252-    }
+app/src/views/review/composables/useReviewData.ts-253-  }
+app/src/views/review/composables/useReviewData.ts-254-
+app/src/views/review/composables/useReviewData.ts:255:  async function loadReviewInfo(
+app/src/views/review/composables/useReviewData.ts-256-    review_id: number | string,
+app/src/views/review/composables/useReviewData.ts-257-    re_review_review_saved: number
+app/src/views/review/composables/useReviewData.ts-258-  ): Promise<void> {
+--
+app/src/views/review/composables/useReviewData.ts-272-    }
+app/src/views/review/composables/useReviewData.ts-273-  }
+app/src/views/review/composables/useReviewData.ts-274-
+app/src/views/review/composables/useReviewData.ts:275:  async function loadStatusInfo(
+app/src/views/review/composables/useReviewData.ts-276-    status_id: number | string,
+app/src/views/review/composables/useReviewData.ts-277-    re_review_status_saved: number
+app/src/views/review/composables/useReviewData.ts-278-  ): Promise<void> {
+--
+app/src/views/review/composables/useReviewData.ts-298-    }
+app/src/views/review/composables/useReviewData.ts-299-  }
+app/src/views/review/composables/useReviewData.ts-300-
+app/src/views/review/composables/useReviewData.ts:301:  function resetEntityContext(): void {
+app/src/views/review/composables/useReviewData.ts-302-    Object.assign(entity_info, EMPTY_ENTITY_INFO);
+app/src/views/review/composables/useReviewData.ts-303-    Object.assign(review_info, new Review() as ReviewInfo, {
+app/src/views/review/composables/useReviewData.ts-304-      review_id: null,
+--
+app/src/views/review/composables/useReviewData.ts-322-    review_info,
+app/src/views/review/composables/useReviewData.ts-323-    status_info,
+app/src/views/review/composables/useReviewData.ts-324-    loading_status_modal,
+app/src/views/review/composables/useReviewData.ts:325:    loadReReviewData,
+app/src/views/review/composables/useReviewData.ts:326:    loadPhenotypesList,
+app/src/views/review/composables/useReviewData.ts:327:    loadVariationOntologyList,
+app/src/views/review/composables/useReviewData.ts:328:    loadStatusList,
+app/src/views/review/composables/useReviewData.ts-329-    getEntity,
+app/src/views/review/composables/useReviewData.ts-330-    loadReviewInfo,
+app/src/views/review/composables/useReviewData.ts-331-    loadStatusInfo,
+app/src/views/review/composables/useReviewData.ts:332:    resetEntityContext,
+app/src/views/review/composables/useReviewData.ts-333-  };
+app/src/views/review/composables/useReviewData.ts-334-}
+app/src/views/review/composables/useReviewData.ts-335-
+--
+app/src/views/review/Review.vue-36-        :data-age-text="data_age_text"
+app/src/views/review/Review.vue-37-        :data-age-style="data_age_style"
+app/src/views/review/Review.vue-38-        :date-year-age="dateYearAge"
+app/src/views/review/Review.vue:39:        @refresh="loadReReviewData"
+app/src/views/review/Review.vue-40-        @new-batch="newBatchApplication"
+app/src/views/review/Review.vue-41-        @add-quick-filter="addQuickFilter"
+app/src/views/review/Review.vue-42-        @remove-quick-filter="removeQuickFilter"
+--
+app/src/views/review/Review.vue-152-// instantiates the four composables, wires them together, and exposes
+app/src/views/review/Review.vue-153-// their public APIs to the Options-API template via the spread return.
+app/src/views/review/Review.vue-154-// Methods retained on the component are either thin glue (e.g. modal
+app/src/views/review/Review.vue:155:// `$refs.show()`, `loadReReviewData` orchestration that calls into both
+app/src/views/review/Review.vue-156-// the data composable AND the filter pagination reset) or pure
+app/src/views/review/Review.vue-157-// formatting helpers (`truncate`, `dateYearAge`).
+app/src/views/review/Review.vue-158-
+--
+app/src/views/review/Review.vue-271-    // intentionally lives in `setup()` (not `watch:`) so it composes
+app/src/views/review/Review.vue-272-    // cleanly with the `useReviewData` reactive surface.
+app/src/views/review/Review.vue-273-    watch(curation_selected, (next) => {
+app/src/views/review/Review.vue:274:      void data.loadReReviewData(next);
+app/src/views/review/Review.vue-275-    });
+app/src/views/review/Review.vue-276-
+app/src/views/review/Review.vue-277-    // Reset to page 1 whenever the filter result set changes shape — this
+--
+app/src/views/review/Review.vue-378-      this.curator_mode =
+app/src/views/review/Review.vue-379-        this.user.user_role[0] === 'Administrator' || this.user.user_role[0] === 'Curator';
+app/src/views/review/Review.vue-380-    }
+app/src/views/review/Review.vue:381:    void this.loadReReviewData();
+app/src/views/review/Review.vue:382:    void this.reviewData.loadPhenotypesList();
+app/src/views/review/Review.vue:383:    void this.reviewData.loadVariationOntologyList();
+app/src/views/review/Review.vue:384:    void this.reviewData.loadStatusList();
+app/src/views/review/Review.vue-385-  },
+app/src/views/review/Review.vue-386-  methods: {
+app/src/views/review/Review.vue-387-    // ---- Modal triggers (template @click handlers) -------------------------
+app/src/views/review/Review.vue-388-
+app/src/views/review/Review.vue-389-    async infoReview(item) {
+app/src/views/review/Review.vue-390-      this.reviewModals.setReviewTarget(item);
+app/src/views/review/Review.vue:391:      await this.reviewData.getEntity(item.entity_id);
+app/src/views/review/Review.vue-392-
+app/src/views/review/Review.vue-393-      // Clear any existing draft and load fresh data from server
+app/src/views/review/Review.vue-394-      this.reviewForm.clearDraft();
+app/src/views/review/Review.vue-395-      await this.reviewForm.loadReviewData(item.review_id, item.re_review_review_saved);
+app/src/views/review/Review.vue-396-
+app/src/views/review/Review.vue-397-      // Load review metadata for the modal footer display
+app/src/views/review/Review.vue:398:      await this.reviewData.loadReviewInfo(item.review_id, item.re_review_review_saved);
+app/src/views/review/Review.vue-399-
+app/src/views/review/Review.vue-400-      this.$refs.reviewModalRef?.show();
+app/src/views/review/Review.vue-401-    },
+app/src/views/review/Review.vue-402-    async infoStatus(item) {
+app/src/views/review/Review.vue-403-      this.reviewModals.setStatusTarget(item);
+app/src/views/review/Review.vue:404:      await this.reviewData.getEntity(item.entity_id);
+app/src/views/review/Review.vue-405-
+app/src/views/review/Review.vue-406-      // Clear any existing draft and load fresh data from server
+app/src/views/review/Review.vue-407-      this.statusForm.clearDraft();
+--
+app/src/views/review/Review.vue-431-        this.makeToast('Status submitted successfully', 'Success', 'success');
+app/src/views/review/Review.vue-432-        this.announce('Status submitted successfully');
+app/src/views/review/Review.vue-433-        this.statusForm.resetForm();
+app/src/views/review/Review.vue:434:        await this.loadReReviewData();
+app/src/views/review/Review.vue-435-      } catch (e) {
+app/src/views/review/Review.vue-436-        this.makeToast(e, 'Error', 'danger');
+app/src/views/review/Review.vue-437-        this.announce('Failed to submit status', 'assertive');
+--
+app/src/views/review/Review.vue-444-        this.makeToast('Review submitted successfully', 'Success', 'success');
+app/src/views/review/Review.vue-445-        this.announce('Review submitted successfully');
+app/src/views/review/Review.vue-446-        this.reviewForm.resetForm();
+app/src/views/review/Review.vue:447:        await this.loadReReviewData();
+app/src/views/review/Review.vue-448-      } catch (e) {
+app/src/views/review/Review.vue-449-        this.makeToast(e, 'Error', 'danger');
+app/src/views/review/Review.vue-450-        this.announce('Failed to submit review', 'assertive');
+--
+app/src/views/review/Review.vue-453-
+app/src/views/review/Review.vue-454-    // ---- Re-review mutations (BModal @ok handlers) -------------------------
+app/src/views/review/Review.vue-455-
+app/src/views/review/Review.vue:456:    async loadReReviewData() {
+app/src/views/review/Review.vue:457:      await this.reviewData.loadReReviewData(this.curation_selected);
+app/src/views/review/Review.vue-458-    },
+app/src/views/review/Review.vue-459-    async handleSubmitOk() {
+app/src/views/review/Review.vue-460-      await this.reviewActions.submitReReviewEntity(this.entity[0].re_review_entity_id);
+app/src/views/review/Review.vue:461:      await this.loadReReviewData();
+app/src/views/review/Review.vue-462-    },
+app/src/views/review/Review.vue-463-    async handleApproveOk() {
+app/src/views/review/Review.vue-464-      await this.reviewActions.approveEntity(this.entity[0].re_review_entity_id, {
+--
+app/src/views/review/Review.vue-466-        review_ok: this.review_approved,
+app/src/views/review/Review.vue-467-      });
+app/src/views/review/Review.vue-468-      this.reviewModals.resetApproveModal();
+app/src/views/review/Review.vue:469:      await this.loadReReviewData();
+app/src/views/review/Review.vue-470-    },
+app/src/views/review/Review.vue-471-    async handleRefuseOk() {
+app/src/views/review/Review.vue-472-      const ok = await this.reviewActions.refuseEntity(
+--
+app/src/views/review/Review.vue-477-        this.makeToast('Re-review refused and flagged for specialist', 'Success', 'success');
+app/src/views/review/Review.vue-478-        this.announce('Re-review refused and flagged for specialist');
+app/src/views/review/Review.vue-479-        this.reviewModals.resetRefuseModal();
+app/src/views/review/Review.vue:480:        await this.loadReReviewData();
+app/src/views/review/Review.vue-481-      } else {
+app/src/views/review/Review.vue-482-        this.announce('Failed to refuse re-review', 'assertive');
+app/src/views/review/Review.vue-483-      }
+--
+app/src/views/review/Review.vue-485-    async handleUnsetSubmission() {
+app/src/views/review/Review.vue-486-      await this.reviewActions.unsubmitEntity(this.entity[0].re_review_entity_id);
+app/src/views/review/Review.vue-487-      this.reviewModals.resetApproveModal();
+app/src/views/review/Review.vue:488:      await this.loadReReviewData();
+app/src/views/review/Review.vue-489-    },
+app/src/views/review/Review.vue-490-    async newBatchApplication() {
+app/src/views/review/Review.vue-491-      try {
+--
+app/src/views/review/Review.spec.ts-342-        ],
+app/src/views/review/Review.spec.ts-343-      });
+app/src/views/review/Review.spec.ts-344-    }
+app/src/views/review/Review.spec.ts:345:    // 2) Entity lookup (getEntity() in infoReview)
+app/src/views/review/Review.spec.ts-346-    // v11.1 W6: typed-entity client routes the filter via `config.params`
+app/src/views/review/Review.spec.ts-347-    // rather than embedding it into the URL. Match either shape so the
+app/src/views/review/Review.spec.ts-348-    // happy/error paths and any pre-W6 callers can still resolve the
+--
+app/src/views/review/Review.spec.ts-534-  };
+app/src/views/review/Review.spec.ts-535-  infoReview: (item: ReReviewRow, index: number, button: unknown) => Promise<void>;
+app/src/views/review/Review.spec.ts-536-  submitReviewChange: () => Promise<void>;
+app/src/views/review/Review.spec.ts:537:  loadReReviewData: () => Promise<void>;
+app/src/views/review/Review.spec.ts-538-  handleSubmitOk: (evt: unknown) => Promise<void>;
+app/src/views/review/Review.spec.ts-539-  handleApproveOk: (evt: unknown) => Promise<void>;
+app/src/views/review/Review.spec.ts-540-  handleUnsetSubmission: (evt: unknown) => Promise<void>;
+--
+app/src/views/review/Review.spec.ts-567-    await vm.infoReview(sampleRow, 0, null);
+app/src/views/review/Review.spec.ts-568-    await flushPromises();
+app/src/views/review/Review.spec.ts-569-
+app/src/views/review/Review.spec.ts:570:    // infoReview triggers getEntity() + useReviewForm.loadReviewData() +
+app/src/views/review/Review.spec.ts:571:    // loadReviewInfo(). Every call routes through axios.get, so verify the
+app/src/views/review/Review.spec.ts-572-    // load-phase hit our stub for each expected URL family.
+app/src/views/review/Review.spec.ts-573-    //
+app/src/views/review/Review.spec.ts:574:    // v11.1 W6: getEntity() now uses the typed `listEntities()` helper, so
+app/src/views/review/Review.spec.ts-575-    // the filter ride-along moves from the URL string to `config.params`.
+app/src/views/review/Review.spec.ts-576-    // Assert the entity request lands on `/api/entity/` AND carries the
+app/src/views/review/Review.spec.ts-577-    // expected `filter=equals(entity_id,...)` query param.
+--
+app/src/views/review/Review.spec.ts-989-    expect(useAuth().token.value).toBe(token);
+app/src/views/review/Review.spec.ts-990-  });
+app/src/views/review/Review.spec.ts-991-
+app/src/views/review/Review.spec.ts:992:  it('apiClient interceptor injects Bearer header for loadReReviewData (GET /api/re_review/table)', async () => {
+app/src/views/review/Review.spec.ts-993-    const axiosMock = await getSharedAxiosMock();
+app/src/views/review/Review.spec.ts-994-    wireHappyPathResponses(axiosMock);
+app/src/views/review/Review.spec.ts-995-
+--
+app/src/views/review/Review.spec.ts-999-    const vm = wrapper.vm as unknown as ReviewVm;
+app/src/views/review/Review.spec.ts-1000-    await flushPromises();
+app/src/views/review/Review.spec.ts-1001-
+app/src/views/review/Review.spec.ts:1002:    // The mounted() hook has already called loadReReviewData once. Confirm
+app/src/views/review/Review.spec.ts-1003-    // the URL reached the mock through `apiClient.get` (same mock object,
+app/src/views/review/Review.spec.ts-1004-    // same spy).
+app/src/views/review/Review.spec.ts-1005-    const getUrls = axiosMock.get.mock.calls.map((c) => c[0] as string);
+--
+app/src/views/review/Review.spec.ts-1015-
+app/src/views/review/Review.spec.ts-1016-    // Trigger another reload explicitly to prove the path stays live.
+app/src/views/review/Review.spec.ts-1017-    axiosMock.get.mockClear();
+app/src/views/review/Review.spec.ts:1018:    await vm.loadReReviewData();
+app/src/views/review/Review.spec.ts-1019-    await flushPromises();
+app/src/views/review/Review.spec.ts-1020-    const reloadUrls = axiosMock.get.mock.calls.map((c) => c[0] as string);
+app/src/views/review/Review.spec.ts-1021-    expect(reloadUrls.some((u) => u.includes('/api/re_review/table'))).toBe(true);
+128-import useStatusForm from '@/views/curate/composables/useStatusForm';
+129-import useReviewForm from '@/views/curate/composables/useReviewForm';
+130:import useReviewData from './composables/useReviewData';
+131-import useReviewFilters from './composables/useReviewFilters';
+132-import useReviewModals from './composables/useReviewModals';
+--
+239-
+240-    // W6 composables: data + filters + modals + actions.
+241:    const data = useReviewData({ onError: onComposableError });
+242-    const filters = useReviewFilters(data.items);
+243-    const modals = useReviewModals();
+--
+270-    // Re-fetch the table when the curator-mode toggle flips. This watch
+271-    // intentionally lives in `setup()` (not `watch:`) so it composes
+272:    // cleanly with the `useReviewData` reactive surface.
+273-    watch(curation_selected, (next) => {
+274-      void data.loadReReviewData(next);
+--
+302-      reviewFormIsSaving,
+303-
+304:      // useReviewData state
+305-      items: data.items,
+306-      isBusy: data.isBusy,
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-17-      )
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-18-    );
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-19-    const e = useEntityInfo();
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts:20:    await e.loadEntity(7);
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-21-    expect(e.entity_info.value.entity_id).toBe(7);
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-22-    expect(e.entity_info.value.symbol).toBe('GRIN2B');
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-23-  });
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-24-
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-25-  // Regression guard for the Modify Entity 500 (gene JKAMP / entity 4646).
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts:26:  // loadEntity() hits GET /api/entity/ (which queries ndd_entity_view). The API's
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-27-  // select_tibble_fields() returns HTTP 500 when ANY requested field is absent
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-28-  // from that view. Commit a586078a made loadEntity request is_active/replaced_by/
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-29-  // details — columns ndd_entity_view does NOT expose — so every entity selection
+--
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-74-
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-75-    const toasts: any[] = [];
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-76-    const e = useEntityInfo({ onToast: (...a) => toasts.push(a) });
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts:77:    await e.loadEntity(3367);
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-78-
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-79-    // The fields rename/deactivate actually consume (all view-backed) are present.
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-80-    expect(requestedFields).toContain('hgnc_id');
+--
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-94-    server.use(http.get('*/api/entity/*', () => HttpResponse.json({ data: [] })));
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-95-    const toasts: any[] = [];
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-96-    const e = useEntityInfo({ onToast: (...a) => toasts.push(a) });
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts:97:    await e.loadEntity(99);
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-98-    expect(e.entity_info.value).toEqual({});
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-99-    expect(toasts.length).toBe(1);
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-100-  });
+--
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-118-      )
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-119-    );
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-120-    const e = useEntityInfo();
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts:121:    await e.loadReview(7);
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-122-    expect(e.reviewLoadedData.value).not.toBeNull();
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-123-    expect(e.select_phenotype.value).toEqual(['present-HP:1']);
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-124-    expect(e.select_gene_reviews.value).toEqual(['PMID:1']);
+--
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-135-      http.get('*/api/entity/7/publications', () => HttpResponse.json([]))
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-136-    );
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-137-    const e = useEntityInfo();
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts:138:    await e.loadReview(7);
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-139-    expect(e.hasReviewChanges.value).toBe(false);
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-140-    e.review_info.value.synopsis = 'CHANGED';
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-141-    expect(e.hasReviewChanges.value).toBe(true);
+--
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-150-      )
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-151-    );
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-152-    const e = useEntityInfo();
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts:153:    await e.loadStatus(7);
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-154-    expect(e.status_info.value.category_id).toBe('definitive');
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-155-  });
+app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts-156-});
+--
+app/src/views/curate/composables/useModifyEntityWorkflows.ts-108-  async function showReviewModify(): Promise<void> {
+app/src/views/curate/composables/useModifyEntityWorkflows.ts-109-    activeWorkflow.value = 'review';
+app/src/views/curate/composables/useModifyEntityWorkflows.ts-110-    modals.setLoading('review', true);
+app/src/views/curate/composables/useModifyEntityWorkflows.ts:111:    await info.loadReview(info.entity_info.value.entity_id);
+app/src/views/curate/composables/useModifyEntityWorkflows.ts-112-    modals.setLoading('review', false);
+app/src/views/curate/composables/useModifyEntityWorkflows.ts-113-  }
+app/src/views/curate/composables/useModifyEntityWorkflows.ts-114-
+--
+app/src/views/curate/composables/useModifyEntityWorkflows.ts-129-    combinedLoading.value = true;
+app/src/views/curate/composables/useModifyEntityWorkflows.ts-130-    try {
+app/src/views/curate/composables/useModifyEntityWorkflows.ts-131-      const entityId = info.entity_info.value.entity_id;
+app/src/views/curate/composables/useModifyEntityWorkflows.ts:132:      await Promise.all([info.loadReview(entityId), statusForm.loadStatusByEntity(entityId)]);
+app/src/views/curate/composables/useModifyEntityWorkflows.ts-133-    } finally {
+app/src/views/curate/composables/useModifyEntityWorkflows.ts-134-      combinedLoading.value = false;
+app/src/views/curate/composables/useModifyEntityWorkflows.ts-135-    }
+--
+app/src/views/curate/composables/useModifyEntityWorkflows.ts-232-      clearActiveWorkflow();
+app/src/views/curate/composables/useModifyEntityWorkflows.ts-233-      return;
+app/src/views/curate/composables/useModifyEntityWorkflows.ts-234-    }
+app/src/views/curate/composables/useModifyEntityWorkflows.ts:235:    await info.loadEntity(entityId);
+app/src/views/curate/composables/useModifyEntityWorkflows.ts-236-    if (info.entity_info.value?.entity_id) {
+app/src/views/curate/composables/useModifyEntityWorkflows.ts-237-      search.entity_loaded.value = true;
+app/src/views/curate/composables/useModifyEntityWorkflows.ts-238-    }
+--
+app/src/views/curate/composables/useEntityInfo.ts-28-  genereviews: string[];
+app/src/views/curate/composables/useEntityInfo.ts-29-}
+app/src/views/curate/composables/useEntityInfo.ts-30-
+app/src/views/curate/composables/useEntityInfo.ts:31:// Fields loadEntity() asks the entity-LIST endpoint (GET /api/entity/) for.
+app/src/views/curate/composables/useEntityInfo.ts-32-// This list MUST be a subset of the columns `ndd_entity_view` exposes
+app/src/views/curate/composables/useEntityInfo.ts-33-// (db/migrations/025_create_core_views.sql) + `synopsis` from the review
+app/src/views/curate/composables/useEntityInfo.ts-34-// left-join: the API's select_tibble_fields() hard-fails (HTTP 500) when any
+--
+app/src/views/curate/composables/useEntityInfo.ts-84-    );
+app/src/views/curate/composables/useEntityInfo.ts-85-  });
+app/src/views/curate/composables/useEntityInfo.ts-86-
+app/src/views/curate/composables/useEntityInfo.ts:87:  async function loadEntity(entityId: number): Promise<void> {
+app/src/views/curate/composables/useEntityInfo.ts-88-    try {
+app/src/views/curate/composables/useEntityInfo.ts-89-      const response: any = await listEntities({
+app/src/views/curate/composables/useEntityInfo.ts-90-        filter: `equals(entity_id,${entityId})`,
+--
+app/src/views/curate/composables/useEntityInfo.ts-105-    }
+app/src/views/curate/composables/useEntityInfo.ts-106-  }
+app/src/views/curate/composables/useEntityInfo.ts-107-
+app/src/views/curate/composables/useEntityInfo.ts:108:  async function loadReview(entityId: number): Promise<void> {
+app/src/views/curate/composables/useEntityInfo.ts-109-    try {
+app/src/views/curate/composables/useEntityInfo.ts-110-      const review_data: any = await getEntityReview(entityId);
+app/src/views/curate/composables/useEntityInfo.ts-111-      const phenotypes_data: any = await getEntityPhenotypes(entityId);
+--
+app/src/views/curate/composables/useEntityInfo.ts-164-    }
+app/src/views/curate/composables/useEntityInfo.ts-165-  }
+app/src/views/curate/composables/useEntityInfo.ts-166-
+app/src/views/curate/composables/useEntityInfo.ts:167:  async function loadStatus(entityId: number): Promise<void> {
+app/src/views/curate/composables/useEntityInfo.ts-168-    try {
+app/src/views/curate/composables/useEntityInfo.ts-169-      const status_data: any = await getEntityStatus(entityId);
+app/src/views/curate/composables/useEntityInfo.ts-170-      status_info.value = new Status(
+
+exec
+/bin/bash -lc "sed -n '1,360p' .planning/superpowers/plans/2026-07-11-security-535-s5-request-ownership-plan.md; rg --files .planning/reviews .planning/superpowers/plans | rg 'security-535-s5(?"'!c)|535-s5'"' | sort; nl -ba app/src/views/admin/composables/useUserData.ts | sed -n '1,245p'; nl -ba app/src/views/admin/composables/useUserData.ts | sed -n '245,450p'" in /home/bernt-popp/development/sysndd/.claude/worktrees/535-s5c-request-ownership
+ succeeded in 0ms:
+# S5 — Frontend Request Ownership (A-B-A / out-of-order races) — Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans. Steps use `- [ ]`.
+
+**Goal:** Stop stale async responses from being applied (or corrupting in-flight bookkeeping) after the view has moved on — the A-B-A and out-of-order response races in `tableRequestCoordinator` and the sibling data composables (#535 P1-7/P2-3). Only the response of the **latest** request for a given consumer may mutate state.
+
+**Architecture:** Each request-ownership site gains a monotonic **generation** (or the natural identity — jobId) captured when a fetch starts. On resolution, a response may (a) clear shared in-flight bookkeeping only if it still **owns** it, and (b) apply data only if its generation is still the **latest** and the consumer is still current. This is a uniform, minimal guard — no refactor of the working composables into the coordinator (noted as a DRY follow-up). `useResource` already implements this (`activeToken`/`myToken` + `AbortController`) and is left unchanged.
+
+**Tech Stack:** Vue 3 composables, TypeScript, Vitest.
+
+## Global Constraints
+
+- Deterministic tests only: drive races with **manually-resolved deferred promises**, never timers/sleeps.
+- Do not change public composable signatures; add internal generation state only.
+- Keep touched files < 600 lines.
+
+---
+
+### Task 1: `tableRequestCoordinator` — generation-based ownership
+
+**Files:**
+- Modify: `app/src/utils/tableRequestCoordinator.ts`
+- Test: `app/src/utils/tableRequestCoordinator.spec.ts` (extend)
+
+**The bug:** identity is the `params` string. After A→B→A, the *original* A promise resolves, matches the new A2's slot (`inFlightParams === "A"`), clears A2's `inFlightPromise`, records A's stale data, and `isCurrent("A")` passes → stale apply + corrupted in-flight state.
+
+- [ ] **Step 1: Write failing deterministic tests** (append to the spec)
+
+```ts
+// Deferred helper
+function deferred<T>() {
+  let resolve!: (v: T) => void; let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+it('A-B-A: the original A response does not apply after A2 supersedes it', async () => {
+  const coord = createTableRequestCoordinator<string>();
+  const applied: string[] = [];
+  let current = 'A';
+  const dA = deferred<string>(); const dB = deferred<string>(); const dA2 = deferred<string>();
+  const rA = coord.request({ params: 'A', fetcher: () => dA.promise, apply: (d) => applied.push(`A:${d}`), onError: () => {}, isCurrent: (p) => p === current });
+  current = 'B';
+  const rB = coord.request({ params: 'B', fetcher: () => dB.promise, apply: (d) => applied.push(`B:${d}`), onError: () => {}, isCurrent: (p) => p === current });
+  current = 'A';
+  const rA2 = coord.request({ params: 'A', fetcher: () => dA2.promise, apply: (d) => applied.push(`A2:${d}`), onError: () => {}, isCurrent: (p) => p === current });
+
+  dA.resolve('stale');   // original A resolves LAST-ish, view is back on A
+  await rA;
+  expect(applied).not.toContain('A:stale'); // stale original A must NOT apply
+
+  dB.resolve('bdata'); await rB;             // B superseded, must not apply
+  expect(applied).not.toContain('B:bdata');
+
+  dA2.resolve('fresh'); await rA2;
+  expect(applied).toContain('A2:fresh');     // the latest A2 applies
+});
+
+it('out-of-order: an earlier request resolving after a later one does not clobber', async () => {
+  const coord = createTableRequestCoordinator<string>();
+  const applied: string[] = [];
+  let current = 'X';
+  const d1 = deferred<string>(); const d2 = deferred<string>();
+  const r1 = coord.request({ params: 'X', fetcher: () => d1.promise, apply: (d) => applied.push(d), onError: () => {}, isCurrent: () => true });
+  current = 'Y';
+  const r2 = coord.request({ params: 'Y', fetcher: () => d2.promise, apply: (d) => applied.push(d), onError: () => {}, isCurrent: (p) => p === current });
+  d2.resolve('y'); await r2;
+  d1.resolve('x'); await r1;
+  expect(applied).toEqual(['y']); // only the latest (Y) applied
+});
+```
+
+- [ ] **Step 2: Run to verify FAIL** — `cd app && npx vitest run src/utils/tableRequestCoordinator.spec.ts`
+
+- [ ] **Step 3: Add the generation counter** to `createTableRequestCoordinator`
+
+Add state: `let inFlightGen = 0; let generation = 0;`
+
+In the **shared** branch, capture the current generation and guard on it:
+```ts
+    if (inFlightParams === params && inFlightPromise) {
+      const source: TableRequestSource = 'shared';
+      const myGen = generation;
+      try {
+        const data = await inFlightPromise;
+        if (myGen !== generation || !isCurrent(params)) return { handled: false, source };
+        apply(data, source);
+        return { handled: true, source };
+      } catch (error) {
+        if (myGen !== generation || !isCurrent(params)) return { handled: false, source };
+        onError(error, source);
+        return { handled: true, source };
+      }
+    }
+```
+
+In the **network** branch, stamp a new generation and guard both the clear and the apply:
+```ts
+    const source: TableRequestSource = 'network';
+    const myGen = ++generation;
+    lastParams = params;
+    lastCallTime = now();
+    lastResponse = null;
+    lastResponseParams = null;
+
+    const promise = fetcher();
+    inFlightPromise = promise;
+    inFlightParams = params;
+    inFlightGen = myGen;
+
+    try {
+      const data = await promise;
+      if (inFlightGen === myGen) {           // only the owner clears/records
+        inFlightPromise = null;
+        inFlightParams = null;
+        lastResponse = data;
+        lastResponseParams = params;
+      }
+      if (myGen !== generation || !isCurrent(params)) return { handled: false, source };
+      apply(data, source);
+      return { handled: true, source };
+    } catch (error) {
+      if (inFlightGen === myGen) {
+        inFlightPromise = null;
+        inFlightParams = null;
+        lastResponse = null;
+        lastResponseParams = null;
+      }
+      if (myGen !== generation || !isCurrent(params)) return { handled: false, source };
+      onError(error, source);
+      return { handled: true, source };
+    }
+```
+
+(Leave the recent-response `cache` branch as-is — it is a synchronous read guarded by `isCurrent`.)
+
+- [ ] **Step 4: Run to verify PASS** (new tests + the whole existing spec stay green).
+
+- [ ] **Step 5: Commit** `git commit -m "fix(app): generation-based request ownership in tableRequestCoordinator (A-B-A) (#535)"`
+
+---
+
+### Task 2: `useSearchSuggestions` — ignore out-of-order responses
+
+**Files:**
+- Modify: `app/src/composables/useSearchSuggestions.ts`
+- Test: `app/src/composables/useSearchSuggestions.spec.ts` (new)
+
+- [ ] **Step 1: Failing test** — mock `apiService.fetchSearchInfo` with deferred promises; fire for `"a"` then `"ab"`, resolve `"a"` LAST, assert `suggestions` reflect `"ab"` (not `"a"`).
+
+- [ ] **Step 2: Add a generation guard** to `fetchSuggestions`:
+
+```ts
+  let requestGeneration = 0;
+
+  async function fetchSuggestions(): Promise<void> {
+    if (query.value.length < 1) { clearSuggestions(); return; }
+    const myGen = ++requestGeneration;
+    isLoading.value = true;
+    try {
+      const response = await apiService.fetchSearchInfo(query.value);
+      if (myGen !== requestGeneration) return;              // a newer query superseded this one
+      [searchObject] = response as unknown as [Record<string, Array<{ link: string }>>];
+      suggestions.value = Object.keys(searchObject).map((key) => ({ label: key, link: searchObject[key][0].link }));
+    } catch {
+      if (myGen !== requestGeneration) return;
+      suggestions.value = []; searchObject = {};
+    } finally {
+      if (myGen === requestGeneration) isLoading.value = false; // only the latest owns the flag
+    }
+  }
+```
+
+- [ ] **Step 3: Run PASS. Commit.**
+
+---
+
+### Task 3: `useUserData` — generation guard on `doLoadData`
+
+**Files:**
+- Modify: `app/src/views/admin/composables/useUserData.ts`
+- Test: `app/src/views/admin/composables/useUserData.spec.ts` (new, or extend if present)
+
+- [ ] **Step 1: Failing test** — mock `getUserTable` with deferred promises; fire load for params P1 then P2 (change tableData), resolve P1 LAST, assert `applyApiResponse` used P2's data and `moduleApiCallInProgress` was not cleared by P1.
+
+- [ ] **Step 2: Add a module generation counter**; in `doLoadData`, when a fetch starts: `const myGen = ++moduleRequestGeneration;`. After `await getUserTable(...)`: only clear `moduleApiCallInProgress`/record `moduleLastApiResponse` and call `applyApiResponse`/`updateBrowserUrl` when `myGen === moduleRequestGeneration`; the `catch` clears `moduleApiCallInProgress` and toasts only when `myGen === moduleRequestGeneration`.
+
+- [ ] **Step 3: Run PASS. Commit.**
+
+---
+
+### Task 4: `useAsyncJob` — ignore a stale poll after the job changes
+
+**Files:**
+- Modify: `app/src/composables/useAsyncJob.ts` (`checkJobStatus`)
+- Test: `app/src/composables/useAsyncJob.spec.ts` (new, or extend)
+
+- [ ] **Step 1: Failing test** — mock `apiClient.get` deferred; start job "j1", trigger a poll, then `startJob('j2')`, then resolve j1's poll; assert j1's status did NOT overwrite j2's state.
+
+- [ ] **Step 2: Capture the polled job id** at the top of `checkJobStatus` (`const polledJobId = jobId.value;`) and, immediately after the `await`, `if (polledJobId !== jobId.value) return;` before any `status/step/progress/error` assignment or `stopPolling()`.
+
+- [ ] **Step 3: Run PASS. Commit.**
+
+---
+
+### Task 5: Confirm `useResource`, verify, PR
+
+- [ ] **Step 1: Confirm `useResource` already guards ownership** — `activeToken`/`myToken` is checked in both the shared-pending and fresh-fetch paths, plus `AbortController`. No change; document it as the reference pattern in the PR.
+- [ ] **Step 2: Verify** — `cd app && npx vitest run src/utils/tableRequestCoordinator.spec.ts src/composables/useSearchSuggestions.spec.ts src/composables/useAsyncJob.spec.ts src/views/admin/composables/useUserData.spec.ts`; `npm run type-check`; `npm run lint` on touched files.
+- [ ] **Step 3: Codex adversarial diff review; fold; open PR referencing #535.**
+
+## Codex plan-review corrections folded (2026-07-11)
+
+Full review in `.planning/reviews/2026-07-11-security-535-s5-plan-codex-review.md`. These **override** the tasks above:
+
+- **Scope: `useResource` moves to a deferred S5b, not "already safe".** It is race-safe across *key changes* (`activeToken`), but **not** across same-key concurrent `refresh()`: `cache.set()`/`cache.endFetch()` (`useResource.ts:101,110,113`) run **unconditionally before** the `myToken !== activeToken` guard, so a stale fetch overwrites/clears a *newer* fetch's cache slot. Fixing it needs a per-fetch owner check on cache completion (only the owning pending promise may `set`/`endFetch`) — a load-bearing SWR change deserving its own PR. S5 documents this gap; it does **not** claim useResource is safe.
+- **Task 1 (coordinator) — confirmed correct, add tests.** The module-level coordinator is shared **by design** across router remounts of the *same table type* (`useEntitiesTable.ts:26`, its own comment) — so supersede-by-generation is the intended behavior; each table type has its own coordinator (no true cross-consumer sharing). Add a **slot-integrity** test (while A2 is pending, a 4th same-params request shares A2 / no new fetch; after A2 resolves the recent-cache branch returns A2) and an **error-path out-of-order** test. All 3 existing spec tests stay green (Codex verified none expect a superseded response to apply).
+- **Task 2 (search) — capture the query too.** Guard on **both** `myGen === requestGeneration` **and** `query.value === requestedQuery`, and **invalidate pending ownership on clear**: bump `requestGeneration` inside `clearSuggestions()` and in the empty-query early return. Add a "clear during pending" test.
+- **Task 3 (useUserData) — singleton, so module generation is fine; also make the cache response-param-safe.** Add `moduleLastApiResponseParams`; the 500 ms recent-cache branch must require `moduleLastApiResponseParams === urlParam` (else a P2 call can serve stale P1 data), and a fresh request clears `moduleLastApiResponse`. Guard **apply, `moduleApiCallInProgress` clear, `isBusy`, and `updateBrowserUrl`** on `myGen === moduleRequestGeneration`. Extend the **existing** spec at `app/src/views/admin/composables/__tests__/useUserData.spec.ts` (not a new path). Tests: out-of-order apply, stale-clears-in-progress, cache-param-safety.
+- **Task 4 (useAsyncJob) — generation, and a stale poll must NOT `stopPolling()`.** Add a generation bumped in `startJob()`/`reset()`; capture it at the top of `checkJobStatus`; after the `await`, if superseded (`myGen !== pollGeneration`) **return early before any mutation and before `stopPolling()`** (the interval is shared via `useIntervalFn`, so stopping it would pause the *new* job). Guard **both** the success path (incl. the 200 `JOB_NOT_FOUND` and terminal branches) **and** the `catch` path (lines 258-271). Tests: stale success, stale **rejection** (must not fail/stop the new job), j1→j2 supersede.
+
+## Self-Review
+
+- Spec coverage: A-B-A `tableRequestCoordinator` → Task 1; the four sibling composables → Tasks 2-4 + Task 5 (useResource already safe). Deterministic A-B-A + out-of-order tests → Tasks 1-4.
+- Consistency: the guard is uniformly "capture identity at start; apply/clear only if still the owner/latest". `myGen !== generation` = superseded; `inFlightGen === myGen` = still owner.
+- No placeholders; each fix shows the exact guarded code.
+rg: regex parse error:
+    (?:security-535-s5(?!c)|535-s5)
+                      ^^^
+error: look-around, including look-ahead and look-behind, is not supported
+
+Consider enabling PCRE2 with the --pcre2 flag, which can handle backreferences
+and look-around.
+     1	import { getCurrentInstance, nextTick, onBeforeUnmount, ref } from 'vue';
+     2	
+     3	import { getUserTable, getRoleList, listUsersByRole } from '@/api/user';
+     4	import type { UserTableResponse } from '@/api/user';
+     5	import useTableData from '@/composables/useTableData';
+     6	import { useExcelExport } from '@/composables/useExcelExport';
+     7	import { useFilterPresets } from '@/composables/useFilterPresets';
+     8	import useUrlParsing from '@/composables/useUrlParsing';
+     9	
+    10	// Module-level TRANSPORT dedup + 500ms response cache (preserves the existing
+    11	// cross-instance semantics from ManageUser.vue line 760). The cached response is
+    12	// keyed by its own params (`moduleLastApiResponseParams`) so it is never served
+    13	// for a request whose params differ (#535 S5b). Consumer-state ownership is
+    14	// instance-local (see `instanceGeneration`), so one instance cannot suppress
+    15	// another's response or leave its `isBusy` stuck.
+    16	let moduleLastApiParams: string | null = null;
+    17	let moduleLastApiCallTime = 0;
+    18	let moduleApiCallInProgress = false;
+    19	let moduleLastApiResponse: unknown = null;
+    20	let moduleLastApiResponseParams: string | null = null;
+    21	// Module-wide monotonic per-fetch-START sequence + the latest start sequence PER
+    22	// PARAMETER KEY (#535 S5b). Param-keying alone does NOT make late-completion order
+    23	// irrelevant: two SAME-param fetches (A1, A2) both write under params A, so a
+    24	// superseded A1 completing in EITHER order could poison the fresher A2. A completing
+    25	// fetch may write the recent-response cache only when it is still the latest-STARTED
+    26	// fetch for its own params (`moduleLatestStartSeqByParam.get(params) === mySeq`), so
+    27	// no out-of-order stale same-param response can poison the cache, while a still-latest
+    28	// fetch for DIFFERENT params (A vs B) is unaffected. The map is module-level so it
+    29	// stays monotonic across instances that share the module cache.
+    30	let moduleFetchSeq = 0;
+    31	const moduleLatestStartSeqByParam = new Map<string, number>();
+    32	
+    33	/** Reset the module-level cache — for use in tests only. */
+    34	export function __resetUserDataCache(): void {
+    35	  moduleLastApiParams = null;
+    36	  moduleLastApiCallTime = 0;
+    37	  moduleApiCallInProgress = false;
+    38	  moduleLastApiResponse = null;
+    39	  moduleLastApiResponseParams = null;
+    40	  moduleFetchSeq = 0;
+    41	  moduleLatestStartSeqByParam.clear();
+    42	}
+    43	
+    44	export interface FilterEntry {
+    45	  content: string | null;
+    46	  join_char: string | null;
+    47	  operator: string;
+    48	}
+    49	
+    50	export type ManageUserFilter = Record<string, FilterEntry>;
+    51	
+    52	export interface RoleOption {
+    53	  value: string;
+    54	  text: string;
+    55	}
+    56	
+    57	export interface UserOption {
+    58	  value: number;
+    59	  text: string;
+    60	  role: string;
+    61	}
+    62	
+    63	export interface UseUserDataOptions {
+    64	  onToast?: (...args: unknown[]) => void;
+    65	  onScrollbarUpdate?: () => void;
+    66	}
+    67	
+    68	export function useUserData(options: UseUserDataOptions = {}) {
+    69	  const { onToast, onScrollbarUpdate } = options;
+    70	
+    71	  const tableData = useTableData({
+    72	    pageSizeInput: 25,
+    73	    sortInput: '+user_name',
+    74	    pageAfterInput: '0',
+    75	  });
+    76	  const { filterObjToStr, filterStrToObj, sortStringToVariables } = useUrlParsing();
+    77	  const filterPresets = useFilterPresets('sysndd-manage-user-presets');
+    78	  const { isExporting, exportToExcel } = useExcelExport();
+    79	
+    80	  const users = ref<Array<Record<string, unknown>>>([]);
+    81	  const role_options = ref<RoleOption[]>([]);
+    82	  const user_options = ref<UserOption[]>([]);
+    83	  const totalPages = ref(0);
+    84	  const isInitializing = ref(true);
+    85	  let loadDataDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+    86	
+    87	  // Instance-local request ownership (#535 S5b). Two orthogonal signals:
+    88	  //  - `latestIntent` is the params string of the most recent load intent, set the
+    89	  //    moment a load is requested (loadData schedule / loadDataNow). An in-flight
+    90	  //    response applies only if its params still equal `latestIntent`, which closes
+    91	  //    the 50ms debounce window (refs already describe P2 while P1 is in flight)
+    92	  //    WITHOUT orphaning a deduped identical request (same params → same intent).
+    93	  //  - `startGeneration` is bumped only when a fetch actually starts, so among
+    94	  //    same-params requests only the latest-started may apply (true A-B-A: A#1, B,
+    95	  //    A2 all in flight → only A2 wins). `disposed` stops any late continuation
+    96	  //    from mutating a torn-down instance.
+    97	  let startGeneration = 0;
+    98	  let latestIntent: string | null = null;
+    99	  let disposed = false;
+   100	  // Independent per-loader generations for the static option lists (#535 S5b MEDIUM):
+   101	  // an older loadRoleList()/loadUserList() completing last must not overwrite the
+   102	  // newer snapshot.
+   103	  let roleListGeneration = 0;
+   104	  let userListGeneration = 0;
+   105	
+   106	  const filter = ref<ManageUserFilter>({
+   107	    any: { content: null, join_char: null, operator: 'contains' },
+   108	    user_name: { content: null, join_char: null, operator: 'contains' },
+   109	    email: { content: null, join_char: null, operator: 'contains' },
+   110	    user_role: { content: null, join_char: ',', operator: 'any' },
+   111	    approved: { content: null, join_char: null, operator: 'equals' },
+   112	    abbreviation: { content: null, join_char: null, operator: 'contains' },
+   113	    first_name: { content: null, join_char: null, operator: 'contains' },
+   114	    family_name: { content: null, join_char: null, operator: 'contains' },
+   115	    orcid: { content: null, join_char: null, operator: 'contains' },
+   116	    comment: { content: null, join_char: null, operator: 'contains' },
+   117	  });
+   118	
+   119	  function buildUrlParam(): string {
+   120	    return `sort=${tableData.sort.value}&filter=${tableData.filter_string.value}&page_after=${tableData.currentItemID.value}&page_size=${tableData.perPage.value}`;
+   121	  }
+   122	
+   123	  function applyApiResponse(data: UserTableResponse, stillOwner: () => boolean): void {
+   124	    // meta is typed `unknown` on the envelope; it's a 1-element array of paging
+   125	    // scalars (Plumber may serialize numbers as strings, hence Number()).
+   126	    const meta = ((data.meta as Array<Record<string, unknown>>) ?? [])[0] ?? {};
+   127	    users.value = data.data as unknown as Array<Record<string, unknown>>;
+   128	    tableData.totalRows.value = Number(meta.totalItems) || 0;
+   129	    nextTick(() => {
+   130	      // The deferred write must re-check ownership: a newer request or an unmount
+   131	      // may have superseded this response between the sync apply and this tick.
+   132	      if (stillOwner()) tableData.currentPage.value = Number(meta.currentPage) || 0;
+   133	    });
+   134	    totalPages.value = Number(meta.totalPages) || 0;
+   135	    tableData.prevItemID.value = Number(meta.prevItemID) || 0;
+   136	    tableData.currentItemID.value = Number(meta.currentItemID) || 0;
+   137	    tableData.nextItemID.value = Number(meta.nextItemID) || 0;
+   138	    tableData.lastItemID.value = Number(meta.lastItemID) || 0;
+   139	    tableData.executionTime.value = Number(meta.executionTime) || 0;
+   140	    onScrollbarUpdate?.();
+   141	  }
+   142	
+   143	  async function doLoadData(): Promise<void> {
+   144	    const urlParam = buildUrlParam();
+   145	    const now = Date.now();
+   146	
+   147	    // Recent-response cache: serve only a NON-NULL response stored under THESE
+   148	    // params, and only if this instance still wants them.
+   149	    if (
+   150	      moduleLastApiResponseParams === urlParam &&
+   151	      moduleLastApiResponse != null &&
+   152	      now - moduleLastApiCallTime < 500
+   153	    ) {
+   154	      if (!disposed && urlParam === latestIntent) {
+   155	        // A current cache hit is a completed current intent: apply, sync the URL,
+   156	        // and clear busy — otherwise a still-pending superseded request (A→B→cached-A)
+   157	        // could leave isBusy stuck true forever.
+   158	        applyApiResponse(
+   159	          moduleLastApiResponse as UserTableResponse,
+   160	          () => !disposed && urlParam === latestIntent
+   161	        );
+   162	        updateBrowserUrl();
+   163	        tableData.isBusy.value = false;
+   164	      }
+   165	      return;
+   166	    }
+   167	    // Transport dedup: an identical request is already in flight. Do NOT bump the
+   168	    // start generation here — the in-flight request is the same intent.
+   169	    if (moduleApiCallInProgress && moduleLastApiParams === urlParam) return;
+   170	
+   171	    // A real fetch starts now → own the start generation. `stillOwner` combines it
+   172	    // with the params intent so it stays stable across applyApiResponse's own ref
+   173	    // mutations (latestIntent only moves on a new loadData/loadDataNow call).
+   174	    const myGen = ++startGeneration;
+   175	    // Module-wide start order, recorded as the latest start for THIS param key so the
+   176	    // recent-response cache write guard below only lets the latest-started same-param
+   177	    // fetch record the cache.
+   178	    const mySeq = ++moduleFetchSeq;
+   179	    moduleLatestStartSeqByParam.set(urlParam, mySeq);
+   180	    const stillOwner = (): boolean =>
+   181	      !disposed && myGen === startGeneration && urlParam === latestIntent;
+   182	
+   183	    moduleLastApiParams = urlParam;
+   184	    moduleLastApiCallTime = now;
+   185	    moduleApiCallInProgress = true;
+   186	    // A fresh request invalidates any stored response until this one records its own.
+   187	    moduleLastApiResponse = null;
+   188	    moduleLastApiResponseParams = null;
+   189	    if (stillOwner()) tableData.isBusy.value = true;
+   190	
+   191	    try {
+   192	      const data = await getUserTable({
+   193	        sort: tableData.sort.value,
+   194	        filter: tableData.filter_string.value,
+   195	        page_after: tableData.currentItemID.value,
+   196	        page_size: String(tableData.perPage.value),
+   197	      });
+   198	      // Transport bookkeeping: the completing fetch clears the in-flight flag. The
+   199	      // recent-response cache is written only if this fetch is still the latest-STARTED
+   200	      // fetch for its own params, so a superseded same-param response completing in ANY
+   201	      // order cannot overwrite (or transiently repopulate) the fresher cached value.
+   202	      moduleApiCallInProgress = false;
+   203	      if (moduleLatestStartSeqByParam.get(urlParam) === mySeq) {
+   204	        moduleLastApiResponse = data;
+   205	        moduleLastApiResponseParams = urlParam;
+   206	      }
+   207	      // Consumer apply: only the latest-started request for the current intent.
+   208	      if (!stillOwner()) return;
+   209	      applyApiResponse(data, stillOwner);
+   210	      updateBrowserUrl();
+   211	    } catch (e) {
+   212	      moduleApiCallInProgress = false;
+   213	      if (!stillOwner()) return;
+   214	      onToast?.(e, 'Error', 'danger');
+   215	    } finally {
+   216	      if (stillOwner()) tableData.isBusy.value = false;
+   217	    }
+   218	  }
+   219	
+   220	  function loadData(): void {
+   221	    // Record the new intent immediately (before the debounce) so an in-flight
+   222	    // response for the previous intent is superseded even during the 50ms window.
+   223	    latestIntent = buildUrlParam();
+   224	    if (loadDataDebounceTimer) clearTimeout(loadDataDebounceTimer);
+   225	    loadDataDebounceTimer = setTimeout(() => {
+   226	      loadDataDebounceTimer = null;
+   227	      void doLoadData();
+   228	    }, 50);
+   229	  }
+   230	
+   231	  // Bypasses debounce for tests + first-paint
+   232	  async function loadDataNow(): Promise<void> {
+   233	    latestIntent = buildUrlParam();
+   234	    return doLoadData();
+   235	  }
+   236	
+   237	  async function loadRoleList(): Promise<void> {
+   238	    const myGen = ++roleListGeneration;
+   239	    const stillCurrent = (): boolean => !disposed && myGen === roleListGeneration;
+   240	    try {
+   241	      const roles = await getRoleList();
+   242	      if (!stillCurrent()) return; // superseded by a newer load or a torn-down instance
+   243	      role_options.value = roles.map((item) => ({
+   244	        value: item.role,
+   245	        text: item.role,
+   245	        text: item.role,
+   246	      }));
+   247	    } catch (e) {
+   248	      if (!stillCurrent()) return;
+   249	      onToast?.(e, 'Error', 'danger');
+   250	    }
+   251	  }
+   252	
+   253	  async function loadUserList(): Promise<void> {
+   254	    const myGen = ++userListGeneration;
+   255	    const stillCurrent = (): boolean => !disposed && myGen === userListGeneration;
+   256	    try {
+   257	      const list = await listUsersByRole({ roles: 'Curator,Reviewer' });
+   258	      if (!stillCurrent()) return; // superseded by a newer load or a torn-down instance
+   259	      user_options.value = list.map((item) => ({
+   260	        value: item.user_id,
+   261	        text: item.user_name,
+   262	        role: item.user_role,
+   263	      }));
+   264	    } catch (e) {
+   265	      if (!stillCurrent()) return;
+   266	      onToast?.(e, 'Error', 'danger');
+   267	    }
+   268	  }
+   269	
+   270	  function updateBrowserUrl(): void {
+   271	    if (isInitializing.value) return;
+   272	    const searchParams = new URLSearchParams();
+   273	    if (tableData.sort.value) searchParams.set('sort', tableData.sort.value);
+   274	    if (tableData.filter_string.value) searchParams.set('filter', tableData.filter_string.value);
+   275	    const currentItemID = String(tableData.currentItemID.value);
+   276	    if (currentItemID !== '' && currentItemID !== '0') {
+   277	      searchParams.set('page_after', String(tableData.currentItemID.value));
+   278	    }
+   279	    searchParams.set('page_size', String(tableData.perPage.value));
+   280	    const newUrl = `${window.location.pathname}?${searchParams.toString()}`;
+   281	    window.history.replaceState({ ...window.history.state }, '', newUrl);
+   282	  }
+   283	
+   284	  function filtered(): void {
+   285	    const next = filterObjToStr(filter.value);
+   286	    if (next !== tableData.filter_string.value) tableData.filter_string.value = next;
+   287	    loadData();
+   288	  }
+   289	
+   290	  function handlePageChange(value: number): void {
+   291	    if (value === 1) tableData.currentItemID.value = 0;
+   292	    else if (value === totalPages.value)
+   293	      tableData.currentItemID.value = Number(tableData.lastItemID.value) || 0;
+   294	    else if (value > tableData.currentPage.value)
+   295	      tableData.currentItemID.value = Number(tableData.nextItemID.value) || 0;
+   296	    else if (value < tableData.currentPage.value)
+   297	      tableData.currentItemID.value = Number(tableData.prevItemID.value) || 0;
+   298	    filtered();
+   299	  }
+   300	
+   301	  function handlePerPageChange(newPerPage: number | string): void {
+   302	    tableData.perPage.value = parseInt(String(newPerPage), 10);
+   303	    tableData.currentItemID.value = 0;
+   304	    filtered();
+   305	  }
+   306	
+   307	  function handleSortByOrDescChange(): void {
+   308	    tableData.currentItemID.value = 0;
+   309	    const sortColumn = tableData.sortBy.value.length > 0 ? tableData.sortBy.value[0].key : '';
+   310	    const sortOrder = tableData.sortBy.value.length > 0 ? tableData.sortBy.value[0].order : 'asc';
+   311	    tableData.sort.value = (sortOrder === 'desc' ? '-' : '+') + sortColumn;
+   312	    filtered();
+   313	  }
+   314	
+   315	  function handleSortUpdate(newSortBy: Array<{ key: string; order: 'asc' | 'desc' }>): void {
+   316	    tableData.sortBy.value = newSortBy;
+   317	    handleSortByOrDescChange();
+   318	  }
+   319	
+   320	  function removeFilters(): void {
+   321	    Object.keys(filter.value).forEach((key) => {
+   322	      const entry = filter.value[key];
+   323	      if (entry && typeof entry === 'object' && 'content' in entry) entry.content = null;
+   324	    });
+   325	    filtered();
+   326	  }
+   327	
+   328	  function clearFilter(key: string): void {
+   329	    if (filter.value[key]) filter.value[key].content = null;
+   330	    filtered();
+   331	  }
+   332	
+   333	  function handleExport(): void {
+   334	    exportToExcel(users.value, {
+   335	      filename: `users_export_${new Date().toISOString().split('T')[0]}`,
+   336	      sheetName: 'Users',
+   337	      headers: {
+   338	        user_name: 'User Name',
+   339	        email: 'Email',
+   340	        user_role: 'Role',
+   341	        approved: 'Approved',
+   342	        abbreviation: 'Abbreviation',
+   343	        first_name: 'First Name',
+   344	        family_name: 'Family Name',
+   345	        orcid: 'ORCID',
+   346	        comment: 'Comment',
+   347	        created_at: 'Created',
+   348	      },
+   349	    });
+   350	  }
+   351	
+   352	  function loadFilterPreset(name: string): boolean {
+   353	    const preset = filterPresets.loadPreset(name);
+   354	    if (!preset) return false;
+   355	    Object.keys(preset).forEach((key) => {
+   356	      if (filter.value[key]) filter.value[key] = preset[key] as FilterEntry;
+   357	    });
+   358	    filtered();
+   359	    return true;
+   360	  }
+   361	
+   362	  function deleteFilterPreset(name: string): void {
+   363	    filterPresets.deletePreset(name);
+   364	  }
+   365	
+   366	  function saveFilterPreset(name: string): void {
+   367	    filterPresets.savePreset(name, JSON.parse(JSON.stringify(filter.value)));
+   368	  }
+   369	
+   370	  // Filter-preset naming uses the app's modal language (SavePresetModal) rather
+   371	  // than a native window.prompt(); the modal state lives here next to the
+   372	  // preset actions it drives.
+   373	  const savePresetModalOpen = ref(false);
+   374	
+   375	  function confirmSavePreset(name: string): void {
+   376	    saveFilterPreset(name);
+   377	    onToast?.(`Saved preset: ${name}`, 'Filter Preset', 'success', true, 3000);
+   378	  }
+   379	
+   380	  function setInitialized(): void {
+   381	    nextTick(() => {
+   382	      isInitializing.value = false;
+   383	    });
+   384	  }
+   385	
+   386	  // Teardown: cancel a pending debounce and invalidate ownership so a late
+   387	  // response cannot apply rows or call history.replaceState() after the view has
+   388	  // unmounted/navigated away. Guarded so a bare composable call (unit tests) does
+   389	  // not warn about a lifecycle hook registered outside a component setup.
+   390	  function dispose(): void {
+   391	    disposed = true;
+   392	    if (loadDataDebounceTimer) {
+   393	      clearTimeout(loadDataDebounceTimer);
+   394	      loadDataDebounceTimer = null;
+   395	    }
+   396	  }
+   397	  if (getCurrentInstance()) {
+   398	    onBeforeUnmount(dispose);
+   399	  }
+   400	
+   401	  return {
+   402	    // table-data passthrough (so the view doesn't need to re-pull useTableData)
+   403	    ...tableData,
+   404	    isExporting,
+   405	    exportToExcel,
+   406	    filterPresets,
+   407	    filterObjToStr,
+   408	    filterStrToObj,
+   409	    sortStringToVariables,
+   410	    // owned state
+   411	    users,
+   412	    role_options,
+   413	    roleOptions: role_options, // canonical TS name
+   414	    user_options,
+   415	    totalPages,
+   416	    filter,
+   417	    isInitializing,
+   418	    // actions
+   419	    loadData,
+   420	    loadDataNow,
+   421	    loadRoleList,
+   422	    loadUserList,
+   423	    filtered,
+   424	    handlePageChange,
+   425	    handlePerPageChange,
+   426	    handleSortByOrDescChange,
+   427	    handleSortUpdate,
+   428	    removeFilters,
+   429	    clearFilter,
+   430	    handleExport,
+   431	    loadFilterPreset,
+   432	    deleteFilterPreset,
+   433	    saveFilterPreset,
+   434	    savePresetModalOpen,
+   435	    confirmSavePreset,
+   436	    setInitialized,
+   437	    // Teardown hook (auto-invoked on unmount when mounted; exposed for tests).
+   438	    dispose,
+   439	  };
+   440	}
+
+exec
+/bin/bash -lc "nl -ba app/src/views/review/Review.vue | sed -n '365,410p'; nl -ba app/src/views/admin/ManagePubtator.vue | sed -n '20,50p'; nl -ba app/src/composables/usePubtatorAdminPanel.ts | sed -n '68,82p'; nl -ba app/src/components/analyses/usePubtatorGenesTable.ts | sed -n '445,460p'; nl -ba app/src/views/curate/composables/useModifyEntityWorkflows.ts | sed -n '218,242p'; nl -ba app/src/views/admin/composables/useAdminTrendData.ts | sed -n '70,135p'; nl -ba app/src/composables/useNetworkData.spec.ts | tail -n 20; nl -ba app/src/views/admin/ManageOntology.spec.ts | head -n 80" in /home/bernt-popp/development/sysndd/.claude/worktrees/535-s5c-request-ownership
+ succeeded in 0ms:
+   365	      // Static config
+   366	      fields: TABLE_FIELDS,
+   367	      legendItems: LEGEND_ITEMS,
+   368	    };
+   369	  },
+   370	  mounted() {
+   371	    // v11.0 closeout F2c: session hydration via useAuth() preserves the
+   372	    // both-or-neither persistence invariant. If there is no session, keep
+   373	    // the default `EMPTY_USER` shape and `curator_mode = 0`.
+   374	    const auth = useAuth();
+   375	    const sessionUser = auth.user.value;
+   376	    if (sessionUser) {
+   377	      this.user = sessionUser;
+   378	      this.curator_mode =
+   379	        this.user.user_role[0] === 'Administrator' || this.user.user_role[0] === 'Curator';
+   380	    }
+   381	    void this.loadReReviewData();
+   382	    void this.reviewData.loadPhenotypesList();
+   383	    void this.reviewData.loadVariationOntologyList();
+   384	    void this.reviewData.loadStatusList();
+   385	  },
+   386	  methods: {
+   387	    // ---- Modal triggers (template @click handlers) -------------------------
+   388	
+   389	    async infoReview(item) {
+   390	      this.reviewModals.setReviewTarget(item);
+   391	      await this.reviewData.getEntity(item.entity_id);
+   392	
+   393	      // Clear any existing draft and load fresh data from server
+   394	      this.reviewForm.clearDraft();
+   395	      await this.reviewForm.loadReviewData(item.review_id, item.re_review_review_saved);
+   396	
+   397	      // Load review metadata for the modal footer display
+   398	      await this.reviewData.loadReviewInfo(item.review_id, item.re_review_review_saved);
+   399	
+   400	      this.$refs.reviewModalRef?.show();
+   401	    },
+   402	    async infoStatus(item) {
+   403	      this.reviewModals.setStatusTarget(item);
+   404	      await this.reviewData.getEntity(item.entity_id);
+   405	
+   406	      // Clear any existing draft and load fresh data from server
+   407	      this.statusForm.clearDraft();
+   408	      await this.statusForm.loadStatusData(item.status_id, item.re_review_status_saved);
+   409	
+   410	      this.$refs.statusModalRef?.show();
+    20	        :meta="lastStatus ? cacheStateLabel : 'No query checked'"
+    21	      >
+    22	        <div data-testid="pubtator-query-workspace">
+    23	          <form class="pubtator-query-form" @submit.prevent="checkStatus">
+    24	            <BFormGroup
+    25	              label="PubTator query"
+    26	              label-for="query-input"
+    27	              class="pubtator-query-form__field"
+    28	            >
+    29	              <textarea
+    30	                id="query-input"
+    31	                v-model="query"
+    32	                class="form-control pubtator-query-form__textarea"
+    33	                placeholder="PubTator search query"
+    34	                :disabled="isJobLoading"
+    35	              ></textarea>
+    36	            </BFormGroup>
+    37	            <div class="pubtator-query-form__actions">
+    38	              <BButton
+    39	                type="submit"
+    40	                variant="primary"
+    41	                :disabled="!query.trim() || isCheckingStatus"
+    42	              >
+    43	                <BSpinner v-if="isCheckingStatus" small class="me-1" />
+    44	                <i v-else class="bi bi-search me-1" aria-hidden="true" />
+    45	                Check status
+    46	              </BButton>
+    47	            </div>
+    48	          </form>
+    49	
+    50	          <div v-if="lastStatus" class="pubtator-status" data-testid="pubtator-status-metrics">
+    68	    return date.toLocaleString();
+    69	  }
+    70	
+    71	  async function checkStatus(): Promise<void> {
+    72	    if (!query.value.trim()) return;
+    73	    feedbackMessage.value = '';
+    74	
+    75	    try {
+    76	      await getCacheStatus(query.value);
+    77	    } catch (err) {
+    78	      feedbackMessage.value = extractApiErrorMessage(err, 'Failed to check cache status');
+    79	      feedbackVariant.value = 'danger';
+    80	    }
+    81	  }
+    82	
+   445	        },
+   446	      });
+   447	      makeToast('Excel file downloaded', 'Success', 'success');
+   448	    } catch (_error) {
+   449	      makeToast('Export failed', 'Error', 'danger');
+   450	    }
+   451	  };
+   452	
+   453	  // Abort all in-flight publication requests on unmount.
+   454	  onUnmounted(() => {
+   455	    cancelAllPublicationFetches();
+   456	  });
+   457	
+   458	  onMounted(() => {
+   459	    const sortObject = sortStringToVariables(props.sortInput);
+   460	    sortBy.value = sortObject.sortBy;
+   218	      // we just close without firing a stray success message.
+   219	      await combined.submit();
+   220	      statusForm.resetForm();
+   221	      clearSelection();
+   222	    } catch {
+   223	      // submitReview / submitForm already toasted the failure; keep the
+   224	      // selection so the curator can fix and retry.
+   225	    }
+   226	  }
+   227	
+   228	  async function onEntitySelected(entityId: number | null): Promise<void> {
+   229	    search.onEntitySelected(entityId);
+   230	    if (!entityId) {
+   231	      info.reset();
+   232	      clearActiveWorkflow();
+   233	      return;
+   234	    }
+   235	    await info.loadEntity(entityId);
+   236	    if (info.entity_info.value?.entity_id) {
+   237	      search.entity_loaded.value = true;
+   238	    }
+   239	  }
+   240	
+   241	  // submitReviewChange bypasses the hasReviewChanges guard (spec compat).
+   242	  async function submitReviewChange(): Promise<void> {
+    70	  const totalEntities = ref(0);
+    71	
+    72	  async function fetchTrendData(): Promise<void> {
+    73	    abortController?.abort();
+    74	    abortController = new AbortController();
+    75	    const currentVersion = ++requestVersion;
+    76	
+    77	    trendData.value = [];
+    78	    trendCategoryData.value = { dates: [], series: {} };
+    79	    loading.value = true;
+    80	
+    81	    try {
+    82	      const params: EntitiesOverTimeParams = {
+    83	        aggregate: 'entity_id',
+    84	        group: 'category',
+    85	        summarize: granularity.value,
+    86	      };
+    87	      const filterValue = buildTrendFilter();
+    88	      if (filterValue !== undefined) {
+    89	        params.filter = filterValue;
+    90	      }
+    91	
+    92	      const response = await getEntitiesOverTime(params, {
+    93	        signal: abortController.signal,
+    94	      });
+    95	
+    96	      if (currentVersion !== requestVersion) return;
+    97	
+    98	      const allData = safeArray<GroupedTimeSeries>(response?.data);
+    99	      trendData.value = mergeGroupedCumulativeSeries(allData);
+   100	      trendCategoryData.value = extractPerGroupSeries(allData);
+   101	
+   102	      if (trendData.value.length > 0) {
+   103	        const maxVal = trendData.value[trendData.value.length - 1].count;
+   104	        totalEntities.value = maxVal;
+   105	        trendYMax.value = Math.max(trendYMax.value ?? 0, maxVal);
+   106	      }
+   107	
+   108	      abortController = null;
+   109	    } catch (error) {
+   110	      if ((error as Error).name !== 'AbortError') {
+   111	        console.error('Failed to fetch trend data:', error);
+   112	        makeToast('Failed to fetch trend data', 'Error', 'danger');
+   113	        trendData.value = [];
+   114	        trendCategoryData.value = { dates: [], series: {} };
+   115	      }
+   116	    } finally {
+   117	      loading.value = false;
+   118	    }
+   119	  }
+   120	
+   121	  // Auto-refetch on control changes
+   122	  watch(granularity, () => fetchTrendData());
+   123	  watch(nddFilter, () => {
+   124	    trendYMax.value = undefined;
+   125	    fetchTrendData();
+   126	  });
+   127	  watch(selectedCategories, () => fetchTrendData());
+   128	
+   129	  // Cleanup
+   130	  onUnmounted(() => {
+   131	    abortController?.abort();
+   132	    abortController = null;
+   133	  });
+   134	
+   135	  return {
+   254	      },
+   255	    });
+   256	
+   257	    const state = useNetworkData();
+   258	
+   259	    await state.fetchNetworkData();
+   260	    const originalGene = state.cytoscapeElements.value.find(
+   261	      (element) => element.data?.id === 'HGNC:1'
+   262	    );
+   263	    expect(originalGene?.data?.symbol).toBe('AAA');
+   264	
+   265	    state.networkData.value!.nodes[0].symbol = 'MUTATED';
+   266	    await nextTick();
+   267	
+   268	    const cachedGene = state.cytoscapeElements.value.find(
+   269	      (element) => element.data?.id === 'HGNC:1'
+   270	    );
+   271	    expect(cachedGene?.data?.symbol).toBe('AAA');
+   272	  });
+   273	});
+     1	// ManageOntology.spec.ts
+     2	/**
+     3	 * #346 Wave 2 Task 6 (ontology domain) — spec for the extracted
+     4	 * `useOntologyAdminTable` controller consumed by `views/admin/ManageOntology.vue`.
+     5	 *
+     6	 * Covers the controller's filter/URL-sync/request/response/pagination/
+     7	 * edit/update/export contract:
+     8	 *   - initial URL state (sort/filter/page_after/page_size) is applied
+     9	 *     before the first request fires, and mounting issues exactly one
+    10	 *     initial GET /api/ontology/variant/table request
+    11	 *   - active-filter chips (`hasActiveFilters`/`activeFilters`) reflect the
+    12	 *     current filter state (status/terms/search labels)
+    13	 *   - cursor pagination transitions (first page -> 0, next -> nextItemID,
+    14	 *     prev -> prevItemID, last -> lastItemID) via handlePageChange, carrying
+    15	 *     the RAW string VariO cursor (e.g. "VariO:0026") to the wire — #531 — and
+    16	 *     applyApiResponse preserving those string cursors instead of Number()-
+    17	 *     coercing them to 0
+    18	 *   - a stale (superseded) response never overwrites newer table state
+    19	 *   - editOntology() deep-copies the row (no shared reference) and
+    20	 *     updateOntologyData() PUTs `{ ontology_details }` via the typed
+    21	 *     `updateVariantOntology` client, then refreshes the row in place,
+    22	 *     closes the modal, and resets the edit buffer
+    23	 *   - handleExport() calls the client-side `exportToExcel` with the
+    24	 *     `ontology_export_<date>` filename, `Ontology` sheet name, and the
+    25	 *     shared `ONTOLOGY_EXPORT_HEADERS` column map
+    26	 *
+    27	 * This is an admin curation-metadata surface (see AGENTS.md "Admin
+    28	 * curation metadata vocabularies"): the update payload shape
+    29	 * (`{ ontology_details: {...} }`) and role gate are unchanged by this
+    30	 * extraction, only re-verified here. `useToast`/`useExcelExport` are
+    31	 * spied at their direct composable module paths, while `useTableData` and
+    32	 * `useUrlParsing` stay real — this
+    33	 * matches the useGenesTable/useEntitiesTable Wave 2 spec pattern.
+    34	 */
+    35	
+    36	import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+    37	import { mount, flushPromises } from '@vue/test-utils';
+    38	import { ref } from 'vue';
+    39	import { createPinia, setActivePinia } from 'pinia';
+    40	import { http, HttpResponse } from 'msw';
+    41	
+    42	import '@/plugins/axios';
+    43	import { server } from '@/test-utils/mocks/server';
+    44	import { primeAuth } from '@/test-utils/primeAuth';
+    45	import { expectBearerHeader } from '@/test-utils/expectBearerHeader';
+    46	import { useAuth } from '@/composables/useAuth';
+    47	import type { VariantOntologyRow } from '@/api/ontology';
+    48	import { ONTOLOGY_EXPORT_HEADERS } from './ontologyTableConfig';
+    49	import ManageOntology from './ManageOntology.vue';
+    50	
+    51	const makeToastSpy = vi.fn();
+    52	const exportToExcelSpy = vi.fn().mockResolvedValue(undefined);
+    53	
+    54	vi.mock('@/composables/useToast', () => ({
+    55	  default: () => ({ makeToast: makeToastSpy }),
+    56	}));
+    57	
+    58	vi.mock('@/composables/useExcelExport', () => ({
+    59	  useExcelExport: () => ({ isExporting: ref(false), exportToExcel: exportToExcelSpy }),
+    60	}));
+    61	
+    62	interface OntologyFilterFieldVm {
+    63	  content: string | string[] | null;
+    64	  operator: string;
+    65	  join_char: string | null;
+    66	}
+    67	
+    68	interface OntologyVm {
+    69	  doLoadData: () => Promise<void>;
+    70	  updateOntologyData: () => Promise<void>;
+    71	  editOntology: (item: VariantOntologyRow) => void;
+    72	  handlePageChange: (value: number) => void;
+    73	  handleExport: () => void;
+    74	  removeFilters: () => void;
+    75	  clearFilter: (key: string) => void;
+    76	  ontologyToEdit: Partial<VariantOntologyRow>;
+    77	  ontologies: VariantOntologyRow[];
+    78	  filter: Record<string, OntologyFilterFieldVm>;
+    79	  showEditModal: boolean;
+    80	  hasActiveFilters: boolean;
+

--- a/.planning/reviews/2026-07-13-security-535-s5c-request-ownership-plan-codex-prompt.md
+++ b/.planning/reviews/2026-07-13-security-535-s5c-request-ownership-plan-codex-prompt.md
@@ -1,0 +1,30 @@
+# #553 S5c request-ownership plan review
+
+Perform a deep xhigh adversarial **plan** review only. Do not edit files. The approved scope is
+exactly the #553 S5c plan at
+`.planning/superpowers/plans/2026-07-13-security-535-s5c-request-ownership-plan.md`.
+
+Read that plan, current target code/tests, and the shipped S5/S5b records:
+
+- `.planning/superpowers/plans/2026-07-12-security-535-s5b-resource-ownership-plan.md`
+- `.planning/reviews/2026-07-13-security-535-s5b-diff-codex-review.md`
+
+Targets:
+
+- `useUserData`: params-keyed shared in-flight transport map with independent subscribing
+  instances.
+- `tableRequestCoordinator`: cross-instance consumer ownership separate from its shared transport.
+- `useEntityInfo`, `useReviewData`, `usePubtatorGenePublications`, `useAdminTrendData`,
+  `useNetworkData`, `usePubtatorAdmin`: generation/slot ownership plus abort protection.
+- `useOntologyAdminTable`: deferred `currentPage` ownership.
+
+The solution must use existing typed `@/api/*` clients only (no raw axios/localStorage), preserve
+public composable APIs, keep source/test files under 600 lines, and add deterministic deferred
+A-B-A/out-of-order tests for stale success, catch, finally, abort cleanup, cross-instance shared
+subscribers, and page reset. Abort is optimization; ownership checks establish correctness.
+
+Attack the plan for stale overwrites, cross-instance suppression, same-param A-B-A slot corruption,
+controller deletion/abort races, unmount/reset and `nextTick` writes, shared preloads, cache poisoning,
+unhandled stale errors, URL/busy regressions, test vacuity, and implementation-size risks. Expand to
+adjacent same-class races in these exact files only. Classify every finding BLOCKER/HIGH/MEDIUM/LOW.
+End exactly with `Verdict: <SHIP|FIX-FIRST>` and state whether any BLOCKER or HIGH remains.

--- a/.planning/reviews/2026-07-13-security-535-s5c-request-ownership-plan-codex-review.md
+++ b/.planning/reviews/2026-07-13-security-535-s5c-request-ownership-plan-codex-review.md
@@ -1,0 +1,24 @@
+# #553 S5c Codex plan review
+
+**Reviewer:** Codex, xhigh, read-only, master-based bounded pass.
+
+**Initial verdict:** `FIX-FIRST` — BLOCKER/HIGH remaining: yes.
+
+## Findings folded before implementation
+
+1. `useEntityInfo.reset()` must abort/invalidate entity, review, and status work; otherwise a
+   pending request can repopulate the cleared form. Added reset-while-pending success/rejection tests.
+2. `useReviewData.resetEntityContext()` must also abort/invalidate `loadStatusInfo` and reset its
+   modal spinner. Each option-list loader gets its own owner because phenotype, variation, and status
+   lists load concurrently; a shared owner would suppress valid results. Added concurrent-list and
+   current/stale status-rejection coverage.
+3. The Ontology test must let A queue its deferred `currentPage` write before B supersedes it; a
+   merely stale network response never enters `applyApiResponse` and cannot expose the bug.
+4. `useNetworkData.clearNetworkData()` is a superseding intent: it must invalidate/detach its local
+   consumer while retaining the shared preload for another instance. Added the two-instance test.
+5. `usePubtatorGenePublications.cancelAll()` followed by same-gene refetch needs a slot-ownership
+   test, not only `resetCache()` coverage.
+6. `loadStatusInfo` needs a current-rejection spinner test plus a stale-rejection no-op test.
+
+All plan findings are folded into the implementation plan above. Production edits begin only with
+test-first RED cases for these corrected invariants.

--- a/.planning/superpowers/plans/2026-07-13-security-535-s5c-request-ownership-plan.md
+++ b/.planning/superpowers/plans/2026-07-13-security-535-s5c-request-ownership-plan.md
@@ -58,9 +58,9 @@
 - Modify: `app/src/views/review/composables/useReviewData.ts`
 - Test: `app/src/views/review/composables/__tests__/useReviewData.spec.ts`
 
-- [ ] Add deferred A-B-A tests for entity, review, and status loads. Resolve the original request last and assert no mixed entity/review/status model, no stale clear/reset, and no stale error toast.
+- [ ] Add deferred A-B-A tests for entity, review, and status loads. Resolve the original request last and assert no mixed entity/review/status model, no stale clear/reset, and no stale error toast. Call `reset()` while each family is pending, then resolve and reject the obsolete request; reset must leave all three state families empty and toast-free.
 - [ ] Add per-read generation + AbortController state. Start a new logical read by aborting and superseding the previous controller; pass `signal` through the existing typed clients. Guard every multi-call `useEntityInfo.loadReview()` mutation as one atomic snapshot.
-- [ ] In `useReviewData`, independently own table, option-list, entity, review-info, and status-info request families. Guard `isBusy`, `loading`, `loading_status_modal`, reactive-object assignment, option clears, and errors. `resetEntityContext()` invalidates its entity/review generations.
+- [ ] In `useReviewData`, independently own table, **each** option list (phenotype, variation, status), entity, review-info, and status-info request families; the three option lists legitimately load concurrently and must not share a generation/controller. Guard `isBusy`, `loading`, `loading_status_modal`, reactive-object assignment, option clears, and errors. `resetEntityContext()` aborts/invalidates entity, review-info, and status-info generations and resets the status-modal spinner. Add a concurrent-three-list deferred test plus current/stale `loadStatusInfo` rejection tests proving only the current failure clears its spinner.
 - [ ] If `useReviewData.ts` approaches 600 lines, move only the request-owner helper/types to an explicitly imported sibling file; preserve its public composable API.
 - [ ] Run both targeted specs GREEN.
 
@@ -76,9 +76,9 @@
 - Modify: `app/src/composables/usePubtatorAdmin.ts`
 - Create: `app/src/composables/usePubtatorAdmin.spec.ts`
 
-- [ ] Add RED tests that supersede a gene/publication read via `resetCache()`/same-gene refetch; stale success, catch, and finally cannot repopulate cache, clear a newer controller, or stop its spinner.
+- [ ] Add RED tests that supersede a gene/publication read via `resetCache()` and `cancelAll()` followed by a same-gene refetch; stale success, catch, and finally cannot repopulate cache, delete a newer controller, or stop its spinner.
 - [ ] Add RED trend/network/admin-status tests with deferred typed-client promises: B wins over A; A's success/catch/finally cannot clear B's data/loading/error/controller. Test actual abort cleanup where a controller exists.
-- [ ] Give each logical key/request family its own generation and controller. `useNetworkData` preserves the global preload promise as the transport slot but races a local abort signal and gates consumer refs/loading by its per-instance generation; cancelling one consumer must not abort the shared preload for another.
+- [ ] Give each logical key/request family its own generation and controller. `useNetworkData` preserves the global preload promise as the transport slot but races a local abort signal and gates consumer refs/loading by its per-instance generation; `clearNetworkData()` aborts/detaches the local waiter and increments its generation. Add a two-instance deferred test proving clearing A leaves A clear while B receives the single shared preload result.
 - [ ] Run all four targeted specs GREEN.
 
 ## Task 6: `useOntologyAdminTable` deferred page ownership
@@ -87,7 +87,7 @@
 - Modify: `app/src/views/admin/composables/useOntologyAdminTable.ts`
 - Test: `app/src/views/admin/ManageOntology.spec.ts`
 
-- [ ] Add a RED deferred-response test: request page A, start page B, resolve A last, then flush `nextTick`; A must not assign B's `currentPage`, cursors, rows, busy flag, or URL.
+- [ ] Add a RED deferred-page test that cannot be rejected by the coordinator before the defect is reached: let A apply and queue its `nextTick(currentPage)` callback, supersede A with B **before that callback flushes**, then flush; A's queued callback must not overwrite B's page. Separately retain the coordinator-level stale-network test for rows/cursors/URL/busy.
 - [ ] Capture a local table-load generation at intent scheduling, pass its ownership predicate into `applyApiResponse`, and recheck it inside the deferred `nextTick(currentPage)` assignment. `doLoadData` passes the same predicate to coordinator apply/error and clears busy only for its own current intent.
 - [ ] Run the focused ManageOntology spec GREEN.
 
@@ -100,5 +100,6 @@
 ## Self-review
 
 - Scope coverage: `useUserData` map → Task 2; coordinator cross-instance semantics → Task 3; entity/review ownership → Task 4; remaining four read composables → Task 5; ontology deferred page write → Task 6.
+- Plan-review folds: reset invalidates every relevant family; concurrent Review lookup lists have separate owners; Ontology exercises the actual deferred callback; network clear detaches one consumer without cancelling another; PubTator covers `cancelAll()` followed by same-key refetch.
 - No new public APIs or raw transport boundary are proposed; implementation is restricted to typed existing clients and S5/S5b identity patterns.
 - Every async mutation class named by the issue—success, error, finally, abort cleanup, shared subscriber, and deferred callback—has a deterministic test task.

--- a/.planning/superpowers/plans/2026-07-13-security-535-s5c-request-ownership-plan.md
+++ b/.planning/superpowers/plans/2026-07-13-security-535-s5c-request-ownership-plan.md
@@ -1,0 +1,104 @@
+# #553 S5c Frontend Request Ownership Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:test-driven-development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure only a read request that still owns a consumer's latest intent may update reactive data, error, busy/loading flags, browser state, or deferred callbacks.
+
+**Architecture:** Follow S5/S5b's two-level model. Each composable owns a monotonic instance generation plus its own `AbortController`; starting a newer logical read aborts and invalidates the old one, and every success/catch/finally/deferred callback checks ownership. Shared transports retain their own slot identity: `useUserData` stores pending promises by parameter key and every subscribing instance applies only when its local generation/params are current; `tableRequestCoordinator` gives each caller a consumer generation rather than using its global transport generation as consumer identity.
+
+**Tech Stack:** Vue 3 composables, typed `@/api/*` clients, AbortController, Vitest/MSW.
+
+---
+
+## Invariants
+
+- No raw axios or direct `localStorage.token` / `localStorage.user` access.
+- Capture identity before every await; stale success, catch, finally, `nextTick`, and abort cleanup are no-ops for consumer state.
+- Abort is best-effort only; generation/slot checks remain the correctness boundary.
+- A shared in-flight transport may serve multiple current consumers, but a transport completion may not clear/replace a newer transport slot.
+- Tests use deferred promises and resolve obsolete work after the newer intent; no sleep-based race tests.
+- Keep every touched source and test below 600 lines. Extract a cohesive test fixture/helper only if a target approaches the ceiling.
+
+## Task 1: Plan review before production edits
+
+**Files:**
+- Create: `.planning/reviews/2026-07-13-security-535-s5c-request-ownership-plan-codex-review.md`
+
+- [ ] Run a background, xhigh, read-only Codex plan review against this plan, the S5/S5b plans/reviews, and the nine target files.
+- [ ] Fold any BLOCKER/HIGH and inexpensive MEDIUM/LOW into this plan before tests or production code.
+
+## Task 2: `useUserData` params-keyed shared transport
+
+**Files:**
+- Modify: `app/src/views/admin/composables/useUserData.ts`
+- Test: `app/src/views/admin/composables/__tests__/useUserData.spec.ts`
+
+- [ ] Add RED tests for two mounted/live instances requesting the same params: exactly one typed-client request, both current subscribers receive the result, and neither instance remains busy.
+- [ ] Add RED tests for A-B-A and stale rejection/finally while the newer request remains pending; prove a stale request cannot clear the new slot, cache, busy flag, or URL.
+- [ ] Replace `moduleApiCallInProgress`/single-param bookkeeping with a module `Map<string, Promise<UserTableResponse>>` and per-param latest-start sequence/cache metadata. A new transport records itself only if it still owns its keyed slot; stale completion cannot delete or cache over a newer same-param transport.
+- [ ] Each `useUserData()` instance retains its own intent generation and params predicate. A shared promise is subscribed to rather than silently returning; success/catch/finally, `nextTick(currentPage)`, and cache apply require that local predicate.
+- [ ] Run the targeted spec GREEN.
+
+## Task 3: Cross-instance table transport ownership
+
+**Files:**
+- Modify: `app/src/utils/tableRequestCoordinator.ts`
+- Test: `app/src/utils/tableRequestCoordinator.spec.ts`
+
+- [ ] Add RED tests with two distinct consumers sharing params: a later request from consumer B must not suppress still-current A; both apply the shared response exactly once.
+- [ ] Add RED tests for one consumer changing params while another stays current, and for stale shared rejection; only the stale consumer is suppressed and the new slot is not cleared.
+- [ ] Separate transport-slot generation (network/cache mutation) from caller-owned request generation. The coordinator keeps one shared in-flight slot but creates a per-caller token, and checks that token plus `isCurrent(params)` around apply/onError.
+- [ ] Run the coordinator spec GREEN.
+
+## Task 4: Entity and review workflow reads
+
+**Files:**
+- Modify: `app/src/views/curate/composables/useEntityInfo.ts`
+- Test: `app/src/views/curate/composables/__tests__/useEntityInfo.spec.ts`
+- Modify: `app/src/views/review/composables/useReviewData.ts`
+- Test: `app/src/views/review/composables/__tests__/useReviewData.spec.ts`
+
+- [ ] Add deferred A-B-A tests for entity, review, and status loads. Resolve the original request last and assert no mixed entity/review/status model, no stale clear/reset, and no stale error toast.
+- [ ] Add per-read generation + AbortController state. Start a new logical read by aborting and superseding the previous controller; pass `signal` through the existing typed clients. Guard every multi-call `useEntityInfo.loadReview()` mutation as one atomic snapshot.
+- [ ] In `useReviewData`, independently own table, option-list, entity, review-info, and status-info request families. Guard `isBusy`, `loading`, `loading_status_modal`, reactive-object assignment, option clears, and errors. `resetEntityContext()` invalidates its entity/review generations.
+- [ ] If `useReviewData.ts` approaches 600 lines, move only the request-owner helper/types to an explicitly imported sibling file; preserve its public composable API.
+- [ ] Run both targeted specs GREEN.
+
+## Task 5: Per-gene, trend, network, and PubTator admin reads
+
+**Files:**
+- Modify: `app/src/composables/usePubtatorGenePublications.ts`
+- Test: `app/src/composables/usePubtatorGenePublications.spec.ts`
+- Modify: `app/src/views/admin/composables/useAdminTrendData.ts`
+- Create: `app/src/views/admin/composables/useAdminTrendData.spec.ts`
+- Modify: `app/src/composables/useNetworkData.ts`
+- Test: `app/src/composables/useNetworkData.spec.ts`
+- Modify: `app/src/composables/usePubtatorAdmin.ts`
+- Create: `app/src/composables/usePubtatorAdmin.spec.ts`
+
+- [ ] Add RED tests that supersede a gene/publication read via `resetCache()`/same-gene refetch; stale success, catch, and finally cannot repopulate cache, clear a newer controller, or stop its spinner.
+- [ ] Add RED trend/network/admin-status tests with deferred typed-client promises: B wins over A; A's success/catch/finally cannot clear B's data/loading/error/controller. Test actual abort cleanup where a controller exists.
+- [ ] Give each logical key/request family its own generation and controller. `useNetworkData` preserves the global preload promise as the transport slot but races a local abort signal and gates consumer refs/loading by its per-instance generation; cancelling one consumer must not abort the shared preload for another.
+- [ ] Run all four targeted specs GREEN.
+
+## Task 6: `useOntologyAdminTable` deferred page ownership
+
+**Files:**
+- Modify: `app/src/views/admin/composables/useOntologyAdminTable.ts`
+- Test: `app/src/views/admin/ManageOntology.spec.ts`
+
+- [ ] Add a RED deferred-response test: request page A, start page B, resolve A last, then flush `nextTick`; A must not assign B's `currentPage`, cursors, rows, busy flag, or URL.
+- [ ] Capture a local table-load generation at intent scheduling, pass its ownership predicate into `applyApiResponse`, and recheck it inside the deferred `nextTick(currentPage)` assignment. `doLoadData` passes the same predicate to coordinator apply/error and clears busy only for its own current intent.
+- [ ] Run the focused ManageOntology spec GREEN.
+
+## Task 7: Final verification, adversarial review, and stacked PR
+
+- [ ] Run all targeted specs, `make code-quality-audit`, `make lint-app`, `cd app && npm run type-check:strict`, `cd app && npm run test:unit`, and `git diff --check` with fresh output.
+- [ ] Run a background deep xhigh Codex diff review. Fold all BLOCKER/HIGH and inexpensive MEDIUM/LOW test-first; repeat until no BLOCKER/HIGH remains. Commit the concise round/verdict record to `.planning/reviews/2026-07-13-security-535-s5c-request-ownership-diff-codex-review.md`.
+- [ ] After a final `git status -sb`, commit on `fix/535-s5c-request-ownership`, push, and create one PR with base `fix/535-composables-bundle-budget`, `Closes #553`, and `Refs #535` on separate lines. Do not merge.
+
+## Self-review
+
+- Scope coverage: `useUserData` map → Task 2; coordinator cross-instance semantics → Task 3; entity/review ownership → Task 4; remaining four read composables → Task 5; ontology deferred page write → Task 6.
+- No new public APIs or raw transport boundary are proposed; implementation is restricted to typed existing clients and S5/S5b identity patterns.
+- Every async mutation class named by the issue—success, error, finally, abort cleanup, shared subscriber, and deferred callback—has a deterministic test task.

--- a/app/src/components/analyses/NetworkVisualization.spec.ts
+++ b/app/src/components/analyses/NetworkVisualization.spec.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   fitToScreen: vi.fn(),
   exportPNG: vi.fn(() => ''),
   exportSVG: vi.fn(() => ''),
+  clearNetworkData: vi.fn(),
   // Controllable data the composables feed the controller.
   nodeElements: [] as ElementLike[],
   initialElements: [] as ElementLike[],
@@ -66,6 +67,7 @@ vi.mock('@/composables/useNetworkData', () => ({
       category_counts: { Definitive: 2, Moderate: 0, Limited: 0 },
     }),
     fetchNetworkData: vi.fn().mockResolvedValue(undefined),
+    clearNetworkData: mocks.clearNetworkData,
     cytoscapeElements: computed(() => mocks.fullElements),
     cytoscapeInitialElements: computed(() => mocks.initialElements),
     cytoscapeNodeElements: computed(() => mocks.nodeElements),
@@ -207,6 +209,7 @@ describe('NetworkVisualization', () => {
     mocks.fitToScreen.mockClear();
     mocks.exportPNG.mockClear();
     mocks.exportSVG.mockClear();
+    mocks.clearNetworkData.mockClear();
     mocks.exportPNG.mockReturnValue('');
     mocks.exportSVG.mockReturnValue('');
     mocks.nodeElements = [];
@@ -229,8 +232,7 @@ describe('NetworkVisualization', () => {
     });
 
     const onClusterClick = mocks.capturedCytoscapeOptions?.onClusterClick as
-      | ((clusterId: number) => void)
-      | undefined;
+      ((clusterId: number) => void) | undefined;
 
     expect(onClusterClick).toBeTypeOf('function');
     onClusterClick?.(1);
@@ -245,8 +247,7 @@ describe('NetworkVisualization', () => {
     });
 
     const onNodeClick = mocks.capturedCytoscapeOptions?.onNodeClick as
-      | ((nodeId: string) => void)
-      | undefined;
+      ((nodeId: string) => void) | undefined;
 
     expect(onNodeClick).toBeTypeOf('function');
     onNodeClick?.('HGNC:1234');
@@ -263,11 +264,9 @@ describe('NetworkVisualization', () => {
     });
 
     const onClusterClick = mocks.capturedCytoscapeOptions?.onClusterClick as
-      | ((clusterId: number) => void)
-      | undefined;
+      ((clusterId: number) => void) | undefined;
     const onBackgroundClick = mocks.capturedCytoscapeOptions?.onBackgroundClick as
-      | (() => void)
-      | undefined;
+      (() => void) | undefined;
 
     expect(onClusterClick).toBeTypeOf('function');
     expect(onBackgroundClick).toBeTypeOf('function');
@@ -322,7 +321,8 @@ describe('NetworkVisualization', () => {
       const wrapper = mount(NetworkVisualization, { global: { stubs: globalStubs } });
       await flushPromises();
 
-      const onLayoutReady = mocks.capturedCytoscapeOptions?.onLayoutReady as (() => void) | undefined;
+      const onLayoutReady = mocks.capturedCytoscapeOptions?.onLayoutReady as
+        (() => void) | undefined;
       expect(onLayoutReady).toBeTypeOf('function');
 
       onLayoutReady?.();
@@ -341,6 +341,35 @@ describe('NetworkVisualization', () => {
       (window as unknown as { requestIdleCallback: unknown }).requestIdleCallback = originalRIC;
     });
 
+    it('does not hydrate queued initial edges after unmount', async () => {
+      const originalRIC = window.requestIdleCallback;
+      let idleCallback: ((deadline: unknown) => void) | null = null;
+      (window as unknown as { requestIdleCallback: unknown }).requestIdleCallback = (
+        cb: (deadline: unknown) => void
+      ) => {
+        idleCallback = cb;
+        return 1;
+      };
+
+      mocks.nodeElements = [{ data: { id: 'A' } }, { data: { id: 'B' } }];
+      mocks.initialElements = [
+        { data: { id: 'A' } },
+        { data: { id: 'B' } },
+        { data: { id: 'A_B', source: 'A', target: 'B' } },
+      ];
+
+      const wrapper = mount(NetworkVisualization, { global: { stubs: globalStubs } });
+      await flushPromises();
+      const onLayoutReady = mocks.capturedCytoscapeOptions?.onLayoutReady as
+        (() => void) | undefined;
+      onLayoutReady?.();
+      wrapper.unmount();
+      idleCallback?.({ didTimeout: false, timeRemaining: () => 0 });
+
+      expect(mocks.updateElements).not.toHaveBeenCalled();
+      (window as unknown as { requestIdleCallback: unknown }).requestIdleCallback = originalRIC;
+    });
+
     it('emits network-ready immediately when there is no initial edge set to hydrate', async () => {
       mocks.nodeElements = [{ data: { id: 'A' } }, { data: { id: 'B' } }];
       mocks.initialElements = [];
@@ -348,7 +377,8 @@ describe('NetworkVisualization', () => {
       const wrapper = mount(NetworkVisualization, { global: { stubs: globalStubs } });
       await flushPromises();
 
-      const onLayoutReady = mocks.capturedCytoscapeOptions?.onLayoutReady as (() => void) | undefined;
+      const onLayoutReady = mocks.capturedCytoscapeOptions?.onLayoutReady as
+        (() => void) | undefined;
       onLayoutReady?.();
       await wrapper.vm.$nextTick();
 
@@ -367,9 +397,7 @@ describe('NetworkVisualization', () => {
       const wrapper = mount(NetworkVisualization, { global: { stubs: globalStubs } });
       await flushPromises();
 
-      const moderate = wrapper
-        .findAll('button')
-        .find((btn) => btn.text().includes('+ Moderate'));
+      const moderate = wrapper.findAll('button').find((btn) => btn.text().includes('+ Moderate'));
       expect(moderate).toBeTruthy();
 
       await moderate!.trigger('click');
@@ -418,6 +446,14 @@ describe('NetworkVisualization', () => {
       expect(disconnectSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('detaches its network-data consumer on unmount', async () => {
+      const wrapper = mount(NetworkVisualization, { global: { stubs: globalStubs } });
+      await flushPromises();
+
+      wrapper.unmount();
+      expect(mocks.clearNetworkData).toHaveBeenCalledTimes(1);
+    });
+
     it('exports a PNG using the network.png filename', async () => {
       mocks.exportPNG.mockReturnValue('data:image/png;base64,AAAA');
 
@@ -431,16 +467,14 @@ describe('NetworkVisualization', () => {
       // element creation isn't counted.
       const anchors: HTMLAnchorElement[] = [];
       const origCreate = document.createElement.bind(document);
-      const createSpy = vi
-        .spyOn(document, 'createElement')
-        .mockImplementation((tag: string) => {
-          const el = origCreate(tag) as HTMLElement;
-          if (tag === 'a') {
-            (el as HTMLAnchorElement).click = vi.fn();
-            anchors.push(el as HTMLAnchorElement);
-          }
-          return el;
-        });
+      const createSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+        const el = origCreate(tag) as HTMLElement;
+        if (tag === 'a') {
+          (el as HTMLAnchorElement).click = vi.fn();
+          anchors.push(el as HTMLAnchorElement);
+        }
+        return el;
+      });
 
       await pngBtn!.trigger('click');
 
@@ -468,16 +502,14 @@ describe('NetworkVisualization', () => {
 
       const anchors: HTMLAnchorElement[] = [];
       const origCreate = document.createElement.bind(document);
-      const createSpy = vi
-        .spyOn(document, 'createElement')
-        .mockImplementation((tag: string) => {
-          const el = origCreate(tag) as HTMLElement;
-          if (tag === 'a') {
-            (el as HTMLAnchorElement).click = vi.fn();
-            anchors.push(el as HTMLAnchorElement);
-          }
-          return el;
-        });
+      const createSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+        const el = origCreate(tag) as HTMLElement;
+        if (tag === 'a') {
+          (el as HTMLAnchorElement).click = vi.fn();
+          anchors.push(el as HTMLAnchorElement);
+        }
+        return el;
+      });
 
       await svgBtn!.trigger('click');
 

--- a/app/src/components/analyses/networkExport.ts
+++ b/app/src/components/analyses/networkExport.ts
@@ -1,0 +1,10 @@
+/** Downloads a Cytoscape SVG export and releases its short-lived object URL. */
+export function downloadNetworkSvg(svgString: string): void {
+  const blob = new Blob([svgString], { type: 'image/svg+xml' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.download = 'network.svg';
+  link.href = url;
+  link.click();
+  URL.revokeObjectURL(url);
+}

--- a/app/src/components/analyses/useNetworkVisualizationController.ts
+++ b/app/src/components/analyses/useNetworkVisualizationController.ts
@@ -37,6 +37,7 @@ import {
   selectSingleNetworkCluster,
   showAllNetworkClusters,
 } from './networkSelection';
+import { downloadNetworkSvg } from './networkExport';
 
 /** Typed emit surface the controller drives on the parent's behalf. */
 export interface NetworkVisualizationEmit {
@@ -59,6 +60,7 @@ export function useNetworkVisualizationController(emit: NetworkVisualizationEmit
     isPreparing,
     metadata,
     fetchNetworkData,
+    clearNetworkData,
     cytoscapeElements,
     cytoscapeInitialElements,
     cytoscapeNodeElements,
@@ -75,7 +77,11 @@ export function useNetworkVisualizationController(emit: NetworkVisualizationEmit
 
   const { filterState } = useFilterSync();
 
-  const { pattern: searchPattern, regex: searchRegex, matches: searchMatches } = useWildcardSearch();
+  const {
+    pattern: searchPattern,
+    regex: searchRegex,
+    matches: searchMatches,
+  } = useWildcardSearch();
 
   const searchMatchCount = ref(0);
 
@@ -84,6 +90,7 @@ export function useNetworkVisualizationController(emit: NetworkVisualizationEmit
   const fullGraphMounted = ref(false);
   const initialEdgesMounted = ref(false);
   const initialEdgeHydrationQueued = ref(false);
+  let disposed = false;
 
   const {
     cy,
@@ -224,6 +231,7 @@ export function useNetworkVisualizationController(emit: NetworkVisualizationEmit
 
     initialEdgeHydrationQueued.value = true;
     const hydrate = () => {
+      if (disposed) return;
       mountInitialGraphElements();
       initialEdgeHydrationQueued.value = false;
     };
@@ -248,6 +256,7 @@ export function useNetworkVisualizationController(emit: NetworkVisualizationEmit
     fullGraphMounted.value = true;
     handleApplyFilters();
     nextTick(() => {
+      if (disposed) return;
       setupTooltipHandlers();
     });
   }
@@ -397,15 +406,7 @@ export function useNetworkVisualizationController(emit: NetworkVisualizationEmit
 
   function handleExportSVG() {
     const svgString = exportSVG();
-    if (svgString) {
-      const blob = new Blob([svgString], { type: 'image/svg+xml' });
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.download = 'network.svg';
-      link.href = url;
-      link.click();
-      URL.revokeObjectURL(url);
-    }
+    if (svgString) downloadNetworkSvg(svgString);
   }
 
   // ---------------------------------------------------------------------------
@@ -439,9 +440,11 @@ export function useNetworkVisualizationController(emit: NetworkVisualizationEmit
   onMounted(async () => {
     // Fetch network data
     await fetchNetworkData();
+    if (disposed) return;
 
     // Wait for DOM update
     await nextTick();
+    if (disposed) return;
 
     if (cytoscapeNodeElements.value.length > 0) {
       initializeCytoscape(cytoscapeNodeElements.value);
@@ -454,6 +457,7 @@ export function useNetworkVisualizationController(emit: NetworkVisualizationEmit
 
     // Setup tooltip handlers after a brief delay to ensure cy is ready
     await nextTick();
+    if (disposed) return;
     setupTooltipHandlers();
 
     // Setup network highlight listeners for bidirectional hover
@@ -461,6 +465,7 @@ export function useNetworkVisualizationController(emit: NetworkVisualizationEmit
 
     // Apply initial filters (defaults to Definitive only)
     await nextTick();
+    if (disposed) return;
     handleApplyFilters();
 
     // Setup resize observer to refit graph when container is resized
@@ -478,6 +483,8 @@ export function useNetworkVisualizationController(emit: NetworkVisualizationEmit
 
   // Cleanup resize observer on unmount
   onBeforeUnmount(() => {
+    disposed = true;
+    clearNetworkData();
     if (resizeObserver) {
       resizeObserver.disconnect();
       resizeObserver = null;
@@ -486,13 +493,14 @@ export function useNetworkVisualizationController(emit: NetworkVisualizationEmit
 
   // Watch for element changes and update the graph
   watch(cytoscapeNodeElements, (newElements) => {
-    if (isInitialized.value && newElements.length > 0) {
+    if (!disposed && isInitialized.value && newElements.length > 0) {
       updateElements(newElements);
       initialEdgesMounted.value = false;
       initialEdgeHydrationQueued.value = false;
       fullGraphMounted.value = false;
       // Re-setup tooltip handlers and apply filters after elements update
       nextTick(() => {
+        if (disposed) return;
         setupTooltipHandlers();
         handleApplyFilters();
       });
@@ -503,8 +511,11 @@ export function useNetworkVisualizationController(emit: NetworkVisualizationEmit
    * Retry loading network data after an error.
    */
   const retryLoadNetwork = async () => {
+    if (disposed) return;
     await fetchNetworkData();
+    if (disposed) return;
     await nextTick();
+    if (disposed) return;
     if (!isInitialized.value) {
       initializeCytoscape(cytoscapeNodeElements.value);
       initialEdgesMounted.value = false;

--- a/app/src/components/analyses/usePublicationsTable.spec.ts
+++ b/app/src/components/analyses/usePublicationsTable.spec.ts
@@ -98,7 +98,8 @@ function baseProps(overrides: Partial<UsePublicationsTableProps> = {}): UsePubli
     fieldsInput: null,
     pageAfterInput: '0',
     pageSizeInput: 10,
-    fspecInput: 'publication_id,Title,Journal,Publication_date,Abstract,Lastname,Firstname,Keywords',
+    fspecInput:
+      'publication_id,Title,Journal,Publication_date,Abstract,Lastname,Firstname,Keywords',
     ...overrides,
   };
 }
@@ -147,6 +148,16 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('initial load', () => {
+  it('does not schedule its initial request after immediate unmount', async () => {
+    const { app } = await mountPublicationsTable(baseProps({ pageSizeInput: 11 }));
+    app.unmount();
+
+    await waitForDebounce();
+    await flushPromises();
+
+    expect(listPublicationsMock).not.toHaveBeenCalled();
+  });
+
   it('applies URL-derived filter, sort, and cursor state before firing the single initial request', async () => {
     listPublicationsMock.mockResolvedValue(makeListResponse([]));
 

--- a/app/src/components/analyses/usePublicationsTable.ts
+++ b/app/src/components/analyses/usePublicationsTable.ts
@@ -8,7 +8,7 @@
 // useLogTable.ts / usePhenotypeClusterTable.ts, #346). Formatting stays
 // delegated to publicationsTableFormatters.ts.
 
-import { nextTick, onMounted, ref, watch, type Ref } from 'vue';
+import { nextTick, onBeforeUnmount, onMounted, ref, watch, type Ref } from 'vue';
 import { useRoute } from 'vue-router';
 import { useToast, useUrlParsing, useColorAndSymbols, useText, useTableData } from '@/composables';
 import Utils from '@/assets/js/utils';
@@ -27,7 +27,7 @@ import {
   type PublicationListResponse,
   type PublicationRecord,
 } from '@/api/publication';
-import { createTableRequestCoordinator } from '@/utils/tableRequestCoordinator';
+import { createTableRequestCoordinator, createTableRequestOwner } from '@/utils/tableRequestCoordinator';
 
 // Module-level request coordinator (survives Vue Router remounts on URL change).
 // Dedupes identical concurrent requests and (via isCurrent) drops a response
@@ -67,6 +67,8 @@ function createEmptyPublicationFilter(): PublicationFilter {
 }
 
 export function usePublicationsTable(props: UsePublicationsTableProps) {
+  const requestConsumer = {};
+  const requestOwner = createTableRequestOwner();
   const { makeToast } = useToast();
   const { filterObjToStr, filterStrToObj, sortStringToVariables } = useUrlParsing();
   const colorAndSymbols = useColorAndSymbols();
@@ -106,6 +108,7 @@ export function usePublicationsTable(props: UsePublicationsTableProps) {
   // ── Local state (was data()) ─────────────────────────────────────────────
   const isInitializing = ref(true); // guards watchers during initial load
   const loadDataDebounceTimer = ref<ReturnType<typeof setTimeout> | null>(null);
+  let initialLoadingTimer: ReturnType<typeof setTimeout> | null = null;
   const totalPages = ref(0); // cursor pagination info not in useTableData
 
   // Table columns
@@ -150,26 +153,31 @@ export function usePublicationsTable(props: UsePublicationsTableProps) {
 
   /** Debounced wrapper for doLoadData to prevent duplicate calls. */
   function loadData(): void {
+    if (requestOwner.isDisposed()) return;
+    const intent = requestOwner.beginIntent();
     if (loadDataDebounceTimer.value) {
       clearTimeout(loadDataDebounceTimer.value);
     }
     loadDataDebounceTimer.value = setTimeout(() => {
       loadDataDebounceTimer.value = null;
-      void doLoadData();
+      void doLoadData(intent);
     }, 50);
   }
 
   /** Fetches /api/publication via the coordinator (dedupe + stale-response guard). */
-  async function doLoadData(): Promise<void> {
+  async function doLoadData(intent = requestOwner.beginIntent()): Promise<void> {
     const buildParams = () =>
       `sort=${sort.value}` +
       `&filter=${filter_string.value}` +
       `&page_after=${currentItemID.value}` +
       `&page_size=${perPage.value}`;
     const urlParam = buildParams();
+    const isCurrentIntent = () => requestOwner.isCurrent(intent);
+    if (!isCurrentIntent()) return;
     isBusy.value = true;
 
     const result = await publicationsRequestCoordinator.request({
+      consumer: requestConsumer,
       params: urlParam,
       fetcher: () =>
         listPublications({
@@ -178,16 +186,16 @@ export function usePublicationsTable(props: UsePublicationsTableProps) {
           page_after: String(currentItemID.value),
           page_size: String(perPage.value),
           fields: props.fspecInput,
-        }),
+      }),
       apply: (data, source) => {
-        applyApiResponse(data);
+        applyApiResponse(data, isCurrentIntent);
         if (source === 'network') {
           // Update URL AFTER API success to prevent component remount mid-call
           updateBrowserUrl();
         }
       },
       onError: (error) => makeToast(error, 'Error', 'danger'),
-      isCurrent: (params) => buildParams() === params,
+      isCurrent: (params) => isCurrentIntent() && buildParams() === params,
     });
 
     if (result.handled) {
@@ -196,7 +204,10 @@ export function usePublicationsTable(props: UsePublicationsTableProps) {
   }
 
   /** Applies API response data to state; reused by every coordinator apply() path. */
-  function applyApiResponse(data: PublicationListResponse): void {
+  function applyApiResponse(
+    data: PublicationListResponse,
+    isCurrentIntent: () => boolean = () => true
+  ): void {
     items.value = data.data;
 
     const metaArr = data.meta as Array<Record<string, unknown>> | undefined;
@@ -206,7 +217,7 @@ export function usePublicationsTable(props: UsePublicationsTableProps) {
 
       // Fix for b-pagination
       void nextTick(() => {
-        currentPage.value = metaObj.currentPage as number;
+        if (isCurrentIntent()) currentPage.value = metaObj.currentPage as number;
       });
       totalPages.value = metaObj.totalPages as number;
       // Publication IDs are strings like "PMID:12345", not numbers. Store as-is
@@ -390,6 +401,7 @@ export function usePublicationsTable(props: UsePublicationsTableProps) {
     // Transform input filter string to object and load data.
     // Use nextTick to ensure Vue reactivity is fully initialized.
     void nextTick(() => {
+      if (requestOwner.isDisposed()) return;
       if (props.filterInput && props.filterInput !== 'null' && props.filterInput !== '') {
         // Parse URL filter string into filter object for proper UI state
         filter.value = filterStrToObj(props.filterInput, filter.value) as PublicationFilter;
@@ -401,13 +413,19 @@ export function usePublicationsTable(props: UsePublicationsTableProps) {
       // Delay marking initialization complete to ensure watchers triggered
       // by filter/sortBy changes above see isInitializing=true
       void nextTick(() => {
-        isInitializing.value = false;
+        if (!requestOwner.isDisposed()) isInitializing.value = false;
       });
     });
 
-    setTimeout(() => {
-      loading.value = false;
+    initialLoadingTimer = setTimeout(() => {
+      if (!requestOwner.isDisposed()) loading.value = false;
     }, 500);
+  });
+
+  onBeforeUnmount(() => {
+    requestOwner.dispose();
+    if (loadDataDebounceTimer.value) clearTimeout(loadDataDebounceTimer.value);
+    if (initialLoadingTimer) clearTimeout(initialLoadingTimer);
   });
 
   return {

--- a/app/src/components/tables/TablesEntities.spec.ts
+++ b/app/src/components/tables/TablesEntities.spec.ts
@@ -153,7 +153,7 @@ function makeEntityRow(overrides: Record<string, unknown> = {}) {
   };
 }
 
-async function mountTable(props: UseEntitiesTableProps = {}) {
+async function mountTable(props: UseEntitiesTableProps = {}, settle = true) {
   setActivePinia(createPinia());
   const router = makeRouter();
   await router.push('/');
@@ -229,7 +229,7 @@ async function mountTable(props: UseEntitiesTableProps = {}) {
     },
   });
 
-  await flushPromises();
+  if (settle) await flushPromises();
   return wrapper;
 }
 
@@ -249,6 +249,14 @@ afterEach(() => {
 });
 
 describe('TablesEntities — WP-F row-expansion ontology outlinks', () => {
+  it('does not schedule its initial request after immediate unmount', async () => {
+    const wrapper = await mountTable({}, false);
+    wrapper.unmount();
+    await flushPromises();
+
+    expect(listEntitiesMock).not.toHaveBeenCalled();
+  });
+
   it('renders without errors and contains the GenericTable wrapper', async () => {
     const wrapper = await mountTable();
     expect(wrapper.find('.generic-table-stub').exists()).toBe(true);

--- a/app/src/components/tables/TablesGenes.spec.ts
+++ b/app/src/components/tables/TablesGenes.spec.ts
@@ -100,7 +100,7 @@ function geneListPayload(overrides: Record<string, unknown> = {}) {
 // two tests' request params can ever collide.
 let mountCallIndex = 0;
 
-async function mountTable(props: Record<string, unknown> = {}) {
+async function mountTable(props: Record<string, unknown> = {}, waitForInitialLoad = true) {
   mountCallIndex += 1;
   setActivePinia(createPinia());
   const router = makeRouter();
@@ -141,12 +141,14 @@ async function mountTable(props: Record<string, unknown> = {}) {
       },
     },
   });
-  await flushPromises();
-  // The initial load is debounced ~50ms (useGenesTable's loadData()); wait it
-  // out so the mounted-component's first request has actually fired before
-  // assertions run.
-  await new Promise((resolve) => setTimeout(resolve, 75));
-  await flushPromises();
+  if (waitForInitialLoad) {
+    await flushPromises();
+    // The initial load is debounced ~50ms (useGenesTable's loadData()); wait it
+    // out so the mounted-component's first request has actually fired before
+    // assertions run.
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    await flushPromises();
+  }
   return wrapper;
 }
 
@@ -164,6 +166,22 @@ describe('TablesGenes — #346 Wave 2 useGenesTable controller', () => {
   // -------------------------------------------------------------------------
   // Initial URL state + exactly-one initial request
   // -------------------------------------------------------------------------
+
+  it('does not schedule its initial request after immediate unmount', async () => {
+    let requestCount = 0;
+    server.use(
+      http.get('/api/gene', () => {
+        requestCount += 1;
+        return HttpResponse.json(geneListPayload());
+      })
+    );
+
+    const wrapper = await mountTable({}, false);
+    wrapper.unmount();
+    await new Promise((resolve) => setTimeout(resolve, 75));
+
+    expect(requestCount).toBe(0);
+  });
 
   it('applies sortInput/filterInput/pageAfterInput and issues exactly one initial request', async () => {
     let requestCount = 0;

--- a/app/src/components/tables/TablesPhenotypes.spec.ts
+++ b/app/src/components/tables/TablesPhenotypes.spec.ts
@@ -43,6 +43,19 @@ vi.mock('@/composables', async () => {
 });
 
 vi.mock('@/utils/tableRequestCoordinator', () => ({
+  createTableRequestOwner: () => {
+    let generation = 0;
+    let disposed = false;
+    return {
+      beginIntent: () => ++generation,
+      isCurrent: (intent: number) => !disposed && intent === generation,
+      isDisposed: () => disposed,
+      dispose: () => {
+        disposed = true;
+        generation += 1;
+      },
+    };
+  },
   createTableRequestCoordinator: () => ({
     request: async ({
       fetcher,
@@ -65,7 +78,7 @@ function makeRouter() {
   });
 }
 
-async function mountSubject(props = {}) {
+async function mountSubject(props = {}, settle = true) {
   setActivePinia(createPinia());
   const router = makeRouter();
   await router.push('/Tables/Phenotypes');
@@ -123,9 +136,11 @@ async function mountSubject(props = {}) {
       },
     },
   });
-  await flushPromises();
-  await new Promise((resolve) => setTimeout(resolve, 75));
-  await flushPromises();
+  if (settle) {
+    await flushPromises();
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    await flushPromises();
+  }
   mountedWrappers.push(wrapper);
   return wrapper;
 }
@@ -324,5 +339,27 @@ describe('TablesPhenotypes', () => {
     expect((exportQuery as URLSearchParams).get('format')).toBe('xlsx');
     expect(clickSpy).toHaveBeenCalled();
     createElementSpy.mockRestore();
+  });
+
+  // This stays last because the composable intentionally retains its phenotype
+  // option cache across remounts; an immediate unmount may populate that cache.
+  it('does not schedule selected-phenotype rows after immediate unmount', async () => {
+    let browseCalls = 0;
+    server.use(
+      http.get('/api/list/phenotype', () => HttpResponse.json({ data: [] })),
+      http.get('/api/phenotype/entities/browse', () => {
+        browseCalls += 1;
+        return HttpResponse.json({ data: [], meta: [] });
+      })
+    );
+
+    const wrapper = await mountSubject(
+      { filterInput: 'all(modifier_phenotype_id,HP:0001250)' },
+      false
+    );
+    wrapper.unmount();
+    await new Promise((resolve) => setTimeout(resolve, 75));
+
+    expect(browseCalls).toBe(0);
   });
 });

--- a/app/src/components/tables/useEntitiesTable.ts
+++ b/app/src/components/tables/useEntitiesTable.ts
@@ -6,13 +6,13 @@
 // useLogTable.ts / usePublicationsTable.ts, issue #346). Static column/
 // filter/detail configuration lives in entityTableConfig.ts.
 
-import { nextTick, onMounted, reactive, ref, watch } from 'vue';
+import { nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue';
 import { useToast, useUrlParsing, useColorAndSymbols, useText, useTableData, useColumnTooltip } from '@/composables';
 import { useUiStore } from '@/stores/ui';
 import { withReturnTo } from '@/utils/returnNavigation';
 import { listEntities, listEntitiesXlsx, type EntityListResponse } from '@/api/entity';
 import { getEntityMappings } from '@/api/disease-mappings';
-import { createTableRequestCoordinator } from '@/utils/tableRequestCoordinator';
+import { createTableRequestCoordinator, createTableRequestOwner } from '@/utils/tableRequestCoordinator';
 import {
   ENTITY_TABLE_FIELDS,
   ENTITY_TABLE_FIELD_DETAILS,
@@ -52,6 +52,8 @@ interface EntityMappingState {
 }
 
 export function useEntitiesTable(props: UseEntitiesTableProps) {
+  const requestConsumer = {};
+  const requestOwner = createTableRequestOwner();
   const { makeToast } = useToast();
   const { filterObjToStr, filterStrToObj, sortStringToVariables } = useUrlParsing();
   const colorAndSymbols = useColorAndSymbols();
@@ -228,12 +230,14 @@ export function useEntitiesTable(props: UseEntitiesTableProps) {
 
   /** Debounced wrapper for doLoadData to prevent duplicate calls from multiple triggers. */
   function loadData(): void {
+    if (requestOwner.isDisposed()) return;
+    const intent = requestOwner.beginIntent();
     if (loadDataDebounceTimer.value) {
       clearTimeout(loadDataDebounceTimer.value);
     }
     loadDataDebounceTimer.value = setTimeout(() => {
       loadDataDebounceTimer.value = null;
-      void doLoadData();
+      void doLoadData(intent);
     }, 50);
   }
 
@@ -242,15 +246,17 @@ export function useEntitiesTable(props: UseEntitiesTableProps) {
   // after-nav budget). Used only by the onMounted hook below; reactivity
   // triggers continue to use loadData() with its 50 ms debounce.
   function loadDataImmediate(): void {
+    if (requestOwner.isDisposed()) return;
+    const intent = requestOwner.beginIntent();
     if (loadDataDebounceTimer.value) {
       clearTimeout(loadDataDebounceTimer.value);
       loadDataDebounceTimer.value = null;
     }
-    void doLoadData();
+    void doLoadData(intent);
   }
 
   /** Fetches /api/entity via the coordinator (dedupe + stale-response guard). */
-  async function doLoadData(): Promise<void> {
+  async function doLoadData(intent = requestOwner.beginIntent()): Promise<void> {
     // `compact` changes the server response shape (count == count_filtered,
     // no global fspec) so it MUST be part of the dedup key — otherwise a
     // remounted instance with different controls visibility would receive a
@@ -259,9 +265,12 @@ export function useEntitiesTable(props: UseEntitiesTableProps) {
       `sort=${sort.value}&filter=${filter_string.value}&page_after=${currentItemID.value}` +
       `&page_size=${perPage.value}&compact=${!props.showFilterControls}`;
     const urlParam = buildParams();
+    const isCurrentIntent = () => requestOwner.isCurrent(intent);
+    if (!isCurrentIntent()) return;
     isBusy.value = true;
 
     const result = await entitiesRequestCoordinator.request({
+      consumer: requestConsumer,
       params: urlParam,
       fetcher: () =>
         listEntities({
@@ -273,9 +282,9 @@ export function useEntitiesTable(props: UseEntitiesTableProps) {
           // so they don't need the global-fspec round-trip. Compact mode
           // pushes the filter to SQL and skips the wasted fspec compute.
           compact: !props.showFilterControls,
-        }),
+      }),
       apply: (data, source) => {
-        applyApiResponse(data);
+        applyApiResponse(data, isCurrentIntent);
         if (source === 'network') {
           // Update URL AFTER API success to prevent component remount during API call
           updateBrowserUrl();
@@ -284,7 +293,7 @@ export function useEntitiesTable(props: UseEntitiesTableProps) {
       onError: (e) => {
         makeToast(e, 'Error', 'danger');
       },
-      isCurrent: (params) => buildParams() === params,
+      isCurrent: (params) => isCurrentIntent() && buildParams() === params,
     });
 
     if (result.handled) {
@@ -294,7 +303,10 @@ export function useEntitiesTable(props: UseEntitiesTableProps) {
   }
 
   /** Applies API response data to state; reused by every coordinator apply() path. */
-  function applyApiResponse(data: EntityListResponse): void {
+  function applyApiResponse(
+    data: EntityListResponse,
+    isCurrentIntent: () => boolean = () => true
+  ): void {
     items.value = data.data;
     const metaArr = data.meta as Array<Record<string, unknown>>;
     const meta = metaArr[0];
@@ -302,7 +314,7 @@ export function useEntitiesTable(props: UseEntitiesTableProps) {
     // this solves an update issue in b-pagination component
     // based on https://github.com/bootstrap-vue/bootstrap-vue/issues/3541
     void nextTick(() => {
-      currentPage.value = meta.currentPage as number;
+      if (isCurrentIntent()) currentPage.value = meta.currentPage as number;
     });
     totalPages.value = meta.totalPages as number;
     prevItemID.value = Number(meta.prevItemID) || 0;
@@ -419,6 +431,7 @@ export function useEntitiesTable(props: UseEntitiesTableProps) {
     // Transform input filter string to object and load data.
     // Use nextTick to ensure Vue reactivity is fully initialized.
     void nextTick(() => {
+      if (requestOwner.isDisposed()) return;
       if (props.filterInput && props.filterInput !== 'null' && props.filterInput !== '') {
         // Parse URL filter string into filter object for proper UI state
         filter.value = filterStrToObj(props.filterInput, filter.value) as EntityFilter;
@@ -432,10 +445,15 @@ export function useEntitiesTable(props: UseEntitiesTableProps) {
       // Delay marking initialization complete to ensure watchers triggered
       // by filter/sortBy changes above see isInitializing=true
       void nextTick(() => {
-        isInitializing.value = false;
+        if (!requestOwner.isDisposed()) isInitializing.value = false;
       });
     });
     // Note: `loading` flips to false inside doLoadData() once the API responds.
+  });
+
+  onBeforeUnmount(() => {
+    requestOwner.dispose();
+    if (loadDataDebounceTimer.value) clearTimeout(loadDataDebounceTimer.value);
   });
 
   return {

--- a/app/src/components/tables/useGenesTable.ts
+++ b/app/src/components/tables/useGenesTable.ts
@@ -18,7 +18,7 @@
 // `generate_cursor_pag_inf()` on the R side). This mirrors the untyped
 // behaviour of the original Options-API `TablesGenes.vue` byte-for-byte.
 
-import { nextTick, onMounted, ref, watch, type Ref } from 'vue';
+import { nextTick, onBeforeUnmount, onMounted, ref, watch, type Ref } from 'vue';
 // Import composables from the barrel so view specs that mock '@/composables'
 // (e.g. TablesGenes.spec.ts) intercept these the same way the SFC did.
 import {
@@ -32,7 +32,7 @@ import {
 import { useUiStore } from '@/stores/ui';
 import { withReturnTo } from '@/utils/returnNavigation';
 import { listGenes, listGenesXlsx, type PaginatedGeneResponse } from '@/api/genes';
-import { createTableRequestCoordinator } from '@/utils/tableRequestCoordinator';
+import { createTableRequestCoordinator, createTableRequestOwner } from '@/utils/tableRequestCoordinator';
 import { GENE_TABLE_FIELDS, GENE_TABLE_DETAIL_FIELDS, type GeneTableField } from './geneTableConfig';
 
 // Module-level coordinator so it survives component remounts (Vue Router
@@ -90,6 +90,8 @@ interface GeneListMeta {
 }
 
 export function useGenesTable(props: UseGenesTableProps) {
+  const requestConsumer = {};
+  const requestOwner = createTableRequestOwner();
   const { makeToast } = useToast();
   const { filterObjToStr, filterStrToObj, sortStringToVariables } = useUrlParsing();
   const colorAndSymbols = useColorAndSymbols();
@@ -202,22 +204,27 @@ export function useGenesTable(props: UseGenesTableProps) {
   // Debounced loadData to prevent duplicate calls from multiple triggers
   // (e.g. the filter watcher firing alongside a direct filtered() call).
   function loadData(): void {
+    if (requestOwner.isDisposed()) return;
+    const intent = requestOwner.beginIntent();
     if (loadDataDebounceTimer.value) {
       clearTimeout(loadDataDebounceTimer.value);
     }
     loadDataDebounceTimer.value = setTimeout(() => {
       loadDataDebounceTimer.value = null;
-      void doLoadData();
+      void doLoadData(intent);
     }, 50);
   }
 
-  async function doLoadData(): Promise<void> {
+  async function doLoadData(intent = requestOwner.beginIntent()): Promise<void> {
     const currentUrlParam = () =>
       `sort=${sort.value}&filter=${filter_string.value}&page_after=${currentItemID.value}&page_size=${perPage.value}`;
 
+    const isCurrentIntent = () => requestOwner.isCurrent(intent);
+    if (!isCurrentIntent()) return;
     isBusy.value = true;
 
     const result = await genesRequestCoordinator.request({
+      consumer: requestConsumer,
       params: currentUrlParam(),
       fetcher: () =>
         listGenes({
@@ -225,9 +232,9 @@ export function useGenesTable(props: UseGenesTableProps) {
           filter: filter_string.value,
           page_after: String(currentItemID.value ?? ''),
           page_size: String(perPage.value),
-        }),
+      }),
       apply: (data, source) => {
-        applyApiResponse(data);
+        applyApiResponse(data, isCurrentIntent);
         if (source === 'network') {
           // Update URL AFTER API success to prevent component remount during
           // the API call.
@@ -237,7 +244,7 @@ export function useGenesTable(props: UseGenesTableProps) {
       onError: (e) => {
         makeToast(e, 'Error', 'danger');
       },
-      isCurrent: (params) => currentUrlParam() === params,
+      isCurrent: (params) => isCurrentIntent() && currentUrlParam() === params,
     });
 
     if (result.handled) {
@@ -250,7 +257,10 @@ export function useGenesTable(props: UseGenesTableProps) {
    * Apply API response data to component state. Extracted to allow reuse
    * when skipping duplicate API calls (see doLoadData's `apply` callback).
    */
-  function applyApiResponse(data: PaginatedGeneResponse): void {
+  function applyApiResponse(
+    data: PaginatedGeneResponse,
+    isCurrentIntent: () => boolean = () => true
+  ): void {
     const meta = data.meta[0] as GeneListMeta;
 
     items.value = data.data;
@@ -258,7 +268,7 @@ export function useGenesTable(props: UseGenesTableProps) {
     // this solves an update issue in b-pagination component
     // based on https://github.com/bootstrap-vue/bootstrap-vue/issues/3541
     void nextTick(() => {
-      currentPage.value = meta.currentPage;
+      if (isCurrentIntent()) currentPage.value = meta.currentPage;
     });
     totalPages.value = meta.totalPages;
     prevItemID.value = meta.prevItemID as unknown as number | null;
@@ -360,6 +370,7 @@ export function useGenesTable(props: UseGenesTableProps) {
     // Transform input filter string to object and load data. Use $nextTick
     // to ensure Vue reactivity is fully initialized.
     void nextTick(() => {
+      if (requestOwner.isDisposed()) return;
       if (props.filterInput && props.filterInput !== 'null' && props.filterInput !== '') {
         // Parse URL filter string into filter object for proper UI state
         filter.value = filterStrToObj(props.filterInput, filter.value) as GeneFilter;
@@ -371,9 +382,14 @@ export function useGenesTable(props: UseGenesTableProps) {
       // Delay marking initialization complete to ensure watchers triggered
       // by filter/sortBy changes above see isInitializing=true
       void nextTick(() => {
-        isInitializing.value = false;
+        if (!requestOwner.isDisposed()) isInitializing.value = false;
       });
     });
+  });
+
+  onBeforeUnmount(() => {
+    requestOwner.dispose();
+    if (loadDataDebounceTimer.value) clearTimeout(loadDataDebounceTimer.value);
   });
 
   return {

--- a/app/src/components/tables/usePhenotypeEntitiesTable.ts
+++ b/app/src/components/tables/usePhenotypeEntitiesTable.ts
@@ -6,7 +6,7 @@
 // the phenotype multi-select toolbar markup lives in
 // PhenotypeFilterToolbar.vue. Mirrors the useLogTable.ts composable shape.
 
-import { nextTick, onMounted, ref, watch, type Ref } from 'vue';
+import { nextTick, onBeforeUnmount, onMounted, ref, watch, type Ref } from 'vue';
 import {
   useToast,
   useUrlParsing,
@@ -24,7 +24,7 @@ import {
   type BrowsePhenotypeEntitiesResponse,
 } from '@/api/phenotype';
 import { listPhenotypes, type PhenotypeRow } from '@/api/list';
-import { createTableRequestCoordinator } from '@/utils/tableRequestCoordinator';
+import { createTableRequestCoordinator, createTableRequestOwner } from '@/utils/tableRequestCoordinator';
 import {
   createDefaultPhenotypeFilter,
   phenotypeLogicOperator,
@@ -111,6 +111,8 @@ const PHENOTYPE_TABLE_FIELDS_DETAILS: Array<Record<string, unknown>> = [
 ];
 
 export function usePhenotypeEntitiesTable(props: UsePhenotypeEntitiesTableProps) {
+  const requestConsumer = {};
+  const requestOwner = createTableRequestOwner();
   const { makeToast } = useToast();
   const { filterObjToStr, filterStrToObj, sortStringToVariables } = useUrlParsing();
   const colorAndSymbols = useColorAndSymbols();
@@ -332,23 +334,28 @@ export function usePhenotypeEntitiesTable(props: UsePhenotypeEntitiesTableProps)
   }
 
   function loadEntitiesFromPhenotypes(): void {
+    if (requestOwner.isDisposed()) return;
+    const intent = requestOwner.beginIntent();
     // Debounce to prevent duplicate calls from multiple triggers
     if (loadDataDebounceTimer.value) {
       clearTimeout(loadDataDebounceTimer.value);
     }
     loadDataDebounceTimer.value = setTimeout(() => {
       loadDataDebounceTimer.value = null;
-      void doLoadEntitiesFromPhenotypes();
+      void doLoadEntitiesFromPhenotypes(intent);
     }, 50);
   }
 
-  async function doLoadEntitiesFromPhenotypes(): Promise<void> {
+  async function doLoadEntitiesFromPhenotypes(intent = requestOwner.beginIntent()): Promise<void> {
     const currentUrlParam = () =>
       `sort=${sort.value}&filter=${filter_string.value}&page_after=${currentItemID.value}&page_size=${perPage.value}`;
     const urlParam = currentUrlParam();
+    const isCurrentIntent = () => requestOwner.isCurrent(intent);
+    if (!isCurrentIntent()) return;
     isBusy.value = true;
 
     const result = await phenotypeEntitiesRequestCoordinator.request({
+      consumer: requestConsumer,
       params: urlParam,
       fetcher: () =>
         browsePhenotypeEntities({
@@ -356,9 +363,9 @@ export function usePhenotypeEntitiesTable(props: UsePhenotypeEntitiesTableProps)
           filter: filter_string.value,
           page_after: currentItemID.value,
           page_size: String(perPage.value),
-        }),
+      }),
       apply: (data, source) => {
-        applyApiResponse(data);
+        applyApiResponse(data, isCurrentIntent);
         if (source === 'network') {
           // Update URL AFTER API success to prevent component remount during the API call
           updateBrowserUrl();
@@ -367,7 +374,7 @@ export function usePhenotypeEntitiesTable(props: UsePhenotypeEntitiesTableProps)
       onError: (e) => {
         makeToast(e, 'Error', 'danger');
       },
-      isCurrent: (params) => currentUrlParam() === params,
+      isCurrent: (params) => isCurrentIntent() && currentUrlParam() === params,
     });
 
     if (result.handled) {
@@ -380,7 +387,10 @@ export function usePhenotypeEntitiesTable(props: UsePhenotypeEntitiesTableProps)
    * Apply API response data to component state. Extracted to allow reuse
    * when skipping duplicate API calls.
    */
-  function applyApiResponse(data: BrowsePhenotypeEntitiesResponse): void {
+  function applyApiResponse(
+    data: BrowsePhenotypeEntitiesResponse,
+    isCurrentIntent: () => boolean = () => true
+  ): void {
     const meta = (data.meta as Array<Record<string, unknown>>)[0];
     fields.value = meta.fspec as Array<Record<string, unknown>>;
     items.value = data.data;
@@ -388,7 +398,7 @@ export function usePhenotypeEntitiesTable(props: UsePhenotypeEntitiesTableProps)
     // this solves an update issue in b-pagination component
     // based on https://github.com/bootstrap-vue/bootstrap-vue/issues/3541
     void nextTick(() => {
-      currentPage.value = meta.currentPage as number;
+      if (isCurrentIntent()) currentPage.value = meta.currentPage as number;
     });
     totalPages.value = meta.totalPages as number;
     prevItemID.value = Number(meta.prevItemID) || 0;
@@ -405,6 +415,7 @@ export function usePhenotypeEntitiesTable(props: UsePhenotypeEntitiesTableProps)
     if (phenotypeIdList().length > 0) {
       loadEntitiesFromPhenotypes();
     } else {
+      requestOwner.beginIntent();
       items.value = [];
       totalRows.value = 0;
       isBusy.value = false;
@@ -500,6 +511,7 @@ export function usePhenotypeEntitiesTable(props: UsePhenotypeEntitiesTableProps)
     // Transform input filter string to object and load data.
     // Use nextTick to ensure Vue reactivity is fully initialized.
     void nextTick(() => {
+      if (requestOwner.isDisposed()) return;
       if (props.filterInput && props.filterInput !== 'null' && props.filterInput !== '') {
         // Parse URL filter string into filter object for proper UI state
         filter.value = filterStrToObj(props.filterInput, filter.value) as PhenotypeTableFilter;
@@ -511,9 +523,14 @@ export function usePhenotypeEntitiesTable(props: UsePhenotypeEntitiesTableProps)
       // Delay marking initialization complete to ensure watchers triggered
       // by filter/sortBy changes above see isInitializing=true
       void nextTick(() => {
-        isInitializing.value = false;
+        if (!requestOwner.isDisposed()) isInitializing.value = false;
       });
     });
+  });
+
+  onBeforeUnmount(() => {
+    requestOwner.dispose();
+    if (loadDataDebounceTimer.value) clearTimeout(loadDataDebounceTimer.value);
   });
 
   return {

--- a/app/src/composables/useNetworkData.spec.ts
+++ b/app/src/composables/useNetworkData.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { nextTick } from 'vue';
 
 import { getNetworkEdges } from '@/api/analysis';
+import type { NetworkResponse } from '@/api/analysis';
 import { useNetworkData } from './useNetworkData';
 
 vi.mock('@/api/analysis', () => ({
@@ -89,6 +90,38 @@ describe('useNetworkData', () => {
     await preload;
 
     expect(getNetworkEdgesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps B able to receive a shared preload after A clears its local state', async () => {
+    let resolveNetwork!: (value: NetworkResponse) => void;
+    const network = new Promise<NetworkResponse>((resolve) => {
+      resolveNetwork = resolve;
+    });
+    getNetworkEdgesMock.mockReturnValue(network);
+    const a = useNetworkData();
+    const b = useNetworkData();
+
+    const requestA = a.fetchNetworkData();
+    const requestB = b.fetchNetworkData();
+    a.clearNetworkData();
+    resolveNetwork({
+      nodes: [],
+      edges: [],
+      metadata: {
+        node_count: 0,
+        edge_count: 0,
+        cluster_count: 0,
+        total_edges: 0,
+        edges_filtered: false,
+        elapsed_seconds: 0.1,
+      },
+    });
+    await Promise.all([requestA, requestB]);
+
+    expect(a.networkData.value).toBeNull();
+    expect(a.isLoading.value).toBe(false);
+    expect(b.networkData.value).not.toBeNull();
+    expect(b.isLoading.value).toBe(false);
   });
 
   it('converts finite API coordinates into Cytoscape positions', async () => {

--- a/app/src/composables/useNetworkData.ts
+++ b/app/src/composables/useNetworkData.ts
@@ -152,6 +152,27 @@ function networkDataError(err: unknown): Error {
   return err instanceof Error ? err : new Error('Failed to fetch network data');
 }
 
+function waitForSharedNetworkRequest<T>(request: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(new DOMException('Network request aborted', 'AbortError'));
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new DOMException('Network request aborted', 'AbortError'));
+    signal.addEventListener('abort', onAbort, { once: true });
+    request.then(
+      (data) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(data);
+      },
+      (error: unknown) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      }
+    );
+  });
+}
+
 /**
  * Composable for fetching and transforming network data
  *
@@ -183,6 +204,8 @@ export function useNetworkData(): NetworkDataState {
   const isLoading = ref(false);
   const error = ref<Error | null>(null);
   const isPreparing = ref(false);
+  let requestGeneration = 0;
+  let requestController: AbortController | null = null;
 
   /**
    * Computed metadata for UI display
@@ -197,6 +220,12 @@ export function useNetworkData(): NetworkDataState {
    * Fetches the supported public-ready network snapshot preset.
    */
   const fetchNetworkData = async (): Promise<void> => {
+    requestController?.abort();
+    const controller = new AbortController();
+    requestController = controller;
+    const generation = ++requestGeneration;
+    const isCurrentRequest = () =>
+      requestGeneration === generation && requestController === controller;
     isLoading.value = true;
     error.value = null;
     isPreparing.value = false;
@@ -205,7 +234,8 @@ export function useNetworkData(): NetworkDataState {
     const startTime = performance.now();
 
     try {
-      const data = await preloadNetworkData();
+      const data = await waitForSharedNetworkRequest(preloadNetworkData(), controller.signal);
+      if (!isCurrentRequest()) return;
       networkData.value = data;
 
       const elapsed = performance.now() - startTime;
@@ -220,11 +250,15 @@ export function useNetworkData(): NetworkDataState {
         );
       }
     } catch (err) {
+      if (!isCurrentRequest()) return;
       isPreparing.value = isSnapshotPreparingError(err);
       error.value = networkDataError(err);
       console.error('Network data fetch error:', err);
     } finally {
-      isLoading.value = false;
+      if (isCurrentRequest()) {
+        isLoading.value = false;
+        requestController = null;
+      }
     }
   };
 
@@ -291,6 +325,9 @@ export function useNetworkData(): NetworkDataState {
    * Clear network data and reset state
    */
   const clearNetworkData = (): void => {
+    requestGeneration += 1;
+    requestController?.abort();
+    requestController = null;
     networkData.value = null;
     error.value = null;
     isPreparing.value = false;

--- a/app/src/composables/usePubtatorAdmin.spec.ts
+++ b/app/src/composables/usePubtatorAdmin.spec.ts
@@ -1,0 +1,83 @@
+import { computed, ref } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PubtatorCacheStatus } from '@/api/publication';
+
+const { getPubtatorCacheStatusMock } = vi.hoisted(() => ({
+  getPubtatorCacheStatusMock: vi.fn(),
+}));
+
+vi.mock('@/api/publication', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/publication')>();
+  return { ...actual, getPubtatorCacheStatus: getPubtatorCacheStatusMock };
+});
+
+vi.mock('@/composables/useAsyncJob', () => ({
+  useAsyncJob: () => ({
+    jobId: ref(null),
+    status: ref('idle'),
+    step: ref(''),
+    progress: ref({ current: 0, total: 0 }),
+    error: ref(null),
+    elapsedSeconds: ref(0),
+    hasRealProgress: computed(() => false),
+    progressPercent: computed(() => null),
+    elapsedTimeDisplay: computed(() => ''),
+    progressVariant: computed(() => 'primary'),
+    statusBadgeClass: computed(() => ''),
+    isLoading: computed(() => false),
+    isPolling: computed(() => false),
+    startJob: vi.fn(),
+    stopPolling: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+import { usePubtatorAdmin } from './usePubtatorAdmin';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+function status(query: string): PubtatorCacheStatus {
+  return {
+    query,
+    cached: true,
+    pages_cached: 1,
+    total_pages_available: 1,
+    total_results_available: 1,
+    cache_date: null,
+    estimated_fetch_time_minutes: 0,
+    message: 'cached',
+  };
+}
+
+describe('usePubtatorAdmin cache-status ownership', () => {
+  beforeEach(() => {
+    getPubtatorCacheStatusMock.mockReset();
+  });
+
+  it('keeps B status state current when stale A rejects out of order', async () => {
+    const a = deferred<PubtatorCacheStatus>();
+    const b = deferred<PubtatorCacheStatus>();
+    getPubtatorCacheStatusMock.mockReturnValueOnce(a.promise).mockReturnValueOnce(b.promise);
+    const admin = usePubtatorAdmin();
+
+    const requestA = admin.getCacheStatus('A');
+    const requestB = admin.getCacheStatus('B');
+    a.reject(new Error('stale failure'));
+    await expect(requestA).rejects.toThrow('stale failure');
+    expect(admin.isCheckingStatus.value).toBe(true);
+    expect(admin.error.value).toBeNull();
+
+    b.resolve(status('B'));
+    await requestB;
+    expect(admin.isCheckingStatus.value).toBe(false);
+    expect(admin.lastStatus.value?.query).toBe('B');
+  });
+});

--- a/app/src/composables/usePubtatorAdmin.ts
+++ b/app/src/composables/usePubtatorAdmin.ts
@@ -36,6 +36,8 @@ export function usePubtatorAdmin() {
   const isCheckingStatus = ref(false);
   const isClearing = ref(false);
   const isBackfilling = ref(false);
+  let statusRequestGeneration = 0;
+  let statusAbortController: AbortController | null = null;
 
   // Use the async job composable for fetch operations
   const asyncJob = useAsyncJob((jobId: string) => `/api/jobs/${encodeURIComponent(jobId)}/status`, {
@@ -46,18 +48,31 @@ export function usePubtatorAdmin() {
    * Get cache status for a query
    */
   async function getCacheStatus(query: string): Promise<PubtatorCacheStatus> {
+    statusAbortController?.abort();
+    const controller = new AbortController();
+    statusAbortController = controller;
+    const generation = ++statusRequestGeneration;
+    const isCurrentRequest = () =>
+      statusRequestGeneration === generation && statusAbortController === controller;
     isCheckingStatus.value = true;
     error.value = null;
 
     try {
-      const status = await getPubtatorCacheStatus({ query });
-      lastStatus.value = status;
+      const status = await getPubtatorCacheStatus({ query }, { signal: controller.signal });
+      if (isCurrentRequest()) {
+        lastStatus.value = status;
+      }
       return status;
     } catch (err) {
-      error.value = err instanceof Error ? err.message : 'Failed to get cache status';
+      if (isCurrentRequest()) {
+        error.value = err instanceof Error ? err.message : 'Failed to get cache status';
+      }
       throw err;
     } finally {
-      isCheckingStatus.value = false;
+      if (isCurrentRequest()) {
+        isCheckingStatus.value = false;
+        statusAbortController = null;
+      }
     }
   }
 

--- a/app/src/composables/usePubtatorAdminPanel.spec.ts
+++ b/app/src/composables/usePubtatorAdminPanel.spec.ts
@@ -1,0 +1,69 @@
+import { computed, ref } from 'vue';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getCacheStatusMock } = vi.hoisted(() => ({ getCacheStatusMock: vi.fn() }));
+
+vi.mock('@/composables/usePubtatorAdmin', () => ({
+  usePubtatorAdmin: () => ({
+    error: ref(null),
+    lastStatus: ref(null),
+    isCheckingStatus: ref(false),
+    isClearing: ref(false),
+    isBackfilling: ref(false),
+    getCacheStatus: getCacheStatusMock,
+    submitFetchJob: vi.fn(),
+    clearCache: vi.fn(),
+    backfillGeneSymbols: vi.fn(),
+    resetJob: vi.fn(),
+    jobId: ref(null),
+    jobStatus: ref('idle'),
+    jobStep: ref(''),
+    jobProgress: ref({ current: 0, total: 0 }),
+    jobError: ref(null),
+    jobElapsedSeconds: ref(0),
+    hasRealProgress: computed(() => false),
+    progressPercent: computed(() => null),
+    elapsedTimeDisplay: computed(() => ''),
+    progressVariant: computed(() => 'primary'),
+    statusBadgeClass: computed(() => ''),
+    isJobLoading: computed(() => false),
+    isPolling: computed(() => false),
+    stopPolling: vi.fn(),
+  }),
+}));
+
+import { usePubtatorAdminPanel } from './usePubtatorAdminPanel';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('usePubtatorAdminPanel request ownership', () => {
+  beforeEach(() => {
+    getCacheStatusMock.mockReset();
+  });
+
+  it('does not show stale A failure feedback after check B begins', async () => {
+    const a = deferred<unknown>();
+    const b = deferred<unknown>();
+    getCacheStatusMock.mockReturnValueOnce(a.promise).mockReturnValueOnce(b.promise);
+    const panel = usePubtatorAdminPanel();
+
+    panel.query.value = 'A';
+    const checkA = panel.checkStatus();
+    panel.query.value = 'B';
+    const checkB = panel.checkStatus();
+    a.reject(new Error('stale failure'));
+    await checkA;
+
+    expect(panel.feedbackMessage.value).toBe('');
+    b.resolve({});
+    await checkB;
+  });
+});

--- a/app/src/composables/usePubtatorAdminPanel.ts
+++ b/app/src/composables/usePubtatorAdminPanel.ts
@@ -43,6 +43,7 @@ export function usePubtatorAdminPanel() {
   // Feedback banner
   const feedbackMessage = ref('');
   const feedbackVariant = ref<FeedbackVariant>('info');
+  let statusCheckGeneration = 0;
 
   const feedbackIcon = computed(() => {
     switch (feedbackVariant.value) {
@@ -70,11 +71,13 @@ export function usePubtatorAdminPanel() {
 
   async function checkStatus(): Promise<void> {
     if (!query.value.trim()) return;
+    const generation = ++statusCheckGeneration;
     feedbackMessage.value = '';
 
     try {
       await getCacheStatus(query.value);
     } catch (err) {
+      if (generation !== statusCheckGeneration) return;
       feedbackMessage.value = extractApiErrorMessage(err, 'Failed to check cache status');
       feedbackVariant.value = 'danger';
     }

--- a/app/src/composables/usePubtatorGenePublications.ownership.spec.ts
+++ b/app/src/composables/usePubtatorGenePublications.ownership.spec.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PubtatorTableResponse } from '@/api/publication';
+
+const { listPubtatorTableMock } = vi.hoisted(() => ({ listPubtatorTableMock: vi.fn() }));
+
+vi.mock('@/api/publication', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/publication')>();
+  return { ...actual, listPubtatorTable: listPubtatorTableMock };
+});
+
+import { usePubtatorGenePublications } from './usePubtatorGenePublications';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function response(pmid: number): PubtatorTableResponse {
+  return { data: [{ pmid }], meta: [], links: [] };
+}
+
+describe('usePubtatorGenePublications request ownership', () => {
+  beforeEach(() => {
+    listPubtatorTableMock.mockReset();
+  });
+
+  it('cancelAll then a same-gene refetch keeps the new slot owned after A settles', async () => {
+    const a = deferred<PubtatorTableResponse>();
+    const b = deferred<PubtatorTableResponse>();
+    listPubtatorTableMock.mockReturnValueOnce(a.promise).mockReturnValueOnce(b.promise);
+    const publications = usePubtatorGenePublications({ makeToast: vi.fn() });
+
+    const requestA = publications.fetchPublications('MECP2', ['1']);
+    publications.cancelAll();
+    const requestB = publications.fetchPublications('MECP2', ['2']);
+
+    a.resolve(response(1));
+    await requestA;
+    expect(publications.isLoading('MECP2')).toBe(true);
+    expect(publications.isCached('MECP2')).toBe(false);
+
+    b.resolve(response(2));
+    await requestB;
+    expect(publications.isLoading('MECP2')).toBe(false);
+    expect(publications.getPublications('MECP2')).toEqual([{ pmid: 2 }]);
+  });
+
+  it('suppresses a typed-client cancellation without importing Axios', async () => {
+    const makeToast = vi.fn();
+    listPubtatorTableMock.mockRejectedValueOnce({ name: 'CanceledError', code: 'ERR_CANCELED' });
+    const publications = usePubtatorGenePublications({ makeToast });
+
+    await publications.fetchPublications('MECP2', ['1']);
+
+    expect(makeToast).not.toHaveBeenCalled();
+    expect(publications.isLoading('MECP2')).toBe(false);
+  });
+});

--- a/app/src/composables/usePubtatorGenePublications.ts
+++ b/app/src/composables/usePubtatorGenePublications.ts
@@ -12,7 +12,6 @@
 //     silent; real errors exit the loading state and surface a toast).
 
 import { ref } from 'vue';
-import axios from 'axios';
 import { listPubtatorTable } from '@/api/publication';
 import type useToast from '@/composables/useToast';
 
@@ -32,6 +31,22 @@ export interface PubtatorPublicationData {
 // string) so consumers can pass useToast().makeToast under strict type-check.
 type MakeToast = ReturnType<typeof useToast>['makeToast'];
 
+/**
+ * Typed API clients surface cancellation as either the platform AbortError or
+ * Axios's transport-shaped CanceledError. Keep that implementation detail at
+ * the boundary without importing the raw client into this composable.
+ */
+function isCancellation(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === 'AbortError') return true;
+  if (typeof error !== 'object' || error === null) return false;
+  const candidate = error as { name?: unknown; code?: unknown };
+  return (
+    candidate.name === 'AbortError' ||
+    candidate.name === 'CanceledError' ||
+    candidate.code === 'ERR_CANCELED'
+  );
+}
+
 export function usePubtatorGenePublications(options: { makeToast: MakeToast }) {
   const { makeToast } = options;
 
@@ -41,6 +56,8 @@ export function usePubtatorGenePublications(options: { makeToast: MakeToast }) {
 
   // AbortControllers for per-gene fetches (prevents orphaned requests).
   const abortControllers = new Map<string, AbortController>();
+  const requestGenerations = new Map<string, number>();
+  let cacheGeneration = 0;
 
   /**
    * Reset the entire cache. Call when the gene filter/sort changes so an
@@ -49,16 +66,20 @@ export function usePubtatorGenePublications(options: { makeToast: MakeToast }) {
    * the freshly-cleared cache.
    */
   const resetCache = (): void => {
+    cacheGeneration += 1;
     abortControllers.forEach((controller) => controller.abort());
     abortControllers.clear();
+    requestGenerations.clear();
     publicationCache.value = {};
     loadingPublications.value = {};
   };
 
   /** Abort and clear every in-flight fetch (call on component unmount). */
   const cancelAll = (): void => {
+    cacheGeneration += 1;
     abortControllers.forEach((controller) => controller.abort());
     abortControllers.clear();
+    requestGenerations.clear();
   };
 
   /**
@@ -73,6 +94,13 @@ export function usePubtatorGenePublications(options: { makeToast: MakeToast }) {
     // Cancel any in-flight request for this gene.
     abortControllers.get(geneSymbol)?.abort();
     const controller = new AbortController();
+    const requestGeneration = (requestGenerations.get(geneSymbol) ?? 0) + 1;
+    const startedCacheGeneration = cacheGeneration;
+    const ownsRequest = () =>
+      cacheGeneration === startedCacheGeneration &&
+      requestGenerations.get(geneSymbol) === requestGeneration &&
+      abortControllers.get(geneSymbol) === controller;
+    requestGenerations.set(geneSymbol, requestGeneration);
     abortControllers.set(geneSymbol, controller);
 
     loadingPublications.value[geneSymbol] = true;
@@ -86,11 +114,14 @@ export function usePubtatorGenePublications(options: { makeToast: MakeToast }) {
         },
         { signal: controller.signal }
       );
+      if (!ownsRequest()) return;
       publicationCache.value[geneSymbol] = (response.data as PubtatorPublicationData[]) || [];
     } catch (error) {
-      // Genuine aborts (axios CanceledError / DOMException AbortError) are not
-      // errors — the caller intentionally cancelled. Stay silent.
-      if (axios.isCancel(error) || (error as Error)?.name === 'AbortError') {
+      if (!ownsRequest()) return;
+      // Genuine aborts are not errors — the caller intentionally cancelled.
+      // `isCancellation` recognises the typed client's transport shape without
+      // pulling the raw Axios client into this composable.
+      if (isCancellation(error)) {
         return;
       }
       // Real failure: surface it and record an empty result so the row exits
@@ -98,16 +129,17 @@ export function usePubtatorGenePublications(options: { makeToast: MakeToast }) {
       makeToast(error, 'Error loading publication details', 'danger');
       publicationCache.value[geneSymbol] = [];
     } finally {
-      abortControllers.delete(geneSymbol);
-      loadingPublications.value[geneSymbol] = false;
+      if (ownsRequest()) {
+        abortControllers.delete(geneSymbol);
+        loadingPublications.value[geneSymbol] = false;
+      }
     }
   };
 
   const getPublications = (geneSymbol: string): PubtatorPublicationData[] =>
     publicationCache.value[geneSymbol] || [];
 
-  const isLoading = (geneSymbol: string): boolean =>
-    loadingPublications.value[geneSymbol] || false;
+  const isLoading = (geneSymbol: string): boolean => loadingPublications.value[geneSymbol] || false;
 
   const isCached = (geneSymbol: string): boolean =>
     publicationCache.value[geneSymbol] !== undefined;

--- a/app/src/utils/tableRequestCoordinator.spec.ts
+++ b/app/src/utils/tableRequestCoordinator.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { createTableRequestCoordinator } from './tableRequestCoordinator';
+import { createTableRequestCoordinator, createTableRequestOwner } from './tableRequestCoordinator';
 
 describe('createTableRequestCoordinator', () => {
   it('awaits an in-flight request before using the recent cache shortcut', async () => {
@@ -191,5 +191,56 @@ describe('createTableRequestCoordinator', () => {
     d1.reject(new Error('stale fail'));
     await r1;
     expect(errors).toEqual([]); // superseded X's rejection must not surface
+  });
+
+  it('keeps current responses for separate table consumers when either starts later', async () => {
+    const coordinator = createTableRequestCoordinator<string>();
+    const consumerA = {};
+    const consumerB = {};
+    const a = deferred<string>();
+    const b = deferred<string>();
+    const appliedA: string[] = [];
+    const appliedB: string[] = [];
+
+    const requestA = coordinator.request({
+      consumer: consumerA,
+      params: 'A',
+      fetcher: () => a.promise,
+      apply: (data) => appliedA.push(data),
+      onError: () => {},
+      isCurrent: () => true,
+    });
+    const requestB = coordinator.request({
+      consumer: consumerB,
+      params: 'B',
+      fetcher: () => b.promise,
+      apply: (data) => appliedB.push(data),
+      onError: () => {},
+      isCurrent: () => true,
+    });
+
+    a.resolve('A current');
+    b.resolve('B current');
+
+    await expect(requestA).resolves.toEqual({ handled: true, source: 'network' });
+    await expect(requestB).resolves.toEqual({ handled: true, source: 'network' });
+    expect(appliedA).toEqual(['A current']);
+    expect(appliedB).toEqual(['B current']);
+  });
+});
+
+describe('createTableRequestOwner', () => {
+  it('invalidates a queued response when superseded or disposed', () => {
+    const owner = createTableRequestOwner();
+    const a = owner.beginIntent();
+    expect(owner.isCurrent(a)).toBe(true);
+
+    const b = owner.beginIntent();
+    expect(owner.isCurrent(a)).toBe(false);
+    expect(owner.isCurrent(b)).toBe(true);
+
+    owner.dispose();
+    expect(owner.isCurrent(b)).toBe(false);
+    expect(owner.isDisposed()).toBe(true);
   });
 });

--- a/app/src/utils/tableRequestCoordinator.ts
+++ b/app/src/utils/tableRequestCoordinator.ts
@@ -5,7 +5,28 @@ export interface TableRequestResult {
   source: TableRequestSource;
 }
 
+/** Instance-local intent ownership for module-coordinated table transports. */
+export function createTableRequestOwner() {
+  let generation = 0;
+  let disposed = false;
+
+  return {
+    beginIntent: (): number => ++generation,
+    isCurrent: (intent: number): boolean => !disposed && generation === intent,
+    isDisposed: (): boolean => disposed,
+    dispose: (): void => {
+      disposed = true;
+      generation += 1;
+    },
+  };
+}
+
 interface TableRequestOptions<T> {
+  // The coordinator is module-scoped so it can preserve a short response
+  // cache across a route remount.  Each composable instance must still own
+  // its own response application: a request from table B cannot make an
+  // in-flight table A response stale merely because it started later.
+  consumer?: object;
   params: string;
   fetcher: () => Promise<T>;
   apply: (data: T, source: TableRequestSource) => void;
@@ -28,8 +49,11 @@ export function createTableRequestCoordinator<T>(recentWindowMs = 500) {
   // in-flight slot (#535 P1-7).
   let inFlightGen = 0;
   let generation = 0;
+  const defaultConsumer = {};
+  const consumerGenerations = new WeakMap<object, number>();
 
   async function request({
+    consumer = defaultConsumer,
     params,
     fetcher,
     apply,
@@ -37,19 +61,32 @@ export function createTableRequestCoordinator<T>(recentWindowMs = 500) {
     isCurrent,
     now = () => Date.now(),
   }: TableRequestOptions<T>): Promise<TableRequestResult> {
-    if (inFlightParams === params && inFlightPromise) {
+    const sharedRequest = inFlightParams === params && inFlightPromise;
+    const priorConsumerGeneration = consumerGenerations.get(consumer);
+    // Repeated same-parameter requests from one consumer join its existing
+    // intent; a different consumer still receives its own ownership token.
+    const reusesConsumerIntent =
+      Boolean(sharedRequest) && priorConsumerGeneration !== undefined && isCurrent(params);
+    const consumerGeneration = reusesConsumerIntent
+      ? priorConsumerGeneration
+      : (priorConsumerGeneration ?? 0) + 1;
+    if (!reusesConsumerIntent) {
+      consumerGenerations.set(consumer, consumerGeneration);
+    }
+    const isConsumerCurrent = () =>
+      consumerGenerations.get(consumer) === consumerGeneration && isCurrent(params);
+
+    if (sharedRequest) {
       const source: TableRequestSource = 'shared';
-      // Borrow the in-flight promise but capture the current generation so a
-      // newer request (even same params) supersedes this borrower.
-      const myGen = generation;
       const shared = inFlightPromise;
+      if (!shared) return { handled: false, source };
       try {
         const data = await shared;
-        if (myGen !== generation || !isCurrent(params)) return { handled: false, source };
+        if (!isConsumerCurrent()) return { handled: false, source };
         apply(data, source);
         return { handled: true, source };
       } catch (error) {
-        if (myGen !== generation || !isCurrent(params)) return { handled: false, source };
+        if (!isConsumerCurrent()) return { handled: false, source };
         onError(error, source);
         return { handled: true, source };
       }
@@ -62,7 +99,7 @@ export function createTableRequestCoordinator<T>(recentWindowMs = 500) {
       lastResponseParams === params
     ) {
       const source: TableRequestSource = 'cache';
-      if (!isCurrent(params)) return { handled: false, source };
+      if (!isConsumerCurrent()) return { handled: false, source };
       apply(lastResponse, source);
       return { handled: true, source };
     }
@@ -89,7 +126,7 @@ export function createTableRequestCoordinator<T>(recentWindowMs = 500) {
         lastResponse = data;
         lastResponseParams = params;
       }
-      if (myGen !== generation || !isCurrent(params)) return { handled: false, source };
+      if (!isConsumerCurrent()) return { handled: false, source };
       apply(data, source);
       return { handled: true, source };
     } catch (error) {
@@ -99,7 +136,7 @@ export function createTableRequestCoordinator<T>(recentWindowMs = 500) {
         lastResponse = null;
         lastResponseParams = null;
       }
-      if (myGen !== generation || !isCurrent(params)) return { handled: false, source };
+      if (!isConsumerCurrent()) return { handled: false, source };
       onError(error, source);
       return { handled: true, source };
     }

--- a/app/src/views/admin/composables/__tests__/useAdminTrendData.spec.ts
+++ b/app/src/views/admin/composables/__tests__/useAdminTrendData.spec.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getEntitiesOverTimeMock } = vi.hoisted(() => ({ getEntitiesOverTimeMock: vi.fn() }));
+
+vi.mock('@/api/statistics', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/statistics')>();
+  return { ...actual, getEntitiesOverTime: getEntitiesOverTimeMock };
+});
+
+import { useAdminTrendData } from '../useAdminTrendData';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('useAdminTrendData request ownership', () => {
+  beforeEach(() => {
+    getEntitiesOverTimeMock.mockReset();
+  });
+
+  it('keeps B loading when stale A rejects out of order', async () => {
+    const a = deferred<{ data: unknown[] }>();
+    const b = deferred<{ data: unknown[] }>();
+    getEntitiesOverTimeMock.mockReturnValueOnce(a.promise).mockReturnValueOnce(b.promise);
+    const makeToast = vi.fn();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const trends = useAdminTrendData(makeToast);
+
+    const requestA = trends.fetchTrendData();
+    const requestB = trends.fetchTrendData();
+    a.reject(new Error('stale failure'));
+    await requestA;
+    expect(trends.loading.value).toBe(true);
+    expect(makeToast).not.toHaveBeenCalled();
+
+    b.resolve({ data: [] });
+    await requestB;
+    expect(trends.loading.value).toBe(false);
+    consoleError.mockRestore();
+  });
+});

--- a/app/src/views/admin/composables/__tests__/useOntologyAdminTable.ownership.spec.ts
+++ b/app/src/views/admin/composables/__tests__/useOntologyAdminTable.ownership.spec.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import type { VariantOntologyListResponse } from '@/api/ontology';
+
+const { nextTickCallbacks, listVariantOntologyMock } = vi.hoisted(() => ({
+  nextTickCallbacks: [] as Array<() => void>,
+  listVariantOntologyMock: vi.fn(),
+}));
+
+vi.mock('vue', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue')>();
+  return {
+    ...actual,
+    nextTick: (callback?: () => void) => {
+      if (callback) nextTickCallbacks.push(callback);
+      return Promise.resolve();
+    },
+  };
+});
+
+vi.mock('@/api/ontology', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/ontology')>();
+  return { ...actual, listVariantOntology: listVariantOntologyMock };
+});
+
+vi.mock('@/composables/useToast', () => ({
+  default: () => ({ makeToast: vi.fn() }),
+}));
+
+vi.mock('@/composables/useExcelExport', () => ({
+  useExcelExport: () => ({ isExporting: { value: false }, exportToExcel: vi.fn() }),
+}));
+
+import { useOntologyAdminTable } from '../useOntologyAdminTable';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function response(currentPage: number): VariantOntologyListResponse {
+  return {
+    data: [],
+    links: [],
+    meta: [
+      {
+        totalItems: 1,
+        currentPage,
+        totalPages: 4,
+        prevItemID: 0,
+        currentItemID: 0,
+        nextItemID: 1,
+        lastItemID: 3,
+        executionTime: 1,
+      },
+    ],
+  };
+}
+
+function flushScheduledTicks(): void {
+  while (nextTickCallbacks.length > 0) {
+    nextTickCallbacks.shift()?.();
+  }
+}
+
+describe('useOntologyAdminTable request ownership', () => {
+  beforeEach(() => {
+    nextTickCallbacks.splice(0);
+    listVariantOntologyMock.mockReset();
+    setActivePinia(createPinia());
+  });
+
+  it('does not let A deferred currentPage overwrite B after B supersedes A', async () => {
+    const a = deferred<VariantOntologyListResponse>();
+    const b = deferred<VariantOntologyListResponse>();
+    listVariantOntologyMock.mockReturnValueOnce(a.promise).mockReturnValueOnce(b.promise);
+    const table = useOntologyAdminTable();
+
+    const requestA = table.doLoadData();
+    a.resolve(response(4));
+    await requestA;
+    expect(nextTickCallbacks).toHaveLength(1);
+
+    table.sort.value = '-vario_id';
+    const requestB = table.doLoadData();
+    flushScheduledTicks();
+    expect(table.currentPage.value).not.toBe(4);
+
+    b.resolve(response(2));
+    await requestB;
+    flushScheduledTicks();
+    expect(table.currentPage.value).toBe(2);
+  });
+
+  it('does not schedule its mount-time load after immediate unmount', () => {
+    const wrapper = mount({
+      setup() {
+        useOntologyAdminTable();
+        return () => null;
+      },
+    });
+
+    wrapper.unmount();
+    flushScheduledTicks();
+
+    expect(listVariantOntologyMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/views/admin/composables/__tests__/useUserData.spec.ts
+++ b/app/src/views/admin/composables/__tests__/useUserData.spec.ts
@@ -164,6 +164,28 @@ describe('useUserData', () => {
 
   // --- S5b request ownership -------------------------------------------------
 
+  it('shares one same-param transport with two current instances and applies it to both', async () => {
+    const axios = await getAxiosMock();
+    let resolve!: (value: unknown) => void;
+    axios.get.mockImplementationOnce(() => new Promise((res) => (resolve = res)));
+
+    const first = useUserData();
+    const second = useUserData();
+    const firstPending = first.loadDataNow();
+    const secondPending = second.loadDataNow();
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+
+    resolve({ status: 200, data: userTablePayload });
+    await Promise.all([firstPending, secondPending]);
+    await flushPromises();
+
+    expect(first.totalRows.value).toBe(2);
+    expect(second.totalRows.value).toBe(2);
+    expect(first.isBusy.value).toBe(false);
+    expect(second.isBusy.value).toBe(false);
+  });
+
   it('an out-of-order stale response does not apply over the newer request', async () => {
     const axios = await getAxiosMock();
     const resolvers: Array<(v: unknown) => void> = [];
@@ -198,7 +220,7 @@ describe('useUserData', () => {
     axios.get.mockImplementationOnce(() => new Promise((res) => (resolveB = res)));
     const pB = data.loadDataNow(); // P2 in flight
     data.totalRows.value = 999; // sentinel — a wrong cache-serve would overwrite this
-    await data.loadDataNow(); // 2nd identical P2 while pending
+    const sharedP2 = data.loadDataNow(); // 2nd identical P2 subscribes while pending
     await Promise.resolve();
     expect(data.totalRows.value).toBe(999); // must NOT serve P1's cached response for P2
 
@@ -206,7 +228,7 @@ describe('useUserData', () => {
       status: 200,
       data: { ...userTablePayload, meta: [{ ...userTablePayload.meta[0], totalItems: 7 }] },
     });
-    await pB;
+    await Promise.all([pB, sharedP2]);
     await flushPromises();
     expect(data.totalRows.value).toBe(7); // the real P2 response applies
   });
@@ -228,11 +250,9 @@ describe('useUserData', () => {
     expect(data.totalRows.value).toBe(555); // disposed → late response ignored
   });
 
-  it('a superseded same-param response completing last does not poison the recent cache', async () => {
-    // A1→B→A2 all in flight; A1 and A2 share params A. A2 (latest) completes first
-    // and caches fresh A; the stale A1 then completes LAST. A subsequent cache hit
-    // for A must serve A2's data, never the stale A1 (param-keying alone does not
-    // protect same-param out-of-order; the module write-sequence guard does).
+  it('A-B-A reuses the original keyed A transport for the current A intent', async () => {
+    // A keyed transport is a valid shared result for a later identical intent. The
+    // map must subscribe A2 to A1 rather than launching a duplicate A2 request.
     const axios = await getAxiosMock();
     const resolvers: Array<(v: unknown) => void> = [];
     axios.get.mockImplementation(() => new Promise((res) => resolvers.push(res)));
@@ -242,21 +262,17 @@ describe('useUserData', () => {
     data.perPage.value = 50;
     const pB = data.loadDataNow(); // B (params B) — resolvers[1]
     data.perPage.value = 25; // back to default params A
-    const pA2 = data.loadDataNow(); // A2 (params A again) — resolvers[2]
+    const pA2 = data.loadDataNow(); // A2 subscribes to A1 (same params)
 
-    // A2 (latest) completes first → caches fresh A (totalItems 77).
-    resolvers[2]({
+    expect(resolvers).toHaveLength(2); // A1 + B only; no duplicate A2 transport
+    resolvers[0]({
       status: 200,
       data: { ...userTablePayload, meta: [{ ...userTablePayload.meta[0], totalItems: 77 }] },
     });
-    await pA2;
-    await flushPromises();
-    // Stale A1 completes LAST (totalItems 2) — must NOT overwrite the cached A2.
-    resolvers[0]({ status: 200, data: userTablePayload });
-    await pA1;
+    await Promise.all([pA1, pA2]);
     await flushPromises();
 
-    // Trigger a cache hit for params A: it must serve A2 (77), not the stale A1 (2).
+    // The current A intent received the shared A transport and recorded it for cache.
     await data.loadDataNow();
     await flushPromises();
     expect(data.totalRows.value).toBe(77);
@@ -268,42 +284,40 @@ describe('useUserData', () => {
     data.dispose();
   });
 
-  it('a stale same-param response resolving BEFORE the newer one does not populate the cache', async () => {
-    // A1→B→A2 (A1, A2 share params A). Here the STALE A1 resolves FIRST, while A2 is
-    // still pending. A1 is not the latest-started A fetch, so it must not write the
-    // recent-response cache — a cache-serve attempt in that window must not return A1.
+  it('a stale shared rejection cannot clear a newer keyed slot or busy state', async () => {
     const axios = await getAxiosMock();
-    const resolvers: Array<(v: unknown) => void> = [];
-    axios.get.mockImplementation(() => new Promise((res) => resolvers.push(res)));
-    const data = useUserData();
+    const pending: Array<{ resolve: (v: unknown) => void; reject: (e: unknown) => void }> = [];
+    axios.get.mockImplementation(
+      () =>
+        new Promise((resolve, reject) => {
+          pending.push({ resolve, reject });
+        })
+    );
+    const staleToasts: unknown[][] = [];
+    const currentToasts: unknown[][] = [];
+    const stale = useUserData({ onToast: (...args) => staleToasts.push(args) });
+    const current = useUserData({ onToast: (...args) => currentToasts.push(args) });
 
-    const pA1 = data.loadDataNow(); // A1 (default params) — resolvers[0]
-    data.perPage.value = 50;
-    const pB = data.loadDataNow(); // B (params B) — resolvers[1]
-    data.perPage.value = 25;
-    const pA2 = data.loadDataNow(); // A2 (params A again, latest A start) — resolvers[2]
+    const staleA = stale.loadDataNow();
+    const currentA = current.loadDataNow(); // shared A transport
+    stale.perPage.value = 50;
+    const staleB = stale.loadDataNow(); // independent B transport
 
-    // Stale A1 resolves FIRST (totalItems 2), while A2 is still pending.
-    resolvers[0]({ status: 200, data: userTablePayload });
-    await pA1;
+    pending[0].reject(new Error('obsolete A'));
+    await Promise.allSettled([staleA, currentA]);
     await flushPromises();
 
-    // Cache-serve attempt for params A must NOT return the stale A1 (cache empty here).
-    data.totalRows.value = 555; // sentinel — a wrong cache-serve would overwrite this
-    const pA3 = data.loadDataNow(); // resolvers[3]
-    await Promise.resolve();
-    await flushPromises();
-    expect(data.totalRows.value).toBe(555); // stale A1 was not served from the cache
+    expect(staleToasts).toEqual([]); // stale A was superseded by B
+    expect(currentToasts).toHaveLength(1); // current shared A receives its failure
+    expect(stale.isBusy.value).toBe(true); // stale A finally did not clear B's spinner
 
-    // Settle the remaining requests so nothing leaks into the next test.
-    resolvers[2]({ status: 200, data: userTablePayload });
-    resolvers[1]({ status: 200, data: userTablePayload });
-    resolvers[3]({ status: 200, data: userTablePayload });
-    await pA2;
-    await pB;
-    await pA3;
+    pending[1].resolve({ status: 200, data: userTablePayload });
+    await staleB;
     await flushPromises();
-    data.dispose();
+    expect(stale.totalRows.value).toBe(2);
+    expect(stale.isBusy.value).toBe(false);
+    stale.dispose();
+    current.dispose();
   });
 
   it('A→B→cached-A does not leave isBusy stuck true', async () => {

--- a/app/src/views/admin/composables/useAdminTrendData.ts
+++ b/app/src/views/admin/composables/useAdminTrendData.ts
@@ -71,8 +71,11 @@ export function useAdminTrendData(
 
   async function fetchTrendData(): Promise<void> {
     abortController?.abort();
-    abortController = new AbortController();
+    const controller = new AbortController();
+    abortController = controller;
     const currentVersion = ++requestVersion;
+    const isCurrentRequest = () =>
+      currentVersion === requestVersion && abortController === controller;
 
     trendData.value = [];
     trendCategoryData.value = { dates: [], series: {} };
@@ -90,10 +93,10 @@ export function useAdminTrendData(
       }
 
       const response = await getEntitiesOverTime(params, {
-        signal: abortController.signal,
+        signal: controller.signal,
       });
 
-      if (currentVersion !== requestVersion) return;
+      if (!isCurrentRequest()) return;
 
       const allData = safeArray<GroupedTimeSeries>(response?.data);
       trendData.value = mergeGroupedCumulativeSeries(allData);
@@ -105,8 +108,8 @@ export function useAdminTrendData(
         trendYMax.value = Math.max(trendYMax.value ?? 0, maxVal);
       }
 
-      abortController = null;
     } catch (error) {
+      if (!isCurrentRequest()) return;
       if ((error as Error).name !== 'AbortError') {
         console.error('Failed to fetch trend data:', error);
         makeToast('Failed to fetch trend data', 'Error', 'danger');
@@ -114,7 +117,10 @@ export function useAdminTrendData(
         trendCategoryData.value = { dates: [], series: {} };
       }
     } finally {
-      loading.value = false;
+      if (isCurrentRequest()) {
+        loading.value = false;
+        abortController = null;
+      }
     }
   }
 
@@ -128,6 +134,7 @@ export function useAdminTrendData(
 
   // Cleanup
   onUnmounted(() => {
+    requestVersion += 1;
     abortController?.abort();
     abortController = null;
   });

--- a/app/src/views/admin/composables/useOntologyAdminTable.ts
+++ b/app/src/views/admin/composables/useOntologyAdminTable.ts
@@ -12,7 +12,7 @@
 // unchanged by this extraction — only the responsibility's *location*
 // moved. Every network call goes through the typed `@/api/ontology` client.
 
-import { computed, nextTick, onMounted, ref, watch, type Ref } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch, type Ref } from 'vue';
 import useToast from '@/composables/useToast';
 import useUrlParsing from '@/composables/useUrlParsing';
 import useTableData from '@/composables/useTableData';
@@ -62,6 +62,7 @@ export interface OntologyActiveFilterEntry {
 }
 
 export function useOntologyAdminTable() {
+  const requestConsumer = {};
   const { makeToast } = useToast();
   const { filterObjToStr, filterStrToObj, sortStringToVariables } = useUrlParsing();
   const { isExporting, exportToExcel } = useExcelExport();
@@ -102,6 +103,8 @@ export function useOntologyAdminTable() {
   // ── Local state (was data()) ─────────────────────────────────────────────
   const isInitializing = ref(true);
   const loadDataDebounceTimer = ref<ReturnType<typeof setTimeout> | null>(null);
+  let tableIntentGeneration = 0;
+  let disposed = false;
   const totalPages = ref(0);
   const ontologies = ref<VariantOntologyRow[]>([]);
   const fields = ref<OntologyTableField[]>([...ONTOLOGY_TABLE_FIELDS]);
@@ -257,23 +260,28 @@ export function useOntologyAdminTable() {
 
   // Load data with debouncing.
   function loadData(): void {
+    if (disposed) return;
+    const intentGeneration = ++tableIntentGeneration;
     if (loadDataDebounceTimer.value) {
       clearTimeout(loadDataDebounceTimer.value);
     }
     loadDataDebounceTimer.value = setTimeout(() => {
       loadDataDebounceTimer.value = null;
-      void doLoadData();
+      void doLoadData(intentGeneration);
     }, 50);
   }
 
   // Actual data loading method with module-level request coordination.
-  async function doLoadData(): Promise<void> {
+  async function doLoadData(intentGeneration = ++tableIntentGeneration): Promise<void> {
     const buildParams = () =>
       `sort=${sort.value}&filter=${filter_string.value}&page_after=${currentItemID.value}&page_size=${perPage.value}`;
     const urlParam = buildParams();
+    const isIntentCurrent = () => !disposed && tableIntentGeneration === intentGeneration;
+    if (!isIntentCurrent()) return;
     isBusy.value = true;
 
     const result = await ontologyRequestCoordinator.request({
+      consumer: requestConsumer,
       params: urlParam,
       fetcher: () =>
         listVariantOntology({
@@ -281,15 +289,15 @@ export function useOntologyAdminTable() {
           filter: filter_string.value,
           page_after: currentItemID.value,
           page_size: perPage.value,
-        }),
+      }),
       apply: (data, source) => {
-        applyApiResponse(data);
+        applyApiResponse(data, isIntentCurrent);
         if (source === 'network') {
           updateBrowserUrl();
         }
       },
       onError: (e) => makeToast(e, 'Error', 'danger'),
-      isCurrent: (params) => buildParams() === params,
+      isCurrent: (params) => isIntentCurrent() && buildParams() === params,
     });
 
     if (result.handled) {
@@ -301,13 +309,18 @@ export function useOntologyAdminTable() {
    * Apply API response data to component state. Extracted to allow reuse
    * when skipping duplicate API calls (see doLoadData's `apply` callback).
    */
-  function applyApiResponse(data: VariantOntologyListResponse): void {
+  function applyApiResponse(
+    data: VariantOntologyListResponse,
+    isIntentCurrent: () => boolean = () => true
+  ): void {
     const meta = (data.meta as OntologyListMeta[])[0];
 
     ontologies.value = data.data;
     totalRows.value = meta.totalItems;
     void nextTick(() => {
-      currentPage.value = meta.currentPage;
+      if (isIntentCurrent()) {
+        currentPage.value = meta.currentPage;
+      }
     });
     totalPages.value = meta.totalPages;
     // VariO cursor IDs are strings like "VariO:0026" — store them as-is so the
@@ -407,11 +420,18 @@ export function useOntologyAdminTable() {
     }
 
     void nextTick(() => {
+      if (disposed) return;
       loadData();
       void nextTick(() => {
-        isInitializing.value = false;
+        if (!disposed) isInitializing.value = false;
       });
     });
+  });
+
+  onBeforeUnmount(() => {
+    disposed = true;
+    tableIntentGeneration += 1;
+    if (loadDataDebounceTimer.value) clearTimeout(loadDataDebounceTimer.value);
   });
 
   return {

--- a/app/src/views/admin/composables/useUserData.ts
+++ b/app/src/views/admin/composables/useUserData.ts
@@ -13,32 +13,23 @@ import useUrlParsing from '@/composables/useUrlParsing';
 // for a request whose params differ (#535 S5b). Consumer-state ownership is
 // instance-local (see `instanceGeneration`), so one instance cannot suppress
 // another's response or leave its `isBusy` stuck.
-let moduleLastApiParams: string | null = null;
 let moduleLastApiCallTime = 0;
-let moduleApiCallInProgress = false;
 let moduleLastApiResponse: unknown = null;
 let moduleLastApiResponseParams: string | null = null;
-// Module-wide monotonic per-fetch-START sequence + the latest start sequence PER
-// PARAMETER KEY (#535 S5b). Param-keying alone does NOT make late-completion order
-// irrelevant: two SAME-param fetches (A1, A2) both write under params A, so a
-// superseded A1 completing in EITHER order could poison the fresher A2. A completing
-// fetch may write the recent-response cache only when it is still the latest-STARTED
-// fetch for its own params (`moduleLatestStartSeqByParam.get(params) === mySeq`), so
-// no out-of-order stale same-param response can poison the cache, while a still-latest
-// fetch for DIFFERENT params (A vs B) is unaffected. The map is module-level so it
-// stays monotonic across instances that share the module cache.
-let moduleFetchSeq = 0;
-const moduleLatestStartSeqByParam = new Map<string, number>();
+// A transport slot belongs to its exact parameter key. The old boolean dedup
+// silently returned for a second live instance, leaving that instance with no
+// rows; callers now subscribe to this promise and apply only if their own
+// instance intent is still current (#535 S5c).
+const moduleInFlightByParams = new Map<string, Promise<UserTableResponse>>();
+let moduleTransportEpoch = 0;
 
 /** Reset the module-level cache — for use in tests only. */
 export function __resetUserDataCache(): void {
-  moduleLastApiParams = null;
   moduleLastApiCallTime = 0;
-  moduleApiCallInProgress = false;
   moduleLastApiResponse = null;
   moduleLastApiResponseParams = null;
-  moduleFetchSeq = 0;
-  moduleLatestStartSeqByParam.clear();
+  moduleTransportEpoch += 1;
+  moduleInFlightByParams.clear();
 }
 
 export interface FilterEntry {
@@ -84,17 +75,16 @@ export function useUserData(options: UseUserDataOptions = {}) {
   const isInitializing = ref(true);
   let loadDataDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
-  // Instance-local request ownership (#535 S5b). Two orthogonal signals:
+  // Instance-local request ownership (#535 S5b/S5c). Two orthogonal signals:
   //  - `latestIntent` is the params string of the most recent load intent, set the
   //    moment a load is requested (loadData schedule / loadDataNow). An in-flight
   //    response applies only if its params still equal `latestIntent`, which closes
   //    the 50ms debounce window (refs already describe P2 while P1 is in flight)
   //    WITHOUT orphaning a deduped identical request (same params → same intent).
-  //  - `startGeneration` is bumped only when a fetch actually starts, so among
-  //    same-params requests only the latest-started may apply (true A-B-A: A#1, B,
-  //    A2 all in flight → only A2 wins). `disposed` stops any late continuation
-  //    from mutating a torn-down instance.
-  let startGeneration = 0;
+  //  - `intentGeneration` is bumped the instant this instance records a load
+  //    intent, including a shared in-flight subscription. `disposed` stops any
+  //    late continuation from mutating a torn-down instance.
+  let intentGeneration = 0;
   let latestIntent: string | null = null;
   let disposed = false;
   // Independent per-loader generations for the static option lists (#535 S5b MEDIUM):
@@ -140,9 +130,29 @@ export function useUserData(options: UseUserDataOptions = {}) {
     onScrollbarUpdate?.();
   }
 
-  async function doLoadData(): Promise<void> {
-    const urlParam = buildUrlParam();
+  function beginLoadIntent(): { generation: number; params: string } {
+    const params = buildUrlParam();
+    latestIntent = params;
+    return { generation: ++intentGeneration, params };
+  }
+
+  async function applyCurrentResponse(
+    data: UserTableResponse,
+    urlParam: string,
+    stillOwner: () => boolean
+  ): Promise<void> {
+    if (!stillOwner()) return;
+    applyApiResponse(data, stillOwner);
+    if (stillOwner()) updateBrowserUrl();
+    if (stillOwner() && urlParam === latestIntent) tableData.isBusy.value = false;
+  }
+
+  async function doLoadData({ generation, params: urlParam }: { generation: number; params: string }): Promise<void> {
     const now = Date.now();
+    const stillOwner = (): boolean =>
+      !disposed && generation === intentGeneration && urlParam === latestIntent;
+
+    if (stillOwner()) tableData.isBusy.value = true;
 
     // Recent-response cache: serve only a NON-NULL response stored under THESE
     // params, and only if this instance still wants them.
@@ -151,67 +161,52 @@ export function useUserData(options: UseUserDataOptions = {}) {
       moduleLastApiResponse != null &&
       now - moduleLastApiCallTime < 500
     ) {
-      if (!disposed && urlParam === latestIntent) {
+      if (stillOwner()) {
         // A current cache hit is a completed current intent: apply, sync the URL,
         // and clear busy — otherwise a still-pending superseded request (A→B→cached-A)
         // could leave isBusy stuck true forever.
-        applyApiResponse(
-          moduleLastApiResponse as UserTableResponse,
-          () => !disposed && urlParam === latestIntent
-        );
-        updateBrowserUrl();
-        tableData.isBusy.value = false;
+        await applyCurrentResponse(moduleLastApiResponse as UserTableResponse, urlParam, stillOwner);
       }
       return;
     }
-    // Transport dedup: an identical request is already in flight. Do NOT bump the
-    // start generation here — the in-flight request is the same intent.
-    if (moduleApiCallInProgress && moduleLastApiParams === urlParam) return;
 
-    // A real fetch starts now → own the start generation. `stillOwner` combines it
-    // with the params intent so it stays stable across applyApiResponse's own ref
-    // mutations (latestIntent only moves on a new loadData/loadDataNow call).
-    const myGen = ++startGeneration;
-    // Module-wide start order, recorded as the latest start for THIS param key so the
-    // recent-response cache write guard below only lets the latest-started same-param
-    // fetch record the cache.
-    const mySeq = ++moduleFetchSeq;
-    moduleLatestStartSeqByParam.set(urlParam, mySeq);
-    const stillOwner = (): boolean =>
-      !disposed && myGen === startGeneration && urlParam === latestIntent;
+    const sharedPromise = moduleInFlightByParams.get(urlParam);
+    if (sharedPromise) {
+      try {
+        await applyCurrentResponse(await sharedPromise, urlParam, stillOwner);
+      } catch (e) {
+        if (stillOwner()) onToast?.(e, 'Error', 'danger');
+      } finally {
+        if (stillOwner()) tableData.isBusy.value = false;
+      }
+      return;
+    }
 
-    moduleLastApiParams = urlParam;
+    const transportEpoch = moduleTransportEpoch;
+    const promise = getUserTable({
+      sort: tableData.sort.value,
+      filter: tableData.filter_string.value,
+      page_after: tableData.currentItemID.value,
+      page_size: String(tableData.perPage.value),
+    });
+    moduleInFlightByParams.set(urlParam, promise);
     moduleLastApiCallTime = now;
-    moduleApiCallInProgress = true;
-    // A fresh request invalidates any stored response until this one records its own.
     moduleLastApiResponse = null;
     moduleLastApiResponseParams = null;
-    if (stillOwner()) tableData.isBusy.value = true;
+    const ownsSlot = (): boolean =>
+      moduleTransportEpoch === transportEpoch && moduleInFlightByParams.get(urlParam) === promise;
 
     try {
-      const data = await getUserTable({
-        sort: tableData.sort.value,
-        filter: tableData.filter_string.value,
-        page_after: tableData.currentItemID.value,
-        page_size: String(tableData.perPage.value),
-      });
-      // Transport bookkeeping: the completing fetch clears the in-flight flag. The
-      // recent-response cache is written only if this fetch is still the latest-STARTED
-      // fetch for its own params, so a superseded same-param response completing in ANY
-      // order cannot overwrite (or transiently repopulate) the fresher cached value.
-      moduleApiCallInProgress = false;
-      if (moduleLatestStartSeqByParam.get(urlParam) === mySeq) {
+      const data = await promise;
+      if (ownsSlot()) {
+        moduleInFlightByParams.delete(urlParam);
         moduleLastApiResponse = data;
         moduleLastApiResponseParams = urlParam;
       }
-      // Consumer apply: only the latest-started request for the current intent.
-      if (!stillOwner()) return;
-      applyApiResponse(data, stillOwner);
-      updateBrowserUrl();
+      await applyCurrentResponse(data, urlParam, stillOwner);
     } catch (e) {
-      moduleApiCallInProgress = false;
-      if (!stillOwner()) return;
-      onToast?.(e, 'Error', 'danger');
+      if (ownsSlot()) moduleInFlightByParams.delete(urlParam);
+      if (stillOwner()) onToast?.(e, 'Error', 'danger');
     } finally {
       if (stillOwner()) tableData.isBusy.value = false;
     }
@@ -220,18 +215,22 @@ export function useUserData(options: UseUserDataOptions = {}) {
   function loadData(): void {
     // Record the new intent immediately (before the debounce) so an in-flight
     // response for the previous intent is superseded even during the 50ms window.
-    latestIntent = buildUrlParam();
+    const intent = beginLoadIntent();
     if (loadDataDebounceTimer) clearTimeout(loadDataDebounceTimer);
     loadDataDebounceTimer = setTimeout(() => {
       loadDataDebounceTimer = null;
-      void doLoadData();
+      void doLoadData(intent);
     }, 50);
   }
 
   // Bypasses debounce for tests + first-paint
   async function loadDataNow(): Promise<void> {
-    latestIntent = buildUrlParam();
-    return doLoadData();
+    const intent = beginLoadIntent();
+    if (loadDataDebounceTimer) {
+      clearTimeout(loadDataDebounceTimer);
+      loadDataDebounceTimer = null;
+    }
+    return doLoadData(intent);
   }
 
   async function loadRoleList(): Promise<void> {

--- a/app/src/views/curate/composables/__tests__/useEntityInfo.ownership.spec.ts
+++ b/app/src/views/curate/composables/__tests__/useEntityInfo.ownership.spec.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  getEntityPhenotypesMock,
+  getEntityPublicationsMock,
+  getEntityReviewMock,
+  getEntityStatusMock,
+  getEntityVariationMock,
+  listEntitiesMock,
+} = vi.hoisted(() => ({
+  getEntityPhenotypesMock: vi.fn(),
+  getEntityPublicationsMock: vi.fn(),
+  getEntityReviewMock: vi.fn(),
+  getEntityStatusMock: vi.fn(),
+  getEntityVariationMock: vi.fn(),
+  listEntitiesMock: vi.fn(),
+}));
+
+vi.mock('@/api/entity', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/entity')>();
+  return {
+    ...actual,
+    getEntityPhenotypes: getEntityPhenotypesMock,
+    getEntityPublications: getEntityPublicationsMock,
+    getEntityReview: getEntityReviewMock,
+    getEntityStatus: getEntityStatusMock,
+    getEntityVariation: getEntityVariationMock,
+    listEntities: listEntitiesMock,
+  };
+});
+
+import { useEntityInfo } from '../useEntityInfo';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('useEntityInfo request ownership', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getEntityPhenotypesMock.mockResolvedValue([]);
+    getEntityPublicationsMock.mockResolvedValue([]);
+    getEntityVariationMock.mockResolvedValue([]);
+  });
+
+  it('reset aborts and invalidates entity and review successes that settle afterwards', async () => {
+    const entity = deferred<{ data: Array<{ entity_id: number; symbol: string }> }>();
+    const review = deferred<Array<Record<string, unknown>>>();
+    listEntitiesMock.mockReturnValue(entity.promise);
+    getEntityReviewMock.mockReturnValue(review.promise);
+    const data = useEntityInfo();
+
+    const entityRequest = data.loadEntity(1);
+    const reviewRequest = data.loadReview(1);
+    data.reset();
+
+    entity.resolve({ data: [{ entity_id: 1, symbol: 'STALE' }] });
+    review.resolve([{ synopsis: 'stale', comment: '', review_id: 1, entity_id: 1 }]);
+    await Promise.all([entityRequest, reviewRequest]);
+
+    expect(data.entity_info.value).toEqual({});
+    expect(data.reviewLoadedData.value).toBeNull();
+    expect(data.review_info.value.synopsis).toBeUndefined();
+  });
+
+  it('reset prevents a stale status rejection from showing a toast', async () => {
+    const status = deferred<unknown>();
+    const toasts: unknown[][] = [];
+    getEntityStatusMock.mockReturnValue(status.promise);
+    const data = useEntityInfo({ onToast: (...args) => toasts.push(args) });
+
+    const statusRequest = data.loadStatus(1);
+    data.reset();
+    status.reject(new Error('stale failure'));
+    await statusRequest;
+
+    expect(toasts).toEqual([]);
+    expect(data.status_info.value.status_id).toBeUndefined();
+  });
+
+  it('passes the review subresource abort signal as the typed client config', async () => {
+    getEntityReviewMock.mockResolvedValue([{ synopsis: '', comment: '', review_id: 1, entity_id: 1 }]);
+    const data = useEntityInfo();
+
+    await data.loadReview(1);
+
+    const config = expect.objectContaining({ signal: expect.any(AbortSignal) });
+    expect(getEntityPhenotypesMock).toHaveBeenCalledWith(1, {}, config);
+    expect(getEntityVariationMock).toHaveBeenCalledWith(1, {}, config);
+    expect(getEntityPublicationsMock).toHaveBeenCalledWith(1, {}, config);
+  });
+});

--- a/app/src/views/curate/composables/__tests__/useReviewForm.spec.ts
+++ b/app/src/views/curate/composables/__tests__/useReviewForm.spec.ts
@@ -45,6 +45,14 @@ vi.mock('@/composables/useFormDraft', () => ({
 
 import useReviewForm from '../useReviewForm';
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
 interface ResolverMap {
   review?: Array<{ synopsis?: string; comment?: string; entity_id?: number }>;
   phenotypes?: Array<{ phenotype_id: number; modifier_id: number }>;
@@ -342,6 +350,48 @@ describe('useReviewForm', () => {
 
       // Should be false after reset (no loaded data)
       expect(hasChanges.value).toBe(false);
+    });
+  });
+
+  describe('request ownership', () => {
+    it('keeps B form state when older A review data resolves last', async () => {
+      const aReview = deferred<Array<{ synopsis: string; comment: string; entity_id: number }>>();
+      const aPhenotypes = deferred<Array<{ phenotype_id: number; modifier_id: number }>>();
+      const aVariation = deferred<Array<{ vario_id: number; modifier_id: number }>>();
+      const aPublications = deferred<Array<{ publication_id: string; publication_type: string }>>();
+      const bReview = deferred<Array<{ synopsis: string; comment: string; entity_id: number }>>();
+      const bPhenotypes = deferred<Array<{ phenotype_id: number; modifier_id: number }>>();
+      const bVariation = deferred<Array<{ vario_id: number; modifier_id: number }>>();
+      const bPublications = deferred<Array<{ publication_id: string; publication_type: string }>>();
+      reviewApiMocks.getReviewById.mockImplementation((id: number) =>
+        id === 1 ? aReview.promise : bReview.promise
+      );
+      reviewApiMocks.getReviewPhenotypes.mockImplementation((id: number) =>
+        id === 1 ? aPhenotypes.promise : bPhenotypes.promise
+      );
+      reviewApiMocks.getReviewVariation.mockImplementation((id: number) =>
+        id === 1 ? aVariation.promise : bVariation.promise
+      );
+      reviewApiMocks.getReviewPublications.mockImplementation((id: number) =>
+        id === 1 ? aPublications.promise : bPublications.promise
+      );
+      const { formData, loadReviewData } = useReviewForm();
+
+      const loadA = loadReviewData(1);
+      const loadB = loadReviewData(2);
+      bReview.resolve([{ synopsis: 'B synopsis', comment: 'B', entity_id: 2 }]);
+      bPhenotypes.resolve([]);
+      bVariation.resolve([]);
+      bPublications.resolve([]);
+      await loadB;
+      aReview.resolve([{ synopsis: 'A synopsis', comment: 'A', entity_id: 1 }]);
+      aPhenotypes.resolve([]);
+      aVariation.resolve([]);
+      aPublications.resolve([]);
+      await loadA;
+
+      expect(formData.synopsis).toBe('B synopsis');
+      expect(formData.comment).toBe('B');
     });
   });
 

--- a/app/src/views/curate/composables/__tests__/useStatusForm.spec.ts
+++ b/app/src/views/curate/composables/__tests__/useStatusForm.spec.ts
@@ -41,6 +41,14 @@ vi.mock('@/composables/useFormDraft', () => ({
 
 import useStatusForm from '../useStatusForm';
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
 describe('useStatusForm', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -218,6 +226,45 @@ describe('useStatusForm', () => {
 
       // Should be false immediately after loading via loadStatusData
       expect(hasChanges.value).toBe(false);
+    });
+  });
+
+  describe('request ownership', () => {
+    it('keeps B form state when older A status data resolves last', async () => {
+      const a =
+        deferred<
+          Array<{
+            status_id: number;
+            entity_id: number;
+            category_id: number;
+            comment: string;
+            problematic: boolean;
+          }>
+        >();
+      const b =
+        deferred<
+          Array<{
+            status_id: number;
+            entity_id: number;
+            category_id: number;
+            comment: string;
+            problematic: boolean;
+          }>
+        >();
+      statusApiMocks.getStatusById.mockImplementation((id: number) =>
+        id === 1 ? a.promise : b.promise
+      );
+      const { formData, loadStatusData } = useStatusForm();
+
+      const loadA = loadStatusData(1, 0);
+      const loadB = loadStatusData(2, 0);
+      b.resolve([{ status_id: 2, entity_id: 2, category_id: 2, comment: 'B', problematic: true }]);
+      await loadB;
+      a.resolve([{ status_id: 1, entity_id: 1, category_id: 1, comment: 'A', problematic: false }]);
+      await loadA;
+
+      expect(formData.status_id).toBe(2);
+      expect(formData.comment).toBe('B');
     });
   });
 

--- a/app/src/views/curate/composables/formLoadOwnership.ts
+++ b/app/src/views/curate/composables/formLoadOwnership.ts
@@ -1,0 +1,44 @@
+/** Instance-local abort/generation ownership for shared curation form state. */
+export interface FormLoadRequest {
+  signal: AbortSignal;
+  isCurrent: () => boolean;
+}
+
+export interface FormLoadOwner {
+  begin: () => FormLoadRequest;
+  cancel: () => void;
+  finish: (request: FormLoadRequest) => void;
+}
+
+export function createFormLoadOwner(): FormLoadOwner {
+  let generation = 0;
+  let controller: AbortController | null = null;
+
+  function begin(): FormLoadRequest {
+    generation += 1;
+    controller?.abort();
+    const nextController = new AbortController();
+    const requestGeneration = generation;
+    controller = nextController;
+    return {
+      signal: nextController.signal,
+      isCurrent: () => generation === requestGeneration && controller === nextController,
+    };
+  }
+
+  function cancel(): void {
+    generation += 1;
+    controller?.abort();
+    controller = null;
+  }
+
+  function finish(request: FormLoadRequest): void {
+    if (request.isCurrent()) controller = null;
+  }
+
+  return { begin, cancel, finish };
+}
+
+export function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
+}

--- a/app/src/views/curate/composables/useEntityInfo.ts
+++ b/app/src/views/curate/composables/useEntityInfo.ts
@@ -28,6 +28,42 @@ interface ReviewSnapshot {
   genereviews: string[];
 }
 
+interface RequestOwner {
+  generation: number;
+  controller: AbortController | null;
+}
+
+interface ActiveRequest {
+  signal: AbortSignal;
+  isCurrent: () => boolean;
+}
+
+function beginRequest(owner: RequestOwner): ActiveRequest {
+  owner.generation += 1;
+  owner.controller?.abort();
+  const controller = new AbortController();
+  const generation = owner.generation;
+  owner.controller = controller;
+  return {
+    signal: controller.signal,
+    isCurrent: () => owner.generation === generation && owner.controller === controller,
+  };
+}
+
+function cancelRequest(owner: RequestOwner): void {
+  owner.generation += 1;
+  owner.controller?.abort();
+  owner.controller = null;
+}
+
+function finishRequest(owner: RequestOwner, request: ActiveRequest): void {
+  if (request.isCurrent()) owner.controller = null;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
+
 // Fields loadEntity() asks the entity-LIST endpoint (GET /api/entity/) for.
 // This list MUST be a subset of the columns `ndd_entity_view` exposes
 // (db/migrations/025_create_core_views.sql) + `synopsis` from the review
@@ -70,6 +106,9 @@ export function useEntityInfo(options: UseEntityInfoOptions = {}) {
   const select_gene_reviews = ref<string[]>([]);
 
   const reviewLoadedData = ref<ReviewSnapshot | null>(null);
+  const entityRequest: RequestOwner = { generation: 0, controller: null };
+  const reviewRequest: RequestOwner = { generation: 0, controller: null };
+  const statusRequest: RequestOwner = { generation: 0, controller: null };
 
   const hasReviewChanges = computed(() => {
     if (!reviewLoadedData.value) return false;
@@ -85,13 +124,15 @@ export function useEntityInfo(options: UseEntityInfoOptions = {}) {
   });
 
   async function loadEntity(entityId: number): Promise<void> {
+    const request = beginRequest(entityRequest);
     try {
       const response: any = await listEntities({
         filter: `equals(entity_id,${entityId})`,
         fields: ENTITY_MUTATION_FIELDS,
         page_size: '1',
         compact: true,
-      });
+      }, { signal: request.signal });
+      if (!request.isCurrent()) return;
       const data = response?.data;
       if (!Array.isArray(data) || data.length === 0) {
         onToast?.(`Entity ${entityId} not found`, 'Error', 'danger');
@@ -100,17 +141,25 @@ export function useEntityInfo(options: UseEntityInfoOptions = {}) {
       }
       entity_info.value = data[0];
     } catch (e) {
+      if (!request.isCurrent() || isAbortError(e)) return;
       onToast?.(e, 'Error', 'danger');
       entity_info.value = {};
+    } finally {
+      finishRequest(entityRequest, request);
     }
   }
 
   async function loadReview(entityId: number): Promise<void> {
+    const request = beginRequest(reviewRequest);
     try {
-      const review_data: any = await getEntityReview(entityId);
-      const phenotypes_data: any = await getEntityPhenotypes(entityId);
-      const variation_data: any = await getEntityVariation(entityId);
-      const publications_data: any = await getEntityPublications(entityId);
+      const review_data: any = await getEntityReview(entityId, { signal: request.signal });
+      if (!request.isCurrent()) return;
+      const phenotypes_data: any = await getEntityPhenotypes(entityId, {}, { signal: request.signal });
+      if (!request.isCurrent()) return;
+      const variation_data: any = await getEntityVariation(entityId, {}, { signal: request.signal });
+      if (!request.isCurrent()) return;
+      const publications_data: any = await getEntityPublications(entityId, {}, { signal: request.signal });
+      if (!request.isCurrent()) return;
 
       const new_phenotype = phenotypes_data.map(
         (item: any) => new Phenotype(item.phenotype_id, item.modifier_id)
@@ -160,13 +209,18 @@ export function useEntityInfo(options: UseEntityInfoOptions = {}) {
         genereviews: [...select_gene_reviews.value],
       };
     } catch (e) {
+      if (!request.isCurrent() || isAbortError(e)) return;
       onToast?.(e, 'Error', 'danger');
+    } finally {
+      finishRequest(reviewRequest, request);
     }
   }
 
   async function loadStatus(entityId: number): Promise<void> {
+    const request = beginRequest(statusRequest);
     try {
-      const status_data: any = await getEntityStatus(entityId);
+      const status_data: any = await getEntityStatus(entityId, { signal: request.signal });
+      if (!request.isCurrent()) return;
       status_info.value = new Status(
         status_data[0].category_id,
         status_data[0].comment,
@@ -175,11 +229,17 @@ export function useEntityInfo(options: UseEntityInfoOptions = {}) {
       status_info.value.status_id = status_data[0].status_id;
       status_info.value.entity_id = status_data[0].entity_id;
     } catch (e) {
+      if (!request.isCurrent() || isAbortError(e)) return;
       onToast?.(e, 'Error', 'danger');
+    } finally {
+      finishRequest(statusRequest, request);
     }
   }
 
   function reset(): void {
+    cancelRequest(entityRequest);
+    cancelRequest(reviewRequest);
+    cancelRequest(statusRequest);
     entity_info.value = {};
     review_info.value = new Review();
     status_info.value = new Status();

--- a/app/src/views/curate/composables/useReviewForm.ts
+++ b/app/src/views/curate/composables/useReviewForm.ts
@@ -17,6 +17,7 @@ import Phenotype from '@/assets/js/classes/submission/submissionPhenotype';
 import Variation from '@/assets/js/classes/submission/submissionVariation';
 import Literature from '@/assets/js/classes/submission/submissionLiterature';
 import useFormDraft from '@/composables/useFormDraft';
+import { createFormLoadOwner, isAbortError } from './formLoadOwnership';
 import {
   createReview,
   getReviewById,
@@ -156,6 +157,7 @@ export default function useReviewForm(entityId?: string | number) {
 
   // Loading state
   const loading = ref(false);
+  const loadOwner = createFormLoadOwner();
 
   // Internal state for tracking review metadata
   const reviewId = ref<number | null>(null);
@@ -241,16 +243,18 @@ export default function useReviewForm(entityId?: string | number) {
     reviewIdInput: number,
     _reReviewReviewSaved?: number
   ): Promise<void> => {
+    const request = loadOwner.begin();
     loading.value = true;
-    reviewId.value = reviewIdInput;
 
     try {
       const [reviewData, phenotypesData, variationData, publicationsData] = await Promise.all([
-        getReviewById(reviewIdInput),
-        getReviewPhenotypes(reviewIdInput),
-        getReviewVariation(reviewIdInput),
-        getReviewPublications(reviewIdInput),
+        getReviewById(reviewIdInput, { signal: request.signal }),
+        getReviewPhenotypes(reviewIdInput, { signal: request.signal }),
+        getReviewVariation(reviewIdInput, { signal: request.signal }),
+        getReviewPublications(reviewIdInput, { signal: request.signal }),
       ]);
+      if (!request.isCurrent()) return;
+      reviewId.value = reviewIdInput;
 
       // Load synopsis and comment
       if (reviewData && reviewData.length > 0) {
@@ -298,11 +302,14 @@ export default function useReviewForm(entityId?: string | number) {
         publications: [...formData.publications],
         genereviews: [...formData.genereviews],
       };
-
-      loading.value = false;
     } catch (error) {
-      loading.value = false;
+      if (!request.isCurrent() || isAbortError(error)) return;
       throw error;
+    } finally {
+      if (request.isCurrent()) {
+        loading.value = false;
+        loadOwner.finish(request);
+      }
     }
   };
 
@@ -385,6 +392,8 @@ export default function useReviewForm(entityId?: string | number) {
    * Reset form to initial state
    */
   const resetForm = () => {
+    loadOwner.cancel();
+    loading.value = false;
     formData.synopsis = '';
     formData.phenotypes = [];
     formData.variationOntology = [];

--- a/app/src/views/curate/composables/useStatusForm.ts
+++ b/app/src/views/curate/composables/useStatusForm.ts
@@ -12,6 +12,7 @@
 import { ref, reactive, computed, watch } from 'vue';
 import Status from '@/assets/js/classes/submission/submissionStatus';
 import useFormDraft from '@/composables/useFormDraft';
+import { createFormLoadOwner, isAbortError } from './formLoadOwnership';
 import { getStatusById, createStatus, updateStatus } from '@/api/status';
 import { getEntityStatus } from '@/api/entity';
 
@@ -59,6 +60,7 @@ const validationRules = {
 export default function useStatusForm(entityId?: string | number) {
   // Loading state
   const loading = ref(false);
+  const loadOwner = createFormLoadOwner();
 
   // Form data state
   const formData = reactive<StatusFormData>({
@@ -151,10 +153,12 @@ export default function useStatusForm(entityId?: string | number) {
    * Load status data from API by status ID
    */
   const loadStatusData = async (statusId: number, reReviewSaved?: number): Promise<void> => {
+    const request = loadOwner.begin();
     loading.value = true;
 
     try {
-      const rows = await getStatusById(statusId);
+      const rows = await getStatusById(statusId, { signal: request.signal });
+      if (!request.isCurrent()) return;
 
       if (!rows || rows.length === 0) {
         throw new Error('Status not found');
@@ -182,10 +186,14 @@ export default function useStatusForm(entityId?: string | number) {
         problematic: formData.problematic,
       };
     } catch (error) {
+      if (!request.isCurrent() || isAbortError(error)) return;
       console.error('Failed to load status:', error);
       throw error;
     } finally {
-      loading.value = false;
+      if (request.isCurrent()) {
+        loading.value = false;
+        loadOwner.finish(request);
+      }
     }
   };
 
@@ -193,10 +201,12 @@ export default function useStatusForm(entityId?: string | number) {
    * Load status data by entity ID (for ModifyEntity view)
    */
   const loadStatusByEntity = async (entityId: number): Promise<void> => {
+    const request = loadOwner.begin();
     loading.value = true;
 
     try {
-      const rows = await getEntityStatus(entityId);
+      const rows = await getEntityStatus(entityId, { signal: request.signal });
+      if (!request.isCurrent()) return;
 
       if (!rows || rows.length === 0) {
         throw new Error('Status not found for entity');
@@ -220,10 +230,14 @@ export default function useStatusForm(entityId?: string | number) {
         problematic: formData.problematic,
       };
     } catch (error) {
+      if (!request.isCurrent() || isAbortError(error)) return;
       console.error('Failed to load status by entity:', error);
       throw error;
     } finally {
-      loading.value = false;
+      if (request.isCurrent()) {
+        loading.value = false;
+        loadOwner.finish(request);
+      }
     }
   };
 
@@ -297,6 +311,8 @@ export default function useStatusForm(entityId?: string | number) {
    * Reset form to initial state
    */
   const resetForm = () => {
+    loadOwner.cancel();
+    loading.value = false;
     formData.category_id = null;
     formData.comment = '';
     formData.problematic = false;

--- a/app/src/views/review/Review.modalOwnership.spec.ts
+++ b/app/src/views/review/Review.modalOwnership.spec.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from 'vitest';
+import Review from './Review.vue';
+
+interface ModalItem {
+  entity_id: number;
+  review_id: number;
+  status_id: number;
+  re_review_review_saved: number;
+  re_review_status_saved: number;
+}
+
+interface ModalContext {
+  modalLoadGeneration: number;
+  reviewModals: {
+    setReviewTarget: (item: ModalItem) => void;
+    setStatusTarget: (item: ModalItem) => void;
+  };
+  reviewData: {
+    getEntity: (entityId: number) => Promise<void>;
+    loadReviewInfo: (reviewId: number, saved: number) => Promise<void>;
+  };
+  reviewForm: {
+    clearDraft: () => void;
+    loadReviewData: (reviewId: number, saved: number) => Promise<void>;
+  };
+  statusForm: {
+    clearDraft: () => void;
+    loadStatusData: (statusId: number, saved: number) => Promise<void>;
+  };
+  $refs: { reviewModalRef: { show: () => void }; statusModalRef: { show: () => void } };
+}
+
+interface ReviewMethods {
+  infoReview: (this: ModalContext, item: ModalItem) => Promise<void>;
+  infoStatus: (this: ModalContext, item: ModalItem) => Promise<void>;
+}
+
+const methods = (Review as unknown as { methods: ReviewMethods }).methods;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function item(entityId: number): ModalItem {
+  return {
+    entity_id: entityId,
+    review_id: entityId + 100,
+    status_id: entityId + 200,
+    re_review_review_saved: 0,
+    re_review_status_saved: 0,
+  };
+}
+
+function context(getEntity: ModalContext['reviewData']['getEntity']): ModalContext {
+  return {
+    modalLoadGeneration: 0,
+    reviewModals: { setReviewTarget: vi.fn(), setStatusTarget: vi.fn() },
+    reviewData: { getEntity, loadReviewInfo: vi.fn().mockResolvedValue(undefined) },
+    reviewForm: { clearDraft: vi.fn(), loadReviewData: vi.fn().mockResolvedValue(undefined) },
+    statusForm: { clearDraft: vi.fn(), loadStatusData: vi.fn().mockResolvedValue(undefined) },
+    $refs: {
+      reviewModalRef: { show: vi.fn() },
+      statusModalRef: { show: vi.fn() },
+    },
+  };
+}
+
+describe('Review.vue modal request ownership', () => {
+  it('rapid A→B review opens do not load A data into B modal', async () => {
+    const first = deferred<void>();
+    const vm = context(vi.fn().mockReturnValueOnce(first.promise).mockResolvedValueOnce(undefined));
+
+    const openA = methods.infoReview.call(vm, item(1));
+    const openB = methods.infoReview.call(vm, item(2));
+    await openB;
+    first.resolve();
+    await openA;
+
+    expect(vm.reviewForm.loadReviewData).toHaveBeenCalledOnce();
+    expect(vm.reviewForm.loadReviewData).toHaveBeenCalledWith(102, 0);
+    expect(vm.$refs.reviewModalRef.show).toHaveBeenCalledOnce();
+  });
+
+  it('rapid A→B status opens do not load A data into B modal', async () => {
+    const first = deferred<void>();
+    const vm = context(vi.fn().mockReturnValueOnce(first.promise).mockResolvedValueOnce(undefined));
+
+    const openA = methods.infoStatus.call(vm, item(1));
+    const openB = methods.infoStatus.call(vm, item(2));
+    await openB;
+    first.resolve();
+    await openA;
+
+    expect(vm.statusForm.loadStatusData).toHaveBeenCalledOnce();
+    expect(vm.statusForm.loadStatusData).toHaveBeenCalledWith(202, 0);
+    expect(vm.$refs.statusModalRef.show).toHaveBeenCalledOnce();
+  });
+
+  it('allows form loaders to own A→B review data after both child loads start', async () => {
+    const firstLoad = deferred<void>();
+    const secondLoad = deferred<void>();
+    const vm = context(vi.fn().mockResolvedValue(undefined));
+    vm.reviewForm.loadReviewData = vi
+      .fn()
+      .mockReturnValueOnce(firstLoad.promise)
+      .mockReturnValueOnce(secondLoad.promise);
+
+    const openA = methods.infoReview.call(vm, item(1));
+    await Promise.resolve();
+    const openB = methods.infoReview.call(vm, item(2));
+    await Promise.resolve();
+    expect(vm.reviewForm.loadReviewData).toHaveBeenCalledTimes(2);
+
+    secondLoad.resolve();
+    await openB;
+    firstLoad.resolve();
+    await openA;
+
+    expect(vm.reviewData.loadReviewInfo).toHaveBeenCalledTimes(1);
+    expect(vm.reviewData.loadReviewInfo).toHaveBeenCalledWith(102, 0);
+    expect(vm.$refs.reviewModalRef.show).toHaveBeenCalledOnce();
+  });
+
+  it('allows form loaders to own A→B status data after both child loads start', async () => {
+    const firstLoad = deferred<void>();
+    const secondLoad = deferred<void>();
+    const vm = context(vi.fn().mockResolvedValue(undefined));
+    vm.statusForm.loadStatusData = vi
+      .fn()
+      .mockReturnValueOnce(firstLoad.promise)
+      .mockReturnValueOnce(secondLoad.promise);
+
+    const openA = methods.infoStatus.call(vm, item(1));
+    await Promise.resolve();
+    const openB = methods.infoStatus.call(vm, item(2));
+    await Promise.resolve();
+    expect(vm.statusForm.loadStatusData).toHaveBeenCalledTimes(2);
+
+    secondLoad.resolve();
+    await openB;
+    firstLoad.resolve();
+    await openA;
+
+    expect(vm.$refs.statusModalRef.show).toHaveBeenCalledOnce();
+  });
+});

--- a/app/src/views/review/Review.vue
+++ b/app/src/views/review/Review.vue
@@ -266,6 +266,7 @@ export default {
     const curation_selected = ref(false);
     const curator_mode = ref(0);
     const user = ref({ ...EMPTY_USER });
+    const modalLoadGeneration = ref(0);
 
     // Re-fetch the table when the curator-mode toggle flips. This watch
     // intentionally lives in `setup()` (not `watch:`) so it composes
@@ -361,6 +362,7 @@ export default {
       curation_selected,
       curator_mode,
       user,
+      modalLoadGeneration,
 
       // Static config
       fields: TABLE_FIELDS,
@@ -387,25 +389,32 @@ export default {
     // ---- Modal triggers (template @click handlers) -------------------------
 
     async infoReview(item) {
+      const generation = ++this.modalLoadGeneration;
       this.reviewModals.setReviewTarget(item);
       await this.reviewData.getEntity(item.entity_id);
+      if (generation !== this.modalLoadGeneration) return;
 
       // Clear any existing draft and load fresh data from server
       this.reviewForm.clearDraft();
       await this.reviewForm.loadReviewData(item.review_id, item.re_review_review_saved);
+      if (generation !== this.modalLoadGeneration) return;
 
       // Load review metadata for the modal footer display
       await this.reviewData.loadReviewInfo(item.review_id, item.re_review_review_saved);
+      if (generation !== this.modalLoadGeneration) return;
 
       this.$refs.reviewModalRef?.show();
     },
     async infoStatus(item) {
+      const generation = ++this.modalLoadGeneration;
       this.reviewModals.setStatusTarget(item);
       await this.reviewData.getEntity(item.entity_id);
+      if (generation !== this.modalLoadGeneration) return;
 
       // Clear any existing draft and load fresh data from server
       this.statusForm.clearDraft();
       await this.statusForm.loadStatusData(item.status_id, item.re_review_status_saved);
+      if (generation !== this.modalLoadGeneration) return;
 
       this.$refs.statusModalRef?.show();
     },

--- a/app/src/views/review/composables/__tests__/useReviewData.ownership.spec.ts
+++ b/app/src/views/review/composables/__tests__/useReviewData.ownership.spec.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TreeNode } from '@/api/list';
+
+const {
+  getReReviewTableMock,
+  getReviewByIdMock,
+  getStatusByIdMock,
+  listEntitiesMock,
+  listPhenotypesTreeMock,
+  listStatusCategoriesTreeMock,
+  listVariationOntologyTreeMock,
+} = vi.hoisted(() => ({
+  getReReviewTableMock: vi.fn(),
+  getReviewByIdMock: vi.fn(),
+  getStatusByIdMock: vi.fn(),
+  listEntitiesMock: vi.fn(),
+  listPhenotypesTreeMock: vi.fn(),
+  listStatusCategoriesTreeMock: vi.fn(),
+  listVariationOntologyTreeMock: vi.fn(),
+}));
+
+vi.mock('@/api/entity', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/entity')>();
+  return { ...actual, listEntities: listEntitiesMock };
+});
+
+vi.mock('@/api/list', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/list')>();
+  return {
+    ...actual,
+    listPhenotypesTree: listPhenotypesTreeMock,
+    listStatusCategoriesTree: listStatusCategoriesTreeMock,
+    listVariationOntologyTree: listVariationOntologyTreeMock,
+  };
+});
+
+vi.mock('@/api/re_review', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/re_review')>();
+  return { ...actual, getReReviewTable: getReReviewTableMock };
+});
+
+vi.mock('@/api/review', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/review')>();
+  return { ...actual, getReviewById: getReviewByIdMock };
+});
+
+vi.mock('@/api/status', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/status')>();
+  return { ...actual, getStatusById: getStatusByIdMock };
+});
+
+import { useReviewData } from '../useReviewData';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+const modifierTree = (id: string, label: string): TreeNode[] => [
+  { id, label: `present: ${label}`, children: [] },
+];
+
+describe('useReviewData request ownership', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps all three concurrently loaded option lists under independent owners', async () => {
+    const phenotypes = deferred<TreeNode[]>();
+    const variation = deferred<TreeNode[]>();
+    const statuses = deferred<TreeNode[]>();
+    listPhenotypesTreeMock.mockReturnValue(phenotypes.promise);
+    listVariationOntologyTreeMock.mockReturnValue(variation.promise);
+    listStatusCategoriesTreeMock.mockReturnValue(statuses.promise);
+    const data = useReviewData();
+
+    const phenotypeRequest = data.loadPhenotypesList();
+    const variationRequest = data.loadVariationOntologyList();
+    const statusRequest = data.loadStatusList();
+    variation.resolve(modifierTree('1-VARIO:1', 'Variation'));
+    statuses.resolve([{ id: 'status', label: 'Status' }]);
+    phenotypes.resolve(modifierTree('1-HP:1', 'Phenotype'));
+    await Promise.all([phenotypeRequest, variationRequest, statusRequest]);
+
+    expect(data.phenotypes_options.value[0].label).toBe('Phenotype');
+    expect(data.variation_ontology_options.value[0].label).toBe('Variation');
+    expect(data.status_options.value).toEqual([{ id: 'status', label: 'Status' }]);
+    const phenotypeSignal = listPhenotypesTreeMock.mock.calls[0][0]?.signal;
+    const variationSignal = listVariationOntologyTreeMock.mock.calls[0][0]?.signal;
+    const statusSignal = listStatusCategoriesTreeMock.mock.calls[0][0]?.signal;
+    expect(phenotypeSignal).toBeInstanceOf(AbortSignal);
+    expect(phenotypeSignal).not.toBe(variationSignal);
+    expect(variationSignal).not.toBe(statusSignal);
+  });
+
+  it('reset invalidates entity, review, and status context requests and clears the status spinner', async () => {
+    const entity = deferred<{ data: Array<{ entity_id: number; symbol: string }> }>();
+    const review = deferred<Array<Record<string, unknown>>>();
+    const status = deferred<Array<Record<string, unknown>>>();
+    listEntitiesMock.mockReturnValue(entity.promise);
+    getReviewByIdMock.mockReturnValue(review.promise);
+    getStatusByIdMock.mockReturnValue(status.promise);
+    const data = useReviewData();
+
+    const entityRequest = data.getEntity(1);
+    const reviewRequest = data.loadReviewInfo(2, 1);
+    const statusRequest = data.loadStatusInfo(3, 1);
+    expect(data.loading_status_modal.value).toBe(true);
+    data.resetEntityContext();
+
+    entity.resolve({ data: [{ entity_id: 1, symbol: 'stale' }] });
+    review.resolve([{ review_id: 2, entity_id: 1, review_user_name: 'stale' }]);
+    status.resolve([{ status_id: 3, entity_id: 1, category_id: 7, comment: 'stale', problematic: 0 }]);
+    await Promise.all([entityRequest, reviewRequest, statusRequest]);
+
+    expect(data.entity_info.symbol).toBe('');
+    expect(data.review_info.review_id).toBeNull();
+    expect(data.status_info.status_id).toBeNull();
+    expect(data.loading_status_modal.value).toBe(false);
+  });
+
+  it('clears the spinner for a current status error while stale status errors do nothing', async () => {
+    const currentError = deferred<unknown>();
+    const stale = deferred<unknown>();
+    const current = deferred<Array<Record<string, unknown>>>();
+    getStatusByIdMock
+      .mockReturnValueOnce(currentError.promise)
+      .mockReturnValueOnce(stale.promise)
+      .mockReturnValueOnce(current.promise);
+    const errors: unknown[] = [];
+    const data = useReviewData({ onError: (error) => errors.push(error) });
+
+    const failedCurrentRequest = data.loadStatusInfo(1, 1);
+    currentError.reject(new Error('current error'));
+    await failedCurrentRequest;
+    expect(data.loading_status_modal.value).toBe(false);
+    expect(errors).toHaveLength(1);
+
+    const staleRequest = data.loadStatusInfo(2, 2);
+    const currentRequest = data.loadStatusInfo(3, 3);
+    stale.reject(new Error('stale error'));
+    await staleRequest;
+    expect(data.loading_status_modal.value).toBe(true);
+    expect(errors).toHaveLength(1);
+
+    current.resolve([{ status_id: 3, entity_id: 1, category_id: 7, comment: '', problematic: 0 }]);
+    await currentRequest;
+    expect(data.loading_status_modal.value).toBe(false);
+    expect(data.status_info.status_id).toBe(3);
+  });
+
+  it('removes old optional status metadata when the entity context resets', () => {
+    const data = useReviewData();
+    Object.assign(data.status_info, {
+      status_id: 7,
+      entity_id: 8,
+      status_user_name: 'stale user',
+      status_user_role: 'Reviewer',
+      status_date: '2026-07-13',
+      re_review_status_saved: 1,
+    });
+
+    data.resetEntityContext();
+
+    expect(data.status_info.status_id).toBeNull();
+    expect(data.status_info.entity_id).toBeNull();
+    expect(data.status_info.status_user_name).toBeNull();
+    expect(data.status_info.status_user_role).toBeNull();
+    expect(data.status_info.status_date).toBeNull();
+    expect(data.status_info.re_review_status_saved).toBeNull();
+  });
+});

--- a/app/src/views/review/composables/useReviewData.ts
+++ b/app/src/views/review/composables/useReviewData.ts
@@ -125,6 +125,42 @@ interface RawTreeNode {
   children?: Array<{ id: string | number; label: string }>;
 }
 
+interface RequestOwner {
+  generation: number;
+  controller: AbortController | null;
+}
+
+interface ActiveRequest {
+  signal: AbortSignal;
+  isCurrent: () => boolean;
+}
+
+function beginRequest(owner: RequestOwner): ActiveRequest {
+  owner.generation += 1;
+  owner.controller?.abort();
+  const controller = new AbortController();
+  const generation = owner.generation;
+  owner.controller = controller;
+  return {
+    signal: controller.signal,
+    isCurrent: () => owner.generation === generation && owner.controller === controller,
+  };
+}
+
+function cancelRequest(owner: RequestOwner): void {
+  owner.generation += 1;
+  owner.controller?.abort();
+  owner.controller = null;
+}
+
+function finishRequest(owner: RequestOwner, request: ActiveRequest): void {
+  if (request.isCurrent()) owner.controller = null;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
+
 /**
  * The phenotype + variation_ontology APIs return a tree where the root
  * label is `present: <name>` and the children are modifiers. The view
@@ -185,6 +221,13 @@ export function useReviewData(options: UseReviewDataOptions = {}): UseReviewData
   });
   const status_info = reactive(new Status()) as UseReviewData['status_info'];
   const loading_status_modal = ref(true);
+  const reReviewRequest: RequestOwner = { generation: 0, controller: null };
+  const phenotypesRequest: RequestOwner = { generation: 0, controller: null };
+  const variationRequest: RequestOwner = { generation: 0, controller: null };
+  const statusListRequest: RequestOwner = { generation: 0, controller: null };
+  const entityRequest: RequestOwner = { generation: 0, controller: null };
+  const reviewRequest: RequestOwner = { generation: 0, controller: null };
+  const statusRequest: RequestOwner = { generation: 0, controller: null };
 
   function reportError(err: unknown): void {
     if (onError) {
@@ -193,9 +236,11 @@ export function useReviewData(options: UseReviewDataOptions = {}): UseReviewData
   }
 
   async function loadReReviewData(curate: boolean): Promise<void> {
+    const request = beginRequest(reReviewRequest);
     isBusy.value = true;
     try {
-      const payload = await getReReviewTable({ curate });
+      const payload = await getReReviewTable({ curate }, { signal: request.signal });
+      if (!request.isCurrent()) return;
       // R serialises the table as `{ data, meta }`; legacy stubs may surface
       // a bare array — accept either.
       const rows = Array.isArray(payload)
@@ -204,51 +249,77 @@ export function useReviewData(options: UseReviewDataOptions = {}): UseReviewData
       items.value = rows;
       totalRows.value = rows.length;
     } catch (err) {
+      if (!request.isCurrent() || isAbortError(err)) return;
       reportError(err);
+    } finally {
+      if (request.isCurrent()) {
+        isBusy.value = false;
+        loading.value = false;
+        finishRequest(reReviewRequest, request);
+      }
     }
-    isBusy.value = false;
-    loading.value = false;
   }
 
   async function loadPhenotypesList(): Promise<void> {
+    const request = beginRequest(phenotypesRequest);
     try {
-      const payload = await listPhenotypesTree();
+      const payload = await listPhenotypesTree({ signal: request.signal });
+      if (!request.isCurrent()) return;
       phenotypes_options.value = transformModifierTree(payload);
     } catch (err) {
+      if (!request.isCurrent() || isAbortError(err)) return;
       reportError(err);
       phenotypes_options.value = [];
+    } finally {
+      finishRequest(phenotypesRequest, request);
     }
   }
 
   async function loadVariationOntologyList(): Promise<void> {
+    const request = beginRequest(variationRequest);
     try {
-      const payload = await listVariationOntologyTree();
+      const payload = await listVariationOntologyTree({ signal: request.signal });
+      if (!request.isCurrent()) return;
       variation_ontology_options.value = transformModifierTree(payload);
     } catch (err) {
+      if (!request.isCurrent() || isAbortError(err)) return;
       reportError(err);
       variation_ontology_options.value = [];
+    } finally {
+      finishRequest(variationRequest, request);
     }
   }
 
   async function loadStatusList(): Promise<void> {
+    const request = beginRequest(statusListRequest);
     try {
-      status_options.value = await listStatusCategoriesTree();
+      const payload = await listStatusCategoriesTree({ signal: request.signal });
+      if (!request.isCurrent()) return;
+      status_options.value = payload;
     } catch (err) {
+      if (!request.isCurrent() || isAbortError(err)) return;
       reportError(err);
+    } finally {
+      finishRequest(statusListRequest, request);
     }
   }
 
   async function getEntity(entity_input: number | string): Promise<void> {
+    const request = beginRequest(entityRequest);
     try {
       const payload = await listEntities({
         filter: `equals(entity_id,${entity_input})`,
-      });
+      }, { signal: request.signal });
+      if (!request.isCurrent()) return;
       const [first] = payload.data as Array<Partial<ReviewEntityInfo>>;
       if (first) {
         Object.assign(entity_info, EMPTY_ENTITY_INFO, first);
       }
     } catch (err) {
+      if (!request.isCurrent() || isAbortError(err)) return;
       reportError(err);
+    } finally {
+      finishRequest(entityRequest, request);
     }
   }
 
@@ -256,8 +327,10 @@ export function useReviewData(options: UseReviewDataOptions = {}): UseReviewData
     review_id: number | string,
     re_review_review_saved: number
   ): Promise<void> {
+    const request = beginRequest(reviewRequest);
     try {
-      const rows = await getReviewById(review_id);
+      const rows = await getReviewById(review_id, { signal: request.signal });
+      if (!request.isCurrent()) return;
       if (rows && rows.length > 0) {
         const row = rows[0];
         review_info.review_id = row.review_id;
@@ -268,7 +341,10 @@ export function useReviewData(options: UseReviewDataOptions = {}): UseReviewData
         review_info.re_review_review_saved = re_review_review_saved;
       }
     } catch (err) {
+      if (!request.isCurrent() || isAbortError(err)) return;
       reportError(err);
+    } finally {
+      finishRequest(reviewRequest, request);
     }
   }
 
@@ -276,9 +352,11 @@ export function useReviewData(options: UseReviewDataOptions = {}): UseReviewData
     status_id: number | string,
     re_review_status_saved: number
   ): Promise<void> {
+    const request = beginRequest(statusRequest);
     loading_status_modal.value = true;
     try {
-      const rows = await getStatusById(status_id);
+      const rows = await getStatusById(status_id, { signal: request.signal });
+      if (!request.isCurrent()) return;
       if (rows && rows.length > 0) {
         const row = rows[0];
         // Replace the reactive backing object's keys (we cannot reassign
@@ -292,13 +370,22 @@ export function useReviewData(options: UseReviewDataOptions = {}): UseReviewData
         status_info.status_date = row.status_date;
         status_info.re_review_status_saved = re_review_status_saved;
       }
-      loading_status_modal.value = false;
     } catch (err) {
+      if (!request.isCurrent() || isAbortError(err)) return;
       reportError(err);
+    } finally {
+      if (request.isCurrent()) {
+        loading_status_modal.value = false;
+        finishRequest(statusRequest, request);
+      }
     }
   }
 
   function resetEntityContext(): void {
+    cancelRequest(entityRequest);
+    cancelRequest(reviewRequest);
+    cancelRequest(statusRequest);
+    loading_status_modal.value = false;
     Object.assign(entity_info, EMPTY_ENTITY_INFO);
     Object.assign(review_info, new Review() as ReviewInfo, {
       review_id: null,
@@ -307,6 +394,14 @@ export function useReviewData(options: UseReviewDataOptions = {}): UseReviewData
       review_user_role: null,
       review_date: null,
       re_review_review_saved: null,
+    });
+    Object.assign(status_info, new Status(), {
+      status_id: null,
+      entity_id: null,
+      status_user_name: null,
+      status_user_role: null,
+      status_date: null,
+      re_review_status_saved: null,
     });
   }
 


### PR DESCRIPTION
## Summary

Implements #553 S5c request ownership across shared user/table transports, curation/review forms, PubTator, trends, and network visualization. Stale responses, aborts, unmount callbacks, and A-B-A paths are generation-owned; all frontend API access remains through typed clients.

## Verification

- `make code-quality-audit`
- `make lint-app`
- `cd app && npm run type-check:strict`
- `cd app && npx vue-tsc --noEmit --incremental false --pretty false`
- `cd app && npm run test:unit` (273 files, 2025 passed, 2 todo)
- Final xhigh Codex diff review: no BLOCKER/HIGH remaining (4 rounds)

Closes #553

Refs #535