### PR TITLE
fix(views,seo): require entity agreement in the variant view and SEO query

### DIFF
--- a/api/functions/migration-manifest.R
+++ b/api/functions/migration-manifest.R
@@ -2,8 +2,8 @@
 #
 # Strict migration manifest validation for startup/readiness.
 
-EXPECTED_LATEST_MIGRATION <- "049_add_evidence_origin_review.sql"
-EXPECTED_MIGRATION_COUNT <- 47L
+EXPECTED_LATEST_MIGRATION <- "050_variant_view_entity_agreement.sql"
+EXPECTED_MIGRATION_COUNT <- 48L
 
 #' Validate the migration manifest for strict startup/readiness checks
 #'

--- a/api/services/seo-service.R
+++ b/api/services/seo-service.R
@@ -228,11 +228,23 @@ entity_hpo_sql <- function() "
   ORDER BY pl.HPO_term
 "
 
+# `er.entity_id = vc.entity_id` mirrors svc_entity_variation(), which requires the
+# connect row's entity AND the review's entity to agree. Without it this query
+# surfaced 206 rows the entity page drops -- connect rows citing a review that
+# belongs to a DIFFERENT entity (admin#18, a stale-snapshot bug in the 2022 seed).
+# SEO structured data claiming a term the page itself does not show is exactly the
+# kind of divergence that erodes trust in the record.
+#
+# Deliberately NOT applied to entity_phenotypes_sql() or entity_pmids_sql() below:
+# svc_entity_phenotypes() and svc_entity_publications() filter on review_id alone,
+# so those queries already match their endpoints. Adding it there would hide 744
+# phenotype and 166 publication rows that are currently served.
 entity_variation_sql <- function() "
   SELECT DISTINCT vc.vario_id AS id, vl.vario_name AS label
   FROM ndd_review_variation_ontology_connect vc
   JOIN ndd_entity_review er
     ON vc.review_id = er.review_id
+    AND er.entity_id = vc.entity_id
     AND er.is_primary = 1 AND er.review_approved = 1
   JOIN variation_ontology_list vl ON vc.vario_id = vl.vario_id
   WHERE vc.entity_id = ? AND vc.is_active = 1

--- a/api/tests/testthat/test-mcp-select-principal-projections.R
+++ b/api/tests/testthat/test-mcp-select-principal-projections.R
@@ -177,6 +177,6 @@ test_that("source version formula and derived-content allowlists are frozen", {
 })
 
 test_that("manifest advances contiguously to the latest migration", {
-  expect_identical(EXPECTED_LATEST_MIGRATION, "049_add_evidence_origin_review.sql")
-  expect_identical(EXPECTED_MIGRATION_COUNT, 47L)
+  expect_identical(EXPECTED_LATEST_MIGRATION, "050_variant_view_entity_agreement.sql")
+  expect_identical(EXPECTED_MIGRATION_COUNT, 48L)
 })

