### PR TITLE
chore(release): v0.30.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.30.8] — 2026-07-20
+
 Close the remaining #344 structural gap (slow external endpoints head-of-line-blocking cheap routes) with a dedicated synchronous **enrichment lane** bulkhead. PR #386/#413 shipped the per-request budgets, ceiling, guards, and observability but deferred true cross-request isolation to #154, which has since been closed — so this adds the process partitioning directly.
 
 ### Added

--- a/api/version_spec.json
+++ b/api/version_spec.json
@@ -1,7 +1,7 @@
 {
   "title": "SysNDD API",
   "description": "This is the API powering the SysNDD website, allowing programmatic access to the database contents.",
-  "version": "0.30.7",
+  "version": "0.30.8",
   "contact": {
     "name": "API Support",
     "url": "https://berntpopp.github.io/sysndd/api.html",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysndd",
-  "version": "0.30.7",
+  "version": "0.30.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysndd",
-      "version": "0.30.7",
+      "version": "0.30.8",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@unhead/vue": "^3.1.8",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.30.7",
+  "version": "0.30.8",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Release bump to **v0.30.8** for the #344 enrichment-lane bulkhead (merged in #592).

Bumps the four version surfaces (app/package.json, app/package-lock.json ×2, api/version_spec.json) and moves the CHANGELOG `[Unreleased]` entry under `## [0.30.8] — 2026-07-20`.

No code change.

https://claude.ai/code/session_01PSaKFPRRwSaberhBGWk5Wb