### PR TITLE
chore(release): v0.30.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.30.14] — 2026-07-30
+
 ### Security
 
 - **`brace-expansion` is pinned to the patched release of every major line in

--- a/api/version_spec.json
+++ b/api/version_spec.json
@@ -1,7 +1,7 @@
 {
   "title": "SysNDD API",
   "description": "This is the API powering the SysNDD website, allowing programmatic access to the database contents.",
-  "version": "0.30.13",
+  "version": "0.30.14",
   "contact": {
     "name": "API Support",
     "url": "https://berntpopp.github.io/sysndd/api.html",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sysndd",
-  "version": "0.30.13",
+  "version": "0.30.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sysndd",
-      "version": "0.30.13",
+      "version": "0.30.14",
       "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@unhead/vue": "^3.2.1",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sysndd",
-  "version": "0.30.13",
+  "version": "0.30.14",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Releases the consolidated dependabot bumps and the `brace-expansion` CVE remediation merged in #609.

Follows the repo release convention (cf. #596 → #597): the dependency work lands first, the version bump follows as its own PR.

## Version surfaces

All four bumped `0.30.13` → `0.30.14`:

- `app/package.json`
- `app/package-lock.json` — **both** root `version` fields (top-level and `packages[""]`)
- `api/version_spec.json`
- `CHANGELOG.md` — `[Unreleased]` promoted to `[0.30.14] — 2026-07-30`

## Contents of this release

**Security** — `brace-expansion` pinned to the patched build of every major line in the frontend tree (CVE-2026-14257 / GHSA-mh99-v99m-4gvg, high; alert #223). Per-major `overrides` land `1.1.18` / `2.1.4` / `5.0.9`, all carrying the upstream `EXPANSION_MAX_LENGTH` guard. A blanket `5.x` bump is deliberately avoided — its CommonJS entry exports a namespace object rather than a callable, breaking every `minimatch` 3/5/9 consumer.

**Changed** — frontend dev deps (`@playwright/test`, `@vue/devtools-api`, `eslint`, `globals`, `postcss`, `prettier`, `sass`, `typescript-eslint`, `vue-tsc`), `jsdom` → `30.x`, and compose images `mysql` `8.4.11` / `axllent/mailpit` `v1.30.6`.

## Verification

`npm ci --legacy-peer-deps --prefer-offline` and `make code-quality-audit` both clean. No source changes here beyond version metadata — the functional gates ran on #609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7njywYE4bCjoJ6YedziVQ