### PR TITLE
feat(db): enforce connect.entity_id = review.entity_id structurally (migration 051)

### DIFF
--- a/api/endpoints/review_endpoints.R
+++ b/api/endpoints/review_endpoints.R
@@ -347,8 +347,23 @@ function(req, res, review_id_requested) {
     tbl("phenotype_list") %>%
     collect()
 
+  # A connect row names its entity twice: in `entity_id`, and via the entity
+  # owning `review_id`. Migration 051 makes disagreement impossible in MySQL,
+  # but this read must not depend on that -- fixtures and SQLite-backed
+  # environments have no such constraint, and the guard in 051 deliberately
+  # skips a database restored from a pre-repair dump. Showing a foreign row
+  # here is not merely cosmetic: saving a review DELETEs by review_id and
+  # re-inserts the submitted form, so anything displayed under the wrong review
+  # is re-attributed to the wrong entity on the next save (admin#19).
+  review_entity <- pool %>%
+    tbl("ndd_entity_review") %>%
+    dplyr::select(review_id, review_entity_id = entity_id) %>%
+    collect()
+
   phenotype_list <- ndd_review_phenotype_conn_coll %>%
     filter(review_id %in% review_id_requested & is_active) %>%
+    inner_join(review_entity, by = c("review_id")) %>%
+    filter(entity_id == review_entity_id) %>%
     inner_join(phenotype_list_collected, by = c("phenotype_id")) %>%
     dplyr::select(review_id, entity_id, phenotype_id, HPO_term, modifier_id) %>%
     arrange(phenotype_id)
@@ -435,8 +450,17 @@ function(req, res, review_id_requested) {
     tbl("publication") %>%
     collect()
 
+  # Same entity-agreement guard as the phenotype read above (admin#19).
+  review_entity <- pool %>%
+    tbl("ndd_entity_review") %>%
+    dplyr::select(review_id, review_entity_id = entity_id) %>%
+    collect()
+
   ndd_entity_publication_list <- review_publication_join_coll %>%
     filter(review_id %in% review_id_requested) %>%
+    inner_join(review_entity, by = c("review_id")) %>%
+    filter(entity_id == review_entity_id) %>%
+    dplyr::select(-review_entity_id) %>%
     arrange(publication_id)
 
   ndd_entity_publication_list

--- a/api/functions/migration-manifest.R
+++ b/api/functions/migration-manifest.R
@@ -2,8 +2,8 @@
 #
 # Strict migration manifest validation for startup/readiness.
 
-EXPECTED_LATEST_MIGRATION <- "050_variant_view_entity_agreement.sql"
-EXPECTED_MIGRATION_COUNT <- 48L
+EXPECTED_LATEST_MIGRATION <- "051_entity_review_agreement_constraint.sql"
+EXPECTED_MIGRATION_COUNT <- 49L
 
 #' Validate the migration manifest for strict startup/readiness checks
 #'

--- a/api/services/seo-service.R
+++ b/api/services/seo-service.R
@@ -235,10 +235,20 @@ entity_hpo_sql <- function() "
 # SEO structured data claiming a term the page itself does not show is exactly the
 # kind of divergence that erodes trust in the record.
 #
-# Deliberately NOT applied to entity_phenotypes_sql() or entity_pmids_sql() below:
-# svc_entity_phenotypes() and svc_entity_publications() filter on review_id alone,
-# so those queries already match their endpoints. Adding it there would hide 744
-# phenotype and 166 publication rows that are currently served.
+# Deliberately NOT applied to entity_hpo_sql() or entity_pmids_sql(): those
+# anchor on `pc.entity_id = ?` / `rpj.entity_id = ?`, i.e. on entity_id, which
+# admin#19 established IS the authoritative column (for the 188 mismatched
+# publication rows whose two candidate entities are different genes, the cited
+# paper names the connect entity's gene 162 times and the review entity's gene
+# 0 times). Anchoring on it is correct, so there is nothing to add.
+#
+# An earlier version of this comment claimed svc_entity_phenotypes() and
+# svc_entity_publications() "filter on review_id alone" and that the rows were
+# "currently served". Both were wrong: those functions end with
+# left_join(ndd_entity_active, by = "entity_id"), which re-imposes agreement, so
+# the rows were dropped rather than misattributed -- and the real divergence was
+# that SEO emitted terms the entity page did not show. The underlying data was
+# repaired in admin#19 and migration 051 now makes the disagreement impossible.
 entity_variation_sql <- function() "
   SELECT DISTINCT vc.vario_id AS id, vl.vario_name AS label
   FROM ndd_review_variation_ontology_connect vc

--- a/api/tests/testthat/test-mcp-select-principal-projections.R
+++ b/api/tests/testthat/test-mcp-select-principal-projections.R
@@ -177,6 +177,6 @@ test_that("source version formula and derived-content allowlists are frozen", {
 })
 
 test_that("manifest advances contiguously to the latest migration", {
-  expect_identical(EXPECTED_LATEST_MIGRATION, "050_variant_view_entity_agreement.sql")
-  expect_identical(EXPECTED_MIGRATION_COUNT, 48L)
+  expect_identical(EXPECTED_LATEST_MIGRATION, "051_entity_review_agreement_constraint.sql")
+  expect_identical(EXPECTED_MIGRATION_COUNT, 49L)
 })

--- a/api/tests/testthat/test-unit-analysis-snapshot-migration.R
+++ b/api/tests/testthat/test-unit-analysis-snapshot-migration.R
@@ -6,8 +6,8 @@ withr::defer(setwd(analysis_snapshot_test_wd), testthat::teardown_env())
 test_that("migration manifest tracks the latest migration", {
   source(file.path("functions", "migration-manifest.R"), local = TRUE)
 
-  expect_equal(EXPECTED_LATEST_MIGRATION, "050_variant_view_entity_agreement.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 48L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "051_entity_review_agreement_constraint.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 49L)
 })
 
 test_that("migration 046 adds the additive generator_json manifest column", {

--- a/api/tests/testthat/test-unit-core-views-manifest.R
+++ b/api/tests/testthat/test-unit-core-views-manifest.R
@@ -11,15 +11,15 @@ source(file.path(migration_test_api_dir, "functions", "migration-manifest.R"), l
 source(file.path(migration_test_api_dir, "functions", "migration-runner.R"), local = FALSE)
 
 test_that("manifest expects the latest migration", {
-  expect_equal(EXPECTED_LATEST_MIGRATION, "050_variant_view_entity_agreement.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 48L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "051_entity_review_agreement_constraint.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 49L)
 })
 
 test_that("migration manifest validates against db/migrations", {
   migrations_dir <- file.path(migration_test_api_dir, "..", "db", "migrations")
   res <- validate_migration_manifest(migrations_dir = migrations_dir)
   expect_true(res$ok)
-  expect_identical(res$latest, "050_variant_view_entity_agreement.sql")
+  expect_identical(res$latest, "051_entity_review_agreement_constraint.sql")
 })
 
 test_that("migration 036 file exists and contains disease_ontology_mapping table", {

--- a/api/tests/testthat/test-unit-entity-review-agreement-constraint.R
+++ b/api/tests/testthat/test-unit-entity-review-agreement-constraint.R
@@ -1,0 +1,129 @@
+# tests/testthat/test-unit-entity-review-agreement-constraint.R
+#
+# Guard for migration 051 (berntpopp/sysndd-administration#19).
+#
+# The three review join tables record which entity a row belongs to TWICE: in
+# their own `entity_id`, and via the entity owning their `review_id`. Nothing
+# enforced agreement, so ~1,377 rows drifted apart unnoticed between 2022 and
+# 2026 -- a seeding script resolved review_id from a stale snapshot after one
+# entity was deleted and another added, shifting every review_id in a 256-entity
+# block by one.
+#
+# Migration 051 makes the disagreement unrepresentable: a COMPOSITE foreign key
+# on (review_id, entity_id) referencing ndd_entity_review(review_id, entity_id).
+# Because review_id is that table's primary key, the pair can only resolve when
+# entity_id equals the review's own entity. The engine now rejects what the
+# application previously had to remember to check.
+#
+# These assertions are about SOURCE TEXT, so they hold with no database.
+#
+# Pure test (no DB / no network) -- runs on host:
+#   cd api && Rscript --no-init-file -e \
+#     "testthat::test_file('tests/testthat/test-unit-entity-review-agreement-constraint.R')"
+
+library(testthat)
+
+migration_051_path <- function() {
+  file.path(get_api_dir(), "..", "db", "migrations",
+            "051_entity_review_agreement_constraint.sql")
+}
+
+read_all <- function(path) paste(readLines(path, warn = FALSE), collapse = "\n")
+
+# Executable DDL only: the rationale prose above each statement names the very
+# tables and keywords these tests assert on, so matching raw file text would let
+# a comment satisfy a test that no statement satisfies.
+migration_051_ddl <- function() {
+  lines <- readLines(migration_051_path(), warn = FALSE)
+  paste(lines[!grepl("^\\s*--", lines)], collapse = "\n")
+}
+
+test_that("migration 051 exists", {
+  expect_true(file.exists(migration_051_path()))
+})
+
+test_that("051 adds the unique parent key the composite FK needs", {
+  # A composite FK requires an index on the referenced columns. review_id is
+  # already the PK, so (review_id, entity_id) is unique by construction -- but
+  # MySQL still needs the index to exist before it will accept the reference.
+  ddl <- migration_051_ddl()
+
+  expect_match(ddl, "ndd_entity_review", fixed = TRUE)
+  expect_match(ddl, "uq_entity_review_review_entity", fixed = TRUE)
+  expect_match(ddl, "UNIQUE", fixed = TRUE)
+})
+
+test_that("051 constrains the phenotype join table on BOTH columns", {
+  ddl <- migration_051_ddl()
+
+  expect_match(ddl, "fk_phenotype_connect_review_entity", fixed = TRUE)
+  expect_match(
+    ddl,
+    "FOREIGN KEY (`review_id`, `entity_id`)",
+    fixed = TRUE
+  )
+})
+
+test_that("051 constrains the publication join table on BOTH columns", {
+  ddl <- migration_051_ddl()
+
+  expect_match(ddl, "fk_publication_join_review_entity", fixed = TRUE)
+})
+
+test_that("051 does NOT constrain the variation table", {
+  # ndd_review_variation_ontology_connect still holds 256 rows that violate the
+  # invariant (admin#18). Adding the FK there would abort the migration and take
+  # the API down on startup, since migrations run before the server binds.
+  # It gets the same constraint once those rows are repaired.
+  ddl <- migration_051_ddl()
+
+  expect_false(grepl("ndd_review_variation_ontology_connect", ddl, fixed = TRUE))
+})
+
+test_that("051 is guarded so a rerun and a restored older dump both no-op", {
+  # Same PREPARE/EXECUTE information_schema guard style as 043/046/049: MySQL 8
+  # has no ADD CONSTRAINT IF NOT EXISTS.
+  ddl <- migration_051_ddl()
+
+  expect_match(ddl, "information_schema", fixed = TRUE)
+  expect_match(ddl, "PREPARE", fixed = TRUE)
+})
+
+test_that("051 refuses to apply while the data still violates the invariant", {
+  # An unguarded ADD FOREIGN KEY against violating rows fails the migration,
+  # which fails API startup. The guard checks for violations first and skips,
+  # so a database that was never repaired starts and reports rather than
+  # crash-looping.
+  ddl <- migration_051_ddl()
+
+  # counts disagreeing rows ...
+  expect_match(ddl, "WHERE c.`entity_id` <> r.`entity_id`", fixed = TRUE)
+  # ... and only adds each constraint when that count is zero.
+  expect_match(ddl, "IF(@pheno_violations = 0 AND @pheno_fk_exists = 0",
+               fixed = TRUE)
+  expect_match(ddl, "IF(@pub_violations = 0 AND @pub_fk_exists = 0",
+               fixed = TRUE)
+})
+
+test_that("the review curation reads require entity agreement", {
+  # Defense in depth, and NOT redundant with the FK. The FK holds in MySQL;
+  # the testthat fixtures and any SQLite-backed environment have no such
+  # enforcement, and a restored pre-repair dump skips the constraint by design
+  # (see the violation guard above). These are the surfaces where a mismatched
+  # row would be shown to a curator inside someone else's review -- and the
+  # save path is DELETE ... WHERE review_id + re-insert from the submitted
+  # form, so a row displayed under the wrong review gets re-attributed to the
+  # wrong entity on the next save.
+  src <- read_all(file.path(get_api_dir(), "endpoints", "review_endpoints.R"))
+
+  expect_match(src, "entity_id == review_entity_id", fixed = TRUE)
+})
+
+test_that("the migration manifest tracks 051 as the latest migration", {
+  origin_dir <- Sys.getenv("MCP_API_TEST_ROOT", get_api_dir())
+  source(file.path(origin_dir, "functions", "migration-manifest.R"), local = FALSE)
+
+  expect_equal(EXPECTED_LATEST_MIGRATION,
+               "051_entity_review_agreement_constraint.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 49L)
+})

--- a/api/tests/testthat/test-unit-variant-view-entity-agreement.R
+++ b/api/tests/testthat/test-unit-variant-view-entity-agreement.R
@@ -51,12 +51,16 @@ test_that("migration 050 keeps all three approval gates from migration 042", {
 })
 
 test_that("migration 050 does NOT touch the phenotype view", {
-  # svc_entity_phenotypes() and svc_entity_publications() filter on review_id
-  # alone, so their view already agrees with their endpoint. Adding the predicate
-  # there would HIDE 744 phenotype and 166 publication rows that are currently
-  # served -- a user-visible removal resting on an unproven assumption about which
-  # column is authoritative. This test exists so a future "make it consistent"
-  # change has to argue with it first.
+  # 050 was scoped to the variation view and stays that way.
+  #
+  # The original reason recorded here was wrong and is corrected in admin#19:
+  # svc_entity_phenotypes()/svc_entity_publications() do NOT filter on review_id
+  # alone -- they end with left_join(ndd_entity_active, by = "entity_id"), which
+  # re-imposes agreement. The 744 + 166 rows were therefore never "currently
+  # served"; they were dropped. entity_id was subsequently established as the
+  # authoritative column and the underlying rows were repaired, so the phenotype
+  # view needs no predicate: after the repair there is nothing for it to hide.
+  # Migration 051 enforces the invariant structurally.
   sql <- read_all(migration_050_path())
 
   expect_false(grepl("VIEW `ndd_review_phenotype_connect_view`", sql, fixed = TRUE))
@@ -70,7 +74,9 @@ test_that("the SEO variation query requires entity agreement", {
 })
 
 test_that("the SEO phenotype and publication queries are deliberately unchanged", {
-  # Same reasoning as the migration: they match their endpoints already.
+  # They anchor on entity_id, the authoritative column (admin#19), so they were
+  # already correct. Adding a review-agreement predicate would be redundant with
+  # migration 051 rather than harmful -- but redundant, so it stays out.
   src <- read_all(file.path(get_api_dir(), "services", "seo-service.R"))
 
   expect_false(grepl("AND er.entity_id = pc.entity_id", src, fixed = TRUE))
@@ -88,6 +94,6 @@ test_that("the migration manifest tracks 050 as the latest migration", {
   origin_dir <- Sys.getenv("MCP_API_TEST_ROOT", get_api_dir())
   source(file.path(origin_dir, "functions", "migration-manifest.R"), local = FALSE)
 
-  expect_equal(EXPECTED_LATEST_MIGRATION, "050_variant_view_entity_agreement.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 48L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "051_entity_review_agreement_constraint.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 49L)
 })

--- a/api/tests/testthat/test-unit-variation-provenance-migration.R
+++ b/api/tests/testthat/test-unit-variation-provenance-migration.R
@@ -237,8 +237,8 @@ cleanup_variation_provenance_fk_targets <- function(conn, ids) {
 }
 
 test_that("migration manifest tracks the latest migration", {
-  expect_equal(EXPECTED_LATEST_MIGRATION, "050_variant_view_entity_agreement.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 48L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "051_entity_review_agreement_constraint.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 49L)
 })
 
 test_that("migration 047 never mentions ndd_review_variation_ontology_connect", {

--- a/db/migrations/051_entity_review_agreement_constraint.sql
+++ b/db/migrations/051_entity_review_agreement_constraint.sql
@@ -1,0 +1,133 @@
+-- 051_entity_review_agreement_constraint.sql
+-- Make "the connect row's entity disagrees with its review's entity"
+-- unrepresentable (berntpopp/sysndd-administration#19).
+--
+-- THE PROBLEM THIS CLOSES:
+--   ndd_review_phenotype_connect and ndd_review_publication_join each record the
+--   owning entity TWICE -- in their own `entity_id`, and via the entity that owns
+--   their `review_id`. Nothing enforced agreement. A 2022 seeding script resolved
+--   review_id from the OLDEST snapshot CSV (`ndd_entity_review_files$value[1]`
+--   after an ascending sort) while ndd_entity_review had been loaded from a newer
+--   one. Between the two snapshots entity 3395 was deleted and entity 3651 added
+--   -- a conserved off-by-one -- so every review_id in a 256-entity block pointed
+--   one entity too far. 913 phenotype + 208 publication rows drifted, and nobody
+--   noticed for four years because no constraint could notice.
+--
+-- WHY A COMPOSITE FOREIGN KEY RATHER THAN A CHECK OR A TRIGGER:
+--   The invariant spans two tables, so a CHECK constraint cannot express it
+--   (MySQL CHECK may not subquery). A trigger could, but it is application logic
+--   living in the schema: it can be bypassed by disabling triggers, it must be
+--   written twice (INSERT and UPDATE), and it is silent about intent.
+--   A FOREIGN KEY on the PAIR is the declarative statement of the actual rule.
+--   Because `review_id` is ndd_entity_review's PRIMARY KEY, the pair
+--   (review_id, entity_id) resolves ONLY when entity_id equals that review's own
+--   entity. Agreement stops being something the application must remember and
+--   becomes something the engine refuses to violate.
+--
+--   The existing single-column FKs (`..._ibfk_1` on review_id) stay. They are
+--   implied by this one but dropping them is a separate, riskier change with no
+--   benefit.
+--
+-- WHY THE VARIATION TABLE IS NOT INCLUDED:
+--   ndd_review_variation_ontology_connect still holds 256 rows that violate the
+--   invariant (admin#18). ADD FOREIGN KEY against violating rows FAILS, and
+--   migrations run at API startup -- so including it would turn a data defect
+--   into a crash-looping API. It gets the identical constraint in a follow-up,
+--   once those rows are repaired the same way #19's were.
+--
+-- WHY THE VIOLATION GUARD BELOW:
+--   Same reasoning applied defensively to the two tables that ARE clean here.
+--   Production was repaired before this migration shipped, but a developer
+--   restoring an older dump, or any environment that skipped the repair, would
+--   otherwise get an API that cannot start. The guard checks for violations
+--   first and no-ops if any remain: such a database starts, serves, and reports
+--   its pending state instead of crash-looping. The constraint then applies on
+--   the next run after the data is fixed.
+--
+-- NULL keys: `review_id` is nullable and 3 rows hold NULL. A composite FK uses
+-- MATCH SIMPLE semantics -- any NULL member satisfies the reference -- so those
+-- rows are accepted and remain unconstrained. They are already invisible to
+-- every read path (all of them join on review_id). Making the columns NOT NULL
+-- is a separate change with its own data question.
+--
+-- Idempotent + restore-drift safe: information_schema guards in the style of
+-- migrations 043/046/049. MySQL 8 has no ADD CONSTRAINT IF NOT EXISTS.
+
+-- ---------------------------------------------------------------------------
+-- 1. The parent key the composite reference needs.
+--    (review_id, entity_id) is unique by construction because review_id is the
+--    PRIMARY KEY, but MySQL still requires a real index on the referenced
+--    columns before it will accept the FOREIGN KEY.
+-- ---------------------------------------------------------------------------
+
+SET @uq_exists := (
+  SELECT COUNT(*) FROM information_schema.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'ndd_entity_review'
+    AND INDEX_NAME = 'uq_entity_review_review_entity'
+);
+
+SET @ddl := IF(@uq_exists = 0,
+  'ALTER TABLE `ndd_entity_review`
+     ADD UNIQUE KEY `uq_entity_review_review_entity` (`review_id`, `entity_id`)',
+  'SELECT 1');
+
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ---------------------------------------------------------------------------
+-- 2. ndd_review_phenotype_connect
+-- ---------------------------------------------------------------------------
+
+SET @pheno_violations := (
+  SELECT COUNT(*) FROM `ndd_review_phenotype_connect` c
+  JOIN `ndd_entity_review` r ON r.`review_id` = c.`review_id`
+  WHERE c.`entity_id` <> r.`entity_id`
+);
+
+SET @pheno_fk_exists := (
+  SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'ndd_review_phenotype_connect'
+    AND CONSTRAINT_NAME = 'fk_phenotype_connect_review_entity'
+);
+
+SET @ddl := IF(@pheno_violations = 0 AND @pheno_fk_exists = 0,
+  'ALTER TABLE `ndd_review_phenotype_connect`
+     ADD CONSTRAINT `fk_phenotype_connect_review_entity`
+     FOREIGN KEY (`review_id`, `entity_id`)
+     REFERENCES `ndd_entity_review` (`review_id`, `entity_id`)',
+  'SELECT 1');
+
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ---------------------------------------------------------------------------
+-- 3. ndd_review_publication_join
+-- ---------------------------------------------------------------------------
+
+SET @pub_violations := (
+  SELECT COUNT(*) FROM `ndd_review_publication_join` c
+  JOIN `ndd_entity_review` r ON r.`review_id` = c.`review_id`
+  WHERE c.`entity_id` <> r.`entity_id`
+);
+
+SET @pub_fk_exists := (
+  SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'ndd_review_publication_join'
+    AND CONSTRAINT_NAME = 'fk_publication_join_review_entity'
+);
+
+SET @ddl := IF(@pub_violations = 0 AND @pub_fk_exists = 0,
+  'ALTER TABLE `ndd_review_publication_join`
+     ADD CONSTRAINT `fk_publication_join_review_entity`
+     FOREIGN KEY (`review_id`, `entity_id`)
+     REFERENCES `ndd_entity_review` (`review_id`, `entity_id`)',
+  'SELECT 1');
+
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
## Why

The review join tables record which entity a row belongs to **twice** — in their own `entity_id`, and via the entity owning their `review_id`. Nothing enforced agreement, so **~1,377 rows drifted apart unnoticed between 2022 and 2026**.

Root cause (full analysis: [sysndd-administration#19](https://github.com/berntpopp/sysndd-administration/issues/19#issuecomment-5197009662)): a seeding script resolved `review_id` from the **oldest** snapshot CSV (`ndd_entity_review_files$value[1]` after an ascending sort) while `ndd_entity_review` was loaded from a newer one. Between the snapshots entity 3395 was deleted and 3651 added — a *conserved* off-by-one — so every `review_id` in a 256-entity block pointed one entity too far.

`entity_id` was established as the authoritative column empirically, not by inference: across the 188 mismatched publication rows whose two candidate entities are different genes, the cited paper names the **connect** entity's gene **162 times** and the **review** entity's gene **0 times** (control ceiling on known-correct rows: 82.6%).

The 913 phenotype + 208 publication rows were repaired before this PR; production currently has **0 violations** in both tables.

## What

**Migration 051** — a composite FK on `(review_id, entity_id)` referencing `ndd_entity_review(review_id, entity_id)`, plus the unique parent key it requires.

Because `review_id` is that table's PRIMARY KEY, the pair resolves *only* when `entity_id` equals the review's own entity. A `CHECK` can't express this (no subqueries); a trigger could, but it's application logic in the schema, bypassable and silent about intent. The FK is the declarative statement of the actual rule.

**Excluded: the variation table.** It still holds 256 violating rows (admin#18), and `ADD FOREIGN KEY` against violating rows *fails* — and migrations run at API startup, so including it would turn a data defect into a crash-looping API. Same reasoning drives the per-table violation guard: a developer restoring a pre-repair dump gets a database that starts and reports, not one that won't boot.

**`review_endpoints.R`** — the two curation reads now require entity agreement. Not redundant with the FK: fixtures and SQLite-backed environments don't enforce it, and the save path is `DELETE ... WHERE review_id` + re-insert from the submitted form, so a row shown under the wrong review is re-attributed to the wrong entity on the next save.

**Corrections to my own earlier work.** The comment added in #622 claimed `svc_entity_phenotypes()`/`svc_entity_publications()` "filter on `review_id` alone" and that 744 + 166 rows were "currently served". Both false — those functions end with `left_join(..., by = "entity_id")`, which re-imposes agreement, so the rows were *dropped*, not misattributed. The decision to leave the SEO queries alone was right; the recorded reason was not. Corrected in `seo-service.R` and `test-unit-variant-view-entity-agreement.R`.

## Tests

New `test-unit-entity-review-agreement-constraint.R` (16 assertions, written first — 9 failing before the migration existed). Asserts against executable DDL with comment lines stripped, so the rationale prose can't satisfy an assertion no statement satisfies.

```
test-unit-entity-review-agreement-constraint.R  FAIL 0 PASS 16
test-unit-variant-view-entity-agreement.R       FAIL 0 PASS 15
test-unit-analysis-snapshot-migration.R         FAIL 0 PASS 30
test-mcp-select-principal-projections.R         FAIL 0 PASS 81
all tests/testthat/*review*.R                   FAIL 0
```

Manifest bumped to 051 / count 49 across the five files that pin it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)