### PR TITLE
feat(db): extend the entity/review agreement FK to the variation table (migration 052)

### DIFF
--- a/api/functions/migration-manifest.R
+++ b/api/functions/migration-manifest.R
@@ -2,8 +2,8 @@
 #
 # Strict migration manifest validation for startup/readiness.
 
-EXPECTED_LATEST_MIGRATION <- "051_entity_review_agreement_constraint.sql"
-EXPECTED_MIGRATION_COUNT <- 49L
+EXPECTED_LATEST_MIGRATION <- "052_variation_review_agreement_constraint.sql"
+EXPECTED_MIGRATION_COUNT <- 50L
 
 #' Validate the migration manifest for strict startup/readiness checks
 #'

--- a/api/tests/testthat/test-mcp-select-principal-projections.R
+++ b/api/tests/testthat/test-mcp-select-principal-projections.R
@@ -177,6 +177,6 @@ test_that("source version formula and derived-content allowlists are frozen", {
 })
 
 test_that("manifest advances contiguously to the latest migration", {
-  expect_identical(EXPECTED_LATEST_MIGRATION, "051_entity_review_agreement_constraint.sql")
-  expect_identical(EXPECTED_MIGRATION_COUNT, 49L)
+  expect_identical(EXPECTED_LATEST_MIGRATION, "052_variation_review_agreement_constraint.sql")
+  expect_identical(EXPECTED_MIGRATION_COUNT, 50L)
 })