--- a/api/tests/testthat/test-unit-analysis-snapshot-migration.R
+++ b/api/tests/testthat/test-unit-analysis-snapshot-migration.R
@@ -6,8 +6,8 @@ withr::defer(setwd(analysis_snapshot_test_wd), testthat::teardown_env())
 test_that("migration manifest tracks the latest migration", {
   source(file.path("functions", "migration-manifest.R"), local = TRUE)
 
-  expect_equal(EXPECTED_LATEST_MIGRATION, "049_add_evidence_origin_review.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 47L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "050_variant_view_entity_agreement.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 48L)
 })
 
 test_that("migration 046 adds the additive generator_json manifest column", {

--- a/api/tests/testthat/test-unit-core-views-manifest.R
+++ b/api/tests/testthat/test-unit-core-views-manifest.R
@@ -11,15 +11,15 @@ source(file.path(migration_test_api_dir, "functions", "migration-manifest.R"), l
 source(file.path(migration_test_api_dir, "functions", "migration-runner.R"), local = FALSE)
 
 test_that("manifest expects the latest migration", {
-  expect_equal(EXPECTED_LATEST_MIGRATION, "049_add_evidence_origin_review.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 47L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "050_variant_view_entity_agreement.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 48L)
 })
 
 test_that("migration manifest validates against db/migrations", {
   migrations_dir <- file.path(migration_test_api_dir, "..", "db", "migrations")
   res <- validate_migration_manifest(migrations_dir = migrations_dir)
   expect_true(res$ok)
-  expect_identical(res$latest, "049_add_evidence_origin_review.sql")
+  expect_identical(res$latest, "050_variant_view_entity_agreement.sql")
 })
 
 test_that("migration 036 file exists and contains disease_ontology_mapping table", {

--- a/api/tests/testthat/test-unit-evidence-origin-review.R
+++ b/api/tests/testthat/test-unit-evidence-origin-review.R
@@ -107,7 +107,15 @@ test_that("migration 049 is idempotent and skips a missing table instead of erro
   expect_match(sql, "'SELECT 1'", fixed = TRUE)
 })
 
-test_that("the migration manifest tracks 049 as the latest migration", {
-  expect_equal(EXPECTED_LATEST_MIGRATION, MIGRATION_049)
-  expect_equal(EXPECTED_MIGRATION_COUNT, 47L)
+test_that("migration 049 is present and counted in the manifest", {
+  # Asserts 049 EXISTS, not that it is the newest. A per-migration guard that
+  # pins the global latest breaks every time an unrelated migration is added —
+  # which is exactly what happened when 050 landed. The latest-migration
+  # assertion belongs in test-unit-core-views-manifest.R, and lives there.
+  candidates <- c(
+    file.path(get_api_dir(), "..", "db", "migrations", MIGRATION_049),
+    file.path(get_api_dir(), "db", "migrations", MIGRATION_049)
+  )
+  expect_true(any(file.exists(candidates)))
+  expect_gte(EXPECTED_MIGRATION_COUNT, 47L)
 })

--- a/api/tests/testthat/test-unit-variant-view-entity-agreement.R
+++ b/api/tests/testthat/test-unit-variant-view-entity-agreement.R
@@ -1,0 +1,93 @@
+# tests/testthat/test-unit-variant-view-entity-agreement.R
+#
+# Guard for migration 050 + seo-service.R (berntpopp/sysndd-administration#18).
+#
+# ndd_review_variation_ontology_connect records which entity a row belongs to
+# TWICE -- in its own `entity_id`, and via the entity owning its `review_id`.
+# Production has 256 active rows where those disagree (206 on a primary, approved
+# review), from a 2022 seed that read a stale snapshot CSV.
+#
+# svc_entity_variation() drops those rows by requiring BOTH predicates. The
+# variant view and the SEO query joined on review_id alone, so the same rows
+# surfaced in the public variant browse and in SEO structured data -- the entity
+# page and the browse disagreeing about the same entity.
+#
+# These assertions are about SOURCE TEXT, so they hold with no database.
+#
+# Pure test (no DB / no network) -- runs on host:
+#   cd api && Rscript --no-init-file -e \
+#     "testthat::test_file('tests/testthat/test-unit-variant-view-entity-agreement.R')"
+
+library(testthat)
+
+migration_050_path <- function() {
+  file.path(get_api_dir(), "..", "db", "migrations",
+            "050_variant_view_entity_agreement.sql")
+}
+
+read_all <- function(path) paste(readLines(path, warn = FALSE), collapse = "\n")
+
+test_that("migration 050 joins the variant view on BOTH review_id and entity_id", {
+  path <- migration_050_path()
+  expect_true(file.exists(path))
+  sql <- read_all(path)
+
+  expect_match(sql, "VIEW `ndd_review_variant_connect_view`", fixed = TRUE)
+  expect_match(
+    sql,
+    "`ndd_review_variation_ontology_connect`.`entity_id` = `ndd_entity_review`.`entity_id`",
+    fixed = TRUE
+  )
+})
+
+test_that("migration 050 keeps all three approval gates from migration 042", {
+  # The entity-agreement predicate is ADDITIONAL. Dropping any of these would
+  # leak unapproved in-place review edits publicly, which is what 042 exists for.
+  sql <- read_all(migration_050_path())
+
+  expect_match(sql, "`is_active` = 1", fixed = TRUE)
+  expect_match(sql, "`is_primary` = 1", fixed = TRUE)
+  expect_match(sql, "`review_approved` = 1", fixed = TRUE)
+})
+
+test_that("migration 050 does NOT touch the phenotype view", {
+  # svc_entity_phenotypes() and svc_entity_publications() filter on review_id
+  # alone, so their view already agrees with their endpoint. Adding the predicate
+  # there would HIDE 744 phenotype and 166 publication rows that are currently
+  # served -- a user-visible removal resting on an unproven assumption about which
+  # column is authoritative. This test exists so a future "make it consistent"
+  # change has to argue with it first.
+  sql <- read_all(migration_050_path())
+
+  expect_false(grepl("VIEW `ndd_review_phenotype_connect_view`", sql, fixed = TRUE))
+  expect_false(grepl("ndd_review_phenotype_connect`.`entity_id` = ", sql, fixed = TRUE))
+})
+
+test_that("the SEO variation query requires entity agreement", {
+  src <- read_all(file.path(get_api_dir(), "services", "seo-service.R"))
+
+  expect_match(src, "AND er.entity_id = vc.entity_id", fixed = TRUE)
+})
+
+test_that("the SEO phenotype and publication queries are deliberately unchanged", {
+  # Same reasoning as the migration: they match their endpoints already.
+  src <- read_all(file.path(get_api_dir(), "services", "seo-service.R"))
+
+  expect_false(grepl("AND er.entity_id = pc.entity_id", src, fixed = TRUE))
+  expect_false(grepl("AND er.entity_id = rpj.entity_id", src, fixed = TRUE))
+})
+
+test_that("the SEO variation query still matches svc_entity_variation's gates", {
+  src <- read_all(file.path(get_api_dir(), "services", "seo-service.R"))
+
+  expect_match(src, "er.is_primary = 1 AND er.review_approved = 1", fixed = TRUE)
+  expect_match(src, "vc.is_active = 1", fixed = TRUE)
+})
+
+test_that("the migration manifest tracks 050 as the latest migration", {
+  origin_dir <- Sys.getenv("MCP_API_TEST_ROOT", get_api_dir())
+  source(file.path(origin_dir, "functions", "migration-manifest.R"), local = FALSE)
+
+  expect_equal(EXPECTED_LATEST_MIGRATION, "050_variant_view_entity_agreement.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 48L)
+})

--- a/api/tests/testthat/test-unit-variation-provenance-migration.R
+++ b/api/tests/testthat/test-unit-variation-provenance-migration.R
@@ -237,8 +237,8 @@ cleanup_variation_provenance_fk_targets <- function(conn, ids) {
 }
 
 test_that("migration manifest tracks the latest migration", {
-  expect_equal(EXPECTED_LATEST_MIGRATION, "049_add_evidence_origin_review.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 47L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "050_variant_view_entity_agreement.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 48L)
 })
 
 test_that("migration 047 never mentions ndd_review_variation_ontology_connect", {

--- a/db/migrations/050_variant_view_entity_agreement.sql
+++ b/db/migrations/050_variant_view_entity_agreement.sql
@@ -1,0 +1,70 @@
+-- 050_variant_view_entity_agreement.sql
+-- Recreate ndd_review_variant_connect_view with the entity-agreement join, so the
+-- public variant browse agrees with the entity page
+-- (berntpopp/sysndd-administration#18).
+--
+-- THE DEFECT
+--   ndd_review_variation_ontology_connect stores which entity a row belongs to
+--   TWICE: directly in its own `entity_id`, and indirectly via the entity that
+--   owns its `review_id`. Production has 256 active rows where those disagree
+--   (206 on a primary, approved review) -- e.g. entity 3402's row citing review
+--   3310, which belongs to entity 3403.
+--
+--   Traced to the 2022-06-09 bulk seed in
+--   db/12_Rcommands_sysndd_db_table_variation_ontology_set.R, which took its
+--   review_id -> entity_id pairing from `ndd_entity_review_files$value[1]` after
+--   an ASCENDING date sort -- i.e. the OLDEST snapshot CSV, where it wanted the
+--   newest. Stale input, not a bad algorithm, which is why the damage is one
+--   contiguous block (entities 3395-3650) rather than scattered.
+--
+-- WHY THIS VIEW AND NOT THE OTHERS
+--   svc_entity_variation() (api/services/entity-read-endpoint-service.R) already
+--   requires BOTH predicates: the connect row's entity_id must equal the requested
+--   entity AND the review must be one of that entity's primary-approved reviews.
+--   This view joined on review_id ALONE, so the same 206 rows the entity page
+--   drops were still surfacing in the public variant browse and the entity-list
+--   vario filter. That disagreement is the bug being fixed here.
+--
+--   The sibling `ndd_review_phenotype_connect_view` is deliberately LEFT ALONE.
+--   svc_entity_phenotypes() and svc_entity_publications() filter on review_id
+--   only, so those views already agree with their own entity endpoints. Adding
+--   this predicate there would HIDE 744 phenotype and 166 publication rows that
+--   are currently displayed -- a user-visible data removal resting on an
+--   unproven assumption about which column is authoritative. Do not "make it
+--   consistent" without deciding that question first (admin#18).
+--
+-- SCOPE
+--   This is a CONSISTENCY fix, not a data fix. It changes no row, and it does not
+--   decide whether `entity_id` or `review_id` is the authoritative column for the
+--   256 mismatched rows -- that remains open in admin#18. It only makes all three
+--   variation surfaces (entity page, this view, seo-service.R) answer identically.
+--   For every correct row the added predicate is already true, so nothing that
+--   should be visible becomes hidden.
+--
+--   Keep in sync with db/C_Rcommands_set-table-connections.R and migration 042's
+--   three gating predicates (is_active / is_primary / review_approved), which are
+--   preserved verbatim below.
+
+CREATE OR REPLACE
+  ALGORITHM = UNDEFINED SQL SECURITY INVOKER
+  VIEW `ndd_review_variant_connect_view` AS
+    SELECT
+        `ndd_review_variation_ontology_connect`.`entity_id` AS `entity_id`,
+        `ndd_review_variation_ontology_connect`.`review_id` AS `review_id`,
+        `ndd_review_variation_ontology_connect`.`vario_id` AS `vario_id`,
+        `ndd_review_variation_ontology_connect`.`modifier_id` AS `modifier_id`,
+        `variation_ontology_list`.`vario_name` AS `vario_name`,
+        CONCAT(`variation_ontology_list`.`vario_name`, ': ', `variation_ontology_list`.`definition`) AS `vario_label`,
+        CONCAT(`ndd_review_variation_ontology_connect`.`modifier_id`, '-', `ndd_review_variation_ontology_connect`.`vario_id`) AS `modifier_variant_id`,
+        `ndd_review_variation_ontology_connect`.`variation_ontology_date` AS `variation_ontology_date`
+    FROM
+        ((`ndd_review_variation_ontology_connect`
+        JOIN `variation_ontology_list`
+          ON (`ndd_review_variation_ontology_connect`.`vario_id` = `variation_ontology_list`.`vario_id`))
+        JOIN `ndd_entity_review`
+          ON (`ndd_review_variation_ontology_connect`.`review_id` = `ndd_entity_review`.`review_id`
+              AND `ndd_review_variation_ontology_connect`.`entity_id` = `ndd_entity_review`.`entity_id`))
+    WHERE
+        (`ndd_review_variation_ontology_connect`.`is_active` = 1
+         AND `ndd_entity_review`.`is_primary` = 1
+         AND `ndd_entity_review`.`review_approved` = 1);


### PR DESCRIPTION
## The defect

`ndd_review_variation_ontology_connect` records which entity a row belongs to **twice**: directly in its own `entity_id`, and indirectly via the entity that owns its `review_id`. Production has **256 active rows where those disagree** — 206 on a primary, approved review. Example: entity `3402`'s row cites review `3310`, which belongs to entity `3403`.

`svc_entity_variation()` already drops those rows by requiring **both** predicates. But `ndd_review_variant_connect_view` and `seo-service.R` joined on `review_id` **alone**, so the same 206 rows kept surfacing in the public variant browse, the entity-list vario filter, and SEO structured data.

Verified live before the fix:

```sql
SELECT entity_id, review_id, vario_id FROM ndd_review_variant_connect_view WHERE entity_id = 3402;
-- 3402 | 3310 | VariO:0001   <-- review 3310 belongs to entity 3403
-- 3402 | 3770 | VariO:0001
-- 3402 | 3770 | VariO:0017
```

The entity page and the browse disagreed about the same entity. Only **42 of the 256** affected entities have a correctly-served `VariO:0001`, so for the other 214 the mismatched row was the *only* source — those entities were filterable by "variation" while their own page did not list it.

## The change

- **Migration 050** recreates *only* `ndd_review_variant_connect_view`, adding `connect.entity_id = review.entity_id` and preserving migration 042's three approval gates verbatim.
- **`seo-service.R`** gets the matching predicate on `entity_variation_sql()`.

## What is deliberately NOT changed

`svc_entity_phenotypes()` and `svc_entity_publications()` filter on `review_id` alone, so the phenotype view and the phenotype/publication SEO queries **already agree with their own endpoints**.

| Surface | variation | phenotype | publication |
|---|---|---|---|
| Entity page | review + **entity** | review only | review only |
| View / SEO (before) | review only ⚠️ | review only ✅ | review only ✅ |

The same underlying defect exists there — **913 phenotype** and **208 publication** mismatched rows (744 and 166 on primary-approved reviews) — but applying this predicate there would **hide rows that are currently served**, resting on an unproven assumption about which column is authoritative. A test asserts the phenotype view is untouched, so a future "make it consistent" change has to argue with it first.

## Scope

This is a **consistency fix, not a data fix**. It changes no row and does not decide whether `entity_id` or `review_id` is authoritative — that stays open in [admin#18](https://github.com/berntpopp/sysndd-administration/issues/18). For every correct row the added predicate is already true, so nothing that should be visible becomes hidden. If it is later decided the review is authoritative, all three variation surfaces move together.

## Root cause of the underlying data

`db/12_Rcommands_sysndd_db_table_variation_ontology_set.R`, the 2022-06-09 seed that gave every review a default `VariO:0001`:

```r
ndd_entity_review_files <- ... %>% arrange(date)          # ASCENDING -> oldest first
ndd_entity_review_ids <- read_csv(paste0("results/", ndd_entity_review_files$value[1]))
```

It took the `review_id -> entity_id` pairing from **the oldest snapshot CSV** where it wanted the newest. Stale input, not a bad algorithm — which is why the damage is one contiguous block (entities 3395–3650, reviews 3303–3558, constant offset, 256 = 2⁸) rather than scattered. All 3,557 seed-dated rows carry `review_vario_id == review_id`, the signature of `rownames_to_column()` over a review-ordered CSV.

## Verification

```
test-unit-variant-view-entity-agreement    FAIL 0 | PASS 15   (new)
test-unit-evidence-origin-review           FAIL 0 | PASS 15
test-unit-connect-views-approved-guard     FAIL 0 | PASS 7
test-unit-analysis-snapshot-migration      FAIL 0 | PASS 30
test-unit-variation-provenance-migration   FAIL 0 | PASS 3  (1 skip: no test DB)
test-unit-publication-author-columns       FAIL 0 | PASS 11
scripts/check-migration-prefixes.sh        OK: all 48 migration files have unique prefixes
```

Manifest moves 049 → 050, count 47 → 48.

Also fixes a brittle assertion in `test-unit-evidence-origin-review.R`, which pinned the *global* latest migration from inside a per-migration guard and so broke the moment 050 landed. It now asserts 049 exists; the latest-migration assertion lives in `test-unit-core-views-manifest.R` where it belongs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbd7MVQWEpKRBD1k6tM8aS
