### PR TITLE
feat(db): add normalized origin_review_id to variation_ontology_evidence (#608)

### DIFF
--- a/api/functions/migration-manifest.R
+++ b/api/functions/migration-manifest.R
@@ -2,8 +2,8 @@
 #
 # Strict migration manifest validation for startup/readiness.
 
-EXPECTED_LATEST_MIGRATION <- "048_widen_publication_author_columns.sql"
-EXPECTED_MIGRATION_COUNT <- 46L
+EXPECTED_LATEST_MIGRATION <- "049_add_evidence_origin_review.sql"
+EXPECTED_MIGRATION_COUNT <- 47L
 
 #' Validate the migration manifest for strict startup/readiness checks
 #'

--- a/api/tests/testthat/test-mcp-select-principal-projections.R
+++ b/api/tests/testthat/test-mcp-select-principal-projections.R
@@ -177,6 +177,6 @@ test_that("source version formula and derived-content allowlists are frozen", {
 })
 
 test_that("manifest advances contiguously to the latest migration", {
-  expect_identical(EXPECTED_LATEST_MIGRATION, "048_widen_publication_author_columns.sql")
-  expect_identical(EXPECTED_MIGRATION_COUNT, 46L)
+  expect_identical(EXPECTED_LATEST_MIGRATION, "049_add_evidence_origin_review.sql")
+  expect_identical(EXPECTED_MIGRATION_COUNT, 47L)
 })

--- a/api/tests/testthat/test-unit-analysis-snapshot-migration.R
+++ b/api/tests/testthat/test-unit-analysis-snapshot-migration.R
@@ -6,8 +6,8 @@ withr::defer(setwd(analysis_snapshot_test_wd), testthat::teardown_env())
 test_that("migration manifest tracks the latest migration", {
   source(file.path("functions", "migration-manifest.R"), local = TRUE)
 
-  expect_equal(EXPECTED_LATEST_MIGRATION, "048_widen_publication_author_columns.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 46L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "049_add_evidence_origin_review.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 47L)
 })
 
 test_that("migration 046 adds the additive generator_json manifest column", {

--- a/api/tests/testthat/test-unit-core-views-manifest.R
+++ b/api/tests/testthat/test-unit-core-views-manifest.R
@@ -11,15 +11,15 @@ source(file.path(migration_test_api_dir, "functions", "migration-manifest.R"), l
 source(file.path(migration_test_api_dir, "functions", "migration-runner.R"), local = FALSE)
 
 test_that("manifest expects the latest migration", {
-  expect_equal(EXPECTED_LATEST_MIGRATION, "048_widen_publication_author_columns.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 46L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "049_add_evidence_origin_review.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 47L)
 })
 
 test_that("migration manifest validates against db/migrations", {
   migrations_dir <- file.path(migration_test_api_dir, "..", "db", "migrations")
   res <- validate_migration_manifest(migrations_dir = migrations_dir)
   expect_true(res$ok)
-  expect_identical(res$latest, "048_widen_publication_author_columns.sql")
+  expect_identical(res$latest, "049_add_evidence_origin_review.sql")
 })
 
 test_that("migration 036 file exists and contains disease_ontology_mapping table", {

--- a/api/tests/testthat/test-unit-evidence-origin-review.R
+++ b/api/tests/testthat/test-unit-evidence-origin-review.R
@@ -1,0 +1,113 @@
+# Static guard for migration 049_add_evidence_origin_review.sql (#608).
+#
+# origin_review_id is what separates an imported variation-ontology term still
+# sitting on the review the February 2026 import wrote to ("unchanged") from one
+# carried into a later curator review ("moved" -- the term now wears a curator's
+# name and a recent review date while resting on unchanged machine evidence).
+# Detecting that laundering is the reason the provenance system exists, so the
+# properties below are not schema niceties:
+#
+#   * It must be a COLUMN, not a key inside evidence_json. The hot read path
+#     deliberately does not select evidence_json, so a JSON key is reachable only
+#     one assertion at a time from the detail endpoint -- useless for "which
+#     imported terms have moved".
+#   * It must stay NULLABLE. Only import-derived evidence has an origin review;
+#     NOT NULL would force a sentinel, which is a fabricated provenance record.
+#   * It must NOT gain a foreign key to ndd_entity_review. The value is a
+#     historical audit fact that outlives the review row, and an FK would take a
+#     shared parent lock on ndd_entity_review for each of the ~8,083 backfill
+#     inserts -- direct contention against live curation.
+#
+# These assertions are deliberately about the migration's TEXT, not a live
+# database: they are the things a future "simplification" would quietly remove,
+# and they must hold in any environment (no DB required).
+#
+# Pure test (no DB / no network) -- runs on host:
+#   cd api && Rscript --no-init-file -e \
+#     "testthat::test_file('tests/testthat/test-unit-evidence-origin-review.R')"
+
+library(testthat)
+
+# Sourced explicitly (mirroring test-unit-core-views-manifest.R) so the manifest
+# assertion at the bottom of this file works when the file is run in isolation.
+origin_review_test_api_dir <- Sys.getenv("MCP_API_TEST_ROOT", get_api_dir())
+source(file.path(origin_review_test_api_dir, "functions", "migration-manifest.R"), local = FALSE)
+
+MIGRATION_049 <- "049_add_evidence_origin_review.sql"
+
+.evidence_origin_review_migration_sql <- function() {
+  candidates <- c(
+    file.path(get_api_dir(), "..", "db", "migrations", MIGRATION_049),
+    file.path(get_api_dir(), "db", "migrations", MIGRATION_049)
+  )
+  path <- candidates[file.exists(candidates)][1]
+  if (is.na(path)) {
+    skip(paste("Migration not found:", MIGRATION_049))
+  }
+  paste(readLines(path, warn = FALSE), collapse = "\n")
+}
+
+# The negative assertions below must read the EXECUTABLE DDL, not the file's
+# prose. This migration's header explains at length why it does NOT create a
+# foreign key -- so a naive grep over the whole file finds "FOREIGN KEY" in the
+# comment that exists to justify its absence, and fails on the very text that
+# documents the correct behaviour.
+.evidence_origin_review_migration_ddl <- function() {
+  lines <- strsplit(.evidence_origin_review_migration_sql(), "\n", fixed = TRUE)[[1]]
+  paste(lines[!grepl("^\\s*--", lines)], collapse = "\n")
+}
+
+test_that("migration 049 adds origin_review_id as a nullable INT column", {
+  sql <- .evidence_origin_review_migration_sql()
+
+  expect_match(sql, "ADD COLUMN `origin_review_id` INT NULL", fixed = TRUE)
+  # NOT NULL would force a sentinel value for every non-import source.
+  expect_false(grepl("`origin_review_id` INT NOT NULL", sql, fixed = TRUE))
+})
+
+test_that("migration 049 indexes the column so the moved/unchanged split is a join", {
+  # Without the index the one query this column exists to serve is a full scan of
+  # every evidence row.
+  sql <- .evidence_origin_review_migration_sql()
+
+  expect_match(sql, "ADD KEY `idx_origin_review` (`origin_review_id`)", fixed = TRUE)
+})
+
+test_that("migration 049 does NOT create a foreign key to ndd_entity_review", {
+  ddl <- .evidence_origin_review_migration_ddl()
+
+  expect_false(grepl("FOREIGN KEY", ddl, fixed = TRUE))
+  expect_false(grepl("REFERENCES", ddl, fixed = TRUE))
+  expect_false(grepl("ndd_entity_review", ddl, fixed = TRUE))
+})
+
+test_that("migration 049 never touches the curated connect table", {
+  # The curated table is rewritten wholesale on every review save; provenance must
+  # never live there, and this migration must never write to it.
+  ddl <- .evidence_origin_review_migration_ddl()
+
+  expect_false(grepl("ndd_review_variation_ontology_connect", ddl, fixed = TRUE))
+  # Whole-file check too: not even a comment should suggest writing there.
+  expect_false(grepl(
+    "INSERT INTO `?ndd_review_variation_ontology_connect",
+    .evidence_origin_review_migration_sql()
+  ))
+})
+
+test_that("migration 049 is idempotent and skips a missing table instead of erroring", {
+  # MySQL 8 has no ADD COLUMN IF NOT EXISTS, so re-application safety has to come
+  # from information_schema guards. Both the column and the index are guarded, and
+  # an absent variation_ontology_evidence table (047 never applied) no-ops.
+  sql <- .evidence_origin_review_migration_sql()
+
+  expect_match(sql, "information_schema.COLUMNS", fixed = TRUE)
+  expect_match(sql, "information_schema.STATISTICS", fixed = TRUE)
+  expect_match(sql, "@vope_table_exists = 1 AND @origin_col_exists = 0", fixed = TRUE)
+  expect_match(sql, "@vope_table_exists = 1 AND @origin_idx_exists = 0", fixed = TRUE)
+  expect_match(sql, "'SELECT 1'", fixed = TRUE)
+})
+
+test_that("the migration manifest tracks 049 as the latest migration", {
+  expect_equal(EXPECTED_LATEST_MIGRATION, MIGRATION_049)
+  expect_equal(EXPECTED_MIGRATION_COUNT, 47L)
+})

--- a/api/tests/testthat/test-unit-variation-provenance-migration.R
+++ b/api/tests/testthat/test-unit-variation-provenance-migration.R
@@ -237,8 +237,8 @@ cleanup_variation_provenance_fk_targets <- function(conn, ids) {
 }
 
 test_that("migration manifest tracks the latest migration", {
-  expect_equal(EXPECTED_LATEST_MIGRATION, "048_widen_publication_author_columns.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 46L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "049_add_evidence_origin_review.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 47L)
 })
 
 test_that("migration 047 never mentions ndd_review_variation_ontology_connect", {

--- a/db/migrations/049_add_evidence_origin_review.sql
+++ b/db/migrations/049_add_evidence_origin_review.sql
@@ -1,0 +1,76 @@
+-- 049_add_evidence_origin_review.sql
+-- Additive: normalized `origin_review_id` on variation_ontology_evidence (issue #608).
+--
+-- WHY A COLUMN AND NOT A KEY INSIDE evidence_json:
+--   The February 2026 import batches recorded which review each annotation was
+--   written to. That fact is what separates an imported term still sitting on its
+--   original review ("unchanged") from one carried into a later curator review
+--   ("moved", i.e. laundered -- the term now wears a curator's name and a recent
+--   review date while resting on unchanged machine evidence). Distinguishing those
+--   is the whole point of the backfill, so it has to be queryable.
+--   evidence_json cannot serve that: the hot read path
+--   (api/functions/variation-provenance-repository.R) deliberately does NOT select
+--   evidence_json, so a JSON key is reachable only from the evidence-detail
+--   endpoint, one assertion at a time. A column makes
+--   "which imported terms have moved" a single indexed join.
+--
+-- WHY NULLABLE:
+--   Only import-derived evidence has an origin review. Curator suggestions and any
+--   future source have none, and pre-049 rows read NULL. NOT NULL would force a
+--   sentinel, which is a fabricated provenance record -- exactly what #608 exists
+--   to stop.
+--
+-- WHY NO FOREIGN KEY TO ndd_entity_review:
+--   Two independent reasons, both deliberate.
+--   1. This is a historical audit fact, not a live reference. "The import wrote to
+--      review N" stays true after review N is deleted or superseded. An FK would
+--      make the audit trail deletable-by-cascade or block the delete outright --
+--      both wrong for a provenance record.
+--   2. Lock amplification. The backfill inserts ~8,083 evidence rows; an FK takes a
+--      shared parent-row lock on ndd_entity_review for every one of them, held to
+--      commit. ndd_entity_review is written by every review save, so that is a
+--      direct contention path against live curation. See the backfill runbook's
+--      adversarial review, finding 3.
+--
+-- Idempotent + restore-drift safe: the information_schema guards mirror migrations
+-- 043 and 046. A rerun sees the column/index already present and no-ops; an absent
+-- variation_ontology_evidence table (i.e. 047 never applied) is skipped rather than
+-- erroring, matching the skip-not-error behaviour of migration 048.
+-- Note: MySQL 8 has no `ADD COLUMN IF NOT EXISTS` (that is MariaDB-only), which is
+-- why these are PREPARE/EXECUTE guards rather than inline IF NOT EXISTS clauses.
+
+SET @vope_table_exists := (
+  SELECT COUNT(*) FROM information_schema.TABLES
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'variation_ontology_evidence'
+);
+
+SET @origin_col_exists := (
+  SELECT COUNT(*) FROM information_schema.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'variation_ontology_evidence'
+    AND COLUMN_NAME = 'origin_review_id'
+);
+
+SET @ddl := IF(@vope_table_exists = 1 AND @origin_col_exists = 0,
+  'ALTER TABLE `variation_ontology_evidence` ADD COLUMN `origin_review_id` INT NULL AFTER `source_version`',
+  'SELECT 1');
+
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @origin_idx_exists := (
+  SELECT COUNT(*) FROM information_schema.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'variation_ontology_evidence'
+    AND INDEX_NAME = 'idx_origin_review'
+);
+
+SET @ddl2 := IF(@vope_table_exists = 1 AND @origin_idx_exists = 0,
+  'ALTER TABLE `variation_ontology_evidence` ADD KEY `idx_origin_review` (`origin_review_id`)',
+  'SELECT 1');
+
+PREPARE stmt2 FROM @ddl2;
+EXECUTE stmt2;
+DEALLOCATE PREPARE stmt2;


### PR DESCRIPTION
## What

Migration `049_add_evidence_origin_review.sql` — additive, nullable `origin_review_id INT` on `variation_ontology_evidence`, plus `idx_origin_review`.

## Why

`origin_review_id` records which review each February 2026 import batch wrote an annotation to. That is what separates an imported term still sitting on its original review (**unchanged**) from one carried into a later curator review (**moved**) — where the term now wears a curator's name and a recent review date while resting on unchanged machine evidence. Detecting that laundering is the reason #608 exists.

Measured against production on 2026-08-05: of 8,111 imported annotations, **7,988 unchanged, 95 moved, 28 no longer current**, across 38 diverged entities.

A key inside `evidence_json` cannot serve this. The hot read path (`variation-provenance-repository.R`) deliberately does not select `evidence_json`, so a JSON key is reachable only one assertion at a time from the detail route — useless for "which imported terms have moved". A column makes it a single indexed join.

## Deliberate choices

**Nullable.** Only import-derived evidence has an origin review. Curator suggestions have none, and pre-049 rows read NULL. `NOT NULL` would force a sentinel — a fabricated provenance record, which is precisely what #608 exists to stop.

**No foreign key to `ndd_entity_review`.** Two independent reasons:
1. This is a historical audit fact, not a live reference. "The import wrote to review N" stays true after review N is deleted or superseded; an FK would make the audit trail cascade-deletable or block the delete outright.
2. Lock amplification. The backfill inserts ~8,083 evidence rows; an FK takes a shared parent-row lock on `ndd_entity_review` for each one, held to commit. That table is written by every review save — direct contention against live curation.

**Schema only.** Every read in `variation-provenance-repository.R` selects columns explicitly, so the new column is inert to the existing API surface. Surfacing it on the evidence-detail route is separate work.

## Blast radius

- `EXPECTED_LATEST_MIGRATION` 048 → 049, `EXPECTED_MIGRATION_COUNT` 46 → 47
- Four test files that pin those constants, re-pinned
- New `test-unit-evidence-origin-review.R` — static guard on nullability, the index, the *absence* of an FK, and the information_schema idempotency guards

## Verification

```
test-unit-evidence-origin-review      FAIL 0 | PASS 15
test-unit-analysis-snapshot-migration FAIL 0 | PASS 30
test-unit-variation-provenance-migration FAIL 0 | PASS 3  (1 skip: no test DB)
test-unit-publication-author-columns  FAIL 0 | PASS 11
test-unit-core-views-manifest         skipped on host: {pool} not installed
scripts/check-migration-prefixes.sh   OK: all 47 migration files have unique prefixes
```

Production is currently at `applied 44` / `expected_latest 046`, so deploying this applies 047, 048 and 049 together.

Tracking: #608 · backfill runbook berntpopp/sysndd-administration#16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbd7MVQWEpKRBD1k6tM8aS