--- a/api/tests/testthat/test-unit-analysis-snapshot-migration.R
+++ b/api/tests/testthat/test-unit-analysis-snapshot-migration.R
@@ -6,8 +6,8 @@ withr::defer(setwd(analysis_snapshot_test_wd), testthat::teardown_env())
 test_that("migration manifest tracks the latest migration", {
   source(file.path("functions", "migration-manifest.R"), local = TRUE)
 
-  expect_equal(EXPECTED_LATEST_MIGRATION, "051_entity_review_agreement_constraint.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 49L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "052_variation_review_agreement_constraint.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 50L)
 })
 
 test_that("migration 046 adds the additive generator_json manifest column", {

--- a/api/tests/testthat/test-unit-core-views-manifest.R
+++ b/api/tests/testthat/test-unit-core-views-manifest.R
@@ -11,15 +11,15 @@ source(file.path(migration_test_api_dir, "functions", "migration-manifest.R"), l
 source(file.path(migration_test_api_dir, "functions", "migration-runner.R"), local = FALSE)
 
 test_that("manifest expects the latest migration", {
-  expect_equal(EXPECTED_LATEST_MIGRATION, "051_entity_review_agreement_constraint.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 49L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "052_variation_review_agreement_constraint.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 50L)
 })
 
 test_that("migration manifest validates against db/migrations", {
   migrations_dir <- file.path(migration_test_api_dir, "..", "db", "migrations")
   res <- validate_migration_manifest(migrations_dir = migrations_dir)
   expect_true(res$ok)
-  expect_identical(res$latest, "051_entity_review_agreement_constraint.sql")
+  expect_identical(res$latest, "052_variation_review_agreement_constraint.sql")
 })
 
 test_that("migration 036 file exists and contains disease_ontology_mapping table", {

--- a/api/tests/testthat/test-unit-entity-review-agreement-constraint.R
+++ b/api/tests/testthat/test-unit-entity-review-agreement-constraint.R
@@ -105,6 +105,53 @@ test_that("051 refuses to apply while the data still violates the invariant", {
                fixed = TRUE)
 })
 
+migration_052_path <- function() {
+  file.path(get_api_dir(), "..", "db", "migrations",
+            "052_variation_review_agreement_constraint.sql")
+}
+
+migration_052_ddl <- function() {
+  lines <- readLines(migration_052_path(), warn = FALSE)
+  paste(lines[!grepl("^\\s*--", lines)], collapse = "\n")
+}
+
+test_that("052 completes the invariant by constraining the variation table", {
+  # 051 covered two of three tables because this one still held 256 violating
+  # rows (admin#18). Those were repaired -- 255 pointed back at their own
+  # entity's seed review, and one whose entity had been deleted outright was
+  # removed -- so the third constraint can finally land.
+  expect_true(file.exists(migration_052_path()))
+  ddl <- migration_052_ddl()
+
+  expect_match(ddl, "fk_variation_connect_review_entity", fixed = TRUE)
+  expect_match(ddl, "ndd_review_variation_ontology_connect", fixed = TRUE)
+  expect_match(ddl, "FOREIGN KEY (`review_id`, `entity_id`)", fixed = TRUE)
+  expect_match(ddl,
+               "REFERENCES `ndd_entity_review` (`review_id`, `entity_id`)",
+               fixed = TRUE)
+})
+
+test_that("052 keeps the same violation guard as 051", {
+  # Identical reasoning: migrations run at API startup, so an unguarded
+  # ADD FOREIGN KEY against a database that skipped the repair would crash-loop
+  # the API rather than merely report.
+  ddl <- migration_052_ddl()
+
+  expect_match(ddl, "WHERE c.`entity_id` <> r.`entity_id`", fixed = TRUE)
+  expect_match(ddl, "IF(@vario_violations = 0 AND @vario_fk_exists = 0",
+               fixed = TRUE)
+  expect_match(ddl, "information_schema", fixed = TRUE)
+  expect_match(ddl, "PREPARE", fixed = TRUE)
+})
+
+test_that("052 does not re-add the parent key 051 already created", {
+  # ndd_entity_review already carries uq_entity_review_review_entity. Adding it
+  # twice would fail on a database where 051 applied.
+  ddl <- migration_052_ddl()
+
+  expect_false(grepl("ADD UNIQUE KEY", ddl, fixed = TRUE))
+})
+
 test_that("the review curation reads require entity agreement", {
   # Defense in depth, and NOT redundant with the FK. The FK holds in MySQL;
   # the testthat fixtures and any SQLite-backed environment have no such
@@ -124,6 +171,6 @@ test_that("the migration manifest tracks 051 as the latest migration", {
   source(file.path(origin_dir, "functions", "migration-manifest.R"), local = FALSE)
 
   expect_equal(EXPECTED_LATEST_MIGRATION,
-               "051_entity_review_agreement_constraint.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 49L)
+               "052_variation_review_agreement_constraint.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 50L)
 })

--- a/api/tests/testthat/test-unit-variant-view-entity-agreement.R
+++ b/api/tests/testthat/test-unit-variant-view-entity-agreement.R
@@ -94,6 +94,6 @@ test_that("the migration manifest tracks 050 as the latest migration", {
   origin_dir <- Sys.getenv("MCP_API_TEST_ROOT", get_api_dir())
   source(file.path(origin_dir, "functions", "migration-manifest.R"), local = FALSE)
 
-  expect_equal(EXPECTED_LATEST_MIGRATION, "051_entity_review_agreement_constraint.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 49L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "052_variation_review_agreement_constraint.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 50L)
 })

--- a/api/tests/testthat/test-unit-variation-provenance-migration.R
+++ b/api/tests/testthat/test-unit-variation-provenance-migration.R
@@ -237,8 +237,8 @@ cleanup_variation_provenance_fk_targets <- function(conn, ids) {
 }
 
 test_that("migration manifest tracks the latest migration", {
-  expect_equal(EXPECTED_LATEST_MIGRATION, "051_entity_review_agreement_constraint.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 49L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "052_variation_review_agreement_constraint.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 50L)
 })
 
 test_that("migration 047 never mentions ndd_review_variation_ontology_connect", {

--- a/db/migrations/052_variation_review_agreement_constraint.sql
+++ b/db/migrations/052_variation_review_agreement_constraint.sql
@@ -1,0 +1,61 @@
+-- 052_variation_review_agreement_constraint.sql
+-- Complete the entity/review agreement invariant: constrain the third and last
+-- join table (berntpopp/sysndd-administration#18, #19).
+--
+-- WHY THIS IS SEPARATE FROM 051:
+--   051 constrained ndd_review_phenotype_connect and ndd_review_publication_join
+--   but deliberately skipped ndd_review_variation_ontology_connect, which still
+--   held 256 rows violating the invariant. ADD FOREIGN KEY against violating
+--   rows FAILS, and migrations run at API startup, so including it then would
+--   have turned a data defect into a crash-looping API.
+--
+--   Those rows have since been repaired: 255 were pointed back at their own
+--   entity's seed-era review (the review they were generated against, before a
+--   stale-snapshot renumbering shifted every review_id in a 256-entity block by
+--   one), and one -- entity 3395, VariO:0001 -- was removed, because that entity
+--   had been deleted from ndd_entity outright and therefore had no review to be
+--   repaired onto. It was the single obstacle to this constraint: the pair
+--   (review_id 3303, entity_id 3395) can never resolve.
+--
+-- WHAT THIS BUYS:
+--   With this in place all three review join tables are covered, and the class
+--   of defect that produced ~1,377 silently misattributed rows between 2022 and
+--   2026 is unrepresentable rather than merely absent.
+--
+-- The unique parent key `uq_entity_review_review_entity` was created by 051 and
+-- is NOT re-added here; doing so would fail wherever 051 has applied.
+--
+-- Guarded identically to 051: a database that skipped the repair no-ops and
+-- starts, rather than failing to boot.
+
+SET @vario_violations := (
+  SELECT COUNT(*) FROM `ndd_review_variation_ontology_connect` c
+  JOIN `ndd_entity_review` r ON r.`review_id` = c.`review_id`
+  WHERE c.`entity_id` <> r.`entity_id`
+);
+
+SET @vario_fk_exists := (
+  SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'ndd_review_variation_ontology_connect'
+    AND CONSTRAINT_NAME = 'fk_variation_connect_review_entity'
+);
+
+SET @parent_key_exists := (
+  SELECT COUNT(*) FROM information_schema.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'ndd_entity_review'
+    AND INDEX_NAME = 'uq_entity_review_review_entity'
+);
+
+SET @ddl := IF(@vario_violations = 0 AND @vario_fk_exists = 0
+               AND @parent_key_exists = 1,
+  'ALTER TABLE `ndd_review_variation_ontology_connect`
+     ADD CONSTRAINT `fk_variation_connect_review_entity`
+     FOREIGN KEY (`review_id`, `entity_id`)
+     REFERENCES `ndd_entity_review` (`review_id`, `entity_id`)',
+  'SELECT 1');
+
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
Completes what #623 started: the composite `(review_id, entity_id)` foreign key now covers **all three** review join tables.

## Why this is a separate migration

051 skipped `ndd_review_variation_ontology_connect` because it still held **256 violating rows** ([admin#18](https://github.com/berntpopp/sysndd-administration/issues/18)). `ADD FOREIGN KEY` against violating rows *fails*, and migrations run at API startup — including it then would have turned a data defect into a crash-looping API.

Those rows were repaired first:

| | |
|---|---|
| rows pointed back at their own entity's seed-era review | **255** |
| rows deleted (entity 3395 — deleted from `ndd_entity`, no review to repair onto) | **1** |
| mismatched rows remaining, any state | **0** |

The deleted row was the single obstacle to this constraint: `(review_id 3303, entity_id 3395)` can never resolve against `ndd_entity_review`, and `is_active = 0` wouldn't have helped since an FK doesn't consult it.

## Safety

All 256 affected rows were `VariO:0001` — the most generic term in the vocabulary — and **none carried a provenance assertion** from the #608 backfill, so nothing moved between "unchanged" and "moved" and the laundering workbook is untouched. Verified before the repair, not assumed.

The repair itself was ledgered with full row capture (including `variation_ontology_date`, which is `NOT NULL` and would otherwise be re-stamped on a rollback re-insert), and the one `DELETE` is gated by a hard-coded authorization list pinning the row's complete identity, checked in both directions — nothing unlisted may be deleted, and nothing listed may be missing.

## Guard

Identical to 051's, plus one addition: the guard also requires `uq_entity_review_review_entity` to already exist, so a database that somehow reaches 052 without 051 no-ops instead of failing. The parent key is deliberately not re-added.

## Tests

```
test-unit-entity-review-agreement-constraint.R  FAIL 0 PASS 26
test-unit-variant-view-entity-agreement.R       FAIL 0 PASS 15
test-unit-analysis-snapshot-migration.R         FAIL 0 PASS 30
test-mcp-select-principal-projections.R         FAIL 0 PASS 81
```

Manifest bumped to 052 / count 50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)