### PR TITLE
fix(db): 053 applies the FK that migration 052 silently skipped

### DIFF
--- a/api/functions/migration-manifest.R
+++ b/api/functions/migration-manifest.R
@@ -2,8 +2,8 @@
 #
 # Strict migration manifest validation for startup/readiness.
 
-EXPECTED_LATEST_MIGRATION <- "052_variation_review_agreement_constraint.sql"
-EXPECTED_MIGRATION_COUNT <- 50L
+EXPECTED_LATEST_MIGRATION <- "053_fix_variation_agreement_constraint_guard.sql"
+EXPECTED_MIGRATION_COUNT <- 51L
 
 #' Validate the migration manifest for strict startup/readiness checks
 #'

--- a/api/tests/testthat/test-mcp-select-principal-projections.R
+++ b/api/tests/testthat/test-mcp-select-principal-projections.R
@@ -177,6 +177,6 @@ test_that("source version formula and derived-content allowlists are frozen", {
 })
 
 test_that("manifest advances contiguously to the latest migration", {
-  expect_identical(EXPECTED_LATEST_MIGRATION, "052_variation_review_agreement_constraint.sql")
-  expect_identical(EXPECTED_MIGRATION_COUNT, 50L)
+  expect_identical(EXPECTED_LATEST_MIGRATION, "053_fix_variation_agreement_constraint_guard.sql")
+  expect_identical(EXPECTED_MIGRATION_COUNT, 51L)
 })

