### PR TITLE
chore(release): v0.30.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.30.9] — 2026-07-23
+
+Consolidated dependency maintenance: merged the five open Dependabot bumps into one change and resolved the open Dependabot security alerts, with the frontend lockfile fully regenerated (`npm install` + `npm audit fix`) so it installs cleanly under `npm ci --legacy-peer-deps`. See #596.
+
+### Changed
+
+- **Docker images:** `axllent/mailpit` v1.30.4 → v1.30.5 (dev + Playwright compose); `fholzer/nginx-brotli` v1.31.2 → v1.31.3 (`app/Dockerfile`).
+- **Frontend production dependencies:** `pinia` ^3.0.4 → ^4.0.2 (major — "technically breaking" only: ESM-only and `@vue/devtools-api` moved to a peer dependency, added as a devDependency per the migration note; the app is `type: module` and only standard pinia APIs are used); `@unhead/vue` ^3.2.1; `swagger-ui`/`swagger-ui-dist` ^5.32.9; `vue` ^3.5.40; `vue-router` ^5.2.0.
+- **Frontend dev dependencies:** `@vitejs/plugin-vue` ^6.0.8; `@vue/compiler-sfc` ^3.5.40; `eslint-plugin-vue` ^10.10.0; `lint-staged` ^17.1.0; `postcss` ^8.5.20.
+
+### Security
+
+- Resolved all open Dependabot security alerts; `npm audit` now reports **0 vulnerabilities**. Patched `brace-expansion` (GHSA-3jxr-9vmj-r5cp, HIGH) and `body-parser` (GHSA-v422-hmwv-36x6), plus the pre-existing HIGH advisories in `fast-uri`, `immutable`, and `svgo`. All fixes are semver-compatible (no forced major upgrades).
+
 ## [0.30.8] — 2026-07-20
 
 Close the remaining #344 structural gap (slow external endpoints head-of-line-blocking cheap routes) with a dedicated synchronous **enrichment lane** bulkhead. PR #386/#413 shipped the per-request budgets, ceiling, guards, and observability but deferred true cross-request isolation to #154, which has since been closed — so this adds the process partitioning directly.

--- a/api/version_spec.json
+++ b/api/version_spec.json
@@ -1,7 +1,7 @@
 {
   "title": "SysNDD API",
   "description": "This is the API powering the SysNDD website, allowing programmatic access to the database contents.",
-  "version": "0.30.8",
+  "version": "0.30.9",
   "contact": {
     "name": "API Support",
     "url": "https://berntpopp.github.io/sysndd/api.html",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysndd",
-  "version": "0.30.8",
+  "version": "0.30.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysndd",
-      "version": "0.30.8",
+      "version": "0.30.9",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@unhead/vue": "^3.2.1",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.30.8",
+  "version": "0.30.9",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Release bump to **v0.30.9** for the consolidated dependency maintenance merged in #596.

Bumps the four version surfaces (`app/package.json`, `app/package-lock.json` ×2 root fields, `api/version_spec.json`) and adds the `0.30.9` CHANGELOG entry.

## What shipped in this version (#596)
- **Docker:** `axllent/mailpit` v1.30.5, `fholzer/nginx-brotli` v1.31.3
- **Frontend:** `pinia` 4.0.2 (ESM-only + `@vue/devtools-api` peer, added as a devDep), `@unhead/vue`, `swagger-ui`/`swagger-ui-dist`, `vue` 3.5.40, `vue-router` 5.2.0, plus the dev toolchain
- **Security:** all open Dependabot alerts resolved — `npm audit` now reports **0 vulnerabilities** (brace-expansion, body-parser, fast-uri, immutable, svgo)

`npm ci --legacy-peer-deps` confirmed in sync at 0.30.9.

https://claude.ai/code/session_018qxsFcPNbFYfoeWmsaGaGB