--- a/api/tests/testthat/test-unit-analysis-snapshot-migration.R
+++ b/api/tests/testthat/test-unit-analysis-snapshot-migration.R
@@ -6,8 +6,8 @@ withr::defer(setwd(analysis_snapshot_test_wd), testthat::teardown_env())
 test_that("migration manifest tracks the latest migration", {
   source(file.path("functions", "migration-manifest.R"), local = TRUE)
 
-  expect_equal(EXPECTED_LATEST_MIGRATION, "052_variation_review_agreement_constraint.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 50L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "053_fix_variation_agreement_constraint_guard.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 51L)
 })
 
 test_that("migration 046 adds the additive generator_json manifest column", {

--- a/api/tests/testthat/test-unit-core-views-manifest.R
+++ b/api/tests/testthat/test-unit-core-views-manifest.R
@@ -11,15 +11,15 @@ source(file.path(migration_test_api_dir, "functions", "migration-manifest.R"), l
 source(file.path(migration_test_api_dir, "functions", "migration-runner.R"), local = FALSE)
 
 test_that("manifest expects the latest migration", {
-  expect_equal(EXPECTED_LATEST_MIGRATION, "052_variation_review_agreement_constraint.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 50L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "053_fix_variation_agreement_constraint_guard.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 51L)
 })
 
 test_that("migration manifest validates against db/migrations", {
   migrations_dir <- file.path(migration_test_api_dir, "..", "db", "migrations")
   res <- validate_migration_manifest(migrations_dir = migrations_dir)
   expect_true(res$ok)
-  expect_identical(res$latest, "052_variation_review_agreement_constraint.sql")
+  expect_identical(res$latest, "053_fix_variation_agreement_constraint_guard.sql")
 })
 
 test_that("migration 036 file exists and contains disease_ontology_mapping table", {

--- a/api/tests/testthat/test-unit-entity-review-agreement-constraint.R
+++ b/api/tests/testthat/test-unit-entity-review-agreement-constraint.R
@@ -115,11 +115,17 @@ migration_052_ddl <- function() {
   paste(lines[!grepl("^\\s*--", lines)], collapse = "\n")
 }
 
-test_that("052 completes the invariant by constraining the variation table", {
+test_that("052 targets the variation table (but see 053 — it never ran)", {
   # 051 covered two of three tables because this one still held 256 violating
   # rows (admin#18). Those were repaired -- 255 pointed back at their own
   # entity's seed review, and one whose entity had been deleted outright was
-  # removed -- so the third constraint can finally land.
+  # removed -- so the third constraint could finally land.
+  #
+  # 052 did NOT land it: its parent-key guard tested `= 1` against a count that
+  # is 2 for a two-column index, so the ALTER was skipped while the migration
+  # recorded as applied. 053 is the one that actually creates the constraint.
+  # These assertions still hold and are kept so the file stays honest about
+  # what 052 contains.
   expect_true(file.exists(migration_052_path()))
   ddl <- migration_052_ddl()
 
@@ -152,6 +158,43 @@ test_that("052 does not re-add the parent key 051 already created", {
   expect_false(grepl("ADD UNIQUE KEY", ddl, fixed = TRUE))
 })
 
+migration_053_path <- function() {
+  file.path(get_api_dir(), "..", "db", "migrations",
+            "053_fix_variation_agreement_constraint_guard.sql")
+}
+
+migration_053_ddl <- function() {
+  lines <- readLines(migration_053_path(), warn = FALSE)
+  paste(lines[!grepl("^\\s*--", lines)], collapse = "\n")
+}
+
+test_that("053 applies the constraint 052 silently skipped", {
+  expect_true(file.exists(migration_053_path()))
+  ddl <- migration_053_ddl()
+
+  expect_match(ddl, "fk_variation_connect_review_entity", fixed = TRUE)
+  expect_match(ddl, "FOREIGN KEY (`review_id`, `entity_id`)", fixed = TRUE)
+})
+
+test_that("053 counts a multi-column index with > 0, never = 1", {
+  # THE BUG 053 EXISTS FOR. information_schema.STATISTICS has one row PER
+  # COLUMN, so the two-column uq_entity_review_review_entity counts as 2.
+  # Migration 052 guarded on `@parent_key_exists = 1`, which was false, so it
+  # no-opped in silence -- health/ready reported "applied 50, pending 0" and the
+  # foreign key was simply absent. An index-existence guard must test > 0.
+  ddl <- migration_053_ddl()
+
+  expect_match(ddl, "@parent_key_exists > 0", fixed = TRUE)
+  expect_false(grepl("@parent_key_exists = 1", ddl, fixed = TRUE))
+})
+
+test_that("053 still refuses to apply over violating data", {
+  ddl <- migration_053_ddl()
+
+  expect_match(ddl, "WHERE c.`entity_id` <> r.`entity_id`", fixed = TRUE)
+  expect_match(ddl, "@vario_violations = 0", fixed = TRUE)
+})
+
 test_that("the review curation reads require entity agreement", {
   # Defense in depth, and NOT redundant with the FK. The FK holds in MySQL;
   # the testthat fixtures and any SQLite-backed environment have no such
@@ -171,6 +214,6 @@ test_that("the migration manifest tracks 051 as the latest migration", {
   source(file.path(origin_dir, "functions", "migration-manifest.R"), local = FALSE)
 
   expect_equal(EXPECTED_LATEST_MIGRATION,
-               "052_variation_review_agreement_constraint.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 50L)
+               "053_fix_variation_agreement_constraint_guard.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 51L)
 })

--- a/api/tests/testthat/test-unit-variant-view-entity-agreement.R
+++ b/api/tests/testthat/test-unit-variant-view-entity-agreement.R
@@ -94,6 +94,6 @@ test_that("the migration manifest tracks 050 as the latest migration", {
   origin_dir <- Sys.getenv("MCP_API_TEST_ROOT", get_api_dir())
   source(file.path(origin_dir, "functions", "migration-manifest.R"), local = FALSE)
 
-  expect_equal(EXPECTED_LATEST_MIGRATION, "052_variation_review_agreement_constraint.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 50L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "053_fix_variation_agreement_constraint_guard.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 51L)
 })

--- a/api/tests/testthat/test-unit-variation-provenance-migration.R
+++ b/api/tests/testthat/test-unit-variation-provenance-migration.R
@@ -237,8 +237,8 @@ cleanup_variation_provenance_fk_targets <- function(conn, ids) {
 }
 
 test_that("migration manifest tracks the latest migration", {
-  expect_equal(EXPECTED_LATEST_MIGRATION, "052_variation_review_agreement_constraint.sql")
-  expect_equal(EXPECTED_MIGRATION_COUNT, 50L)
+  expect_equal(EXPECTED_LATEST_MIGRATION, "053_fix_variation_agreement_constraint_guard.sql")
+  expect_equal(EXPECTED_MIGRATION_COUNT, 51L)
 })
 
 test_that("migration 047 never mentions ndd_review_variation_ontology_connect", {

--- a/db/migrations/053_fix_variation_agreement_constraint_guard.sql
+++ b/db/migrations/053_fix_variation_agreement_constraint_guard.sql
@@ -1,0 +1,62 @@
+-- 053_fix_variation_agreement_constraint_guard.sql
+-- Apply the constraint that migration 052 silently skipped
+-- (berntpopp/sysndd-administration#18, #19).
+--
+-- WHAT WENT WRONG IN 052:
+--   Its guard required `@parent_key_exists = 1`, where @parent_key_exists came
+--   from information_schema.STATISTICS for the index
+--   `uq_entity_review_review_entity`. STATISTICS holds one row PER COLUMN of an
+--   index, and that index has two columns (review_id, entity_id) -- so the count
+--   is 2, the condition was false, and the ALTER never ran.
+--
+--   It failed in the worst available way: silently. The migration was recorded
+--   as applied, health/ready reported "applied 50, pending 0, manifest ok", and
+--   the foreign key was simply not there. Nothing surfaced it except explicitly
+--   asking information_schema whether the constraint existed. CI did not catch
+--   it either -- the smoke test asserts the API starts, not that a constraint
+--   was created.
+--
+--   Migration 051 was not affected: its equivalent guard tested `= 0`
+--   (absence), which a count of 2 does not satisfy either way it is read.
+--
+-- THE FIX: an index-existence guard must ask `> 0`, never `= 1`. 052 is left
+-- exactly as it shipped -- it is already recorded as applied, so editing it
+-- would change history without re-running anything.
+--
+-- Otherwise identical to 052: same constraint, same name, same violation guard,
+-- so a database that skipped the repair still no-ops rather than failing to
+-- boot, and a database where 052 somehow did apply sees the FK already present
+-- and no-ops too.
+
+SET @vario_violations := (
+  SELECT COUNT(*) FROM `ndd_review_variation_ontology_connect` c
+  JOIN `ndd_entity_review` r ON r.`review_id` = c.`review_id`
+  WHERE c.`entity_id` <> r.`entity_id`
+);
+
+SET @vario_fk_exists := (
+  SELECT COUNT(*) FROM information_schema.TABLE_CONSTRAINTS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'ndd_review_variation_ontology_connect'
+    AND CONSTRAINT_NAME = 'fk_variation_connect_review_entity'
+);
+
+-- `> 0`, not `= 1`: STATISTICS has one row per indexed column.
+SET @parent_key_exists := (
+  SELECT COUNT(*) FROM information_schema.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'ndd_entity_review'
+    AND INDEX_NAME = 'uq_entity_review_review_entity'
+);
+
+SET @ddl := IF(@vario_violations = 0 AND @vario_fk_exists = 0
+               AND @parent_key_exists > 0,
+  'ALTER TABLE `ndd_review_variation_ontology_connect`
+     ADD CONSTRAINT `fk_variation_connect_review_entity`
+     FOREIGN KEY (`review_id`, `entity_id`)
+     REFERENCES `ndd_entity_review` (`review_id`, `entity_id`)',
+  'SELECT 1');
+
+PREPARE stmt FROM @ddl;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
## The bug

Migration 052 (#624) was supposed to put the composite FK on `ndd_review_variation_ontology_connect`. It didn't. Its guard read:

```sql
SET @parent_key_exists := (
  SELECT COUNT(*) FROM information_schema.STATISTICS
  WHERE ... AND INDEX_NAME = 'uq_entity_review_review_entity');

SET @ddl := IF(... AND @parent_key_exists = 1, 'ALTER TABLE ...', 'SELECT 1');
```

`information_schema.STATISTICS` holds **one row per column** of an index. `uq_entity_review_review_entity` has two columns, so the count is **2**, `= 1` was false, and the `ALTER` never ran.

**It failed silently, which is the part worth fixing properly.** 052 recorded as applied; `health/ready` reported `applied 50, pending 0, manifest ok`; the constraint was simply absent. CI didn't catch it either — the smoke test asserts the API *starts*, not that a constraint *exists*.

It surfaced only on post-deploy verification: asking `information_schema` directly whether the FK was there, and watching a deliberately violating `UPDATE` be **accepted**.

Migration 051 was unaffected — its equivalent guard tested `= 0` (absence), which a count of 2 fails either way it's read.

## The fix

053 is 052 with `> 0`, which is what an index-existence guard must ask.

052 is left exactly as it shipped. It's already recorded as applied, so editing it would rewrite history without re-running anything.

## Tests

The test that would have caught this now exists and pins the form explicitly:

```r
expect_match(ddl, "@parent_key_exists > 0", fixed = TRUE)
expect_false(grepl("@parent_key_exists = 1", ddl, fixed = TRUE))
```

The 052 assertions are relabelled — the file no longer claims 052 completed the invariant, because it didn't.

```
test-unit-entity-review-agreement-constraint.R  FAIL 0 PASS 33
test-unit-variant-view-entity-agreement.R       FAIL 0 PASS 15
test-unit-analysis-snapshot-migration.R         FAIL 0 PASS 30
test-mcp-select-principal-projections.R         FAIL 0 PASS 81
```

Manifest bumped to 053 / count 51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)